### PR TITLE
Remove Debug Console Logs

### DIFF
--- a/src/contexts/wallet-context.tsx
+++ b/src/contexts/wallet-context.tsx
@@ -187,7 +187,6 @@ export function WalletProvider({ children }: { children: ReactNode }): ReactElem
     // Listen for wallet lock events from background
     const handleLockMessage = ({ data }: { data: { locked: boolean } }) => {
       if (data.locked) {
-        console.log('[WalletContext] Received lock event from background');
         // Immediately update state to trigger navigation
         setWalletState((prev) => ({
           ...prev,

--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -10,7 +10,6 @@ export default defineBackground(() => {
   
   // Check session recovery state on startup (non-blocking)
   checkSessionRecovery().then(recoveryState => {
-    console.log('Session recovery state:', recoveryState);
     
     if (recoveryState === SessionRecoveryState.LOCKED) {
       // Session expired or doesn't exist - ensure everything is locked
@@ -21,7 +20,6 @@ export default defineBackground(() => {
     } else if (recoveryState === SessionRecoveryState.NEEDS_REAUTH) {
       // Valid session but secrets lost - notify popup to show auth modal
       // The popup will handle this when it checks wallet state
-      console.log('Session valid but re-authentication needed');
     }
   }).catch(error => {
     console.error('Session recovery check failed:', error);
@@ -32,7 +30,6 @@ export default defineBackground(() => {
   if (chrome?.alarms?.onAlarm) {
     chrome.alarms.onAlarm.addListener(async (alarm) => {
       if (alarm.name === 'session-expiry') {
-        console.log('Session expired via alarm');
         const walletService = getWalletService();
         await walletService.lockAllWallets();
       }

--- a/src/entrypoints/content.ts
+++ b/src/entrypoints/content.ts
@@ -95,7 +95,6 @@ export default defineContentScript({
       await injectScript("/injected.js", {
         keepInDom: true,
       });
-      console.log('Injected XCP Wallet provider successfully.');
     } catch (error) {
       console.error('Failed to inject XCP Wallet provider:', error);
     }

--- a/src/services/providerService.ts
+++ b/src/services/providerService.ts
@@ -181,7 +181,6 @@ export function createProviderService(): ProviderService {
    * Handle provider requests from dApps
    */
   async function handleRequest(origin: string, method: string, params: any[] = [], metadata?: any): Promise<any> {
-    console.log('Provider request:', { origin, method, params });
     
     // Log request signing information if available
     if (metadata?.signature) {
@@ -559,12 +558,6 @@ export function createProviderService(): ProviderService {
           }
           
           // User approved - compose the transaction with potentially updated params
-          console.log('Composing order with final params:', {
-            originalParams: orderParams,
-            updatedParams: result.updatedParams,
-            finalParams,
-            address: activeAddress.address
-          });
           
           const composeResult = await composeTransaction(
             'order',

--- a/src/utils/blockchain/bitcoin/bareMultisig.ts
+++ b/src/utils/blockchain/bitcoin/bareMultisig.ts
@@ -120,7 +120,6 @@ export async function consolidateBareMultisig(
   tx.finalize();
 
   const signedTx = tx.hex;
-  console.log('Transaction signed successfully with hybrid signing logic.');
   return signedTx;
 }
 

--- a/src/utils/blockchain/bitcoin/uncompressedSigner.ts
+++ b/src/utils/blockchain/bitcoin/uncompressedSigner.ts
@@ -93,7 +93,6 @@ export function hybridSignTransaction(
     }
   } catch (e) {
     // Standard signing failed, will try custom signing below
-    console.log('Standard signing failed, attempting custom signing for uncompressed keys');
   }
   
   // Check each input for uncompressed key requirements


### PR DESCRIPTION
- Remove console.log statements from providerService.ts
- Remove console.log from wallet-context.tsx lock event handler
- Remove console.log from bareMultisig.ts transaction signing
- Remove console.log from uncompressedSigner.ts fallback logic
- Remove console.log statements from background.ts session recovery
- Remove console.log from content.ts provider injection

These debug statements should only run in development mode to keep production logs clean.