### PR TITLE
Correct Wallet Limits

### DIFF
--- a/src/pages/wallet/add-wallet.tsx
+++ b/src/pages/wallet/add-wallet.tsx
@@ -6,8 +6,7 @@ import { Button } from '@/components/button';
 import { useHeader } from '@/contexts/header-context';
 import { ErrorAlert } from '@/components/error-alert';
 import { useWallet } from '@/contexts/wallet-context';
-
-const MAX_WALLETS = 20;
+import { MAX_WALLETS } from '@/utils/wallet/walletManager';
 
 /**
  * AddWallet component provides options for creating or importing a wallet.

--- a/src/pages/wallet/select-wallet.tsx
+++ b/src/pages/wallet/select-wallet.tsx
@@ -6,6 +6,7 @@ import { WalletList } from '@/components/lists/wallet-list';
 import { useHeader } from '@/contexts/header-context';
 import { useWallet } from '@/contexts/wallet-context';
 import { ErrorAlert } from '@/components/error-alert';
+import { MAX_WALLETS } from '@/utils/wallet/walletManager';
 import type { Wallet } from '@/utils/wallet';
 
 /**
@@ -13,7 +14,7 @@ import type { Wallet } from '@/utils/wallet';
  *
  * Features:
  * - Displays a list of wallets for selection
- * - Provides an option to add a new wallet with a limit of 10
+ * - Provides an option to add a new wallet with a limit of 20
  * - Navigates to the index on wallet selection
  */
 function SelectWallet() {
@@ -22,13 +23,12 @@ function SelectWallet() {
   const { wallets, activeWallet, setActiveWallet } = useWallet();
   const [error, setError] = useState<string | null>(null);
 
-  // Constants for paths and limits
+  // Constants for paths
   const PATHS = {
     BACK: '/',
     ADD_WALLET: '/add-wallet',
     INDEX: '/index',
   } as const;
-  const MAX_WALLETS = 10;
 
   const handleAddWallet = useCallback(() => {
     if (wallets.length >= MAX_WALLETS) {

--- a/src/utils/wallet/walletManager.ts
+++ b/src/utils/wallet/walletManager.ts
@@ -28,8 +28,8 @@ export interface Wallet {
   addresses: Address[];
 }
 
-const MAX_WALLETS = 20;
-const MAX_ADDRESSES_PER_WALLET = 100;
+export const MAX_WALLETS = 20;
+export const MAX_ADDRESSES_PER_WALLET = 100;
 
 export class WalletManager {
   private wallets: Wallet[] = [];


### PR DESCRIPTION
- Export MAX_ADDRESSES_PER_WALLET (100) and MAX_WALLETS (20) constants from walletManager
- Fix select-address screen to use MAX_ADDRESSES_PER_WALLET instead of hardcoded 20
- Fix select-wallet screen to use MAX_WALLETS instead of hardcoded 10
- Add isAddingAddress loading state to prevent spam-clicking that bypasses limits
- Update UI to show loading state while adding addresses

The slowness when adding addresses is due to storage operations but this is necessary for persistence.