### PR TITLE
Unconfirmed BTC Balance

### DIFF
--- a/src/hooks/useAssetDetails.ts
+++ b/src/hooks/useAssetDetails.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useMemo } from "react";
 import { useHeader } from "@/contexts/header-context";
 import { useWallet } from "@/contexts/wallet-context";
-import { fetchBTCBalance } from "@/utils/blockchain/bitcoin";
+import { fetchBTCBalanceDetailed } from "@/utils/blockchain/bitcoin";
 import { fetchAssetDetailsAndBalance, fetchTokenUtxos } from "@/utils/blockchain/counterparty";
 import { AssetInfo } from '@/types/asset';
 
@@ -130,10 +130,11 @@ export function useAssetDetails(asset: string, options?: UseAssetDetailsOptions)
         let result: AssetDetails;
 
         if (asset === 'BTC') {
-          const balanceSats = await fetchBTCBalance(activeAddress.address);
+          const balanceInfo = await fetchBTCBalanceDetailed(activeAddress.address);
+          // Use total (confirmed + unconfirmed) for available balance
           result = {
             isDivisible: true,
-            availableBalance: (balanceSats / 1e8).toString(),
+            availableBalance: (balanceInfo.total / 1e8).toString(),
             assetInfo: {
               asset_longname: null,
               description: 'Bitcoin',

--- a/src/utils/blockchain/bitcoin/balance.ts
+++ b/src/utils/blockchain/bitcoin/balance.ts
@@ -1,5 +1,11 @@
 import { toSatoshis } from '@/utils/numeric';
 
+export interface BTCBalanceInfo {
+  confirmed: number;
+  unconfirmed: number;
+  total: number;
+}
+
 /**
  * Fetches the Bitcoin balance (in satoshis) for a given address by querying multiple API endpoints.
  * The function returns as soon as one of the endpoints successfully returns a balance.
@@ -10,6 +16,19 @@ import { toSatoshis } from '@/utils/numeric';
  * @throws Error if all API calls fail or no valid balance is returned.
  */
 export async function fetchBTCBalance(address: string, timeoutMs = 5000): Promise<number> {
+  const balanceInfo = await fetchBTCBalanceDetailed(address, timeoutMs);
+  return balanceInfo.total;
+}
+
+/**
+ * Fetches detailed Bitcoin balance info including confirmed and unconfirmed amounts.
+ *
+ * @param address - The Bitcoin address.
+ * @param timeoutMs - Timeout in milliseconds for each API request (default: 5000ms).
+ * @returns A Promise that resolves to the detailed balance info.
+ * @throws Error if all API calls fail or no valid balance is returned.
+ */
+export async function fetchBTCBalanceDetailed(address: string, timeoutMs = 5000): Promise<BTCBalanceInfo> {
   const endpoints = [
     `https://blockstream.info/api/address/${address}`,
     `https://mempool.space/api/address/${address}`,
@@ -26,8 +45,8 @@ export async function fetchBTCBalance(address: string, timeoutMs = 5000): Promis
         continue;
       }
       const data = await resp.json();
-      const parsed = parseBTCBalance(endpoint, data);
-      if (parsed !== null && parsed !== undefined && typeof parsed === 'number') {
+      const parsed = parseBTCBalanceDetailed(endpoint, data);
+      if (parsed !== null) {
         return parsed;
       }
     } catch (error) {
@@ -69,6 +88,18 @@ async function fetchWithTimeout(
  * @returns The balance in satoshis if successfully parsed; otherwise null.
  */
 function parseBTCBalance(endpoint: string, data: any): number | null {
+  const detailed = parseBTCBalanceDetailed(endpoint, data);
+  return detailed ? detailed.total : null;
+}
+
+/**
+ * Parses detailed balance info from various API responses.
+ *
+ * @param endpoint - The endpoint URL that was called.
+ * @param data - The parsed JSON response.
+ * @returns The detailed balance info if successfully parsed; otherwise null.
+ */
+function parseBTCBalanceDetailed(endpoint: string, data: any): BTCBalanceInfo | null {
   try {
     // Format from blockstream.info or mempool.space.
     if (endpoint.includes('blockstream.info') || endpoint.includes('mempool.space')) {
@@ -76,19 +107,44 @@ function parseBTCBalance(endpoint: string, data: any): number | null {
       const spent = BigInt(data.chain_stats.spent_txo_sum);
       const memFunded = BigInt(data.mempool_stats.funded_txo_sum);
       const memSpent = BigInt(data.mempool_stats.spent_txo_sum);
-      return Number(funded - spent + memFunded - memSpent);
+      
+      const confirmed = Number(funded - spent);
+      const unconfirmed = Number(memFunded - memSpent);
+      
+      return {
+        confirmed,
+        unconfirmed,
+        total: confirmed + unconfirmed
+      };
     }
     // Format from blockcypher.com.
     if (endpoint.includes('blockcypher.com')) {
-      return data.final_balance;
+      const confirmed = data.balance || 0;
+      const unconfirmed = data.unconfirmed_balance || 0;
+      return {
+        confirmed,
+        unconfirmed,
+        total: data.final_balance || (confirmed + unconfirmed)
+      };
     }
     // Format from blockchain.info.
     if (endpoint.includes('blockchain.info')) {
-      return data.final_balance;
+      // blockchain.info doesn't provide unconfirmed separately in this endpoint
+      return {
+        confirmed: data.final_balance,
+        unconfirmed: 0,
+        total: data.final_balance
+      };
     }
     // Format from sochain.com.
     if (endpoint.includes('sochain.com')) {
-      return Number(toSatoshis(Number(data.data.confirmed_balance)));
+      const confirmed = Number(toSatoshis(Number(data.data.confirmed_balance)));
+      const unconfirmed = Number(toSatoshis(Number(data.data.unconfirmed_balance || 0)));
+      return {
+        confirmed,
+        unconfirmed,
+        total: confirmed + unconfirmed
+      };
     }
   } catch (err) {
     console.warn(`Error parsing response from ${endpoint}:`, err);


### PR DESCRIPTION
- Add BTCBalanceInfo interface to track confirmed/unconfirmed amounts separately
- Create fetchBTCBalanceDetailed() to get detailed balance breakdown
- Update balance list to show unconfirmed amounts with spinner indicator
- Display pending transactions with amber text and spinning icon
- Use total balance (confirmed + unconfirmed) for available balance in send forms
- Support multiple blockchain APIs (mempool.space, blockstream, blockcypher, etc.)

This helps users see their pending transactions and prevents accidental double-spending while transactions are unconfirmed.