### PR TITLE
Replace Drag and Drop

### DIFF
--- a/src/components/cards/pinnable-asset-card.tsx
+++ b/src/components/cards/pinnable-asset-card.tsx
@@ -1,5 +1,6 @@
 import { type ReactElement } from "react";
 import { TbPinned, TbPinnedFilled } from "react-icons/tb";
+import { FiChevronUp, FiChevronDown } from "react-icons/fi";
 import { AssetIcon } from "@/components/asset-icon";
 
 /**
@@ -12,8 +13,12 @@ interface PinnableAssetCardProps {
   isPinned: boolean;
   /** Handler for pin/unpin toggle */
   onPinToggle: (symbol: string) => void;
-  /** Whether the card is being dragged (for drag and drop support) */
-  isDragging?: boolean;
+  /** Whether to show up/down arrows */
+  showArrows?: boolean;
+  /** Handler for moving up */
+  onMoveUp?: () => void;
+  /** Handler for moving down */
+  onMoveDown?: () => void;
   /** Optional click handler for the card itself */
   onClick?: (symbol: string) => void;
   /** Optional custom CSS classes */
@@ -29,7 +34,7 @@ interface PinnableAssetCardProps {
  * Features:
  * - Asset icon and symbol display
  * - Pin/unpin toggle button with visual feedback
- * - Drag and drop support via isDragging prop
+ * - Optional up/down arrow buttons for reordering
  * - Simplified design focused on pinning functionality
  * 
  * @param props - The component props
@@ -41,7 +46,9 @@ interface PinnableAssetCardProps {
  *   symbol="XCP"
  *   isPinned={true}
  *   onPinToggle={handlePinToggle}
- *   isDragging={false}
+ *   showArrows={true}
+ *   onMoveUp={handleMoveUp}
+ *   onMoveDown={handleMoveDown}
  * />
  * ```
  */
@@ -49,7 +56,9 @@ export function PinnableAssetCard({
   symbol,
   isPinned,
   onPinToggle,
-  isDragging = false,
+  showArrows = false,
+  onMoveUp,
+  onMoveDown,
   onClick,
   className = ""
 }: PinnableAssetCardProps): ReactElement {
@@ -67,9 +76,7 @@ export function PinnableAssetCard({
 
   return (
     <div
-      className={`flex items-center justify-between p-3 bg-white rounded-lg shadow-sm hover:bg-gray-50 ${
-        isDragging ? "shadow-lg opacity-90" : ""
-      } ${onClick ? "cursor-pointer" : ""} ${className}`}
+      className={`flex items-center justify-between p-3 bg-white rounded-lg shadow-sm hover:bg-gray-50 ${onClick ? "cursor-pointer" : ""} ${className}`}
       onClick={handleCardClick}
       role={onClick ? "button" : undefined}
       tabIndex={onClick ? 0 : undefined}
@@ -88,23 +95,66 @@ export function PinnableAssetCard({
         </div>
       </div>
 
-      {/* Pin/Unpin Button */}
-      <button
-        onClick={handlePinClick}
-        className={`p-2 rounded-md transition-all hover:scale-110 ${
-          isPinned 
-            ? "bg-blue-500 text-white hover:bg-blue-600" 
-            : "bg-gray-100 text-gray-600 hover:bg-gray-200"
-        }`}
-        aria-label={isPinned ? `Unpin ${symbol}` : `Pin ${symbol}`}
-        title={isPinned ? "Unpin asset" : "Pin asset"}
-      >
-        {isPinned ? (
-          <TbPinnedFilled className="w-4 h-4" />
-        ) : (
-          <TbPinned className="w-4 h-4" />
+      {/* Right side controls */}
+      <div className="flex items-center gap-1">
+        {/* Up/Down arrows */}
+        {showArrows && (
+          <div className="flex items-center gap-0.5">
+            <button
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                onMoveUp?.();
+              }}
+              disabled={!onMoveUp}
+              className={`p-1 rounded transition-all ${
+                !onMoveUp
+                  ? "text-gray-300 cursor-not-allowed"
+                  : "text-gray-600 hover:text-blue-600 hover:bg-blue-50"
+              }`}
+              aria-label={`Move ${symbol} up`}
+              title="Move up"
+            >
+              <FiChevronUp className="w-4 h-4" />
+            </button>
+            <button
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                onMoveDown?.();
+              }}
+              disabled={!onMoveDown}
+              className={`p-1 rounded transition-all ${
+                !onMoveDown
+                  ? "text-gray-300 cursor-not-allowed"
+                  : "text-gray-600 hover:text-blue-600 hover:bg-blue-50"
+              }`}
+              aria-label={`Move ${symbol} down`}
+              title="Move down"
+            >
+              <FiChevronDown className="w-4 h-4" />
+            </button>
+          </div>
         )}
-      </button>
+
+        {/* Pin/Unpin Button */}
+        <button
+          onClick={handlePinClick}
+          className={`p-2 rounded-md transition-all hover:scale-110 ${
+            isPinned
+              ? "bg-blue-500 text-white hover:bg-blue-600"
+              : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+          }`}
+          aria-label={isPinned ? `Unpin ${symbol}` : `Pin ${symbol}`}
+          title={isPinned ? "Unpin asset" : "Pin asset"}
+        >
+          {isPinned ? (
+            <TbPinnedFilled className="w-4 h-4" />
+          ) : (
+            <TbPinned className="w-4 h-4" />
+          )}
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/pages/settings/pinned-assets-settings.tsx
+++ b/src/pages/settings/pinned-assets-settings.tsx
@@ -3,7 +3,6 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import { FiHelpCircle, FiChevronUp, FiChevronDown } from "react-icons/fi";
-import { useDragAndDrop } from "@/hooks/useDragAndDrop";
 import { Button } from "@/components/button";
 import { SearchInput } from "@/components/inputs/search-input";
 import { PinnableAssetCard } from "@/components/cards/pinnable-asset-card";
@@ -30,7 +29,7 @@ const CONSTANTS = {
  * Features:
  * - Search for assets to pin
  * - Pin/unpin assets
- * - Reorder pinned assets via drag and drop
+ * - Reorder pinned assets via up/down arrows
  * - Limit of 10 pinned assets
  *
  * @returns {ReactElement} The rendered pinned assets settings UI.
@@ -137,21 +136,6 @@ export default function PinnedAssetsSettings(): ReactElement {
     await handleReorder(newPinnedAssets);
   };
 
-  const {
-    draggedIndex,
-    dragOverIndex,
-    isDragging,
-    ghostPosition,
-    handleDragStart,
-    handleDragEnter,
-    handleDragOver,
-    handleDragEnd,
-    handleDrop,
-    handleDragLeave,
-  } = useDragAndDrop({
-    items: pinnedAssets,
-    onReorder: handleReorder,
-  });
 
 
   const SearchItemComponent = ({ asset }: { asset: { symbol: string } }): ReactElement => {
@@ -175,77 +159,18 @@ export default function PinnedAssetsSettings(): ReactElement {
   };
 
   const PinnedItemComponent = ({ symbol, index }: { symbol: string; index: number }): ReactElement => {
-    const isBeingDragged = draggedIndex === index;
-    const isDragOver = dragOverIndex === index;
-    const showDropIndicator = isDragOver && draggedIndex !== null && draggedIndex !== index;
     const isFirst = index === 0;
     const isLast = index === pinnedAssets.length - 1;
 
     return (
-      <div className="relative group">
-        {/* Drop indicator - shows where the item will be placed */}
-        {showDropIndicator && (
-          <div className="absolute -top-1 left-0 right-0 h-1 bg-blue-500 rounded-full z-10 animate-pulse" />
-        )}
-
-        <div className="flex items-center gap-2">
-          {/* Main draggable card */}
-          <div
-            draggable
-            onDragStart={(e) => handleDragStart(e, index)}
-            onDragEnter={(e) => handleDragEnter(e, index)}
-            onDragOver={(e) => handleDragOver(e, index)}
-            onDrop={(e) => handleDrop(e, index)}
-            onDragEnd={handleDragEnd}
-            onDragLeave={handleDragLeave}
-            className={`flex-1 cursor-move transition-all duration-200 ${
-              isBeingDragged ? "opacity-30 scale-95" : ""
-            } ${
-              showDropIndicator ? "transform translate-y-1" : ""
-            }`}
-            style={{
-              transition: isDragging ? 'all 0.2s ease' : 'none',
-            }}
-          >
-            <PinnableAssetCard
-              symbol={symbol}
-              isPinned={true}
-              isDragging={isBeingDragged}
-              onPinToggle={handleRemoveAsset}
-            />
-          </div>
-
-          {/* Up/Down arrow buttons - shown on hover or always on mobile */}
-          <div className="flex flex-col gap-1 opacity-0 group-hover:opacity-100 transition-opacity touch:opacity-100">
-            <button
-              onClick={() => moveAsset(index, 'up')}
-              disabled={isFirst}
-              className={`p-1 rounded transition-all ${
-                isFirst
-                  ? "text-gray-300 cursor-not-allowed"
-                  : "text-gray-600 hover:text-blue-600 hover:bg-blue-50"
-              }`}
-              aria-label={`Move ${symbol} up`}
-              title="Move up"
-            >
-              <FiChevronUp className="w-4 h-4" />
-            </button>
-            <button
-              onClick={() => moveAsset(index, 'down')}
-              disabled={isLast}
-              className={`p-1 rounded transition-all ${
-                isLast
-                  ? "text-gray-300 cursor-not-allowed"
-                  : "text-gray-600 hover:text-blue-600 hover:bg-blue-50"
-              }`}
-              aria-label={`Move ${symbol} down`}
-              title="Move down"
-            >
-              <FiChevronDown className="w-4 h-4" />
-            </button>
-          </div>
-        </div>
-      </div>
+      <PinnableAssetCard
+        symbol={symbol}
+        isPinned={true}
+        onPinToggle={handleRemoveAsset}
+        showArrows={true}
+        onMoveUp={!isFirst ? () => moveAsset(index, 'up') : undefined}
+        onMoveDown={!isLast ? () => moveAsset(index, 'down') : undefined}
+      />
     );
   };
 
@@ -279,7 +204,7 @@ export default function PinnedAssetsSettings(): ReactElement {
             <h3 className="text-lg font-semibold mb-2">Pinned</h3>
             {showHelpText && (
               <p className="text-sm text-gray-500 mb-2">
-                Pin up to 10 assets to the top of your main screen. Drag to reorder or use arrow buttons.
+                Pin up to 10 assets to the top of your main screen. Use arrow buttons to reorder.
               </p>
             )}
             <div className="space-y-2">
@@ -324,26 +249,6 @@ export default function PinnedAssetsSettings(): ReactElement {
         </div>
       </div>
 
-      {/* Ghost element that follows cursor while dragging */}
-      {isDragging && ghostPosition && draggedIndex !== null && pinnedAssets[draggedIndex] && (
-        <div
-          className="fixed pointer-events-none z-50 opacity-80"
-          style={{
-            left: `${ghostPosition.x + 10}px`,
-            top: `${ghostPosition.y - 20}px`,
-            transform: 'rotate(2deg)',
-          }}
-        >
-          <div className="bg-white rounded-lg shadow-2xl p-3 border border-blue-300">
-            <PinnableAssetCard
-              symbol={pinnedAssets[draggedIndex]}
-              isPinned={true}
-              onPinToggle={() => {}}
-              className="min-w-[200px]"
-            />
-          </div>
-        </div>
-      )}
     </div>
   );
 } 


### PR DESCRIPTION
- Remove drag-and-drop functionality from pinned assets settings
- Add up/down arrow buttons inside the asset pill component
- Position arrows and pin icon together on the right side
- Simplify component structure and improve maintainability
- Preserve all reordering functionality with cleaner UX