### PR TITLE
Implement State Locking

### DIFF
--- a/src/contexts/wallet-context.tsx
+++ b/src/contexts/wallet-context.tsx
@@ -10,7 +10,7 @@ import { onMessage } from 'webext-bridge/popup'; // Import for popup context
 import { getWalletService } from "@/services/walletService";
 import { getKeychainSettings } from "@/utils/storage/settingsStorage";
 import { AddressType } from "@/utils/blockchain/bitcoin";
-import type { Wallet, Address } from "@/utils/wallet";
+import { withStateLock, type Wallet, type Address } from "@/utils/wallet";
 
 /**
  * Authentication state enum.
@@ -77,15 +77,19 @@ interface WalletContextType {
 const WalletContext = createContext<WalletContextType | undefined>(undefined);
 
 /**
- * Wraps an async function with state refresh.
+ * Wraps an async function with state refresh and proper locking.
+ * This ensures operations are serialized and state is consistent.
  */
 const withRefresh = <T extends (...args: any[]) => Promise<any>>(
   fn: T,
-  refresh: () => Promise<void>
+  refresh: () => Promise<void>,
+  lockKey: string = 'wallet-operation'
 ) => async (...args: Parameters<T>): Promise<Awaited<ReturnType<T>>> => {
-  const result = await fn(...args);
-  await refresh();
-  return result;
+  return withStateLock(lockKey, async () => {
+    const result = await fn(...args);
+    await refresh();
+    return result;
+  });
 };
 
 /**
@@ -107,10 +111,9 @@ export function WalletProvider({ children }: { children: ReactNode }): ReactElem
   const refreshInProgress = React.useRef(false);
 
   const refreshWalletState = useCallback(async () => {
-    if (refreshInProgress.current) return;
-    refreshInProgress.current = true;
-
-    try {
+    // Use proper locking instead of simple ref check
+    return withStateLock('wallet-refresh', async () => {
+      try {
       await walletService.loadWallets();
       const allWallets = await walletService.getWallets();
       const newState: WalletState = { ...walletState };
@@ -173,12 +176,11 @@ export function WalletProvider({ children }: { children: ReactNode }): ReactElem
       if (!walletsEqual || activeChanged || addressChanged || lockChanged || !walletState.loaded) {
         setWalletState(newState);
       }
-    } catch (error) {
-      console.error("Error refreshing wallet state:", error);
-      setWalletState((prev) => ({ ...prev, loaded: true }));
-    } finally {
-      refreshInProgress.current = false;
-    }
+      } catch (error) {
+        console.error("Error refreshing wallet state:", error);
+        setWalletState((prev) => ({ ...prev, loaded: true }));
+      }
+    });
   }, [walletService, walletState]);
 
   useEffect(() => {
@@ -207,7 +209,8 @@ export function WalletProvider({ children }: { children: ReactNode }): ReactElem
 
   const setActiveWallet = useCallback(
     async (wallet: Wallet | null, useLastActive?: boolean) => {
-      if (wallet) {
+      return withStateLock('wallet-set-active', async () => {
+        if (wallet) {
         await walletService.setActiveWallet(wallet.id);
         const lastActiveAddress = useLastActive ? await walletService.getLastActiveAddress() : undefined;
         const newActiveAddress =
@@ -228,18 +231,20 @@ export function WalletProvider({ children }: { children: ReactNode }): ReactElem
           walletLocked: !anyUnlocked,
         }));
         if (newActiveAddress) await walletService.setLastActiveAddress(newActiveAddress.address);
-      } else {
-        await walletService.setActiveWallet("");
-        setWalletState((prev) => ({ ...prev, activeWallet: null, activeAddress: null }));
-      }
+        } else {
+          await walletService.setActiveWallet("");
+          setWalletState((prev) => ({ ...prev, activeWallet: null, activeAddress: null }));
+        }
+      });
     },
     [walletService]
   );
 
   const setActiveAddress = useCallback(
     async (address: Address | null) => {
-      const oldAddress = walletState.activeAddress?.address;
-      const newAddress = address?.address;
+      return withStateLock('wallet-set-address', async () => {
+        const oldAddress = walletState.activeAddress?.address;
+        const newAddress = address?.address;
       
       // Handle address switch - emit accountsChanged to all connected sites
       if (oldAddress && newAddress && oldAddress !== newAddress) {
@@ -255,9 +260,10 @@ export function WalletProvider({ children }: { children: ReactNode }): ReactElem
           });
         }
       }
-      
-      setWalletState((prev) => ({ ...prev, activeAddress: address }));
-      if (address) await walletService.setLastActiveAddress(address.address);
+        
+        setWalletState((prev) => ({ ...prev, activeAddress: address }));
+        if (address) await walletService.setLastActiveAddress(address.address);
+      });
     },
     [walletService, walletState.activeAddress]
   );
@@ -282,19 +288,21 @@ export function WalletProvider({ children }: { children: ReactNode }): ReactElem
     unlockWallet: withRefresh(walletService.unlockWallet, async () => {
       await refreshWalletState();
       setWalletState((prev) => ({ ...prev, authState: AuthState.Unlocked }));
-    }),
+    }, 'wallet-unlock'),
     lockAll: async () => {
-      // Immediately set state to locked to trigger navigation
-      setWalletState((prev) => ({
-        ...prev,
-        authState: AuthState.Locked,
-        walletLocked: true,
-        activeWallet: null,
-        activeAddress: null,
-      }));
-      
-      // Then actually lock in the background
-      await walletService.lockAllWallets();
+      return withStateLock('wallet-lock', async () => {
+        // Immediately set state to locked to trigger navigation
+        setWalletState((prev) => ({
+          ...prev,
+          authState: AuthState.Locked,
+          walletLocked: true,
+          activeWallet: null,
+          activeAddress: null,
+        }));
+        
+        // Then actually lock in the background
+        await walletService.lockAllWallets();
+      });
     },
     setActiveWallet,
     setActiveAddress,

--- a/src/utils/wallet/index.ts
+++ b/src/utils/wallet/index.ts
@@ -1,2 +1,3 @@
 export * from './settingsManager';
 export * from './walletManager';
+export * from './stateLockManager';

--- a/src/utils/wallet/stateLockManager.ts
+++ b/src/utils/wallet/stateLockManager.ts
@@ -1,0 +1,205 @@
+/**
+ * State Lock Manager
+ * Provides mutex-like locking for preventing race conditions in wallet state operations
+ */
+
+type LockResolver = () => void;
+
+interface Lock {
+  id: string;
+  acquired: boolean;
+  queue: LockResolver[];
+  timeout?: NodeJS.Timeout;
+}
+
+class StateLockManager {
+  private locks: Map<string, Lock> = new Map();
+  private readonly DEFAULT_TIMEOUT = 30000; // 30 seconds timeout for locks
+
+  /**
+   * Acquire a lock for a specific resource
+   * @param resource - The resource identifier to lock
+   * @param timeout - Optional timeout in milliseconds (default: 30 seconds)
+   * @returns Promise that resolves when lock is acquired
+   */
+  async acquire(resource: string, timeout: number = this.DEFAULT_TIMEOUT): Promise<() => void> {
+    return new Promise((resolve, reject) => {
+      let lock = this.locks.get(resource);
+      
+      if (!lock) {
+        // Create new lock and acquire immediately
+        lock = {
+          id: resource,
+          acquired: true,
+          queue: [],
+        };
+        this.locks.set(resource, lock);
+        
+        // Set timeout for lock
+        const timeoutId = setTimeout(() => {
+          console.warn(`Lock timeout for resource: ${resource}`);
+          this.forceRelease(resource);
+        }, timeout);
+        
+        lock.timeout = timeoutId;
+        
+        // Return release function
+        resolve(() => this.release(resource));
+      } else if (!lock.acquired) {
+        // Lock exists but not acquired (shouldn't happen)
+        lock.acquired = true;
+        
+        // Set new timeout
+        if (lock.timeout) clearTimeout(lock.timeout);
+        lock.timeout = setTimeout(() => {
+          console.warn(`Lock timeout for resource: ${resource}`);
+          this.forceRelease(resource);
+        }, timeout);
+        
+        resolve(() => this.release(resource));
+      } else {
+        // Lock is acquired, add to queue
+        lock.queue.push(() => {
+          lock!.acquired = true;
+          
+          // Set timeout for this lock acquisition
+          if (lock!.timeout) clearTimeout(lock!.timeout);
+          lock!.timeout = setTimeout(() => {
+            console.warn(`Lock timeout for resource: ${resource}`);
+            this.forceRelease(resource);
+          }, timeout);
+          
+          resolve(() => this.release(resource));
+        });
+      }
+    });
+  }
+
+  /**
+   * Release a lock for a specific resource
+   * @param resource - The resource identifier to release
+   */
+  private release(resource: string): void {
+    const lock = this.locks.get(resource);
+    
+    if (!lock) {
+      console.warn(`Attempting to release non-existent lock: ${resource}`);
+      return;
+    }
+    
+    // Clear timeout
+    if (lock.timeout) {
+      clearTimeout(lock.timeout);
+      lock.timeout = undefined;
+    }
+    
+    if (lock.queue.length > 0) {
+      // Pass lock to next in queue
+      const next = lock.queue.shift();
+      if (next) {
+        next();
+      }
+    } else {
+      // No one waiting, remove lock
+      this.locks.delete(resource);
+    }
+  }
+
+  /**
+   * Force release a lock (used for timeout scenarios)
+   * @param resource - The resource identifier to force release
+   */
+  private forceRelease(resource: string): void {
+    const lock = this.locks.get(resource);
+    
+    if (!lock) return;
+    
+    // Clear timeout
+    if (lock.timeout) {
+      clearTimeout(lock.timeout);
+      lock.timeout = undefined;
+    }
+    
+    // Process entire queue with timeout errors
+    lock.queue.forEach(resolver => {
+      console.error(`Lock queue cleared due to timeout: ${resource}`);
+    });
+    
+    // Remove the lock entirely
+    this.locks.delete(resource);
+  }
+
+  /**
+   * Check if a resource is currently locked
+   * @param resource - The resource identifier to check
+   */
+  isLocked(resource: string): boolean {
+    const lock = this.locks.get(resource);
+    return lock ? lock.acquired : false;
+  }
+
+  /**
+   * Get the number of waiters for a resource
+   * @param resource - The resource identifier
+   */
+  getQueueLength(resource: string): number {
+    const lock = this.locks.get(resource);
+    return lock ? lock.queue.length : 0;
+  }
+
+  /**
+   * Clear all locks (use with caution)
+   */
+  clearAll(): void {
+    this.locks.forEach(lock => {
+      if (lock.timeout) {
+        clearTimeout(lock.timeout);
+      }
+    });
+    this.locks.clear();
+  }
+}
+
+// Export singleton instance
+export const stateLockManager = new StateLockManager();
+
+/**
+ * Decorator for methods that need state locking
+ * @param lockKey - The key to use for locking (can be a function that returns a key)
+ */
+export function withLock(lockKey: string | ((this: any, ...args: any[]) => string)) {
+  return function (target: any, propertyName: string, descriptor: PropertyDescriptor) {
+    const originalMethod = descriptor.value;
+    
+    descriptor.value = async function (...args: any[]) {
+      const key = typeof lockKey === 'function' ? lockKey.call(this, ...args) : lockKey;
+      const release = await stateLockManager.acquire(key);
+      
+      try {
+        return await originalMethod.apply(this, args);
+      } finally {
+        release();
+      }
+    };
+    
+    return descriptor;
+  };
+}
+
+/**
+ * Helper function to run code with a lock
+ * @param lockKey - The resource to lock
+ * @param fn - The function to run while holding the lock
+ */
+export async function withStateLock<T>(
+  lockKey: string,
+  fn: () => Promise<T>
+): Promise<T> {
+  const release = await stateLockManager.acquire(lockKey);
+  
+  try {
+    return await fn();
+  } finally {
+    release();
+  }
+}


### PR DESCRIPTION
- Created StateLockManager utility in wallet folder for mutex-like locking
- Exported through wallet barrel file for clean imports
- Prevents concurrent refreshWalletState operations in wallet context
- Added locking to critical wallet operations (unlock, lock, setActive)
- Implements timeout mechanism to prevent deadlocks (30s default)
- Uses queue-based approach for serializing wallet state operations
- Each operation type has its own lock key to prevent unnecessary blocking

This eliminates race conditions that could lead to corrupted wallet state