### PR TITLE
Request Timeouts on all APIs

### DIFF
--- a/src/utils/api/axiosConfig.ts
+++ b/src/utils/api/axiosConfig.ts
@@ -1,0 +1,156 @@
+/**
+ * Centralized Axios Configuration
+ * Provides configured axios instances with proper timeouts and error handling
+ */
+
+import axios, { AxiosInstance, AxiosError, AxiosRequestConfig } from 'axios';
+
+// Default timeout values (in milliseconds)
+export const API_TIMEOUTS = {
+  DEFAULT: 30000,     // 30 seconds for most requests
+  QUICK: 10000,       // 10 seconds for simple lookups
+  LONG: 60000,        // 60 seconds for complex operations
+  BROADCAST: 45000,   // 45 seconds for transaction broadcasts
+} as const;
+
+// Retry configuration
+const RETRY_CONFIG = {
+  maxRetries: 3,
+  retryDelay: 1000,  // Start with 1 second
+  maxRetryDelay: 5000,
+  shouldRetry: (error: AxiosError) => {
+    // Retry on network errors or 5xx server errors
+    if (!error.response) return true; // Network error
+    return error.response.status >= 500 && error.response.status < 600;
+  }
+};
+
+/**
+ * Create an axios instance with timeout and retry logic
+ */
+export function createAxiosInstance(
+  baseConfig?: AxiosRequestConfig,
+  timeout: number = API_TIMEOUTS.DEFAULT
+): AxiosInstance {
+  const instance = axios.create({
+    timeout,
+    ...baseConfig,
+    headers: {
+      'Content-Type': 'application/json',
+      ...baseConfig?.headers,
+    },
+  });
+
+  // Add request interceptor for logging in development
+  if (process.env.NODE_ENV === 'development') {
+    instance.interceptors.request.use(
+      (config) => {
+        console.debug(`[API] ${config.method?.toUpperCase()} ${config.url}`, {
+          timeout: config.timeout,
+          params: config.params,
+        });
+        return config;
+      },
+      (error) => Promise.reject(error)
+    );
+  }
+
+  // Add response interceptor for error handling
+  instance.interceptors.response.use(
+    (response) => response,
+    async (error: AxiosError) => {
+      // Handle timeout specifically
+      if (error.code === 'ECONNABORTED' || error.message.includes('timeout')) {
+        console.error('[API] Request timeout:', error.config?.url);
+        
+        // Create a more user-friendly error
+        const timeoutError = new Error(
+          `Request timed out after ${error.config?.timeout}ms. Please check your connection and try again.`
+        );
+        (timeoutError as any).code = 'TIMEOUT';
+        (timeoutError as any).originalError = error;
+        throw timeoutError;
+      }
+
+      // Handle network errors
+      if (!error.response) {
+        console.error('[API] Network error:', error.message);
+        const networkError = new Error(
+          'Network error. Please check your internet connection.'
+        );
+        (networkError as any).code = 'NETWORK_ERROR';
+        (networkError as any).originalError = error;
+        throw networkError;
+      }
+
+      // Log other errors
+      console.error('[API] Request failed:', {
+        url: error.config?.url,
+        status: error.response?.status,
+        message: error.response?.data || error.message,
+      });
+
+      throw error;
+    }
+  );
+
+  return instance;
+}
+
+/**
+ * Retry logic wrapper for axios requests
+ */
+export async function withRetry<T>(
+  requestFn: () => Promise<T>,
+  maxRetries: number = RETRY_CONFIG.maxRetries
+): Promise<T> {
+  let lastError: any;
+  let delay = RETRY_CONFIG.retryDelay;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await requestFn();
+    } catch (error) {
+      lastError = error;
+      
+      // Don't retry if it's not retryable
+      if (!RETRY_CONFIG.shouldRetry(error as AxiosError)) {
+        throw error;
+      }
+
+      // Don't retry after last attempt
+      if (attempt === maxRetries) {
+        break;
+      }
+
+      console.warn(`[API] Retry attempt ${attempt + 1}/${maxRetries} after ${delay}ms`);
+      await new Promise(resolve => setTimeout(resolve, delay));
+      
+      // Exponential backoff with jitter
+      delay = Math.min(
+        delay * 2 + Math.random() * 1000,
+        RETRY_CONFIG.maxRetryDelay
+      );
+    }
+  }
+
+  throw lastError;
+}
+
+// Pre-configured instances for different use cases
+export const apiClient = createAxiosInstance({}, API_TIMEOUTS.DEFAULT);
+export const quickApiClient = createAxiosInstance({}, API_TIMEOUTS.QUICK);
+export const longApiClient = createAxiosInstance({}, API_TIMEOUTS.LONG);
+export const broadcastApiClient = createAxiosInstance({}, API_TIMEOUTS.BROADCAST);
+
+/**
+ * Helper to make a request with a specific timeout
+ */
+export async function requestWithTimeout<T>(
+  config: AxiosRequestConfig,
+  timeout: number = API_TIMEOUTS.DEFAULT
+): Promise<T> {
+  const instance = createAxiosInstance({}, timeout);
+  const response = await instance.request<T>(config);
+  return response.data;
+}

