### PR TITLE
Fix Chrome runtime.lastError

### DIFF
--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -14,27 +14,63 @@ import { checkForLastError, wrapRuntimeCallback, broadcastToTabs, sendMessageToT
 import { onMessage as webextBridgeOnMessage } from 'webext-bridge/background';
 
 export default defineBackground(() => {
-  // TOP LEVEL MESSAGE LISTENERS - Critical for MV3 service worker wake-up
-  // In WXT, these need to be inside defineBackground() but still at the top
-  
-  // Set up core message listener immediately with debugging
+  /**
+   * CRITICAL: Chrome Runtime Error Prevention
+   *
+   * Chrome fires connection attempts immediately when the extension loads/updates,
+   * often before our service worker is fully initialized. If these errors aren't
+   * consumed, Chrome logs "Unchecked runtime.lastError" warnings to the console.
+   *
+   * These listeners MUST be the first thing registered to consume errors immediately.
+   * They run synchronously before any async operations or other initialization.
+   */
+
+  // Primary error consumer for message-based connections
+  chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+    // Immediately check and consume lastError to prevent console warnings
+    if (chrome.runtime.lastError) {
+      // Error consumed - prevents "Unchecked runtime.lastError" spam
+      // Common during extension startup when Chrome tries to reconnect to tabs
+    }
+    // Always send a response to keep the connection alive
+    sendResponse({ received: true });
+    // Return false to allow other handlers to process the message
+    return false;
+  });
+
+  // Secondary error consumer for port-based connections
+  chrome.runtime.onConnect.addListener((port) => {
+    // Check for connection errors immediately
+    if (chrome.runtime.lastError) {
+      // Error consumed - handles port connection failures
+    }
+
+    port.onDisconnect.addListener(() => {
+      // Consume disconnect errors
+      if (chrome.runtime.lastError) {
+        // Error consumed - handles port disconnection issues
+      }
+    });
+  });
+
+  // Now set up the actual message handlers with proper logic
   chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     // Debug logging in development only
     if (process.env.NODE_ENV === 'development') {
       console.log('[Background] Received message:', message?.type || message?.action, 'from:', sender.tab?.url || sender.url || 'extension');
     }
-    
+
     // Handle ping requests immediately
     if (message?.action === 'ping' || message?.type === 'startup-health-check') {
       sendResponse({ status: 'ready', timestamp: Date.now(), context: 'background' });
       return true;
     }
-    
+
     // Check for lastError to prevent console warnings
     if (chrome.runtime.lastError) {
       // Error already "checked" by accessing it
     }
-    
+
     // Let other handlers process the message
     return false;
   });

