### PR TITLE
Fix Settings Pages

### DIFF
--- a/src/contexts/settings-context.tsx
+++ b/src/contexts/settings-context.tsx
@@ -61,14 +61,10 @@ export function SettingsProvider({ children }: { children: ReactNode }): ReactEl
   }, [loadSettings]);
 
   const updateSettingsHandler = useCallback(async (newSettings: Partial<KeychainSettings>) => {
-    try {
-      setIsLoading(true);
-      await updateKeychainSettings(newSettings);
-      const updated = await getKeychainSettings();
-      setSettings(updated);
-    } finally {
-      setIsLoading(false);
-    }
+    // Update state immediately for instant UI response
+    setSettings(prev => ({ ...prev, ...newSettings }));
+    // Then persist to storage in background
+    await updateKeychainSettings(newSettings);
   }, []);
 
   return (

--- a/src/pages/compose/order/form.tsx
+++ b/src/pages/compose/order/form.tsx
@@ -53,6 +53,7 @@ export function OrderForm({
   const { pending } = useFormStatus();
 
   const [activeTab, setActiveTab] = useState<"buy" | "sell" | "settings">(initialFormData?.give_quantity ? "sell" : "buy");
+  const [previousTab, setPreviousTab] = useState<"buy" | "sell">(initialFormData?.give_quantity ? "sell" : "buy");
   const [price, setPrice] = useState<string>("");
   const [error, setError] = useState<{ message: string; } | null>(null);
   const [customExpiration, setCustomExpiration] = useState<number | undefined>(undefined);
@@ -111,6 +112,7 @@ export function OrderForm({
     if (newTab !== "settings") {
       setTabLoading(true);
       setTimeout(() => setTabLoading(false), 150);
+      setPreviousTab(newTab); // Remember the last buy/sell tab
     }
     setActiveTab(newTab);
   };
@@ -143,7 +145,7 @@ export function OrderForm({
           <button
             type="button"
             className={`text-lg font-semibold bg-transparent p-0 cursor-pointer focus:outline-none ${
-              activeTab === "buy" ? "underline" : ""
+              activeTab === "buy" || (activeTab === "settings" && previousTab === "buy") ? "underline" : ""
             }`}
             onClick={() => handleTabChange("buy")}
             disabled={pending}
@@ -153,7 +155,7 @@ export function OrderForm({
           <button
             type="button"
             className={`text-lg font-semibold bg-transparent p-0 cursor-pointer focus:outline-none ${
-              activeTab === "sell" ? "underline" : ""
+              activeTab === "sell" || (activeTab === "settings" && previousTab === "sell") ? "underline" : ""
             }`}
             onClick={() => handleTabChange("sell")}
             disabled={pending}
@@ -166,11 +168,11 @@ export function OrderForm({
           className={`p-2 hover:bg-gray-100 rounded-full transition-colors ${
             activeTab === "settings" ? "bg-gray-100" : ""
           }`}
-          onClick={() => handleTabChange("settings")}
+          onClick={() => activeTab === "settings" ? handleTabChange(previousTab) : handleTabChange("settings")}
           disabled={pending}
           aria-label="Order Settings"
         >
-          <FaCog className="w-5 h-5 text-gray-600" aria-hidden="true" />
+          <FaCog className="w-4 h-4 text-gray-600" aria-hidden="true" />
         </button>
       </div>
       {tabLoading ? (

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -11,8 +11,8 @@ import {
   FaHistory,
   FaExternalLinkAlt,
   FaLock,
-  FaCog,
 } from "react-icons/fa";
+import { TbPinned } from "react-icons/tb";
 import { RadioGroup } from "@headlessui/react";
 import { Button } from "@/components/button";
 import { AssetList } from "@/components/lists/asset-list";
@@ -167,7 +167,7 @@ export default function Index(): ReactElement {
             className="p-2 hover:bg-gray-100 rounded-full transition-colors cursor-pointer"
             aria-label="Manage Pinned Assets"
           >
-            <FaCog className="w-4 h-4 text-gray-600" aria-hidden="true" />
+            <TbPinned className="w-4 h-4 text-gray-600" aria-hidden="true" />
           </button>
           {!isTabView && (
             <button

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -164,10 +164,10 @@ export default function Index(): ReactElement {
         <div className="flex items-center space-x-2">
           <button
             onClick={() => navigate(CONSTANTS.PATHS.PINNED_ASSETS)}
-            className="p-2 hover:bg-gray-100 rounded-full transition-colors cursor-pointer"
+            className="p-1 hover:bg-gray-100 rounded-full transition-colors cursor-pointer"
             aria-label="Manage Pinned Assets"
           >
-            <TbPinned className="w-4 h-4 text-gray-600" aria-hidden="true" />
+            <TbPinned className="w-5 h-5 text-gray-600" aria-hidden="true" />
           </button>
           {!isTabView && (
             <button

--- a/src/pages/settings/advanced-settings.tsx
+++ b/src/pages/settings/advanced-settings.tsx
@@ -106,7 +106,7 @@ export default function AdvancedSettings(): ReactElement {
         <div className="flex items-center justify-between">
           <Label className="font-bold">Enable MPMA Sends</Label>
           <Switch
-            defaultChecked={settings.enableMPMA}
+            checked={settings.enableMPMA}
             onChange={(checked) => updateSettings({ enableMPMA: checked })}
             className={`${settings.enableMPMA ? "bg-blue-600" : "bg-gray-200"} p-0 relative inline-flex h-6 w-11 items-center rounded-full transition-colors cursor-pointer`}
           >
@@ -126,7 +126,7 @@ export default function AdvancedSettings(): ReactElement {
         <div className="flex items-center justify-between">
           <Label className="font-bold">Advanced Broadcasts</Label>
           <Switch
-            defaultChecked={settings.enableAdvancedBroadcasts}
+            checked={settings.enableAdvancedBroadcasts}
             onChange={(checked) => updateSettings({ enableAdvancedBroadcasts: checked })}
             className={`${settings.enableAdvancedBroadcasts ? "bg-blue-600" : "bg-gray-200"} p-0 relative inline-flex h-6 w-11 items-center rounded-full transition-colors cursor-pointer`}
           >
@@ -146,7 +146,7 @@ export default function AdvancedSettings(): ReactElement {
         <div className="flex items-center justify-between">
           <Label className="font-bold">Use Unconfirmed TXs</Label>
           <Switch
-            defaultChecked={settings.allowUnconfirmedTxs}
+            checked={settings.allowUnconfirmedTxs}
             onChange={(checked) => updateSettings({ allowUnconfirmedTxs: checked })}
             className={`${settings.allowUnconfirmedTxs ? "bg-blue-600" : "bg-gray-200"} p-0 relative inline-flex h-6 w-11 items-center rounded-full transition-colors cursor-pointer`}
           >
@@ -166,7 +166,7 @@ export default function AdvancedSettings(): ReactElement {
         <div className="flex items-center justify-between">
           <Label className="font-bold">Show/Hide Help Text</Label>
           <Switch
-            defaultChecked={settings.showHelpText}
+            checked={settings.showHelpText}
             onChange={(checked) => updateSettings({ showHelpText: checked })}
             className={`${settings.showHelpText ? "bg-blue-600" : "bg-gray-200"} p-0 relative inline-flex h-6 w-11 items-center rounded-full transition-colors cursor-pointer`}
           >
@@ -186,7 +186,7 @@ export default function AdvancedSettings(): ReactElement {
         <div className="flex items-center justify-between">
           <Label className="font-bold">Anonymous Analytics</Label>
           <Switch
-            defaultChecked={settings.analyticsAllowed}
+            checked={settings.analyticsAllowed}
             onChange={(checked) => updateSettings({ analyticsAllowed: checked })}
             className={`${settings.analyticsAllowed ? "bg-blue-600" : "bg-gray-200"} p-0 relative inline-flex h-6 w-11 items-center rounded-full transition-colors cursor-pointer`}
           >
@@ -202,25 +202,27 @@ export default function AdvancedSettings(): ReactElement {
         </Description>
       </Field>
 
-      <Field>
-        <div className="flex items-center justify-between">
-          <Label className="font-bold">Transaction Dry Run</Label>
-          <Switch
-            defaultChecked={settings.transactionDryRun}
-            onChange={(checked) => updateSettings({ transactionDryRun: checked })}
-            className={`${settings.transactionDryRun ? "bg-blue-600" : "bg-gray-200"} p-0 relative inline-flex h-6 w-11 items-center rounded-full transition-colors cursor-pointer`}
-          >
-            <span
-              className={`${
-                settings.transactionDryRun ? "translate-x-6" : "translate-x-1"
-              } inline-block h-4 w-4 transform rounded-full bg-white transition-transform`}
-            />
-          </Switch>
-        </div>
-        <Description className={`mt-2 text-sm text-gray-500 ${shouldShowHelpText ? "" : "hidden"}`}>
-          When enabled, transactions will be simulated instead of being broadcast to the network.
-        </Description>
-      </Field>
+      {process.env.NODE_ENV === 'development' && (
+        <Field>
+          <div className="flex items-center justify-between">
+            <Label className="font-bold">Transaction Dry Run</Label>
+            <Switch
+              checked={settings.transactionDryRun}
+              onChange={(checked) => updateSettings({ transactionDryRun: checked })}
+              className={`${settings.transactionDryRun ? "bg-blue-600" : "bg-gray-200"} p-0 relative inline-flex h-6 w-11 items-center rounded-full transition-colors cursor-pointer`}
+            >
+              <span
+                className={`${
+                  settings.transactionDryRun ? "translate-x-6" : "translate-x-1"
+                } inline-block h-4 w-4 transform rounded-full bg-white transition-transform`}
+              />
+            </Switch>
+          </div>
+          <Description className={`mt-2 text-sm text-gray-500 ${shouldShowHelpText ? "" : "hidden"}`}>
+            When enabled, transactions will be simulated instead of being broadcast to the network.
+          </Description>
+        </Field>
+      )}
     </div>
   );
 }

--- a/src/pages/settings/connected-sites.tsx
+++ b/src/pages/settings/connected-sites.tsx
@@ -1,13 +1,12 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
-import { FiX, FiGlobe, FiClock } from "react-icons/fi";
+import { FiX, FiGlobe } from "react-icons/fi";
+import { FaSync } from "react-icons/fa";
 import { Button } from "@/components/button";
 import { useHeader } from "@/contexts/header-context";
-import { useSettings } from "@/contexts/settings-context";
-import { getKeychainSettings } from "@/utils/storage/settingsStorage";
-import { trackEvent } from "@/utils/fathom";
+import { getKeychainSettings, updateKeychainSettings } from "@/utils/storage/settingsStorage";
 import { getProviderService } from "@/services/providerService";
 import type { ReactElement } from "react";
 
@@ -41,19 +40,6 @@ export default function ConnectedSites(): ReactElement {
   const [connectedSites, setConnectedSites] = useState<ConnectedSite[]>([]);
   const [loading, setLoading] = useState(true);
 
-  // Configure header
-  useEffect(() => {
-    setHeaderProps({
-      title: "Connected Sites",
-      onBack: () => navigate(CONSTANTS.PATHS.BACK),
-    });
-  }, [setHeaderProps, navigate]);
-
-  // Load connections on mount
-  useEffect(() => {
-    loadConnections();
-  }, []);
-
   const loadConnections = async () => {
     try {
       setLoading(true);
@@ -79,50 +65,68 @@ export default function ConnectedSites(): ReactElement {
    * Disconnects a site.
    */
   const handleDisconnectSite = async (origin: string) => {
-    const hostname = new URL(origin).hostname;
-    if (!confirm(`Disconnect ${hostname}?\n\nThis site will need to request permission again to access your wallet.`)) {
-      return;
-    }
-
     try {
-      // Track the disconnect event
-      await trackEvent('site_disconnect');
+      // Update UI immediately for instant feedback
+      setConnectedSites(prev => prev.filter(site => site.origin !== origin));
       
-      // Use provider service to disconnect and emit events
+      // Call provider service in background (for proper cleanup/events)
       const providerService = getProviderService();
-      await providerService.disconnect(origin);
-      
-      // Reload connections
-      await loadConnections();
+      providerService.disconnect(origin).catch(error => {
+        console.error('Provider disconnect error:', error);
+        // Reload if there was an error to ensure UI is in sync
+        loadConnections();
+      });
     } catch (error) {
       console.error('Failed to disconnect site:', error);
+      loadConnections(); // Reload on error
     }
   };
 
   /**
    * Disconnects all sites.
    */
-  const handleDisconnectAll = async () => {
-    if (!confirm('Disconnect all sites?\n\nAll connected sites will need to request permission again.')) {
-      return;
-    }
-
+  const handleDisconnectAll = useCallback(async () => {
     try {
-      // Track the disconnect all event
-      await trackEvent('disconnect_all_sites');
+      // Update UI immediately for instant feedback
+      const sitesToDisconnect = [...connectedSites];
+      setConnectedSites([]);
       
-      // Use provider service to disconnect each site
+      // Call provider service for each site in background
       const providerService = getProviderService();
-      await Promise.all(
-        connectedSites.map(site => providerService.disconnect(site.origin))
-      );
-      
-      await loadConnections();
+      Promise.all(
+        sitesToDisconnect.map(site => 
+          providerService.disconnect(site.origin).catch(err => 
+            console.error(`Failed to disconnect ${site.origin}:`, err)
+          )
+        )
+      ).catch(() => {
+        // If something went wrong, reload to ensure UI is in sync
+        loadConnections();
+      });
     } catch (error) {
       console.error('Failed to disconnect all sites:', error);
+      loadConnections(); // Reload on error
     }
-  };
+  }, [connectedSites]);
 
+
+  // Configure header with reset button when sites exist
+  useEffect(() => {
+    setHeaderProps({
+      title: "Connected Sites",
+      onBack: () => navigate(CONSTANTS.PATHS.BACK),
+      rightButton: connectedSites.length > 0 ? {
+        icon: <FaSync aria-hidden="true" />,
+        onClick: handleDisconnectAll,
+        ariaLabel: "Disconnect all sites",
+      } : undefined,
+    });
+  }, [setHeaderProps, navigate, connectedSites.length, handleDisconnectAll]);
+
+  // Load connections on mount
+  useEffect(() => {
+    loadConnections();
+  }, []);
 
   if (loading) {
     return (
@@ -137,22 +141,10 @@ export default function ConnectedSites(): ReactElement {
   }
 
   return (
-    <div className="p-4 space-y-4" role="main" aria-labelledby="connected-sites-title">
+    <div className={connectedSites.length === 0 ? 'h-full flex items-center justify-center' : 'p-4 space-y-4'} role="main" aria-labelledby="connected-sites-title">
       <h2 id="connected-sites-title" className="sr-only">
         Connected Sites
       </h2>
-      
-      {/* Header with disconnect all button */}
-      {connectedSites.length > 0 && (
-        <div className="flex justify-end">
-          <Button
-            color="red"
-            onClick={handleDisconnectAll}
-          >
-            Disconnect All
-          </Button>
-        </div>
-      )}
 
       {connectedSites.length === 0 ? (
         <div className="bg-gray-50 rounded-lg p-8 text-center">
@@ -190,17 +182,6 @@ export default function ConnectedSites(): ReactElement {
           ))}
         </div>
       )}
-
-      {/* Info section */}
-      <div className="mt-6 p-4 bg-blue-50 rounded-lg">
-        <h3 className="text-sm font-medium text-blue-900 mb-2">About Connected Sites</h3>
-        <ul className="text-xs text-blue-700 space-y-1">
-          <li>• Sites connect to your wallet and can see your active address</li>
-          <li>• When you switch addresses, connected sites are notified</li>
-          <li>• Sites must request approval for each transaction</li>
-          <li>• You can disconnect sites at any time</li>
-        </ul>
-      </div>
     </div>
   );
 }

--- a/src/pages/settings/order-settings.tsx
+++ b/src/pages/settings/order-settings.tsx
@@ -11,11 +11,11 @@ interface OrderSettingsProps {
 
 // Common expiration presets (in blocks)
 const EXPIRATION_PRESETS = [
+  { label: '1 Hour', blocks: 6 },
   { label: '1 Day', blocks: 144 },
   { label: '1 Week', blocks: 1008 },
   { label: '2 Weeks', blocks: 2016 },
   { label: '1 Month', blocks: 4320 },
-  { label: '2 Months', blocks: 8640 },
   { label: 'Max', blocks: 8064 },
 ];
 

--- a/src/pages/settings/pinned-assets-settings.tsx
+++ b/src/pages/settings/pinned-assets-settings.tsx
@@ -235,7 +235,7 @@ export default function PinnedAssetsSettings(): ReactElement {
       <div className="h-full flex flex-col">
         {pinnedAssets.length > 0 ? (
           <>
-            <h3 className="text-lg font-semibold mb-2">Pinned Assets</h3>
+            <h3 className="text-lg font-semibold mb-2">Pinned</h3>
             {showHelpText && (
               <p className="text-sm text-gray-500 mb-2">
                 Pin up to 10 assets to the top of your main screen. Drag to reorder.

--- a/src/pages/settings/security-settings.tsx
+++ b/src/pages/settings/security-settings.tsx
@@ -135,13 +135,6 @@ export default function SecuritySettings(): ReactElement {
           )}
           
           <div className="bg-white border border-gray-200 rounded-xl p-6 shadow-sm space-y-6">
-            <div className="text-center mb-4">
-              <h3 className="text-xl font-bold text-gray-800">Change Password</h3>
-              <p className="text-sm text-gray-600 mt-1">
-                Update your wallet password to keep your funds secure
-              </p>
-            </div>
-            
             <Field>
               <Label className="font-bold text-gray-700">Current Password</Label>
               <Input
@@ -211,7 +204,7 @@ export default function SecuritySettings(): ReactElement {
             </Button>
           </div>
           
-          <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
+          <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4 mb-6">
             <p className="text-sm text-yellow-800">
               <strong>Security Tip:</strong> Use a strong, unique password that you don't use for any other accounts. Consider using a password manager.
             </p>


### PR DESCRIPTION
  Fixes settings page flicker and improves UI/UX across multiple settings pages.

  Changes

  - Settings flicker fix: Remove loading state during updates, use controlled Switch components
  - Connected sites: Instant disconnect, reset button in header, cleaner empty state
  - Order compose: Maintain Buy/Sell context when accessing settings
  - Security page: Cleaner layout without redundant headings
  - Order settings: Add 1 hour expiration option
  - Minor: Hide dev-only features in production, consistent icon sizing