### PR TITLE
Remove React Idle Timer Dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "react": "19.1.1",
         "react-dom": "19.1.1",
         "react-icons": "5.5.0",
-        "react-idle-timer": "5.7.2",
         "react-intersection-observer": "9.16.0",
         "react-router-dom": "7.9.0",
         "webext-bridge": "6.0.1"
@@ -6864,15 +6863,6 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "*"
-      }
-    },
-    "node_modules/react-idle-timer": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/react-idle-timer/-/react-idle-timer-5.7.2.tgz",
-      "integrity": "sha512-+BaPfc7XEUU5JFkwZCx6fO1bLVK+RBlFH+iY4X34urvIzZiZINP6v2orePx3E6pAztJGE7t4DzvL7if2SL/0GQ==",
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
       }
     },
     "node_modules/react-intersection-observer": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "react": "19.1.1",
     "react-dom": "19.1.1",
     "react-icons": "5.5.0",
-    "react-idle-timer": "5.7.2",
     "react-intersection-observer": "9.16.0",
     "react-router-dom": "7.9.0",
     "webext-bridge": "6.0.1"

--- a/src/contexts/app-providers.tsx
+++ b/src/contexts/app-providers.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, type ReactNode, type ReactElement } from 'react';
-import { IdleTimerProvider } from 'react-idle-timer';
 import { ErrorBoundary } from '@/components/error-boundary';
 import { HeaderProvider } from './header-context';
 import { LoadingProvider } from './loading-context';
@@ -8,6 +7,7 @@ import { SettingsProvider } from './settings-context';
 import { WalletProvider } from './wallet-context';
 import { useWallet } from './wallet-context';
 import { useSettings } from './settings-context';
+import { useIdleTimer } from '@/hooks/useIdleTimer';
 
 /**
  * Props for the AppProviders component.
@@ -51,22 +51,16 @@ function IdleTimerWrapper({ children }: { children: ReactNode }): ReactElement |
   // Disable idle timer if timeout is 0 or undefined
   const isIdleTimerEnabled = settings.autoLockTimeout && settings.autoLockTimeout > 0;
 
-  if (!isIdleTimerEnabled) {
-    // If idle timer is disabled, just render children
-    return <>{children}</>;
-  }
+  // Use native idle timer hook
+  useIdleTimer({
+    timeout: settings.autoLockTimeout || 0,
+    onIdle: handleIdle,
+    onActive: handleAction,
+    disabled: !isIdleTimerEnabled || authState !== 'UNLOCKED',
+    stopOnIdle: true,
+  });
 
-  return (
-    <IdleTimerProvider
-      timeout={settings.autoLockTimeout}
-      onAction={handleAction}
-      onIdle={handleIdle}
-      disabled={authState !== 'UNLOCKED'} // Disable timer when not unlocked
-      stopOnIdle={true} // Stop timer when idle to save resources
-    >
-      {children}
-    </IdleTimerProvider>
-  );
+  return <>{children}</>;
 }
 
 /**

--- a/src/hooks/useIdleTimer.ts
+++ b/src/hooks/useIdleTimer.ts
@@ -31,7 +31,7 @@ export function useIdleTimer(options: UseIdleTimerOptions) {
   } = options;
 
   const [isIdle, setIsIdle] = useState(false);
-  const timeoutRef = useRef<NodeJS.Timeout>();
+  const timeoutRef = useRef<NodeJS.Timeout | undefined>(undefined);
   const isIdleRef = useRef(false);
   const eventsRef = useRef(events);
   const onIdleRef = useRef(onIdle);

--- a/src/hooks/useIdleTimer.ts
+++ b/src/hooks/useIdleTimer.ts
@@ -1,0 +1,117 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export interface UseIdleTimerOptions {
+  timeout: number;
+  onIdle?: () => void;
+  onActive?: () => void;
+  events?: string[];
+  disabled?: boolean;
+  stopOnIdle?: boolean;
+}
+
+const DEFAULT_EVENTS = [
+  'mousedown',
+  'mousemove',
+  'keydown',
+  'wheel',
+  'touchstart',
+  'touchmove',
+  'scroll',
+  'resize',
+];
+
+export function useIdleTimer(options: UseIdleTimerOptions) {
+  const {
+    timeout,
+    onIdle,
+    onActive,
+    events = DEFAULT_EVENTS,
+    disabled = false,
+    stopOnIdle = false,
+  } = options;
+
+  const [isIdle, setIsIdle] = useState(false);
+  const timeoutRef = useRef<NodeJS.Timeout>();
+  const isIdleRef = useRef(false);
+  const eventsRef = useRef(events);
+  const onIdleRef = useRef(onIdle);
+  const onActiveRef = useRef(onActive);
+
+  // Update refs when callbacks change
+  useEffect(() => {
+    onIdleRef.current = onIdle;
+    onActiveRef.current = onActive;
+  }, [onIdle, onActive]);
+
+  const reset = useCallback(() => {
+    if (disabled) return;
+
+    clearTimeout(timeoutRef.current);
+
+    if (isIdleRef.current) {
+      isIdleRef.current = false;
+      setIsIdle(false);
+      onActiveRef.current?.();
+    }
+
+    timeoutRef.current = setTimeout(() => {
+      isIdleRef.current = true;
+      setIsIdle(true);
+      onIdleRef.current?.();
+    }, timeout);
+  }, [timeout, disabled]);
+
+  const handleActivity = useCallback(() => {
+    if (disabled) return;
+    if (stopOnIdle && isIdleRef.current) return;
+    reset();
+  }, [reset, disabled, stopOnIdle]);
+
+  useEffect(() => {
+    if (disabled) {
+      clearTimeout(timeoutRef.current);
+      return;
+    }
+
+    // Start the timer
+    reset();
+
+    // Add event listeners
+    eventsRef.current.forEach(event => {
+      window.addEventListener(event, handleActivity);
+    });
+
+    // Cleanup
+    return () => {
+      clearTimeout(timeoutRef.current);
+      eventsRef.current.forEach(event => {
+        window.removeEventListener(event, handleActivity);
+      });
+    };
+  }, [handleActivity, reset, disabled]);
+
+  // Update events if they change
+  useEffect(() => {
+    const oldEvents = eventsRef.current;
+    const newEvents = events;
+
+    // Remove old event listeners
+    const eventsToRemove = oldEvents.filter(e => !newEvents.includes(e));
+    eventsToRemove.forEach(event => {
+      window.removeEventListener(event, handleActivity);
+    });
+
+    // Add new event listeners
+    const eventsToAdd = newEvents.filter(e => !oldEvents.includes(e));
+    eventsToAdd.forEach(event => {
+      window.addEventListener(event, handleActivity);
+    });
+
+    eventsRef.current = newEvents;
+  }, [events, handleActivity]);
+
+  return {
+    isIdle,
+    reset,
+  };
+}


### PR DESCRIPTION
- Created custom useIdleTimer hook to replace react-idle-timer dependency
- Updated app-providers.tsx to use the native hook
- Removed react-idle-timer from package.json dependencies
- Maintains same functionality with reduced bundle size