### PR TITLE
Add fee_required field to buy BTC orders

### DIFF
--- a/src/pages/assets/view-balance.tsx
+++ b/src/pages/assets/view-balance.tsx
@@ -79,6 +79,12 @@ export default function ViewBalance(): ReactElement {
             path: `${CONSTANTS.PATHS.COMPOSE}/send/BTC`,
           },
           {
+            id: "order",
+            name: "DEX Order",
+            description: "Create a new order on the DEX",
+            path: `${CONSTANTS.PATHS.COMPOSE}/order/BTC`,
+          },
+          {
             id: "btcpay",
             name: "BTCPay",
             description: "Pay for an order match with BTC",

--- a/src/pages/compose/order/review.tsx
+++ b/src/pages/compose/order/review.tsx
@@ -80,6 +80,9 @@ export function ReviewOrder({
     ...(result.params.expiration !== 8064
       ? [{ label: "Expiration", value: `${result.params.expiration} blocks` }]
       : []),
+    ...(result.params.fee_required && Number(result.params.fee_required) > 0
+      ? [{ label: "Fee Required", value: `${result.params.fee_required} satoshis` }]
+      : []),
   ];
 
   return (

--- a/src/utils/blockchain/counterparty/compose.ts
+++ b/src/utils/blockchain/counterparty/compose.ts
@@ -153,6 +153,7 @@ export interface OrderOptions extends BaseComposeOptions {
   get_asset: string;
   get_quantity: number;
   expiration: number;
+  fee_required?: number;
 }
 
 export interface SendOptions extends BaseComposeOptions {
@@ -526,6 +527,7 @@ export async function composeOrder(options: OrderOptions): Promise<ApiResponse> 
     get_asset,
     get_quantity,
     expiration,
+    fee_required = 0,
     sat_per_vbyte,
     max_fee,
     encoding,
@@ -536,7 +538,7 @@ export async function composeOrder(options: OrderOptions): Promise<ApiResponse> 
     get_asset,
     get_quantity: get_quantity.toString(),
     expiration: expiration.toString(),
-    fee_required: '0',
+    fee_required: fee_required.toString(),
     ...(max_fee !== undefined && { max_fee: max_fee.toString() }),
   };
   return composeTransaction('order', paramsObj, sourceAddress, sat_per_vbyte, encoding);


### PR DESCRIPTION
  This PR implements the fee_required parameter for DEX orders, allowing users to specify a minimum transaction fee
   when creating buy orders for BTC.

  Changes

  - Re-enabled DEX Order option in the BTC balance menu, positioned above BTCPay for better workflow
  - Added fee_required field to order composition that only displays when buying BTC
  - Fixed quote asset selection - users can now change the quote asset from the default XCP to any other asset
  - Enhanced UI feedback with sat/vB estimation for the fee requirement

  Implementation Details

  - The fee_required field defaults to 0 (no minimum fee)
  - When set, it specifies the minimum tx fee (in satoshis) that must be paid by a BTCPay to match the order
  - The UI shows the approximate sat/vB rate based on an average 250-byte BTCPay transaction
  - The field is only applicable and visible when buying BTC (selling another asset for BTC)

  Technical Changes

  - Updated OrderOptions interface to include optional fee_required parameter
  - Modified composeOrder function to pass fee_required to the API
  - Added state management for quote asset selection in the order form
  - Enhanced OrderSettings component with fee requirement UI