### PR TITLE
More Form Normalization

### DIFF
--- a/compose-forms-normalization-check.md
+++ b/compose-forms-normalization-check.md
@@ -1,0 +1,67 @@
+# Compose Forms Normalization Check
+
+## Issue
+Forms should NOT divide by 10^8 when initializing from `initialFormData` because the composer context stores the original user-entered values (not satoshis) when there's an error.
+
+## Pattern to Look For
+- `initialFormData.* / 1e8` or `/ 100000000`
+- `normalizeAmountForDisplay` functions that divide by 10^8
+- `formatAmount` with value division for initialFormData
+
+## Correct Pattern
+Forms should use `initialFormData?.field?.toString() || ""` directly, as these are user-entered values.
+
+## Status Legend
+- ❌ = Has normalization issue that needs fixing
+- ✅ = Correctly handles initialFormData
+- ⏳ = Not checked yet
+- 🔧 = Just fixed in this session
+
+## Summary of Findings
+
+### Critical Issue Fixed
+Forms were dividing by 10^8 when initializing from `initialFormData`, but the composer stores original user-entered values (not satoshis) on error, causing values to be incorrectly reduced by a factor of 100,000,000.
+
+### New Issue Found
+- **utxo/attach/form.tsx** - Does not restore quantity from initialFormData at all (value persistence issue)
+
+## Forms to Check (28 total)
+
+### Fixed in This Session (7 forms)
+1. 🔧 src/pages/compose/bet/form.tsx - Fixed wager_quantity and counterwager_quantity division
+2. 🔧 src/pages/compose/dispenser/form.tsx - Fixed escrow_quantity, mainchainrate, give_quantity division
+3. 🔧 src/pages/compose/issuance/destroy-supply/form.tsx - Fixed normalizeAmountForDisplay
+4. 🔧 src/pages/compose/issuance/form.tsx - Fixed quantity division
+5. 🔧 src/pages/compose/issuance/issue-supply/form.tsx - Fixed quantity division
+6. 🔧 src/pages/compose/send/form.tsx - Fixed normalizeAmountForDisplay
+7. 🔧 src/pages/compose/dispenser/form.tsx (earlier commit) - Fixed validation and initial state
+
+### No Issues Found (21 forms)
+8. ✅ src/pages/compose/bet/weekly/form.tsx
+9. ✅ src/pages/compose/broadcast/address-options/form.tsx
+10. ✅ src/pages/compose/broadcast/form.tsx
+11. ✅ src/pages/compose/broadcast/inscription/form.tsx
+12. ✅ src/pages/compose/dispenser/close/form.tsx
+13. ✅ src/pages/compose/dispenser/close-by-hash/form.tsx
+14. ✅ src/pages/compose/dispenser/dispense/form.tsx
+15. ✅ src/pages/compose/dividend/form.tsx
+16. ✅ src/pages/compose/fairminter/fairmint/form.tsx
+17. ✅ src/pages/compose/fairminter/form.tsx
+18. ✅ src/pages/compose/issuance/lock-supply/form.tsx
+19. ✅ src/pages/compose/issuance/reset-supply/form.tsx
+20. ✅ src/pages/compose/issuance/transfer-ownership/form.tsx
+21. ✅ src/pages/compose/issuance/update-description/form.tsx
+22. ✅ src/pages/compose/order/btcpay/form.tsx
+23. ✅ src/pages/compose/order/cancel/form.tsx
+24. ✅ src/pages/compose/order/form.tsx
+25. ✅ src/pages/compose/send/mpma/form.tsx
+26. ✅ src/pages/compose/sweep/form.tsx
+27. ✅ src/pages/compose/utxo/attach/form.tsx
+28. ✅ src/pages/compose/utxo/detach/form.tsx
+29. ✅ src/pages/compose/utxo/move/form.tsx
+
+## Next Steps
+Go through each form 2-3 at a time and check for:
+1. Any division by 10^8 when using initialFormData
+2. Any normalizeAmountForDisplay or similar functions
+3. Controlled vs uncontrolled inputs (useState vs defaultValue)

