### PR TITLE
Address Type Detection on Import

### DIFF
--- a/src/utils/blockchain/bitcoin/__tests__/addressTypeDetector.test.ts
+++ b/src/utils/blockchain/bitcoin/__tests__/addressTypeDetector.test.ts
@@ -12,11 +12,12 @@ vi.mock('@/utils/blockchain/bitcoin/balance');
 describe('Address Type Detector', () => {
   const testMnemonic = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
 
-  const mockAddresses = {
+  const mockAddresses: Record<AddressFormat, string> = {
     [AddressFormat.P2PKH]: '1LqBGSKuX5yYUonjxT5qGfpUsXKYYWeabA',
     [AddressFormat.P2WPKH]: 'bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu',
     [AddressFormat.P2SH_P2WPKH]: '37VucYSaXLCAsxYyAPfbSi9eh4iEcbShgf',
     [AddressFormat.P2TR]: 'bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr',
+    [AddressFormat.Counterwallet]: '1CounterpartyXXXXXXXXXXXXXXXUWLpVr',
   };
 
   beforeEach(() => {

--- a/src/utils/blockchain/bitcoin/__tests__/addressTypeDetector.test.ts
+++ b/src/utils/blockchain/bitcoin/__tests__/addressTypeDetector.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { detectAddressFormat, detectAddressFormatFromPreviews, getPreviewAddresses } from '@/utils/blockchain/bitcoin/addressTypeDetector';
+import { AddressFormat } from '@/utils/blockchain/bitcoin/address';
+import { fetchTokenBalances } from '@/utils/blockchain/counterparty/api';
+import { hasAddressActivity } from '@/utils/blockchain/bitcoin/balance';
+import * as bitcoinAddress from '@/utils/blockchain/bitcoin/address';
+
+// Mock the external dependencies
+vi.mock('@/utils/blockchain/counterparty/api');
+vi.mock('@/utils/blockchain/bitcoin/balance');
+
+describe('Address Type Detector', () => {
+  const testMnemonic = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+  const mockAddresses = {
+    [AddressFormat.P2PKH]: '1LqBGSKuX5yYUonjxT5qGfpUsXKYYWeabA',
+    [AddressFormat.P2WPKH]: 'bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu',
+    [AddressFormat.P2SH_P2WPKH]: '37VucYSaXLCAsxYyAPfbSi9eh4iEcbShgf',
+    [AddressFormat.P2TR]: 'bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Mock getAddressFromMnemonic to return predictable addresses
+    vi.spyOn(bitcoinAddress, 'getAddressFromMnemonic').mockImplementation(
+      (mnemonic, path, format) => {
+        return mockAddresses[format] || 'mock-address';
+      }
+    );
+  });
+
+  describe('detectAddressFormat', () => {
+    it('should detect P2PKH (Legacy) when it has activity', async () => {
+      vi.mocked(fetchTokenBalances).mockResolvedValue([]);
+      vi.mocked(hasAddressActivity)
+        .mockResolvedValueOnce(true)  // P2PKH has activity
+        .mockResolvedValue(false);
+
+      const result = await detectAddressFormat(testMnemonic);
+      expect(result).toBe(AddressFormat.P2PKH);
+    });
+
+    it('should detect P2WPKH (Native SegWit) when it has activity', async () => {
+      vi.mocked(fetchTokenBalances).mockResolvedValue([]);
+      vi.mocked(hasAddressActivity)
+        .mockResolvedValueOnce(false)  // P2PKH no activity
+        .mockResolvedValueOnce(true)   // P2WPKH has activity
+        .mockResolvedValue(false);
+
+      const result = await detectAddressFormat(testMnemonic);
+      expect(result).toBe(AddressFormat.P2WPKH);
+    });
+
+    it('should detect P2SH_P2WPKH (Nested SegWit) when it has activity', async () => {
+      vi.mocked(fetchTokenBalances).mockResolvedValue([]);
+      vi.mocked(hasAddressActivity)
+        .mockResolvedValueOnce(false)  // P2PKH no activity
+        .mockResolvedValueOnce(false)  // P2WPKH no activity
+        .mockResolvedValueOnce(true)   // P2SH_P2WPKH has activity
+        .mockResolvedValue(false);
+
+      const result = await detectAddressFormat(testMnemonic);
+      expect(result).toBe(AddressFormat.P2SH_P2WPKH);
+    });
+
+    it('should default to P2TR (Taproot) when no activity found', async () => {
+      vi.mocked(fetchTokenBalances).mockResolvedValue([]);
+      vi.mocked(hasAddressActivity).mockResolvedValue(false);
+
+      const result = await detectAddressFormat(testMnemonic);
+      expect(result).toBe(AddressFormat.P2TR);
+    });
+
+    it('should detect based on Counterparty token activity', async () => {
+      // P2PKH address has tokens
+      vi.mocked(fetchTokenBalances)
+        .mockResolvedValueOnce([{ asset: 'XCP', quantity: '100' }] as any)
+        .mockResolvedValue([]);
+      vi.mocked(hasAddressActivity).mockResolvedValue(false);
+
+      const result = await detectAddressFormat(testMnemonic);
+      expect(result).toBe(AddressFormat.P2PKH);
+    });
+
+    it('should prioritize Counterparty activity over Bitcoin activity', async () => {
+      // P2PKH has tokens (will be detected first)
+      vi.mocked(fetchTokenBalances)
+        .mockResolvedValueOnce([{ asset: 'PEPE', quantity: '1000' }] as any)  // P2PKH has tokens
+        .mockResolvedValue([]);
+      vi.mocked(hasAddressActivity).mockResolvedValue(false);
+
+      const result = await detectAddressFormat(testMnemonic);
+      expect(result).toBe(AddressFormat.P2PKH);  // P2PKH checked first and has tokens
+    });
+
+    it('should use cached previews when provided', async () => {
+      const cachedPreviews = {
+        [AddressFormat.P2PKH]: 'cached-p2pkh-address',
+        [AddressFormat.P2WPKH]: 'cached-p2wpkh-address',
+      };
+
+      vi.mocked(fetchTokenBalances).mockResolvedValue([]);
+      vi.mocked(hasAddressActivity)
+        .mockResolvedValueOnce(false)  // cached-p2pkh-address no activity
+        .mockResolvedValueOnce(true);  // cached-p2wpkh-address has activity
+
+      const result = await detectAddressFormat(testMnemonic, cachedPreviews);
+      expect(result).toBe(AddressFormat.P2WPKH);
+
+      // Should not have called getAddressFromMnemonic for cached addresses
+      expect(bitcoinAddress.getAddressFromMnemonic).toHaveBeenCalledTimes(1); // Only for P2SH_P2WPKH
+    });
+
+    it('should handle API failures gracefully', async () => {
+      vi.mocked(fetchTokenBalances).mockRejectedValue(new Error('API failed'));
+      vi.mocked(hasAddressActivity).mockRejectedValue(new Error('API failed'));
+
+      const result = await detectAddressFormat(testMnemonic);
+      expect(result).toBe(AddressFormat.P2TR);
+    });
+
+    it('should skip Taproot checking since it is the fallback', async () => {
+      vi.mocked(fetchTokenBalances).mockResolvedValue([]);
+      vi.mocked(hasAddressActivity).mockResolvedValue(false);
+
+      await detectAddressFormat(testMnemonic);
+
+      // Should only generate 3 addresses (not 4, skipping Taproot)
+      expect(bitcoinAddress.getAddressFromMnemonic).toHaveBeenCalledTimes(3);
+      expect(bitcoinAddress.getAddressFromMnemonic).toHaveBeenCalledWith(
+        testMnemonic,
+        expect.stringContaining("m/44'/0'/0'/0/0"),
+        AddressFormat.P2PKH
+      );
+      expect(bitcoinAddress.getAddressFromMnemonic).toHaveBeenCalledWith(
+        testMnemonic,
+        expect.stringContaining("m/84'/0'/0'/0/0"),
+        AddressFormat.P2WPKH
+      );
+      expect(bitcoinAddress.getAddressFromMnemonic).toHaveBeenCalledWith(
+        testMnemonic,
+        expect.stringContaining("m/49'/0'/0'/0/0"),
+        AddressFormat.P2SH_P2WPKH
+      );
+      // Should NOT call for P2TR
+      expect(bitcoinAddress.getAddressFromMnemonic).not.toHaveBeenCalledWith(
+        testMnemonic,
+        expect.stringContaining("m/86'/0'/0'/0/0"),
+        AddressFormat.P2TR
+      );
+    });
+  });
+
+  describe('detectAddressFormatFromPreviews', () => {
+    it('should detect format from cached previews only', async () => {
+      const previews = {
+        [AddressFormat.P2PKH]: 'preview-p2pkh',
+        [AddressFormat.P2WPKH]: 'preview-p2wpkh',
+        [AddressFormat.P2SH_P2WPKH]: 'preview-p2sh',
+      };
+
+      vi.mocked(fetchTokenBalances).mockResolvedValue([]);
+      vi.mocked(hasAddressActivity)
+        .mockResolvedValueOnce(false)  // P2PKH no activity
+        .mockResolvedValueOnce(true);  // P2WPKH has activity
+
+      const result = await detectAddressFormatFromPreviews(previews);
+      expect(result).toBe(AddressFormat.P2WPKH);
+    });
+
+    it('should skip addresses not in previews', async () => {
+      const previews = {
+        [AddressFormat.P2WPKH]: 'preview-p2wpkh',
+        // P2PKH and P2SH_P2WPKH not provided
+      };
+
+      vi.mocked(fetchTokenBalances).mockResolvedValue([]);
+      vi.mocked(hasAddressActivity).mockResolvedValue(true);
+
+      const result = await detectAddressFormatFromPreviews(previews);
+      expect(result).toBe(AddressFormat.P2WPKH);
+
+      // Should only check the one address provided
+      expect(hasAddressActivity).toHaveBeenCalledTimes(1);
+      expect(hasAddressActivity).toHaveBeenCalledWith('preview-p2wpkh');
+    });
+
+    it('should default to P2TR when no activity found', async () => {
+      const previews = {
+        [AddressFormat.P2PKH]: 'preview-p2pkh',
+        [AddressFormat.P2WPKH]: 'preview-p2wpkh',
+      };
+
+      vi.mocked(fetchTokenBalances).mockResolvedValue([]);
+      vi.mocked(hasAddressActivity).mockResolvedValue(false);
+
+      const result = await detectAddressFormatFromPreviews(previews);
+      expect(result).toBe(AddressFormat.P2TR);
+    });
+  });
+
+  describe('getPreviewAddresses', () => {
+    it('should generate preview addresses for all formats', () => {
+      // Reset mock to use original implementation
+      vi.mocked(bitcoinAddress.getAddressFromMnemonic).mockRestore();
+
+      // Mock it again with implementation that returns format-specific addresses
+      vi.spyOn(bitcoinAddress, 'getAddressFromMnemonic').mockImplementation(
+        (mnemonic, path, format) => mockAddresses[format] || 'unknown'
+      );
+
+      const previews = getPreviewAddresses(testMnemonic);
+
+      expect(previews[AddressFormat.P2PKH]).toBe(mockAddresses[AddressFormat.P2PKH]);
+      expect(previews[AddressFormat.P2WPKH]).toBe(mockAddresses[AddressFormat.P2WPKH]);
+      expect(previews[AddressFormat.P2SH_P2WPKH]).toBe(mockAddresses[AddressFormat.P2SH_P2WPKH]);
+      expect(previews[AddressFormat.P2TR]).toBe(mockAddresses[AddressFormat.P2TR]);
+      expect(previews[AddressFormat.Counterwallet]).toBeDefined();
+    });
+
+    it('should handle address generation failures gracefully', () => {
+      // The order in getPreviewAddresses is: P2PKH, P2SH_P2WPKH, P2WPKH, P2TR, Counterwallet
+      vi.mocked(bitcoinAddress.getAddressFromMnemonic)
+        .mockImplementationOnce(() => mockAddresses[AddressFormat.P2PKH])  // P2PKH succeeds
+        .mockImplementationOnce(() => { throw new Error('Failed to generate'); })  // P2SH_P2WPKH fails
+        .mockImplementation((mnemonic, path, format) => mockAddresses[format] || 'unknown');
+
+      const previews = getPreviewAddresses(testMnemonic);
+
+      expect(previews[AddressFormat.P2PKH]).toBe(mockAddresses[AddressFormat.P2PKH]);
+      expect(previews[AddressFormat.P2SH_P2WPKH]).toBeUndefined(); // Failed
+      expect(previews[AddressFormat.P2WPKH]).toBeDefined();
+    });
+  });
+});

--- a/src/utils/blockchain/bitcoin/addressTypeDetector.ts
+++ b/src/utils/blockchain/bitcoin/addressTypeDetector.ts
@@ -1,0 +1,154 @@
+import { AddressFormat, getAddressFromMnemonic, getDerivationPathForAddressFormat, hasAddressActivity } from '@/utils/blockchain/bitcoin';
+import { fetchTokenBalances } from '@/utils/blockchain/counterparty/api';
+
+interface AddressTypeCheck {
+  format: AddressFormat;
+  address: string;
+  hasTransactions: boolean;
+}
+
+/**
+ * Check if an address has any transaction history using existing API utilities
+ * Returns true if any provider confirms transactions or token balances
+ */
+async function checkAddressActivity(address: string): Promise<boolean> {
+  // First check Counterparty API for token balances - most specific indicator
+  try {
+    const balances = await fetchTokenBalances(address, { limit: 1 });
+    if (balances && balances.length > 0) {
+      console.log(`Address ${address} has Counterparty token activity`);
+      return true;
+    }
+  } catch (error) {
+    console.warn('Counterparty balance check failed:', error);
+  }
+
+  // Check Bitcoin transaction history using our balance module helper
+  try {
+    const hasActivity = await hasAddressActivity(address);
+    if (hasActivity) {
+      console.log(`Address ${address} has Bitcoin transaction history`);
+      return true;
+    }
+  } catch (error) {
+    console.warn('Bitcoin activity check failed:', error);
+  }
+
+  // No activity found
+  return false;
+}
+
+/**
+ * Detect the most likely address format for a mnemonic by checking blockchain activity
+ * @param mnemonic The mnemonic phrase to check
+ * @param cachedPreviews Optional cached address previews to avoid re-derivation
+ * @returns The detected address format, or P2TR as default
+ */
+export async function detectAddressFormat(
+  mnemonic: string,
+  cachedPreviews?: Partial<Record<AddressFormat, string>>
+): Promise<AddressFormat> {
+  // Check these formats for activity (skip Taproot since it's the fallback)
+  const addressFormatsToCheck: AddressFormat[] = [
+    AddressFormat.P2PKH,        // Legacy (most common)
+    AddressFormat.P2WPKH,       // Native SegWit (bc1)
+    AddressFormat.P2SH_P2WPKH,  // Nested SegWit (3)
+  ];
+
+  // First, generate all preview addresses (or use cached ones)
+  const formatAddressMap: Map<AddressFormat, string> = new Map();
+
+  for (const format of addressFormatsToCheck) {
+    try {
+      let address: string;
+      if (cachedPreviews?.[format]) {
+        address = cachedPreviews[format];
+      } else {
+        // Generate the first address (index 0) for this format
+        const path = `${getDerivationPathForAddressFormat(format)}/0`;
+        address = getAddressFromMnemonic(mnemonic, path, format);
+      }
+      formatAddressMap.set(format, address);
+    } catch (error) {
+      console.warn(`Failed to generate address for ${format}:`, error);
+    }
+  }
+
+  // Check each address for activity in order of priority
+  for (const [format, address] of formatAddressMap.entries()) {
+    try {
+      const hasActivity = await checkAddressActivity(address);
+      if (hasActivity) {
+        console.log(`Detected address format: ${format}`);
+        return format;
+      }
+    } catch (error) {
+      console.warn(`Failed to check ${format}:`, error);
+    }
+  }
+
+  // Default to P2TR (Taproot) for best efficiency
+  console.log('No activity detected or API failed, defaulting to P2TR');
+  return AddressFormat.P2TR;
+}
+
+/**
+ * Get preview addresses for all address formats
+ * Used in settings to show users what addresses would look like
+ */
+export function getPreviewAddresses(mnemonic: string): Record<AddressFormat, string> {
+  const formats = [
+    AddressFormat.P2PKH,
+    AddressFormat.P2SH_P2WPKH,
+    AddressFormat.P2WPKH,
+    AddressFormat.P2TR,
+    AddressFormat.Counterwallet,
+  ];
+
+  const previews: Partial<Record<AddressFormat, string>> = {};
+
+  for (const format of formats) {
+    try {
+      const path = `${getDerivationPathForAddressFormat(format)}/0`;
+      previews[format] = getAddressFromMnemonic(mnemonic, path, format);
+    } catch (error) {
+      console.warn(`Failed to generate preview for ${format}:`, error);
+    }
+  }
+
+  return previews as Record<AddressFormat, string>;
+}
+
+/**
+ * Detect address format from cached previews only (no derivation needed)
+ * Useful for checking existing wallets where we already have the preview addresses
+ */
+export async function detectAddressFormatFromPreviews(
+  previews: Partial<Record<AddressFormat, string>>
+): Promise<AddressFormat> {
+  // Check these formats for activity (skip Taproot since it's the fallback)
+  const addressFormatsToCheck: AddressFormat[] = [
+    AddressFormat.P2PKH,        // Legacy (most common)
+    AddressFormat.P2WPKH,       // Native SegWit (bc1)
+    AddressFormat.P2SH_P2WPKH,  // Nested SegWit (3)
+  ];
+
+  // Check each preview address for activity
+  for (const format of addressFormatsToCheck) {
+    const address = previews[format];
+    if (!address) continue;
+
+    try {
+      const hasActivity = await checkAddressActivity(address);
+      if (hasActivity) {
+        console.log(`Detected format ${format} from cached preview`);
+        return format;
+      }
+    } catch (error) {
+      console.warn(`Failed to check ${format} preview:`, error);
+    }
+  }
+
+  // Default to P2TR (Taproot) for best efficiency
+  return AddressFormat.P2TR;
+}

--- a/src/utils/blockchain/bitcoin/index.ts
+++ b/src/utils/blockchain/bitcoin/index.ts
@@ -14,3 +14,4 @@ export * from './transactionBroadcaster';
 export * from './transactionSigner';
 export * from './uncompressedSigner';
 export * from './utxo';
+export * from './addressTypeDetector';


### PR DESCRIPTION
- Auto-detect address format by checking blockchain activity
- Check Counterparty tokens first, then Bitcoin transactions
- Add hasAddressActivity helper to balance.ts
- Optimize API calls (3-8 calls instead of 12+)
- Default to P2TR (Taproot) when no activity found
- Add comprehensive test coverage for detection logic
- Fix mnemonic input deletion issues in import wallet UI