### PR TITLE
Move Order Balance Header

### DIFF
--- a/src/pages/compose/order/form.tsx
+++ b/src/pages/compose/order/form.tsx
@@ -136,6 +136,16 @@ export function OrderForm({
 
   return (
     <div className="space-y-4">
+      {activeAddress && giveAssetDetails && (
+        <BalanceHeader
+          balance={{
+            asset: giveAsset,
+            quantity_normalized: giveAssetDetails.availableBalance,
+            asset_info: giveAssetDetails.assetInfo || undefined,
+          }}
+          className="mb-3"
+        />
+      )}
       <div className="flex justify-between items-center mb-2">
         <div className="flex space-x-4">
           <button
@@ -222,20 +232,6 @@ export function OrderForm({
             
             formAction(formData);
           }}
-          header={
-            activeAddress ? (
-              giveAssetDetails ? (
-                <BalanceHeader
-                  balance={{
-                    asset: giveAsset,
-                    quantity_normalized: giveAssetDetails.availableBalance,
-                    asset_info: giveAssetDetails.assetInfo || undefined,
-                  }}
-                  className="mt-1 mb-3"
-                />
-              ) : null
-            ) : null
-          }
         >
           {validationError && (
             <div className="mb-4">


### PR DESCRIPTION
Move the BalanceHeader component above the tab navigation so it remains visible when viewing order settings or switching between buy/sell tabs. This provides consistent balance context throughout the order flow.