### PR TITLE
Wallet Session Restoration

### DIFF
--- a/src/pages/auth/unlock-wallet.tsx
+++ b/src/pages/auth/unlock-wallet.tsx
@@ -9,7 +9,7 @@ import { useWallet } from "@/contexts/wallet-context";
 
 const UnlockWallet = () => {
   const navigate = useNavigate();
-  const { unlockWallet, wallets } = useWallet();
+  const { unlockWallet, wallets, activeWallet } = useWallet();
   const { setHeaderProps } = useHeader();
   const [isUnlocking, setIsUnlocking] = useState(false);
   const [error, setError] = useState<string | undefined>();
@@ -41,9 +41,11 @@ const UnlockWallet = () => {
       if (!wallets.length) {
         throw new Error("No wallets found. Please create or import a wallet first.");
       }
-      
-      const walletId = wallets[0].id;
-      await unlockWallet(walletId, password);
+
+      // Unlock the previously active wallet if it exists, otherwise the first wallet
+      // This preserves the user's last active wallet selection after session timeout
+      const walletToUnlock = activeWallet || wallets[0];
+      await unlockWallet(walletToUnlock.id, password);
       navigate(PATHS.SUCCESS);
     } catch (err) {
       console.error("Error unlocking wallet:", err);

--- a/src/utils/wallet/walletManager.ts
+++ b/src/utils/wallet/walletManager.ts
@@ -372,8 +372,14 @@ export class WalletManager {
         wallet.addresses = [this.deriveAddressFromPrivateKey(privKeyData, wallet.addressFormat)];
         wallet.addressCount = 1;
       }
-      this.activeWalletId = walletId;
-      
+
+      // Don't override the active wallet when unlocking
+      // The active wallet should be preserved from settings (lastActiveWalletId)
+      // Only set it if there's no active wallet yet
+      if (!this.activeWalletId) {
+        this.activeWalletId = walletId;
+      }
+
       // Initialize session with timeout from settings
       const settings = await settingsManager.getSettings();
       const timeout = settings?.autoLockTimeout || 5 * 60 * 1000; // Default 5 minutes


### PR DESCRIPTION
When a session expires and the user logs back in, the previously active wallet is now restored instead of always switching to the first wallet.

Changes:
- unlock-wallet.tsx: Unlock the previously active wallet instead of always wallets[0]
- walletManager.ts: Don't override activeWalletId when unlocking a wallet