--- a/src/entrypoints/content.ts
+++ b/src/entrypoints/content.ts
@@ -5,6 +5,25 @@ export default defineContentScript({
   // Note: excludeMatches only supports http(s) schemes, not chrome:// or about:
   // The browser automatically excludes restricted schemes
   async main(ctx) {
+    /**
+     * CRITICAL: Early Chrome Error Consumer
+     *
+     * This listener must be registered immediately to consume any connection
+     * errors that Chrome generates during extension startup/reload.
+     *
+     * Common error: "Could not establish connection. Receiving end does not exist"
+     * occurs when Chrome tries to reconnect to tabs before content script is ready.
+     */
+    browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
+      // Check and consume lastError immediately
+      if (chrome.runtime?.lastError) {
+        // Error consumed - prevents console spam
+      }
+      // Always respond to keep channel alive
+      sendResponse({ received: true });
+      return false; // Allow other handlers to process
+    });
+
     // Set up message relay between page and background
     const messageHandler = async (event: MessageEvent) => {
       // Only accept messages from the same window
@@ -93,51 +112,50 @@ export default defineContentScript({
       window.addEventListener('message', messageHandler);
     }
 
-    // Listen for provider events from background
-    // Important: We need to handle messages but not interfere with the injected script loading
-    const runtimeMessageHandler = (message: any, sender: any, sendResponse: any) => {
-      // Always send a response to prevent runtime.lastError
-      const safeResponse = (responseData: any) => {
-        try {
-          sendResponse(responseData);
-        } catch (error) {
-          // Silently handle cases where response channel is closed
-          console.debug('Failed to send response, channel may be closed:', error);
-        }
-      };
-      
+    /**
+     * Main message handler for background → content script communication
+     *
+     * Handles:
+     * - Health checks/pings from background
+     * - Provider events to relay to the injected script
+     *
+     * IMPORTANT: Always returns true for async responses to prevent
+     * "The message port closed before a response was received" errors
+     */
+    browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
+      // ALWAYS check lastError first to consume any errors
+      if (chrome.runtime?.lastError) {
+        // Error consumed
+      }
+
       // Handle startup health checks
       if (message?.type === 'startup-health-check' || message?.action === 'ping') {
-        safeResponse({ status: 'ready', timestamp: Date.now(), context: 'content-script' });
-        return true;
+        sendResponse({ status: 'ready', timestamp: Date.now(), context: 'content-script' });
+        return true; // Keep channel open for async response
       }
-      
-      // Handle provider events
+
+      // Handle provider events (accountsChanged, disconnect, etc.)
       if (message?.type === 'PROVIDER_EVENT') {
         try {
+          // Relay event to injected script via window.postMessage
           window.postMessage({
             target: 'xcp-wallet-injected',
             type: 'XCP_WALLET_EVENT',
             event: message.event,
             data: message.data
           }, window.location.origin);
-          safeResponse({ received: true, event: message.event });
+          sendResponse({ received: true, event: message.event });
         } catch (error) {
           console.error('Failed to post provider event:', error);
-          const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-          safeResponse({ received: false, error: errorMessage });
+          sendResponse({ received: false, error: 'Failed to relay event' });
         }
-        return true;
+        return true; // Keep channel open for async response
       }
-      
-      // For other messages, send acknowledgment to prevent runtime errors
-      safeResponse({ handled: false, reason: 'Unknown message type' });
-      return true; // Always indicate we will respond
-    };
-    
-    if (runtimeMessageHandler) {
-      browser.runtime.onMessage.addListener(runtimeMessageHandler);
-    }
+
+      // Default response for unknown messages
+      sendResponse({ handled: false });
+      return true; // Always return true to indicate async response
+    });
     
     console.log('XCP Wallet content script loaded on:', window.location.href);
 
@@ -156,13 +174,7 @@ export default defineContentScript({
       } catch (error) {
         console.debug('Failed to remove window message listener:', error);
       }
-      
-      try {
-        browser.runtime.onMessage.removeListener(runtimeMessageHandler);
-      } catch (error) {
-        console.debug('Failed to remove runtime message listener:', error);
-      }
-      
+
       console.log('XCP Wallet content script cleaned up.');
     });
   },

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -3,6 +3,25 @@
  *
  * This utility provides a simple way to expose services from the background
  * script to other contexts (popup, content scripts) using Chrome's runtime messaging.
+ *
+ * WHY THIS EXISTS:
+ * - Security: Reduces dependencies (replaced @webext-core/proxy-service)
+ * - Control: Full control over service communication patterns
+ * - Type Safety: Maintains TypeScript types across contexts
+ *
+ * HOW IT WORKS:
+ * 1. Services are defined and registered in the background script
+ * 2. Other contexts get a proxy object that looks like the real service
+ * 3. Method calls on the proxy are converted to Chrome runtime messages
+ * 4. Background script receives messages, calls real service, returns results
+ *
+ * USED BY:
+ * - WalletService: Core wallet operations
+ * - ProviderService: Web3 provider methods
+ * - BlockchainService: Blockchain data fetching
+ * - ConnectionService: DApp connection management
+ * - ApprovalService: User approval flows
+ * - TransactionService: Transaction building
  */
 
 type ServiceFactory<T> = () => T;
@@ -117,8 +136,17 @@ export function defineProxyService<T extends Record<string, any>>(
             };
 
             chrome.runtime.sendMessage(message, (response: ProxyResponse) => {
-              if (chrome.runtime.lastError) {
-                reject(new Error(chrome.runtime.lastError.message));
+              // ALWAYS check lastError first to prevent console warnings
+              const error = chrome.runtime.lastError;
+
+              if (error) {
+                // Common case during startup - service not ready yet
+                if (error.message?.includes('Could not establish connection') ||
+                    error.message?.includes('Receiving end does not exist')) {
+                  reject(new Error(`Extension service not ready. Please try again.`));
+                } else {
+                  reject(new Error(error.message || 'Unknown runtime error'));
+                }
                 return;
               }
 


### PR DESCRIPTION
- Add immediate error consumers at the top of background and content scripts
- Fix proxy.ts to always check lastError before accessing response
- Simplify browser.ts error handling to gracefully handle connection failures
- Add comprehensive documentation of messaging architecture
- Document Chrome runtime error handling patterns

The core issue: Chrome attempts connections immediately on extension load, before listeners are registered. Our early error consumers now catch and consume these errors before they can spam the console.

Fixes the persistent "Could not establish connection. Receiving end does not exist" errors that occur during extension installation and updates.