### PR TITLE
Restore Unlock Design

### DIFF
--- a/src/components/composer.tsx
+++ b/src/components/composer.tsx
@@ -206,7 +206,6 @@ function ComposerInner<T>({
               onUnlock={handleUnlockAndSign}
               onCancel={() => setShowAuthModal(false)}
               submitText="Authorize"
-              showLockIcon
             />
           </div>
         </div>

--- a/src/components/screens/__tests__/unlock-screen.test.tsx
+++ b/src/components/screens/__tests__/unlock-screen.test.tsx
@@ -35,11 +35,17 @@ describe('UnlockScreen', () => {
       expect(screen.getByText('Custom subtitle text')).toBeInTheDocument();
     });
 
-    it('should show lock icon when showLockIcon is true', () => {
-      render(<UnlockScreen onUnlock={mockOnUnlock} showLockIcon />);
+    it('should show title and subtitle correctly', () => {
+      render(
+        <UnlockScreen 
+          onUnlock={mockOnUnlock} 
+          title="XCP Wallet"
+          subtitle="v0.0.1"
+        />
+      );
       
-      const lockIconContainer = screen.getByText('Unlock Wallet').parentElement?.parentElement;
-      expect(lockIconContainer?.querySelector('svg')).toBeInTheDocument();
+      expect(screen.getByText('XCP Wallet')).toBeInTheDocument();
+      expect(screen.getByText('v0.0.1')).toBeInTheDocument();
     });
 
     it('should show cancel button when onCancel is provided', () => {

--- a/src/components/screens/__tests__/unlock-screen.test.tsx
+++ b/src/components/screens/__tests__/unlock-screen.test.tsx
@@ -66,10 +66,12 @@ describe('UnlockScreen', () => {
       expect(screen.getByRole('button', { name: 'Authorize' })).toBeInTheDocument();
     });
 
-    it('should display help text at the bottom', () => {
+    it('should display simple clean interface', () => {
       render(<UnlockScreen onUnlock={mockOnUnlock} />);
       
-      expect(screen.getByText(/Your password is never stored/)).toBeInTheDocument();
+      // Should have the clean white box without extra help text
+      const container = screen.getByRole('button', { name: 'Unlock' }).closest('.bg-white');
+      expect(container).toHaveClass('rounded-lg', 'shadow-md');
     });
   });
 

--- a/src/components/screens/unlock-screen.tsx
+++ b/src/components/screens/unlock-screen.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState, useEffect, useRef, type ReactElement } from "react";
-import { FiLock, FiAlertCircle } from "react-icons/fi";
 import { Button } from "@/components/button";
 import { PasswordInput } from "@/components/inputs/password-input";
 
@@ -55,11 +54,6 @@ interface UnlockScreenProps {
   submitText?: string;
   
   /**
-   * Whether to show a lock icon in the header
-   */
-  showLockIcon?: boolean;
-  
-  /**
    * Additional CSS classes for the container
    */
   className?: string;
@@ -84,10 +78,9 @@ interface UnlockScreenProps {
  * ```tsx
  * // Full page usage
  * <UnlockScreen
- *   title="Welcome Back"
- *   subtitle="Enter your password to unlock your wallet"
+ *   title="XCP Wallet"
+ *   subtitle="v0.0.1"
  *   onUnlock={handleUnlock}
- *   showLockIcon
  * />
  * 
  * // Modal usage
@@ -109,7 +102,6 @@ export function UnlockScreen({
   minPasswordLength = 8,
   placeholder = "Enter your password",
   submitText = "Unlock",
-  showLockIcon = false,
   className = "",
 }: UnlockScreenProps): ReactElement {
   const [password, setPassword] = useState("");
@@ -184,72 +176,49 @@ export function UnlockScreen({
   return (
     <div className={`flex flex-col h-full ${className}`}>
       <div className="flex-grow flex items-center justify-center p-4">
-        <div className="w-full max-w-md">
-          <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-8">
-            {/* Header Section */}
-            <div className="text-center mb-6">
-              {showLockIcon && (
-                <div className="flex justify-center mb-4">
-                  <div className="p-3 bg-blue-100 dark:bg-blue-900 rounded-full">
-                    <FiLock className="w-8 h-8 text-blue-600 dark:text-blue-400" />
-                  </div>
-                </div>
-              )}
-              
-              <h1 className="text-2xl font-bold text-gray-900 dark:text-white mb-2">
-                {title}
-              </h1>
-              
-              {subtitle && (
-                <p className="text-sm text-gray-600 dark:text-gray-400">
-                  {subtitle}
-                </p>
-              )}
-            </div>
+        <div className="w-full max-w-md bg-white rounded-lg shadow-md p-6">
+          {/* Header Section - Simple title */}
+          <h1 className="text-3xl mb-5 flex justify-between items-center">
+            <span className="font-bold">{title}</span>
+            {subtitle && (
+              <span className="text-base font-normal text-gray-500">{subtitle}</span>
+            )}
+          </h1>
+          
+          {/* Form Section */}
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <PasswordInput
+              name="password"
+              placeholder={placeholder}
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              onKeyDown={handleKeyDown}
+              disabled={isSubmitting}
+              innerRef={passwordInputRef}
+              aria-label="Password"
+              aria-invalid={!!error}
+              aria-describedby={error ? "password-error" : undefined}
+            />
             
-            {/* Error Message */}
+            {/* Error Message - Simple inline error */}
             {error && (
-              <div 
-                className="mb-4 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg flex items-start gap-2"
-                role="alert"
-                aria-live="polite"
-              >
-                <FiAlertCircle className="w-5 h-5 text-red-600 dark:text-red-400 flex-shrink-0 mt-0.5" />
-                <span className="text-sm text-red-700 dark:text-red-400">
-                  {error}
-                </span>
-              </div>
+              <p className="text-red-500 text-sm" role="alert">
+                {error}
+              </p>
             )}
             
-            {/* Form Section */}
-            <form onSubmit={handleSubmit} className="space-y-4">
-              <PasswordInput
-                name="password"
-                placeholder={placeholder}
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                onKeyDown={handleKeyDown}
-                disabled={isSubmitting}
-                innerRef={passwordInputRef}
-                aria-label="Password"
-                aria-invalid={!!error}
-                aria-describedby={error ? "password-error" : undefined}
-              />
-              
-              {/* Action Buttons */}
-              <div className={`flex ${onCancel ? 'justify-between' : 'justify-center'} gap-3`}>
-                {onCancel && (
-                  <Button 
-                    type="button"
-                    onClick={handleCancel}
-                    variant="transparent"
-                    disabled={isSubmitting}
-                    className="flex-1"
-                  >
-                    Cancel
-                  </Button>
-                )}
-                
+            {/* Action Buttons */}
+            {onCancel ? (
+              <div className="flex justify-between gap-3">
+                <Button 
+                  type="button"
+                  onClick={handleCancel}
+                  variant="transparent"
+                  disabled={isSubmitting}
+                  className="flex-1"
+                >
+                  Cancel
+                </Button>
                 <Button 
                   type="submit"
                   disabled={!password || isSubmitting}
@@ -259,15 +228,17 @@ export function UnlockScreen({
                   {isSubmitting ? "Unlocking..." : submitText}
                 </Button>
               </div>
-            </form>
-            
-            {/* Help Text */}
-            <div className="mt-6 text-center">
-              <p className="text-xs text-gray-500 dark:text-gray-400">
-                Your password is never stored and is used only to decrypt your wallet.
-              </p>
-            </div>
-          </div>
+            ) : (
+              <Button 
+                type="submit"
+                fullWidth
+                disabled={!password || isSubmitting}
+                aria-label={isSubmitting ? "Unlocking..." : submitText}
+              >
+                {isSubmitting ? "Unlocking..." : submitText}
+              </Button>
+            )}
+          </form>
         </div>
       </div>
     </div>

--- a/src/pages/actions/sign-message.tsx
+++ b/src/pages/actions/sign-message.tsx
@@ -315,7 +315,6 @@ export default function SignMessage(): ReactElement {
               onUnlock={handleUnlockAndSign}
               onCancel={() => setShowAuthModal(false)}
               submitText="Authorize"
-              showLockIcon
             />
           </div>
         </div>

--- a/src/pages/auth/unlock-wallet.tsx
+++ b/src/pages/auth/unlock-wallet.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { FiHelpCircle } from "react-icons/fi";
-import { Button } from "@/components/button";
-import { PasswordInput } from "@/components/inputs/password-input";
+import { UnlockScreen } from "@/components/screens/unlock-screen";
 import { useHeader } from "@/contexts/header-context";
 import { useWallet } from "@/contexts/wallet-context";
 
@@ -14,14 +13,11 @@ const UnlockWallet = () => {
   const { setHeaderProps } = useHeader();
   const [isUnlocking, setIsUnlocking] = useState(false);
   const [error, setError] = useState<string | undefined>();
-  const [password, setPassword] = useState("");
-  const passwordInputRef = useRef<HTMLInputElement>(null);
 
   const PATHS = {
     SUCCESS: "/index",
     HELP_URL: "https://youtube.com", // Replace with actual help URL
   } as const;
-  const MIN_PASSWORD_LENGTH = 8;
 
   useEffect(() => {
     setHeaderProps({
@@ -34,68 +30,45 @@ const UnlockWallet = () => {
     });
   }, [setHeaderProps]);
 
-  useEffect(() => {
-    passwordInputRef.current?.focus();
-  }, []);
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
+  /**
+   * Handle password unlock
+   */
+  const handleUnlock = async (password: string): Promise<void> => {
     setError(undefined);
-
-    if (!password) {
-      setError("Password cannot be empty.");
-      return;
-    }
-    if (password.length < MIN_PASSWORD_LENGTH) {
-      setError(`Password must be at least ${MIN_PASSWORD_LENGTH} characters.`);
-      return;
-    }
-
     setIsUnlocking(true);
+
     try {
       if (!wallets.length) {
-        throw new Error("No wallets found.");
+        throw new Error("No wallets found. Please create or import a wallet first.");
       }
+      
       const walletId = wallets[0].id;
       await unlockWallet(walletId, password);
       navigate(PATHS.SUCCESS);
     } catch (err) {
       console.error("Error unlocking wallet:", err);
-      setError("Invalid password. Please try again.");
+      
+      // Re-throw error so UnlockScreen can handle it
+      throw new Error(
+        err instanceof Error && err.message.includes("No wallets")
+          ? err.message
+          : "Invalid password. Please try again."
+      );
     } finally {
       setIsUnlocking(false);
     }
   };
 
   return (
-    <div className="flex flex-col h-full" role="main" aria-labelledby="unlock-wallet-title">
-      <div className="flex-grow flex items-center justify-center p-4">
-        <div className="w-full max-w-md bg-white rounded-lg shadow-md p-6">
-          <h1 id="unlock-wallet-title" className="text-3xl mb-5 flex justify-between items-center">
-            <span className="font-bold">XCP Wallet</span>
-            <span className="text-base font-normal text-gray-500">v0.0.1</span>
-          </h1>
-          <form onSubmit={handleSubmit} className="space-y-4">
-            <PasswordInput
-              name="password"
-              placeholder="Enter your password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              disabled={isUnlocking}
-              innerRef={passwordInputRef}
-            />
-            {error && (
-              <p className="text-red-500 text-sm" role="alert">
-                {error}
-              </p>
-            )}
-            <Button type="submit" fullWidth disabled={isUnlocking} aria-label="Unlock Wallet">
-              {isUnlocking ? "Unlocking..." : "Unlock"}
-            </Button>
-          </form>
-        </div>
-      </div>
-    </div>
+    <UnlockScreen
+      title="XCP Wallet"
+      subtitle="v0.0.1"
+      onUnlock={handleUnlock}
+      error={error}
+      isSubmitting={isUnlocking}
+      placeholder="Enter your password"
+      submitText="Unlock"
+    />
   );
 };
 

--- a/src/pages/auth/unlock-wallet.tsx
+++ b/src/pages/auth/unlock-wallet.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { FiHelpCircle } from "react-icons/fi";
-import { UnlockScreen } from "@/components/screens/unlock-screen";
+import { Button } from "@/components/button";
+import { PasswordInput } from "@/components/inputs/password-input";
 import { useHeader } from "@/contexts/header-context";
 import { useWallet } from "@/contexts/wallet-context";
 
@@ -13,11 +14,14 @@ const UnlockWallet = () => {
   const { setHeaderProps } = useHeader();
   const [isUnlocking, setIsUnlocking] = useState(false);
   const [error, setError] = useState<string | undefined>();
+  const [password, setPassword] = useState("");
+  const passwordInputRef = useRef<HTMLInputElement>(null);
 
   const PATHS = {
     SUCCESS: "/index",
     HELP_URL: "https://youtube.com", // Replace with actual help URL
   } as const;
+  const MIN_PASSWORD_LENGTH = 8;
 
   useEffect(() => {
     setHeaderProps({
@@ -30,45 +34,68 @@ const UnlockWallet = () => {
     });
   }, [setHeaderProps]);
 
-  /**
-   * Handle password unlock
-   */
-  const handleUnlock = async (password: string): Promise<void> => {
-    setError(undefined);
-    setIsUnlocking(true);
+  useEffect(() => {
+    passwordInputRef.current?.focus();
+  }, []);
 
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(undefined);
+
+    if (!password) {
+      setError("Password cannot be empty.");
+      return;
+    }
+    if (password.length < MIN_PASSWORD_LENGTH) {
+      setError(`Password must be at least ${MIN_PASSWORD_LENGTH} characters.`);
+      return;
+    }
+
+    setIsUnlocking(true);
     try {
       if (!wallets.length) {
-        throw new Error("No wallets found. Please create or import a wallet first.");
+        throw new Error("No wallets found.");
       }
-      
       const walletId = wallets[0].id;
       await unlockWallet(walletId, password);
       navigate(PATHS.SUCCESS);
     } catch (err) {
       console.error("Error unlocking wallet:", err);
-      
-      // Re-throw error so UnlockScreen can handle it
-      throw new Error(
-        err instanceof Error && err.message.includes("No wallets")
-          ? err.message
-          : "Invalid password. Please try again."
-      );
+      setError("Invalid password. Please try again.");
     } finally {
       setIsUnlocking(false);
     }
   };
 
   return (
-    <UnlockScreen
-      title="Welcome Back"
-      subtitle="Enter your password to unlock your XCP Wallet"
-      onUnlock={handleUnlock}
-      error={error}
-      isSubmitting={isUnlocking}
-      showLockIcon
-      className="h-screen"
-    />
+    <div className="flex flex-col h-full" role="main" aria-labelledby="unlock-wallet-title">
+      <div className="flex-grow flex items-center justify-center p-4">
+        <div className="w-full max-w-md bg-white rounded-lg shadow-md p-6">
+          <h1 id="unlock-wallet-title" className="text-3xl mb-5 flex justify-between items-center">
+            <span className="font-bold">XCP Wallet</span>
+            <span className="text-base font-normal text-gray-500">v0.0.1</span>
+          </h1>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <PasswordInput
+              name="password"
+              placeholder="Enter your password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              disabled={isUnlocking}
+              innerRef={passwordInputRef}
+            />
+            {error && (
+              <p className="text-red-500 text-sm" role="alert">
+                {error}
+              </p>
+            )}
+            <Button type="submit" fullWidth disabled={isUnlocking} aria-label="Unlock Wallet">
+              {isUnlocking ? "Unlocking..." : "Unlock"}
+            </Button>
+          </form>
+        </div>
+      </div>
+    </div>
   );
 };
 


### PR DESCRIPTION
- Remove complex UnlockScreen component usage
- Restore simple, clean design with "XCP Wallet" title and version
- Direct password form without extra styling/icons
- White box on simple background as in original
- Keep functionality while simplifying the UI
- Maintains auto-focus and validation as before

The UnlockScreen component added too much complexity and changed the simple, clean aesthetic that was originally intended.