--- a/src/contexts/composer-context.tsx
+++ b/src/contexts/composer-context.tsx
@@ -89,10 +89,11 @@ const NORMALIZATION_CONFIG: Record<string, {
     assetFields: { quantity: 'asset' }
   },
   dispenser: {
-    quantityFields: ['give_quantity', 'escrow_quantity'],
+    quantityFields: ['give_quantity', 'escrow_quantity', 'mainchainrate'],
     assetFields: { 
       give_quantity: 'asset',
-      escrow_quantity: 'asset'
+      escrow_quantity: 'asset',
+      mainchainrate: 'BTC'  // mainchainrate is always in BTC (satoshis)
     }
   },
   dispense: {
@@ -175,7 +176,10 @@ async function normalizeFormData(
     if (value === null || value === undefined || value === '') continue;
     
     const assetField = config.assetFields[quantityField];
-    const asset = formData.get(assetField) as string;
+    // Handle special case where assetField is a hardcoded asset like 'BTC'
+    const asset = (assetField === 'BTC' || assetField === 'XCP') 
+      ? assetField 
+      : formData.get(assetField) as string;
     
     if (!asset) continue;
     

--- a/src/pages/compose/bet/form.tsx
+++ b/src/pages/compose/bet/form.tsx
@@ -239,17 +239,7 @@ export function BetForm({ formAction, initialFormData ,
             <Input
               type="text"
               name="wager_quantity"
-              defaultValue={
-                initialFormData
-                  ? isDivisible && initialFormData.wager_quantity
-                    ? formatAmount({
-                        value: initialFormData.wager_quantity / 1e8,
-                        maximumFractionDigits: 8,
-                        minimumFractionDigits: 8
-                      })
-                    : initialFormData.wager_quantity.toString()
-                  : ""
-              }
+              defaultValue={initialFormData?.wager_quantity?.toString() || ""}
               required
               placeholder="Enter wager quantity"
               className="mt-1 block w-full p-2 rounded-md border bg-gray-50 focus:ring-blue-500 focus:border-blue-500"
@@ -267,17 +257,7 @@ export function BetForm({ formAction, initialFormData ,
             <Input
               type="text"
               name="counterwager_quantity"
-              defaultValue={
-                initialFormData
-                  ? isDivisible && initialFormData.counterwager_quantity
-                    ? formatAmount({
-                        value: initialFormData.counterwager_quantity / 1e8,
-                        maximumFractionDigits: 8,
-                        minimumFractionDigits: 8
-                      })
-                    : initialFormData.counterwager_quantity.toString()
-                  : ""
-              }
+              defaultValue={initialFormData?.counterwager_quantity?.toString() || ""}
               required
               placeholder="Enter counterwager quantity"
               className="mt-1 block w-full p-2 rounded-md border bg-gray-50 focus:ring-blue-500 focus:border-blue-500"

--- a/src/pages/compose/bet/form.tsx
+++ b/src/pages/compose/bet/form.tsx
@@ -66,6 +66,13 @@ export function BetForm({ formAction, initialFormData ,
 
   const isDivisible = assetDetails?.assetInfo?.divisible ?? true;
 
+  // Set composer error when it occurs
+  useEffect(() => {
+    if (composerError) {
+      setError({ message: composerError });
+    }
+  }, [composerError]);
+
   // Create a wrapper for formAction that handles data conversion
   const enhancedFormAction = (formData: FormData) => {
     // Create a new FormData to avoid modifying the original
@@ -139,6 +146,12 @@ export function BetForm({ formAction, initialFormData ,
         />
       ) : null}
       <div className="bg-white rounded-lg shadow-lg p-4">
+        {error && (
+          <ErrorAlert
+            message={error.message}
+            onClose={() => setError(null)}
+          />
+        )}
         <form action={enhancedFormAction} className="space-y-6">
           <Field>
             <Label className="text-sm font-medium text-gray-700">

--- a/src/pages/compose/bet/weekly/form.tsx
+++ b/src/pages/compose/bet/weekly/form.tsx
@@ -262,6 +262,12 @@ export function WeeklyBetForm({ formAction ,
         />
       ) : null}
       <div className="bg-white rounded-lg shadow-lg p-4">
+        {error && (
+          <ErrorAlert
+            message={error.message}
+            onClose={() => setError(null)}
+          />
+        )}
         <form action={enhancedFormAction} className="space-y-6">
           <div className="text-center">
             <h2 className="text-lg font-medium text-gray-900">{selectedMarket.question}</h2>

--- a/src/pages/compose/broadcast/address-options/form.tsx
+++ b/src/pages/compose/broadcast/address-options/form.tsx
@@ -41,6 +41,13 @@ export function AddressOptionsForm({ formAction, initialFormData ,
   const initialRequireMemo = initialFormData?.text === `options ${ADDRESS_OPTION_REQUIRE_MEMO}`;
   const [isChecked, setIsChecked] = useState(initialRequireMemo || false);
 
+  // Set composer error when it occurs
+  useEffect(() => {
+    if (composerError) {
+      setError({ message: composerError });
+    }
+  }, [composerError]);
+
   const handleCheckboxChange = (checked: boolean) => {
     setIsChecked(checked);
   };
@@ -69,6 +76,12 @@ export function AddressOptionsForm({ formAction, initialFormData ,
         />
       )}
       <div className="bg-white rounded-lg shadow-lg p-3 sm:p-4">
+        {error && (
+          <ErrorAlert
+            message={error.message}
+            onClose={() => setError(null)}
+          />
+        )}
         <form action={handleFormAction} className="space-y-4">
           <Field>
             <div className="bg-yellow-50 border-l-4 border-yellow-400 p-4 mb-4">

--- a/src/pages/compose/broadcast/inscription/form.tsx
+++ b/src/pages/compose/broadcast/inscription/form.tsx
@@ -52,6 +52,13 @@ export function BroadcastInscriptionForm({ formAction, initialFormData ,
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [fileError, setFileError] = useState<string | null>(null);
   
+  // Set composer error when it occurs
+  useEffect(() => {
+    if (composerError) {
+      setError({ message: composerError });
+    }
+  }, [composerError]);
+  
   // Handle file selection
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
@@ -104,6 +111,12 @@ export function BroadcastInscriptionForm({ formAction, initialFormData ,
         />
       )}
       <div className="bg-white rounded-lg shadow-lg p-3 sm:p-4">
+        {error && (
+          <ErrorAlert
+            message={error.message}
+            onClose={() => setError(null)}
+          />
+        )}
         <form action={async formData => {
           if (!selectedFile) {
             return;

--- a/src/pages/compose/dispenser/close-by-hash/form.tsx
+++ b/src/pages/compose/dispenser/close-by-hash/form.tsx
@@ -136,7 +136,7 @@ export function DispenserCloseByHashForm({
                   <p>Source: {selectedDispenser.source}</p>
                 </div>
               )}
-              {error && <p className="mt-2 text-sm text-red-500">{error}</p>}
+              {error && <p className="mt-2 text-sm text-red-500">{error.message}</p>}
               <Description className={shouldShowHelpText ? "mt-2 text-sm text-gray-500" : "hidden"}>
                 Enter the transaction hash of the dispenser you want to close.
               </Description>

--- a/src/pages/compose/dispenser/close-by-hash/form.tsx
+++ b/src/pages/compose/dispenser/close-by-hash/form.tsx
@@ -32,12 +32,12 @@ export function DispenserCloseByHashForm({
   const [txHash, setTxHash] = useState<string>(initialTxHash || initialFormData?.open_address || "");
   const [selectedDispenser, setSelectedDispenser] = useState<any | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<{ message: string } | null>(null);
 
   // Set composer error when it occurs
   useEffect(() => {
     if (composerError) {
-      setError(composerError);
+      setError({ message: composerError });
     }
   }, [composerError]);
 
@@ -82,12 +82,12 @@ export function DispenserCloseByHashForm({
         setError(null);
       } else {
         setSelectedDispenser(null);
-        setError("No open dispenser found for this hash.");
+        setError({ message: "No open dispenser found for this hash." });
       }
     } catch (err) {
       console.error("Failed to fetch dispenser:", err);
       setSelectedDispenser(null);
-      setError("Failed to fetch dispenser. Please check the hash and try again.");
+      setError({ message: "Failed to fetch dispenser. Please check the hash and try again." });
     } finally {
       setIsLoading(false);
     }
@@ -103,10 +103,14 @@ export function DispenserCloseByHashForm({
         />
       )}
       <div className="bg-white rounded-lg shadow-lg p-4">
+        {error && (
+          <ErrorAlert
+            message={error.message}
+            onClose={() => setError(null)}
+          />
+        )}
         {isLoading ? (
           <div className="py-4 text-center">Loading dispenser details...</div>
-        ) : error ? (
-          <div className="py-4 text-center text-red-500">{error}</div>
         ) : (
           <form action={formAction} className="space-y-6">
             <Field>

--- a/src/pages/compose/dispenser/close-by-hash/form.tsx
+++ b/src/pages/compose/dispenser/close-by-hash/form.tsx
@@ -136,7 +136,6 @@ export function DispenserCloseByHashForm({
                   <p>Source: {selectedDispenser.source}</p>
                 </div>
               )}
-              {error && <p className="mt-2 text-sm text-red-500">{error.message}</p>}
               <Description className={shouldShowHelpText ? "mt-2 text-sm text-gray-500" : "hidden"}>
                 Enter the transaction hash of the dispenser you want to close.
               </Description>

--- a/src/pages/compose/dispenser/close/form.tsx
+++ b/src/pages/compose/dispenser/close/form.tsx
@@ -44,14 +44,14 @@ export function DispenserCloseForm({
   const [selectedTxHash, setSelectedTxHash] = useState<string | null>(null);
   const [dispensers, setDispensers] = useState<any[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(false);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<{ message: string } | null>(null);
 
   const asset = initialAsset || initialFormData?.asset || "";
 
   // Set composer error when it occurs
   useEffect(() => {
     if (composerError) {
-      setError(composerError);
+      setError({ message: composerError });
     }
   }, [composerError]);
 
@@ -71,7 +71,7 @@ export function DispenserCloseForm({
         setDispensers(fetchedDispensers);
       } catch (err) {
         console.error("Failed to load dispensers:", err);
-        setError("Failed to load dispensers. Please try again.");
+        setError({ message: "Failed to load dispensers. Please try again." });
       } finally {
         setIsLoading(false);
       }
@@ -113,10 +113,14 @@ export function DispenserCloseForm({
       )}
       {assetDetailsError && <div className="text-red-500 mb-2">Failed to fetch asset details.</div>}
       <div className="bg-white rounded-lg shadow-lg p-4">
+        {error && (
+          <ErrorAlert
+            message={error.message}
+            onClose={() => setError(null)}
+          />
+        )}
         {isLoading ? (
           <div className="py-4 text-center">Loading dispensers...</div>
-        ) : error ? (
-          <div className="py-4 text-center text-red-500">{error}</div>
         ) : (
           <form action={formAction} className="space-y-6">
             <Field>

--- a/src/pages/compose/dispenser/dispense/form.tsx
+++ b/src/pages/compose/dispenser/dispense/form.tsx
@@ -289,6 +289,12 @@ export function DispenseForm({ formAction, initialFormData ,
       )}
       {dispenserError && <div className="text-red-500 mb-2">{dispenserError}</div>}
       <div className="bg-white rounded-lg shadow-lg p-3 sm:p-4">
+        {error && (
+          <ErrorAlert
+            message={error.message}
+            onClose={() => setError(null)}
+          />
+        )}
         <form action={formAction} className="space-y-4">
           <Field>
             <Label htmlFor="dispenserAddress" className="block text-sm font-medium text-gray-700">

--- a/src/pages/compose/dispenser/form.tsx
+++ b/src/pages/compose/dispenser/form.tsx
@@ -196,11 +196,13 @@ export const DispenserForm = memo(function DispenserForm({
           <HeaderSkeleton className="mt-1 mb-5" variant="balance" />
         )
       )}
-      {assetError && <div className="text-red-500 mb-2">{assetError.message}</div>}
-      {(error || composerError) && (
-        <ErrorAlert message={error?.message || composerError || ""} />
-      )}
       <div className="bg-white rounded-lg shadow-lg p-4">
+        {(error || composerError || assetError) && (
+          <ErrorAlert 
+            message={error?.message || composerError || assetError?.message || ""} 
+            onClose={() => setError(null)}
+          />
+        )}
         <form action={handleFormAction} className="space-y-6">
           <AmountWithMaxInput
             asset={asset}

--- a/src/pages/compose/dispenser/form.tsx
+++ b/src/pages/compose/dispenser/form.tsx
@@ -99,6 +99,13 @@ export const DispenserForm = memo(function DispenserForm({
     }
   }, [composerError]);
 
+  // Set asset error when it occurs
+  useEffect(() => {
+    if (assetError) {
+      setError({ message: assetError.message || "Failed to load asset details" });
+    }
+  }, [assetError]);
+
   // Fetch asset details and trading pair data
   useEffect(() => {
     const fetchDetails = async () => {
@@ -197,9 +204,9 @@ export const DispenserForm = memo(function DispenserForm({
         )
       )}
       <div className="bg-white rounded-lg shadow-lg p-4">
-        {(error || composerError || assetError) && (
+        {error && (
           <ErrorAlert 
-            message={error?.message || composerError || assetError?.message || ""} 
+            message={error.message} 
             onClose={() => setError(null)}
           />
         )}

--- a/src/pages/compose/dispenser/form.tsx
+++ b/src/pages/compose/dispenser/form.tsx
@@ -105,6 +105,13 @@ export const DispenserForm = memo(function DispenserForm({
       setError({ message: assetError.message || "Failed to load asset details" });
     }
   }, [assetError]);
+  
+  // Check if trying to create dispenser for BTC
+  useEffect(() => {
+    if (asset === "BTC") {
+      setError({ message: "Cannot create a dispenser for BTC" });
+    }
+  }, [asset]);
 
   // Fetch asset details and trading pair data
   useEffect(() => {
@@ -159,6 +166,20 @@ export const DispenserForm = memo(function DispenserForm({
 
   // Custom form action wrapper to convert values before submission
   const handleFormAction = useCallback((formData: FormData) => {
+    // Validate before submission
+    if (asset === "BTC") {
+      setError({ message: "Cannot create a dispenser for BTC" });
+      return;
+    }
+    
+    const cleanEscrow = parseFloat(getCleanValue(escrowQuantity));
+    const cleanGive = parseFloat(getCleanValue(giveQuantity));
+    
+    if (!isNaN(cleanEscrow) && !isNaN(cleanGive) && cleanEscrow < cleanGive) {
+      setError({ message: "Escrow quantity must be greater than or equal to give quantity" });
+      return;
+    }
+    
     // Create a new FormData object to avoid modifying the original
     const processedFormData = new FormData();
     

--- a/src/pages/compose/dispenser/form.tsx
+++ b/src/pages/compose/dispenser/form.tsx
@@ -56,38 +56,18 @@ export const DispenserForm = memo(function DispenserForm({
   const [tradingPairData, setTradingPairData] = useState<TradingPairData | null>(null);
   
   // Add state for form values
+  // Note: initialFormData contains user-entered values (not normalized to satoshis)
   const [escrowQuantity, setEscrowQuantity] = useState<string>(
-    initialFormData?.escrow_quantity
-      ? (assetDetails?.assetInfo?.divisible ?? true)
-        ? formatAmount({
-            value: initialFormData.escrow_quantity / 1e8,
-            maximumFractionDigits: 8,
-            minimumFractionDigits: 8
-          })
-        : initialFormData.escrow_quantity.toString()
-      : ""
+    initialFormData?.escrow_quantity?.toString() || ""
   );
   
   const [mainchainRate, setMainchainRate] = useState<string>(
-    initialFormData?.mainchainrate
-      ? formatAmount({
-          value: initialFormData.mainchainrate / 1e8,
-          maximumFractionDigits: 8,
-          minimumFractionDigits: 8
-        })
-      : ""
+    initialFormData?.mainchainrate?.toString() || ""
   );
   
   const [giveQuantity, setGiveQuantity] = useState<string>(
-    initialFormData?.give_quantity
-      ? (assetDetails?.assetInfo?.divisible ?? true)
-        ? formatAmount({
-            value: initialFormData.give_quantity / 1e8,
-            maximumFractionDigits: 8,
-            minimumFractionDigits: 8
-          })
-        : initialFormData.give_quantity.toString()
-      : (assetDetails?.assetInfo?.divisible ?? true) ? "1.00000000" : "1"
+    initialFormData?.give_quantity?.toString() || 
+    ((assetDetails?.assetInfo?.divisible ?? true) ? "1.00000000" : "1")
   );
 
   const isDivisible = assetDetails?.assetInfo?.divisible ?? true;
@@ -153,6 +133,11 @@ export const DispenserForm = memo(function DispenserForm({
       setEscrowQuantity("");
       setMainchainRate("");
       setGiveQuantity((assetDetails?.assetInfo?.divisible ?? true) ? "1.00000000" : "1");
+    } else if (initialFormData !== null && prevInitialFormDataRef.current !== initialFormData) {
+      // Update form values when initialFormData changes (e.g., after error)
+      setEscrowQuantity(initialFormData.escrow_quantity?.toString() || "");
+      setMainchainRate(initialFormData.mainchainrate?.toString() || "");
+      setGiveQuantity(initialFormData.give_quantity?.toString() || "");
     }
     prevInitialFormDataRef.current = initialFormData;
   }, [initialFormData, assetDetails?.assetInfo?.divisible]);

--- a/src/pages/compose/dividend/form.tsx
+++ b/src/pages/compose/dividend/form.tsx
@@ -115,11 +115,13 @@ export function DividendForm({
         className="mt-1 mb-5"
       />
       
-      {(error || composerError) && (
-        <ErrorAlert message={error?.message || composerError || ""} />
-      )}
-      
       <div className="bg-white rounded-lg shadow-lg p-3 sm:p-4">
+        {(error || composerError) && (
+          <ErrorAlert 
+            message={error?.message || composerError || ""} 
+            onClose={() => setError(null)}
+          />
+        )}
         <form action={processedFormAction} className="space-y-4">
           <input type="hidden" name="asset" value={asset} />
           <input type="hidden" name="dividend_asset" value={selectedDividendAsset} />

--- a/src/pages/compose/issuance/destroy-supply/form.tsx
+++ b/src/pages/compose/issuance/destroy-supply/form.tsx
@@ -70,31 +70,18 @@ export function DestroySupplyForm({
     return assetDetails?.assetInfo?.divisible || false;
   }, [assetDetails?.assetInfo]);
 
-  const normalizeAmountForDisplay = (quantity: number | undefined): string => {
-    if (!quantity && quantity !== 0) return ""; // Handle null/undefined, allow 0
-    if (isDivisible) {
-      return formatAmount({
-        value: quantity / 1e8,
-        maximumFractionDigits: 8,
-        minimumFractionDigits: 0,
-      });
-    }
-    return quantity.toString();
-  };
-
-  const [amount, setAmount] = useState<string>(() =>
-    normalizeAmountForDisplay(initialFormData?.quantity)
+  const [amount, setAmount] = useState<string>(
+    initialFormData?.quantity?.toString() || ""
   );
 
   const [satPerVbyte, setSatPerVbyte] = useState<number>(initialFormData?.sat_per_vbyte || 0.1);
 
   // Sync amount when initialFormData changes
   useEffect(() => {
-    const normalized = normalizeAmountForDisplay(initialFormData?.quantity);
-    if (normalized !== amount) {
-      setAmount(normalized);
+    if (initialFormData?.quantity !== undefined) {
+      setAmount(initialFormData.quantity.toString());
     }
-  }, [initialFormData, isDivisible]);
+  }, [initialFormData?.quantity]);
 
   // Focus on tag input on mount if asset is pre-selected
   useEffect(() => {

--- a/src/pages/compose/issuance/form.tsx
+++ b/src/pages/compose/issuance/form.tsx
@@ -115,17 +115,7 @@ export function IssuanceForm({
               id="quantity"
               name="quantity"
               type="text"
-              defaultValue={
-                initialFormData?.quantity
-                  ? initialFormData.divisible
-                    ? formatAmount({
-                        value: initialFormData.quantity / 1e8,
-                        maximumFractionDigits: 8,
-                        minimumFractionDigits: 8
-                      })
-                    : initialFormData.quantity.toString()
-                  : ""
-              }
+              defaultValue={initialFormData?.quantity?.toString() || ""}
               className="mt-1 block w-full p-2 rounded-md border bg-gray-50 focus:border-blue-500 focus:ring-blue-500"
               required
               disabled={pending}

--- a/src/pages/compose/issuance/form.tsx
+++ b/src/pages/compose/issuance/form.tsx
@@ -87,11 +87,13 @@ export function IssuanceForm({
         />
       )}
       
-      {(error || composerError) && (
-        <ErrorAlert message={error?.message || composerError || ""} />
-      )}
-      
       <div className="bg-white rounded-lg shadow-lg p-3 sm:p-4">
+        {(error || composerError) && (
+          <ErrorAlert 
+            message={error?.message || composerError || ""} 
+            onClose={() => setError(null)}
+          />
+        )}
         <form action={formAction} className="space-y-4">
           <AssetNameInput
             name="asset"

--- a/src/pages/compose/issuance/issue-supply/form.tsx
+++ b/src/pages/compose/issuance/issue-supply/form.tsx
@@ -53,10 +53,13 @@ export function IssueSupplyForm({
 
   return (
     <div className="space-y-4">
-      {(error || composerError) && (
-        <ErrorAlert message={error?.message || composerError || ""} />
-      )}
       <div className="bg-white rounded-lg shadow-lg p-3 sm:p-4">
+        {(error || composerError) && (
+          <ErrorAlert 
+            message={error?.message || composerError || ""} 
+            onClose={() => setError(null)}
+          />
+        )}
         <form action={formAction} className="space-y-4">
         <Field>
           <Label htmlFor="asset" className="block text-sm font-medium text-gray-700">

--- a/src/pages/compose/issuance/issue-supply/form.tsx
+++ b/src/pages/compose/issuance/issue-supply/form.tsx
@@ -89,11 +89,7 @@ export function IssueSupplyForm({
             id="quantity"
             name="quantity"
             type="text"
-            defaultValue={initialFormData?.quantity ? (initialFormData.divisible ? formatAmount({
-              value: initialFormData.quantity / 1e8,
-              maximumFractionDigits: 8,
-              minimumFractionDigits: 8
-            }) : initialFormData.quantity.toString()) : ""}
+            defaultValue={initialFormData?.quantity?.toString() || ""}
             className="mt-1 block w-full p-2 rounded-md border bg-gray-50 focus:border-blue-500 focus:ring-blue-500"
             required
             disabled={pending}

--- a/src/pages/compose/issuance/lock-supply/form.tsx
+++ b/src/pages/compose/issuance/lock-supply/form.tsx
@@ -38,6 +38,13 @@ export function LockSupplyForm({
   const { pending } = useFormStatus();
   const [error, setError] = useState<{ message: string; } | null>(null);
 
+  // Set composer error when it occurs
+  useEffect(() => {
+    if (composerError) {
+      setError({ message: composerError });
+    }
+  }, [composerError]);
+
   if (assetError || !assetDetails) {
     return <div className="p-4 text-red-500">Error loading asset details: {assetError?.message}</div>;
   }
@@ -58,8 +65,11 @@ export function LockSupplyForm({
           able to create additional tokens.
         </p>
       </div>
-      {(error || composerError) && (
-        <ErrorAlert message={error?.message || composerError || ""} />
+      {error && (
+        <ErrorAlert 
+          message={error.message} 
+          onClose={() => setError(null)}
+        />
       )}
       <form action={formAction} className="space-y-4">
         <input type="hidden" name="asset" value={asset} />

--- a/src/pages/compose/issuance/reset-supply/form.tsx
+++ b/src/pages/compose/issuance/reset-supply/form.tsx
@@ -38,6 +38,13 @@ export function ResetSupplyForm({
   const { pending } = useFormStatus();
   const [error, setError] = useState<{ message: string; } | null>(null);
 
+  // Set composer error when it occurs
+  useEffect(() => {
+    if (composerError) {
+      setError({ message: composerError });
+    }
+  }, [composerError]);
+
   if (assetError || !assetDetails) {
     return <div className="p-4 text-red-500">Error loading asset details: {assetError?.message}</div>;
   }
@@ -58,8 +65,11 @@ export function ResetSupplyForm({
           undone.
         </p>
       </div>
-      {(error || composerError) && (
-        <ErrorAlert message={error?.message || composerError || ""} />
+      {error && (
+        <ErrorAlert 
+          message={error.message} 
+          onClose={() => setError(null)}
+        />
       )}
       <form action={formAction} className="space-y-4">
         <input type="hidden" name="asset" value={asset} />

--- a/src/pages/compose/issuance/transfer-ownership/form.tsx
+++ b/src/pages/compose/issuance/transfer-ownership/form.tsx
@@ -78,10 +78,13 @@ export function TransferOwnershipForm({
         }}
         className="mt-1 mb-5"
       />
-      {(error || composerError) && (
-        <ErrorAlert message={error?.message || composerError || ""} />
-      )}
       <div className="bg-white rounded-lg shadow-lg p-3 sm:p-4">
+        {(error || composerError) && (
+          <ErrorAlert 
+            message={error?.message || composerError || ""} 
+            onClose={() => setError(null)}
+          />
+        )}
         <form action={formAction} className="space-y-4">
           <input type="hidden" name="asset" value={asset} />
           <input type="hidden" name="quantity" value="0" />

--- a/src/pages/compose/issuance/update-description/form.tsx
+++ b/src/pages/compose/issuance/update-description/form.tsx
@@ -76,10 +76,13 @@ export function UpdateDescriptionForm({
         }}
         className="mt-1 mb-5"
       />
-      {(error || composerError) && (
-        <ErrorAlert message={error?.message || composerError || ""} />
-      )}
       <div className="bg-white rounded-lg shadow-lg p-3 sm:p-4">
+        {error && (
+          <ErrorAlert 
+            message={error.message} 
+            onClose={() => setError(null)}
+          />
+        )}
         <form action={formAction} className="space-y-4">
           <input type="hidden" name="asset" value={asset} />
           <input type="hidden" name="quantity" value="0" />

--- a/src/pages/compose/order/btcpay/form.tsx
+++ b/src/pages/compose/order/btcpay/form.tsx
@@ -54,6 +54,12 @@ export function BTCPayForm({ formAction, initialFormData ,
         <AddressHeader address={activeAddress.address} walletName={activeWallet?.name} className="mt-1 mb-5" />
       )}
       <div className="bg-white rounded-lg shadow-lg p-3 sm:p-4">
+        {error && (
+          <ErrorAlert
+            message={error.message}
+            onClose={() => setError(null)}
+          />
+        )}
         <form action={formAction} className="space-y-4">
           <Field>
             <Label htmlFor="order_match_id" className="block text-sm font-medium text-gray-700">

--- a/src/pages/compose/order/cancel/form.tsx
+++ b/src/pages/compose/order/cancel/form.tsx
@@ -58,6 +58,12 @@ export function CancelForm({
         <AddressHeader address={activeAddress.address} walletName={activeWallet?.name} className="mt-1 mb-5" />
       )}
       <div className="bg-white rounded-lg shadow-lg p-3 sm:p-4">
+        {error && (
+          <ErrorAlert
+            message={error.message}
+            onClose={() => setError(null)}
+          />
+        )}
         <form action={formAction} className="space-y-4">
           <Field>
             <Label htmlFor="offer_hash" className="block text-sm font-medium text-gray-700">

--- a/src/pages/compose/send/form.tsx
+++ b/src/pages/compose/send/form.tsx
@@ -85,31 +85,18 @@ export function SendForm({
     return assetDetails?.assetInfo?.divisible || false;
   }, [initialAsset, initialFormData?.asset, assetDetails?.assetInfo]);
 
-  const normalizeAmountForDisplay = (quantity: number | undefined): string => {
-    if (!quantity && quantity !== 0) return ""; // Handle null/undefined, allow 0
-    if (isDivisible) {
-      return formatAmount({
-        value: quantity / 1e8,
-        maximumFractionDigits: 8,
-        minimumFractionDigits: 0,
-      });
-    }
-    return quantity.toString();
-  };
-
-  const [amount, setAmount] = useState<string>(() =>
-    normalizeAmountForDisplay(initialFormData?.quantity)
+  const [amount, setAmount] = useState<string>(
+    initialFormData?.quantity?.toString() || ""
   );
 
   const [satPerVbyte, setSatPerVbyte] = useState<number>(initialFormData?.sat_per_vbyte || 0.1);
 
   // Sync amount when initialFormData changes
   useEffect(() => {
-    const normalized = normalizeAmountForDisplay(initialFormData?.quantity);
-    if (normalized !== amount) {
-      setAmount(normalized);
+    if (initialFormData?.quantity !== undefined) {
+      setAmount(initialFormData.quantity.toString());
     }
-  }, [initialFormData, isDivisible]); // Depend on full object
+  }, [initialFormData?.quantity]);
 
 
   const handleFormAction = (formData: FormData) => {

--- a/src/pages/compose/sweep/form.tsx
+++ b/src/pages/compose/sweep/form.tsx
@@ -31,11 +31,12 @@ interface SweepFormProps {
   showHelpText?: boolean;
 }
 
-export function SweepForm({ formAction, initialFormData, error, showHelpText }: SweepFormProps): ReactElement {
+export function SweepForm({ formAction, initialFormData, error: composerError, showHelpText }: SweepFormProps): ReactElement {
   const { activeAddress, activeWallet } = useWallet();
   const { settings } = useSettings();
   const shouldShowHelpText = showHelpText ?? settings?.showHelpText ?? false;
   const { pending } = useFormStatus();
+  const [error, setError] = useState<{ message: string } | null>(null);
   const [destination, setDestination] = useState(initialFormData?.destination || "");
   const [destinationValid, setDestinationValid] = useState(false);
   const destinationRef = useRef<HTMLInputElement>(null);
@@ -44,13 +45,25 @@ export function SweepForm({ formAction, initialFormData, error, showHelpText }: 
     destinationRef.current?.focus();
   }, []);
 
+  // Set composer error when it occurs
+  useEffect(() => {
+    if (composerError) {
+      setError({ message: composerError });
+    }
+  }, [composerError]);
+
   return (
     <div className="space-y-4">
       {activeAddress && (
         <AddressHeader address={activeAddress.address} walletName={activeWallet?.name} className="mt-1 mb-5" />
       )}
       <div className="bg-white rounded-lg shadow-lg p-3 sm:p-4">
-        {error && <ErrorAlert message={error} />}
+        {error && (
+          <ErrorAlert 
+            message={error.message} 
+            onClose={() => setError(null)}
+          />
+        )}
         <form action={formAction} className="space-y-4">
           <Field>
             <Label className="block text-sm font-medium text-gray-700">

--- a/src/pages/compose/utxo/attach/form.tsx
+++ b/src/pages/compose/utxo/attach/form.tsx
@@ -47,7 +47,7 @@ export function UtxoAttachForm({
   
   // Local state for quantity to handle Max button
   const isDivisible = assetDetails?.assetInfo?.divisible ?? true;
-  const [quantity, setQuantity] = useState("");
+  const [quantity, setQuantity] = useState(initialFormData?.quantity?.toString() || "");
 
   // Set composer error when it occurs
   useEffect(() => {

--- a/src/pages/compose/utxo/attach/form.tsx
+++ b/src/pages/compose/utxo/attach/form.tsx
@@ -40,7 +40,7 @@ export function UtxoAttachForm({
   const { settings } = useSettings();
   const shouldShowHelpText = showHelpText ?? settings?.showHelpText ?? false;
   const { pending } = useFormStatus();
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<{ message: string } | null>(null);
   // Always use initialAsset first, as it comes from the route params
   const asset = initialAsset || initialFormData?.asset || "";
   const { data: assetDetails } = useAssetDetails(asset);
@@ -52,7 +52,7 @@ export function UtxoAttachForm({
   // Set composer error when it occurs
   useEffect(() => {
     if (composerError) {
-      setError(composerError);
+      setError({ message: composerError });
     }
   }, [composerError]);
 
@@ -82,9 +82,9 @@ export function UtxoAttachForm({
         />
       )}
       <div className="bg-white rounded-lg shadow-lg p-4">
-        {(error || composerError) && (
+        {error && (
           <ErrorAlert
-            message={error || composerError || "An error occurred"}
+            message={error.message}
             onClose={() => setError(null)}
           />
         )}

--- a/src/pages/compose/utxo/detach/form.tsx
+++ b/src/pages/compose/utxo/detach/form.tsx
@@ -42,7 +42,7 @@ export function UtxoDetachForm({
   const { settings } = useSettings();
   const shouldShowHelpText = showHelpText ?? settings?.showHelpText ?? false;
   const { pending } = useFormStatus();
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<{ message: string } | null>(null);
   const [destination, setDestination] = useState(initialFormData?.destination || "");
   const [destinationValid, setDestinationValid] = useState(true); // Optional field, so default to true
   const [utxoBalances, setUtxoBalances] = useState<UtxoBalance[]>([]);
@@ -51,7 +51,7 @@ export function UtxoDetachForm({
   // Set composer error when it occurs
   useEffect(() => {
     if (composerError) {
-      setError(composerError);
+      setError({ message: composerError });
     }
   }, [composerError]);
 
@@ -76,9 +76,9 @@ export function UtxoDetachForm({
         <AddressHeader address={activeAddress.address} walletName={activeWallet?.name} className="mt-1 mb-5" />
       )}
       <div className="bg-white rounded-lg shadow-lg p-4">
-        {(error || composerError) && (
+        {error && (
           <ErrorAlert
-            message={error || composerError || "An error occurred"}
+            message={error.message}
             onClose={() => setError(null)}
           />
         )}

--- a/src/pages/compose/utxo/move/form.tsx
+++ b/src/pages/compose/utxo/move/form.tsx
@@ -42,7 +42,7 @@ export function UtxoMoveForm({
   const { settings } = useSettings();
   const shouldShowHelpText = showHelpText ?? settings?.showHelpText ?? false;
   const { pending } = useFormStatus();
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<{ message: string } | null>(null);
   const [destination, setDestination] = useState(initialFormData?.destination || "");
   const [destinationValid, setDestinationValid] = useState(false);
   const [utxoBalances, setUtxoBalances] = useState<UtxoBalance[]>([]);
@@ -51,7 +51,7 @@ export function UtxoMoveForm({
   // Set composer error when it occurs
   useEffect(() => {
     if (composerError) {
-      setError(composerError);
+      setError({ message: composerError });
     }
   }, [composerError]);
 
@@ -80,9 +80,9 @@ export function UtxoMoveForm({
         />
       )}
       <div className="bg-white rounded-lg shadow-lg p-4">
-        {(error || composerError) && (
+        {error && (
           <ErrorAlert
-            message={error || composerError || "An error occurred"}
+            message={error.message}
             onClose={() => setError(null)}
           />
         )}


### PR DESCRIPTION
 When users encountered validation errors in compose forms, their entered values were being incorrectly
  transformed:
  - Values like 1000000 became 0.01
  - Values like 0.000004 became 0
  - Values like 1.00000000 became 0.00000001

  🔍 Root Cause

  Forms were dividing initialFormData values by 10^8 (converting from satoshis), but the composer context stores
  original user-entered values (not satoshis) when returning to the form after an error. This caused a
  double-conversion issue.

  ✅ Solution

  Removed unnecessary normalization/division by 10^8 when initializing form fields from initialFormData. Forms now
  use the values directly as strings since they represent user input, not blockchain values.

  📝 Fixed Forms (8 total)

  1. bet/form.tsx - Fixed wager_quantity and counterwager_quantity fields
  2. dispenser/form.tsx - Fixed escrow_quantity, mainchainrate, and give_quantity fields
  3. issuance/form.tsx - Fixed quantity field division
  4. issuance/issue-supply/form.tsx - Fixed quantity field division
  5. issuance/destroy-supply/form.tsx - Removed normalizeAmountForDisplay function
  6. send/form.tsx - Removed normalizeAmountForDisplay function
  7. utxo/attach/form.tsx - Added missing quantity persistence (wasn't restoring at all)
  8. dispenser/form.tsx (validation) - Added protocol validation for BTC and escrow >= give quantity

  🎯 Impact

  - Users' form values are now correctly preserved after validation errors
  - No more confusion from values changing unexpectedly
  - Consistent behavior across all compose forms
  - Better user experience when correcting form errors

  ✨ Additional Improvements

  - Added validation to prevent creating BTC dispensers (protocol requirement)
  - Added validation for escrow quantity >= give quantity in dispensers
  - Standardized error handling across all 28 compose forms