### PR TITLE
Improve Wallet Lock State Sync

### DIFF
--- a/src/hooks/useAuthGuard.ts
+++ b/src/hooks/useAuthGuard.ts
@@ -1,0 +1,29 @@
+import { useEffect, useRef } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { useWallet } from '@/contexts/wallet-context';
+
+/**
+ * Global auth guard hook that monitors wallet lock state changes and navigates immediately.
+ * This ensures instant navigation when the wallet locks, regardless of where the user is.
+ */
+export function useAuthGuard() {
+  const { authState, wallets } = useWallet();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const previousAuthState = useRef(authState);
+
+  useEffect(() => {
+    // Detect transition from UNLOCKED to LOCKED
+    if (previousAuthState.current === 'UNLOCKED' && authState === 'LOCKED' && wallets.length > 0) {
+      console.log('[Auth Guard] Wallet locked, navigating to unlock screen');
+      navigate('/unlock-wallet', { 
+        replace: true,
+        state: { from: location.pathname }
+      });
+    }
+    
+    previousAuthState.current = authState;
+  }, [authState, wallets.length, navigate, location.pathname]);
+
+  return { isProtected: authState === 'UNLOCKED' };
+}

--- a/src/middleware/auth-required.tsx
+++ b/src/middleware/auth-required.tsx
@@ -1,18 +1,28 @@
 import { useEffect } from 'react';
-import { useNavigate, Outlet } from 'react-router-dom';
+import { useNavigate, Outlet, useLocation } from 'react-router-dom';
 import { useWallet } from '@/contexts/wallet-context';
+import { useAuthGuard } from '@/hooks/useAuthGuard';
 
 export function AuthRequired() {
   const { authState, wallets } = useWallet();
   const navigate = useNavigate();
+  const location = useLocation();
+
+  // Monitor for real-time lock events
+  useAuthGuard();
 
   useEffect(() => {
+    // Simple, direct navigation based on auth state
     if (authState === 'LOCKED' && wallets.length > 0) {
-      navigate('/unlock-wallet', { replace: true });
-    } else if (authState === 'ONBOARDING_NEEDED' || !authState) {
+      navigate('/unlock-wallet', { 
+        replace: true,
+        state: { from: location.pathname }
+      });
+    } else if (authState === 'ONBOARDING_NEEDED' || wallets.length === 0) {
       navigate('/onboarding', { replace: true });
     }
-  }, [authState, wallets, navigate]);
+  }, [authState, wallets.length, navigate, location.pathname]);
 
+  // Only render outlet when fully authenticated
   return authState === 'UNLOCKED' ? <Outlet /> : null;
 }


### PR DESCRIPTION
- Fix race condition in lockAll() by setting state immediately before background operations
- Add useAuthGuard hook to detect real-time lock state transitions
- Remove redundant polling interval that was checking every 5 seconds
- Simplify AuthRequired middleware for cleaner navigation logic
- Remove cross-tab sync via localStorage (unnecessary for single extension)
- Ensure immediate navigation when wallet locks from idle timer or session expiry

This ensures users are immediately redirected to unlock screen when the wallet locks, preventing the issue where users could navigate while wallet was locked.