### PR TITLE
Standardize Loading State

### DIFF
--- a/src/components/__tests__/layout.test.tsx
+++ b/src/components/__tests__/layout.test.tsx
@@ -43,11 +43,19 @@ vi.mock('@/contexts/header-context', () => ({
 }));
 
 const mockIsLoading = vi.fn();
+const mockCurrentMessage = vi.fn();
 vi.mock('@/contexts/loading-context', () => ({
   useLoading: () => ({
-    isLoading: mockIsLoading()
-  }),
-  Spinner: () => <div data-testid="spinner">Loading...</div>
+    isLoading: mockIsLoading(),
+    currentMessage: mockCurrentMessage()
+  })
+}));
+
+// Mock the Spinner component
+vi.mock('@/components/spinner', () => ({
+  Spinner: ({ message }: { message?: string }) => (
+    <div data-testid="spinner">{message || 'Loading...'}</div>
+  )
 }));
 
 describe('Layout', () => {
@@ -75,6 +83,7 @@ describe('Layout', () => {
 
   it('should render spinner when loading', () => {
     mockIsLoading.mockReturnValue(true);
+    mockCurrentMessage.mockReturnValue('Loading...');
     render(<Layout />);
     
     expect(screen.getByTestId('spinner')).toBeInTheDocument();

--- a/src/components/inputs/__tests__/block-height-input.test.tsx
+++ b/src/components/inputs/__tests__/block-height-input.test.tsx
@@ -32,7 +32,7 @@ describe('BlockHeightInput', () => {
     vi.clearAllMocks();
     mockUseBlockHeight.mockReturnValue({
       blockHeight: null,
-      loading: false,
+      isLoading: false,
       error: null,
       refresh: vi.fn()
     });
@@ -99,7 +99,7 @@ describe('BlockHeightInput', () => {
     
     mockUseBlockHeight.mockReturnValue({
       blockHeight: 850123,
-      loading: false,
+      isLoading: false,
       error: null,
       refresh
     });
@@ -118,7 +118,7 @@ describe('BlockHeightInput', () => {
   it('should disable Now button while loading', () => {
     mockUseBlockHeight.mockReturnValue({
       blockHeight: null,
-      loading: true,
+      isLoading: true,
       error: null,
       refresh: vi.fn()
     });
@@ -134,7 +134,7 @@ describe('BlockHeightInput', () => {
     
     mockUseBlockHeight.mockReturnValue({
       blockHeight: null,
-      loading: false,
+      isLoading: false,
       error: 'Network error',
       refresh: vi.fn()
     });
@@ -150,7 +150,7 @@ describe('BlockHeightInput', () => {
     
     mockUseBlockHeight.mockReturnValue({
       blockHeight: null,
-      loading: false,
+      isLoading: false,
       error: null,
       refresh
     });
@@ -228,7 +228,7 @@ describe('BlockHeightInput', () => {
     
     mockUseBlockHeight.mockReturnValue({
       blockHeight: null,
-      loading: false,
+      isLoading: false,
       error: null,
       refresh
     });
@@ -246,7 +246,7 @@ describe('BlockHeightInput', () => {
     
     mockUseBlockHeight.mockReturnValue({
       blockHeight: null,
-      loading: true,
+      isLoading: true,
       error: null,
       refresh
     });
@@ -265,7 +265,7 @@ describe('BlockHeightInput', () => {
     
     mockUseBlockHeight.mockReturnValue({
       blockHeight: null,
-      loading: false,
+      isLoading: false,
       error: null,
       refresh
     });
@@ -299,7 +299,7 @@ describe('BlockHeightInput', () => {
     
     mockUseBlockHeight.mockReturnValue({
       blockHeight: 850000,
-      loading: false,
+      isLoading: false,
       error: null,
       refresh
     });

--- a/src/components/inputs/__tests__/fee-rate-input.test.tsx
+++ b/src/components/inputs/__tests__/fee-rate-input.test.tsx
@@ -39,7 +39,7 @@ describe('FeeRateInput', () => {
     it('should show loading state when fee rates are loading', () => {
       mockUseFeeRates.mockReturnValue({
         feeRates: null,
-        loading: true,
+        isLoading: true,
         error: null,
         uniquePresetOptions: []
       });
@@ -54,7 +54,7 @@ describe('FeeRateInput', () => {
     it('should show custom input when fee rates fail to load', () => {
       mockUseFeeRates.mockReturnValue({
         feeRates: null,
-        loading: false,
+        isLoading: false,
         error: 'Failed to fetch fee rates',
         uniquePresetOptions: []
       });
@@ -86,7 +86,7 @@ describe('FeeRateInput', () => {
     beforeEach(() => {
       mockUseFeeRates.mockReturnValue({
         feeRates: mockFeeRates,
-        loading: false,
+        isLoading: false,
         error: null,
         uniquePresetOptions: mockPresetOptions
       });
@@ -127,7 +127,7 @@ describe('FeeRateInput', () => {
     beforeEach(() => {
       mockUseFeeRates.mockReturnValue({
         feeRates: mockFeeRates,
-        loading: false,
+        isLoading: false,
         error: null,
         uniquePresetOptions: mockPresetOptions
       });
@@ -159,7 +159,7 @@ describe('FeeRateInput', () => {
     beforeEach(() => {
       mockUseFeeRates.mockReturnValue({
         feeRates: mockFeeRates,
-        loading: false,
+        isLoading: false,
         error: null,
         uniquePresetOptions: mockPresetOptions
       });
@@ -196,7 +196,7 @@ describe('FeeRateInput', () => {
     beforeEach(() => {
       mockUseFeeRates.mockReturnValue({
         feeRates: mockFeeRates,
-        loading: false,
+        isLoading: false,
         error: null,
         uniquePresetOptions: mockPresetOptions
       });

--- a/src/components/inputs/amount-with-max-input.tsx
+++ b/src/components/inputs/amount-with-max-input.tsx
@@ -58,7 +58,7 @@ export function AmountWithMaxInput({
   onMaxClick,
   hasError = false,
 }: AmountWithMaxInputProps) {
-  const [loading, setLoading] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
   
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
     onChange(e.target.value);
@@ -84,7 +84,7 @@ export function AmountWithMaxInput({
 
     try {
       setError(null);
-      setLoading(true);
+      setIsLoading(true);
 
       const estimationDestination =
         destination && isValidBase58Address(destination)
@@ -142,7 +142,7 @@ export function AmountWithMaxInput({
         setError("Failed to estimate max amount.");
       }
     } finally {
-      setLoading(false);
+      setIsLoading(false);
     }
   }, [
     sourceAddress, 
@@ -219,8 +219,8 @@ export function AmountWithMaxInput({
         <Button
           variant="input"
           onClick={handleMaxClick}
-          disabled={loading || disabled || (disableMaxButton && !onMaxClick)}
-          aria-label={loading ? "Calculating maximum amount..." : "Use maximum available amount"}
+          disabled={isLoading || disabled || (disableMaxButton && !onMaxClick)}
+          aria-label={isLoading ? "Calculating maximum amount..." : "Use maximum available amount"}
           className="absolute right-1 top-1/2 transform -translate-y-1/2 px-2 py-1 text-sm"
         >
           Max

--- a/src/components/inputs/asset-select-input.tsx
+++ b/src/components/inputs/asset-select-input.tsx
@@ -7,6 +7,7 @@ import {
   ComboboxOption,
 } from "@headlessui/react";
 import { FiChevronDown, FiCheck } from "react-icons/fi";
+import { FaSpinner } from "react-icons/fa";
 import { useWallet } from "@/contexts/wallet-context";
 import { useSettings } from "@/contexts/settings-context";
 
@@ -37,6 +38,7 @@ export function AssetSelectInput({
   const [query, setQuery] = useState("");
   const [assets, setAssets] = useState<Asset[]>([]);
   const [isInitialLoad, setIsInitialLoad] = useState(true);
+  const [isLoading, setIsLoading] = useState(false);
   const { activeWallet } = useWallet();
   const { settings } = useSettings();
 
@@ -57,6 +59,7 @@ export function AssetSelectInput({
         return;
       }
       setIsInitialLoad(false);
+      setIsLoading(true);
       try {
         const response = await fetch(
           `https://app.xcp.io/api/v1/search?type=assets&query=${query}`
@@ -65,6 +68,9 @@ export function AssetSelectInput({
         setAssets(data.assets);
       } catch (error) {
         console.error("Failed to fetch assets:", error);
+        setAssets([]);
+      } finally {
+        setIsLoading(false);
       }
     };
 
@@ -133,10 +139,17 @@ export function AssetSelectInput({
                 className="absolute inset-y-0 right-0 flex items-center justify-center px-1 m-1 w-11"
                 onClick={handleComboboxButtonClick}
               >
-                <FiChevronDown
-                  className="h-5 w-5 text-gray-400"
-                  aria-hidden="true"
-                />
+                {isLoading ? (
+                  <FaSpinner
+                    className="h-4 w-4 text-gray-400 animate-spin"
+                    aria-hidden="true"
+                  />
+                ) : (
+                  <FiChevronDown
+                    className="h-5 w-5 text-gray-400"
+                    aria-hidden="true"
+                  />
+                )}
               </ComboboxButton>
             </div>
             {assets.length > 0 && (

--- a/src/components/inputs/block-height-input.tsx
+++ b/src/components/inputs/block-height-input.tsx
@@ -32,7 +32,7 @@ export function BlockHeightInput({
   placeholder = "Enter block height",
 }: BlockHeightInputProps) {
   // Use our custom hook with autoFetch set to false
-  const { blockHeight, loading, error, refresh } = useBlockHeight({ autoFetch: false });
+  const { blockHeight, isLoading, error, refresh } = useBlockHeight({ autoFetch: false });
   
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
     onChange(e.target.value);
@@ -40,7 +40,7 @@ export function BlockHeightInput({
   };
   
   const handleNowButtonClick = async () => {
-    if (disabled || loading) return;
+    if (disabled || isLoading) return;
     
     try {
       // Clear any previous errors
@@ -88,7 +88,7 @@ export function BlockHeightInput({
           <Button
             variant="input"
             onClick={handleNowButtonClick}
-            disabled={disabled || loading}
+            disabled={disabled || isLoading}
             aria-label="Use current block height"
             className="px-2 py-1 text-sm"
           >

--- a/src/components/inputs/fee-rate-input.tsx
+++ b/src/components/inputs/fee-rate-input.tsx
@@ -27,7 +27,7 @@ export function FeeRateInput({
   disabled = false,
   onFeeRateChange,
 }: FeeRateInputProps) {
-  const { feeRates, loading, error: fetchError, uniquePresetOptions } = useFeeRates(true);
+  const { feeRates, isLoading, error: fetchError, uniquePresetOptions } = useFeeRates(true);
   const [selectedOption, setSelectedOption] = useState<LocalFeeRateOption>("fast");
   const [customInput, setCustomInput] = useState<string>("0.1");
   const [internalError, setInternalError] = useState<string | null>(null);
@@ -159,7 +159,7 @@ export function FeeRateInput({
     }
   };
 
-  if (loading) {
+  if (isLoading) {
     return (
       <Field>
         <Label className="block text-sm font-medium text-gray-700">

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -2,7 +2,8 @@ import { Outlet } from 'react-router-dom';
 import { Header } from '@/components/header';
 import { Footer } from '@/components/footer';
 import { useHeader } from '@/contexts/header-context';
-import { useLoading, Spinner } from '@/contexts/loading-context';
+import { useLoading } from '@/contexts/loading-context';
+import { Spinner } from '@/components/spinner';
 
 interface LayoutProps {
   showFooter?: boolean;
@@ -10,13 +11,19 @@ interface LayoutProps {
 
 export function Layout({ showFooter = false }: LayoutProps) {
   const { headerProps } = useHeader();
-  const { isLoading } = useLoading();
+  const { isLoading, currentMessage } = useLoading();
 
   return (
     <div className="flex flex-col h-screen bg-gray-100">
       <Header {...headerProps} />
       <main className="flex-1 overflow-y-auto no-scrollbar relative">
-        {isLoading ? <Spinner /> : <Outlet />}
+        {isLoading ? (
+          <div className="flex items-center justify-center h-full">
+            <Spinner message={currentMessage} />
+          </div>
+        ) : (
+          <Outlet />
+        )}
       </main>
       {showFooter && <Footer />}
     </div>

--- a/src/contexts/__tests__/loading-context.test.tsx
+++ b/src/contexts/__tests__/loading-context.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, act, renderHook, waitFor } from '@testing-library/react';
-import { LoadingProvider, useLoading, Spinner } from '../loading-context';
+import { LoadingProvider, useLoading } from '../loading-context';
+import { Spinner } from '../../components/spinner';
 import React from 'react';
 
 describe('LoadingContext', () => {
@@ -328,14 +329,14 @@ describe('LoadingContext', () => {
   describe('Loading UI', () => {
     it('should render loading spinner when loading', async () => {
       const TestComponent = () => {
-        const { showLoading } = useLoading();
+        const { showLoading, isLoading, currentMessage } = useLoading();
         React.useEffect(() => {
           showLoading('Testing');
         }, [showLoading]);
         return (
           <div>
             <div>Content</div>
-            <Spinner />
+            {isLoading && <Spinner message={currentMessage} />}
           </div>
         );
       };
@@ -358,11 +359,11 @@ describe('LoadingContext', () => {
 
     it('should show loading message in UI', async () => {
       const TestComponent = () => {
-        const { showLoading } = useLoading();
+        const { showLoading, isLoading, currentMessage } = useLoading();
         React.useEffect(() => {
           showLoading('Processing transaction...');
         }, [showLoading]);
-        return <Spinner />;
+        return isLoading ? <Spinner message={currentMessage} /> : null;
       };
 
       render(

--- a/src/contexts/loading-context.tsx
+++ b/src/contexts/loading-context.tsx
@@ -130,27 +130,3 @@ export function useLoading(): LoadingContextType {
   return context;
 }
 
-/**
- * Props for Spinner component.
- */
-interface SpinnerProps {
-  className?: string;
-}
-
-/**
- * Displays a loading spinner when loading is active.
- * @param {SpinnerProps} props - Component props
- * @returns {ReactElement | null} Spinner or null if not loading
- */
-export function Spinner({ className = "" }: SpinnerProps): ReactElement | null {
-  const { isLoading, currentMessage } = useLoading();
-  if (!isLoading) return null;
-  return (
-    <div className={`flex flex-col items-center justify-center h-full ${className}`}>
-      <FaSpinner className="animate-spin text-4xl text-blue-500" />
-      {currentMessage && (
-        <p className="mt-4 text-gray-600 text-center font-medium">{currentMessage}</p>
-      )}
-    </div>
-  );
-}

--- a/src/hooks/__tests__/useBlockHeight.test.ts
+++ b/src/hooks/__tests__/useBlockHeight.test.ts
@@ -24,11 +24,11 @@ describe('useBlockHeight', () => {
     const { result } = renderHook(() => useBlockHeight());
 
     // Initially loading
-    expect(result.current.loading).toBe(true);
+    expect(result.current.isLoading).toBe(true);
     expect(result.current.blockHeight).toBeNull();
 
     await waitFor(() => {
-      expect(result.current.loading).toBe(false);
+      expect(result.current.isLoading).toBe(false);
     });
 
     expect(getCurrentBlockHeight).toHaveBeenCalled();
@@ -43,7 +43,7 @@ describe('useBlockHeight', () => {
     const { result } = renderHook(() => useBlockHeight());
 
     await waitFor(() => {
-      expect(result.current.loading).toBe(false);
+      expect(result.current.isLoading).toBe(false);
     });
 
     expect(result.current.blockHeight).toBeNull();
@@ -103,7 +103,7 @@ describe('useBlockHeight', () => {
   it('should not fetch on mount when autoFetch is false', async () => {
     const { result } = renderHook(() => useBlockHeight({ autoFetch: false }));
 
-    expect(result.current.loading).toBe(false);
+    expect(result.current.isLoading).toBe(false);
     expect(result.current.blockHeight).toBeNull();
     expect(getCurrentBlockHeight).not.toHaveBeenCalled();
   });
@@ -114,7 +114,7 @@ describe('useBlockHeight', () => {
     const { result } = renderHook(() => useBlockHeight());
 
     await waitFor(() => {
-      expect(result.current.loading).toBe(false);
+      expect(result.current.isLoading).toBe(false);
     });
 
     expect(result.current.blockHeight).toBe(0);
@@ -142,7 +142,7 @@ describe('useBlockHeight', () => {
     const { result } = renderHook(() => useBlockHeight());
 
     await waitFor(() => {
-      expect(result.current.loading).toBe(false);
+      expect(result.current.isLoading).toBe(false);
     });
 
     // Rapid refresh calls
@@ -162,7 +162,7 @@ describe('useBlockHeight', () => {
     const { result } = renderHook(() => useBlockHeight());
 
     await waitFor(() => {
-      expect(result.current.loading).toBe(false);
+      expect(result.current.isLoading).toBe(false);
     });
 
     expect(result.current.error).toBe('Unable to fetch current block height.');

--- a/src/hooks/__tests__/useFeeRates.test.ts
+++ b/src/hooks/__tests__/useFeeRates.test.ts
@@ -26,11 +26,11 @@ describe('useFeeRates', () => {
     const { result } = renderHook(() => useFeeRates());
 
     // Initially loading
-    expect(result.current.loading).toBe(true);
+    expect(result.current.isLoading).toBe(true);
     expect(result.current.feeRates).toBeNull();
 
     await waitFor(() => {
-      expect(result.current.loading).toBe(false);
+      expect(result.current.isLoading).toBe(false);
     });
 
     expect(getFeeRates).toHaveBeenCalled();
@@ -45,7 +45,7 @@ describe('useFeeRates', () => {
     const { result } = renderHook(() => useFeeRates());
 
     await waitFor(() => {
-      expect(result.current.loading).toBe(false);
+      expect(result.current.isLoading).toBe(false);
     });
 
     expect(result.current.feeRates).toBeNull();
@@ -56,7 +56,7 @@ describe('useFeeRates', () => {
     const { result } = renderHook(() => useFeeRates());
 
     await waitFor(() => {
-      expect(result.current.loading).toBe(false);
+      expect(result.current.isLoading).toBe(false);
     });
 
     expect(result.current.uniquePresetOptions).toHaveLength(3);
@@ -90,7 +90,7 @@ describe('useFeeRates', () => {
     const { result } = renderHook(() => useFeeRates());
 
     await waitFor(() => {
-      expect(result.current.loading).toBe(false);
+      expect(result.current.isLoading).toBe(false);
     });
 
     // Should only have 2 unique values (30 and 20)
@@ -100,7 +100,7 @@ describe('useFeeRates', () => {
   it('should handle autoFetch false', async () => {
     const { result } = renderHook(() => useFeeRates(false));
 
-    expect(result.current.loading).toBe(false);
+    expect(result.current.isLoading).toBe(false);
     expect(result.current.feeRates).toBeNull();
     expect(getFeeRates).not.toHaveBeenCalled();
   });

--- a/src/hooks/useBlockHeight.ts
+++ b/src/hooks/useBlockHeight.ts
@@ -21,21 +21,21 @@ export function useBlockHeight(options: UseBlockHeightOptions = {}) {
   } = options;
   
   const [blockHeight, setBlockHeight] = useState<number | null>(null);
-  const [loading, setLoading] = useState<boolean>(autoFetch);
+  const [isLoading, setIsLoading] = useState<boolean>(autoFetch);
   const [error, setError] = useState<string | null>(null);
 
   const fetchBlockHeight = async (forceRefresh = false) => {
-    setLoading(true);
+    setIsLoading(true);
     setError(null);
     
     try {
       const height = await getCurrentBlockHeight(forceRefresh);
       setBlockHeight(height);
-      setLoading(false);
+      setIsLoading(false);
     } catch (err: any) {
       console.error('Error fetching block height:', err);
       setError(err.message || 'Unable to fetch current block height.');
-      setLoading(false);
+      setIsLoading(false);
     }
   };
 
@@ -44,7 +44,7 @@ export function useBlockHeight(options: UseBlockHeightOptions = {}) {
     if (autoFetch) {
       fetchBlockHeight();
     } else {
-      setLoading(false);
+      setIsLoading(false);
     }
   }, [autoFetch]);
 
@@ -61,7 +61,7 @@ export function useBlockHeight(options: UseBlockHeightOptions = {}) {
 
   return { 
     blockHeight, 
-    loading, 
+    isLoading, 
     error, 
     refresh: () => fetchBlockHeight(true) 
   };

--- a/src/hooks/useFeeRates.ts
+++ b/src/hooks/useFeeRates.ts
@@ -11,7 +11,7 @@ export interface FeeOption {
 
 export function useFeeRates(autoFetch = true) {
   const [feeRates, setFeeRates] = useState<FeeRates | null>(null);
-  const [loading, setLoading] = useState<boolean>(autoFetch);
+  const [isLoading, setIsLoading] = useState<boolean>(autoFetch);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -19,15 +19,15 @@ export function useFeeRates(autoFetch = true) {
       getFeeRates()
         .then((rates) => {
           setFeeRates(rates);
-          setLoading(false);
+          setIsLoading(false);
         })
         .catch((err) => {
           console.error(err);
           setError('Unable to fetch fee rates.');
-          setLoading(false);
+          setIsLoading(false);
         });
     } else {
-      setLoading(false);
+      setIsLoading(false);
     }
   }, [autoFetch]);
 
@@ -47,5 +47,5 @@ export function useFeeRates(autoFetch = true) {
     return presets;
   }, [feeRates]);
 
-  return { feeRates, loading, error, uniquePresetOptions };
+  return { feeRates, isLoading, error, uniquePresetOptions };
 }

--- a/src/pages/compose/utxo/detach/form.tsx
+++ b/src/pages/compose/utxo/detach/form.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, useRef } from "react";
 import { useFormStatus } from "react-dom";
 import { useNavigate } from "react-router-dom";
 import { Field, Label, Description, Input } from "@headlessui/react";
+import { FaSpinner } from "react-icons/fa";
 import { Button } from "@/components/button";
 import { ErrorAlert } from "@/components/error-alert";
 import { AddressHeader } from "@/components/headers/address-header";
@@ -46,6 +47,7 @@ export function UtxoDetachForm({
   const [destination, setDestination] = useState(initialFormData?.destination || "");
   const [destinationValid, setDestinationValid] = useState(true); // Optional field, so default to true
   const [utxoBalances, setUtxoBalances] = useState<UtxoBalance[]>([]);
+  const [isLoadingBalances, setIsLoadingBalances] = useState(false);
   const destinationRef = useRef<HTMLInputElement>(null);
 
   // Set composer error when it occurs
@@ -62,10 +64,14 @@ export function UtxoDetachForm({
     // Fetch UTXO balances if we have a UTXO
     const utxo = initialUtxo || initialFormData?.sourceUtxo;
     if (utxo) {
+      setIsLoadingBalances(true);
       fetchUtxoBalances(utxo).then(response => {
         setUtxoBalances(response.result || []);
       }).catch(err => {
         console.error('Failed to fetch UTXO balances:', err);
+        setUtxoBalances([]);
+      }).finally(() => {
+        setIsLoadingBalances(false);
       });
     }
   }, [initialUtxo, initialFormData?.sourceUtxo]);
@@ -104,7 +110,14 @@ export function UtxoDetachForm({
                   {formatTxid(initialUtxo || initialFormData?.sourceUtxo || '')}
                 </span>
                 <span className="text-sm text-gray-500">
-                  {utxoBalances.length} {utxoBalances.length === 1 ? 'Balance' : 'Balances'}
+                  {isLoadingBalances ? (
+                    <span className="flex items-center gap-1">
+                      <FaSpinner className="animate-spin h-3 w-3" />
+                      Loading...
+                    </span>
+                  ) : (
+                    `${utxoBalances.length} ${utxoBalances.length === 1 ? 'Balance' : 'Balances'}`
+                  )}
                 </span>
               </div>
             </div>

--- a/src/pages/compose/utxo/move/form.tsx
+++ b/src/pages/compose/utxo/move/form.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, useRef } from "react";
 import { useFormStatus } from "react-dom";
 import { useNavigate } from "react-router-dom";
 import { Field, Label, Description, Input } from "@headlessui/react";
+import { FaSpinner } from "react-icons/fa";
 import { Button } from "@/components/button";
 import { ErrorAlert } from "@/components/error-alert";
 import { AddressHeader } from "@/components/headers/address-header";
@@ -46,6 +47,7 @@ export function UtxoMoveForm({
   const [destination, setDestination] = useState(initialFormData?.destination || "");
   const [destinationValid, setDestinationValid] = useState(false);
   const [utxoBalances, setUtxoBalances] = useState<UtxoBalance[]>([]);
+  const [isLoadingBalances, setIsLoadingBalances] = useState(false);
   const destinationRef = useRef<HTMLInputElement>(null);
 
   // Set composer error when it occurs
@@ -62,10 +64,14 @@ export function UtxoMoveForm({
     // Fetch UTXO balances if we have a UTXO
     const utxo = initialUtxo || initialFormData?.sourceUtxo;
     if (utxo) {
+      setIsLoadingBalances(true);
       fetchUtxoBalances(utxo).then(response => {
         setUtxoBalances(response.result || []);
       }).catch(err => {
         console.error('Failed to fetch UTXO balances:', err);
+        setUtxoBalances([]);
+      }).finally(() => {
+        setIsLoadingBalances(false);
       });
     }
   }, [initialUtxo, initialFormData?.sourceUtxo]);
@@ -108,7 +114,14 @@ export function UtxoMoveForm({
                   {formatTxid(initialUtxo || initialFormData?.sourceUtxo || '')}
                 </span>
                 <span className="text-sm text-gray-500">
-                  {utxoBalances.length} {utxoBalances.length === 1 ? 'Balance' : 'Balances'}
+                  {isLoadingBalances ? (
+                    <span className="flex items-center gap-1">
+                      <FaSpinner className="animate-spin h-3 w-3" />
+                      Loading...
+                    </span>
+                  ) : (
+                    `${utxoBalances.length} ${utxoBalances.length === 1 ? 'Balance' : 'Balances'}`
+                  )}
                 </span>
               </div>
             </div>

--- a/src/pages/provider/approval-queue.tsx
+++ b/src/pages/provider/approval-queue.tsx
@@ -13,7 +13,7 @@ export default function ApprovalQueue() {
   const { setHeaderProps } = useHeader();
   const [requests, setRequests] = useState<ApprovalRequest[]>([]);
   const [currentIndex, setCurrentIndex] = useState(0);
-  const [loading, setLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(true);
 
   const getRequestTitle = (request: ApprovalRequest) => {
     switch (request.type) {
@@ -55,7 +55,7 @@ export default function ApprovalQueue() {
       try {
         const queue = await providerService.getApprovalQueue();
         setRequests(queue);
-        setLoading(false);
+        setIsLoading(false);
         
         // If queue is empty on load, close the window
         if (queue.length === 0) {
@@ -63,7 +63,7 @@ export default function ApprovalQueue() {
         }
       } catch (error) {
         console.error('Failed to load approval queue:', error);
-        setLoading(false);
+        setIsLoading(false);
       }
     };
     
@@ -184,7 +184,7 @@ export default function ApprovalQueue() {
     }
   };
 
-  if (loading) {
+  if (isLoading) {
     return (
       <div className="flex items-center justify-center h-screen p-4">
         <div className="text-center">

--- a/src/pages/provider/approve-transaction.tsx
+++ b/src/pages/provider/approve-transaction.tsx
@@ -5,7 +5,7 @@ import { getWalletService } from '@/services/walletService';
 export default function ApproveTransaction() {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
-  const [loading, setLoading] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
   const [transactionDetails, setTransactionDetails] = useState<any>(null);
   const [error, setError] = useState<string>('');
 
@@ -29,7 +29,7 @@ export default function ApproveTransaction() {
   }, [rawTx]);
 
   const handleApprove = async () => {
-    setLoading(true);
+    setIsLoading(true);
     try {
       // Send approval to background
       await browser.runtime.sendMessage({
@@ -42,7 +42,7 @@ export default function ApproveTransaction() {
       window.close();
     } catch (err) {
       setError('Failed to approve transaction');
-      setLoading(false);
+      setIsLoading(false);
     }
   };
 
@@ -121,17 +121,17 @@ export default function ApproveTransaction() {
         <div className="flex space-x-3">
           <button
             onClick={handleReject}
-            disabled={loading}
+            disabled={isLoading}
             className="flex-1 px-4 py-2 border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-100 disabled:opacity-50"
           >
             Reject
           </button>
           <button
             onClick={handleApprove}
-            disabled={loading}
+            disabled={isLoading}
             className="flex-1 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50"
           >
-            {loading ? 'Signing...' : 'Sign Transaction'}
+            {isLoading ? 'Signing...' : 'Sign Transaction'}
           </button>
         </div>
       </div>

--- a/src/pages/settings/connected-sites.tsx
+++ b/src/pages/settings/connected-sites.tsx
@@ -39,11 +39,11 @@ export default function ConnectedSites(): ReactElement {
   const navigate = useNavigate();
   const { setHeaderProps } = useHeader();
   const [connectedSites, setConnectedSites] = useState<ConnectedSite[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(true);
 
   const loadConnections = useCallback(async () => {
     try {
-      setLoading(true);
+      setIsLoading(true);
       console.log('Loading connected sites from settings...');
       const settings = await getKeychainSettings();
       console.log('Connected websites:', settings.connectedWebsites);
@@ -58,7 +58,7 @@ export default function ConnectedSites(): ReactElement {
     } catch (error) {
       console.error('Failed to load connections:', error);
     } finally {
-      setLoading(false);
+      setIsLoading(false);
     }
   }, []);
 
@@ -133,7 +133,7 @@ export default function ConnectedSites(): ReactElement {
     loadConnections();
   }, [loadConnections]);
 
-  if (loading) {
+  if (isLoading) {
     return (
       <div className="p-4">
         <div className="animate-pulse space-y-4">


### PR DESCRIPTION
- Rename all `loading` state variables to `isLoading` for consistency
- Remove duplicate Spinner export from loading-context.tsx
- Fix Spinner imports to use standalone component from @/components/spinner
- Add missing loading states to asset-select-input for API calls
- Add loading indicators to UTXO forms for balance fetching
- Update all test files to use new isLoading naming
- Maintain separation between global loading context (critical ops) and local loading states (component-specific)

This improves consistency and user feedback throughout the application while maintaining appropriate architectural separation.