--- a/src/utils/blockchain/bitcoin/bareMultisig.ts
+++ b/src/utils/blockchain/bitcoin/bareMultisig.ts
@@ -1,5 +1,5 @@
-import axios from 'axios';
 import { Transaction, SigHash, OutScript } from '@scure/btc-signer';
+import { quickApiClient, API_TIMEOUTS } from '@/utils/api/axiosConfig';
 import { hexToBytes, bytesToHex } from '@noble/hashes/utils';
 import { getPublicKey } from '@noble/secp256k1';
 import { getKeychainSettings } from '@/utils/storage/settingsStorage';
@@ -160,10 +160,10 @@ function varIntSize(n: number): number {
  * Fetch bare multisig UTXOs for the given address.
  */
 async function fetchBareMultisigUTXOs(address: string): Promise<UTXO[]> {
-  const response = await axios.get<{ data: any[] }>(`https://app.xcp.io/api/v1/address/${address}/utxos`);
+  const response = await quickApiClient.get<{ data: any[] }>(`https://app.xcp.io/api/v1/address/${address}/utxos`);
   const utxos = response.data.data;
   if (!utxos || utxos.length === 0) throw new Error('No bare multisig UTXOs found');
-  return utxos.map((utxo) => ({
+  return utxos.map((utxo: any) => ({
     txid: utxo.txid,
     vout: utxo.vout,
     amount: parseFloat(utxo.amount),
@@ -187,7 +187,9 @@ async function fetchPreviousRawTransaction(txid: string): Promise<string | null>
   ];
   for (const endpoint of endpoints) {
     try {
-      const response = await axios.get<any>(typeof endpoint.url === 'function' ? await endpoint.url() : endpoint.url);
+      const url = typeof endpoint.url === 'function' ? await endpoint.url() : endpoint.url;
+      // Use quickApiClient with 10 second timeout for transaction lookups
+      const response = await quickApiClient.get(url);
       return endpoint.transform(response.data);
     } catch (_) {
       continue;

--- a/src/utils/blockchain/bitcoin/transactionBroadcaster.ts
+++ b/src/utils/blockchain/bitcoin/transactionBroadcaster.ts
@@ -1,4 +1,4 @@
-import { AxiosResponse } from 'axios';
+import axios, { AxiosResponse } from 'axios';
 import { broadcastApiClient, withRetry } from '@/utils/api/axiosConfig';
 import { getKeychainSettings } from '@/utils/storage/settingsStorage';
 

--- a/src/utils/blockchain/bitcoin/transactionBroadcaster.ts
+++ b/src/utils/blockchain/bitcoin/transactionBroadcaster.ts
@@ -1,4 +1,5 @@
-import axios, { AxiosResponse } from 'axios';
+import { AxiosResponse } from 'axios';
+import { broadcastApiClient, withRetry } from '@/utils/api/axiosConfig';
 import { getKeychainSettings } from '@/utils/storage/settingsStorage';
 
 export interface TransactionResponse {
@@ -95,10 +96,14 @@ export async function broadcastTransaction(signedTxHex: string): Promise<Transac
   for (const endpoint of broadcastEndpoints) {
     try {
       const url = await endpoint.getUrl(signedTxHex);
-      const response = await axios.post(
-        url,
-        endpoint.getData(signedTxHex),
-        { headers: endpoint.headers }
+      // Use broadcast-specific timeout (45 seconds) with retry logic
+      const response = await withRetry(
+        () => broadcastApiClient.post(
+          url,
+          endpoint.getData(signedTxHex),
+          { headers: endpoint.headers }
+        ),
+        2 // Only retry twice for broadcasts
       );
       if (response.status >= 200 && response.status < 300) {
         const formatted = formatResponse(endpoint, response);

--- a/src/utils/blockchain/bitcoin/transactionBroadcaster.ts
+++ b/src/utils/blockchain/bitcoin/transactionBroadcaster.ts
@@ -105,7 +105,7 @@ export async function broadcastTransaction(signedTxHex: string): Promise<Transac
         ),
         2 // Only retry twice for broadcasts
       );
-      if (response.status >= 200 && response.status < 300) {
+      if (response && response.status >= 200 && response.status < 300) {
         const formatted = formatResponse(endpoint, response);
         if (formatted && formatted.txid) {
           return formatted;

--- a/src/utils/blockchain/bitcoin/utxo.ts
+++ b/src/utils/blockchain/bitcoin/utxo.ts
@@ -1,3 +1,4 @@
+import axios from 'axios';
 import { quickApiClient } from '@/utils/api/axiosConfig';
 import { getKeychainSettings } from '@/utils/storage/settingsStorage';
 

--- a/src/utils/blockchain/bitcoin/utxo.ts
+++ b/src/utils/blockchain/bitcoin/utxo.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import { quickApiClient } from '@/utils/api/axiosConfig';
 import { getKeychainSettings } from '@/utils/storage/settingsStorage';
 
 /**
@@ -25,7 +25,8 @@ export interface UTXO {
  */
 export async function fetchUTXOs(address: string, signal?: AbortSignal): Promise<UTXO[]> {
   try {
-    const response = await axios.get<UTXO[]>(
+    // Use quickApiClient with 10 second timeout for UTXO lookups
+    const response = await quickApiClient.get<UTXO[]>(
       `https://mempool.space/api/address/${address}/utxo`,
       { signal }
     );

--- a/src/utils/blockchain/counterparty/api.ts
+++ b/src/utils/blockchain/counterparty/api.ts
@@ -1,3 +1,4 @@
+import axios from 'axios';
 import { apiClient, quickApiClient, API_TIMEOUTS } from '@/utils/api/axiosConfig';
 import { fetchBTCBalance } from '@/utils/blockchain/bitcoin';
 import { formatAmount } from '@/utils/format';

--- a/src/utils/blockchain/counterparty/api.ts
+++ b/src/utils/blockchain/counterparty/api.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import { apiClient, quickApiClient, API_TIMEOUTS } from '@/utils/api/axiosConfig';
 import { fetchBTCBalance } from '@/utils/blockchain/bitcoin';
 import { formatAmount } from '@/utils/format';
 import { fromSatoshis } from '@/utils/numeric';
@@ -165,6 +165,26 @@ async function getApiBase() {
 }
 
 /**
+ * Helper function to make Counterparty API calls with proper timeout handling
+ * @param path - The API path (will be appended to base URL)
+ * @param params - Optional query parameters
+ * @param useQuickTimeout - Use quick timeout (10s) instead of default (30s)
+ * @returns The response data
+ */
+async function cpApiGet<T = any>(
+  path: string,
+  params?: Record<string, any>,
+  useQuickTimeout: boolean = false
+): Promise<T> {
+  const base = await getApiBase();
+  const url = `${base}${path}`;
+  const client = useQuickTimeout ? quickApiClient : apiClient;
+  
+  const response = await client.get<T>(url, { params });
+  return response.data;
+}
+
+/**
  * Fetches the token balances for a given address.
  *
  * @param address - The Bitcoin address to fetch balances for.
@@ -186,19 +206,17 @@ export async function fetchTokenBalances(
     const verbose = options.verbose ?? true;
     const sort = options.sort ?? null;
 
-    const base = await getApiBase();
-    const response = await axios.get(
-      `${base}/v2/addresses/${address}/balances`,
+    // Use cpApiGet helper with proper timeout
+    const data = await cpApiGet<any>(
+      `/v2/addresses/${address}/balances`,
       {
-        params: {
-          verbose: verbose,
-          limit: limit,
-          offset: offset,
-          sort: sort,
-        },
-      }
+        verbose: verbose,
+        limit: limit,
+        offset: offset,
+        sort: sort,
+      },
+      true // Use quick timeout for balance lookups
     );
-    const data = response.data;
 
     if (!data.result || !Array.isArray(data.result)) {
       return [];

--- a/src/utils/blockchain/counterparty/compose.ts
+++ b/src/utils/blockchain/counterparty/compose.ts
@@ -1,3 +1,4 @@
+import axios from 'axios';
 import { apiClient, longApiClient } from '@/utils/api/axiosConfig';
 import { getKeychainSettings } from '@/utils/storage/settingsStorage';
 


### PR DESCRIPTION
- Created centralized axios configuration with proper timeouts
- Default 30s timeout for standard requests
- Quick 10s timeout for simple lookups (UTXOs, balances)
- Long 60s timeout for complex operations (transaction composition)
- Broadcast 45s timeout for transaction broadcasts
- Added retry logic with exponential backoff for transient failures
- Improved error messages for timeout scenarios
- Updated critical API calls in bareMultisig, transactionBroadcaster, utxo, counterparty API

This prevents hanging operations and improves user experience with clear timeout errors