### PR TITLE
FreeWallet Segwit Support

### DIFF
--- a/src/pages/settings/address-type-settings.tsx
+++ b/src/pages/settings/address-type-settings.tsx
@@ -165,6 +165,8 @@ export default function AddressTypeSettings(): ReactElement {
         return "Taproot (P2TR)";
       case AddressFormat.Counterwallet:
           return "CounterWallet (P2PKH)";
+      case AddressFormat.CounterwalletSegwit:
+          return "CounterWallet SegWit (bc1)";
       default:
         return type;
     }
@@ -202,16 +204,25 @@ export default function AddressTypeSettings(): ReactElement {
       >
         <SelectionCardGroup>
           {CONSTANTS.AVAILABLE_ADDRESS_TYPES.filter((type) => {
-            // Only show Counterwallet if it's the current address type
-            if (type === AddressFormat.Counterwallet) {
-              return activeWallet?.addressFormat === AddressFormat.Counterwallet;
+            const isCounterwallet = activeWallet?.addressFormat === AddressFormat.Counterwallet ||
+                                    activeWallet?.addressFormat === AddressFormat.CounterwalletSegwit;
+
+            // For Counterwallet users, only show Counterwallet and CounterwalletSegwit options
+            if (isCounterwallet) {
+              return type === AddressFormat.Counterwallet || type === AddressFormat.CounterwalletSegwit;
             }
+
+            // For non-Counterwallet users, hide both Counterwallet formats
+            if (type === AddressFormat.Counterwallet || type === AddressFormat.CounterwalletSegwit) {
+              return false;
+            }
+
             return true;
           }).map((type) => {
             const typeLabel = getAddressFormatDescription(type);
-            const isCounterwallet = activeWallet?.addressFormat === AddressFormat.Counterwallet;
-            const isDisabled = isCounterwallet && type !== AddressFormat.Counterwallet;
-            const disabledReason = (isCounterwallet && type !== AddressFormat.Counterwallet) ? "Create new wallet to use this address type" : undefined;
+            // No addresses should be disabled since we're filtering them properly
+            const isDisabled = false;
+            const disabledReason = undefined;
             // Use loaded address preview
             const address = addresses[type] || "";
             const addressPreview = address ? formatAddress(address) : "";

--- a/src/pages/settings/address-type-settings.tsx
+++ b/src/pages/settings/address-type-settings.tsx
@@ -9,7 +9,7 @@ import { ErrorAlert } from "@/components/error-alert";
 import { Spinner } from "@/components/spinner";
 import { useHeader } from "@/contexts/header-context";
 import { useWallet } from "@/contexts/wallet-context";
-import { AddressFormat } from '@/utils/blockchain/bitcoin';
+import { AddressFormat, isCounterwalletFormat } from '@/utils/blockchain/bitcoin';
 import { formatAddress } from "@/utils/format";
 import type { ReactElement } from "react";
 
@@ -166,7 +166,7 @@ export default function AddressTypeSettings(): ReactElement {
       case AddressFormat.Counterwallet:
           return "CounterWallet (P2PKH)";
       case AddressFormat.CounterwalletSegwit:
-          return "CounterWallet SegWit (bc1)";
+          return "CounterWallet SegWit (P2WPKH)";
       default:
         return type;
     }
@@ -204,25 +204,22 @@ export default function AddressTypeSettings(): ReactElement {
       >
         <SelectionCardGroup>
           {CONSTANTS.AVAILABLE_ADDRESS_TYPES.filter((type) => {
-            const isCounterwallet = activeWallet?.addressFormat === AddressFormat.Counterwallet ||
-                                    activeWallet?.addressFormat === AddressFormat.CounterwalletSegwit;
+            const isCounterwallet = activeWallet?.addressFormat &&
+                                   isCounterwalletFormat(activeWallet.addressFormat);
 
             // For Counterwallet users, only show Counterwallet and CounterwalletSegwit options
             if (isCounterwallet) {
-              return type === AddressFormat.Counterwallet || type === AddressFormat.CounterwalletSegwit;
+              return isCounterwalletFormat(type);
             }
 
             // For non-Counterwallet users, hide both Counterwallet formats
-            if (type === AddressFormat.Counterwallet || type === AddressFormat.CounterwalletSegwit) {
+            if (isCounterwalletFormat(type)) {
               return false;
             }
 
             return true;
           }).map((type) => {
             const typeLabel = getAddressFormatDescription(type);
-            // No addresses should be disabled since we're filtering them properly
-            const isDisabled = false;
-            const disabledReason = undefined;
             // Use loaded address preview
             const address = addresses[type] || "";
             const addressPreview = address ? formatAddress(address) : "";
@@ -233,8 +230,6 @@ export default function AddressTypeSettings(): ReactElement {
                 value={type}
                 title={typeLabel}
                 description={addressPreview}
-                disabled={isDisabled}
-                disabledReason={disabledReason}
               />
             );
           })}

--- a/src/utils/blockchain/bitcoin/__tests__/address.test.ts
+++ b/src/utils/blockchain/bitcoin/__tests__/address.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { getDerivationPathForAddressFormat, encodeAddress, getAddressFromMnemonic, isValidBase58Address } from '@/utils/blockchain/bitcoin/address';
+import { getDerivationPathForAddressFormat, encodeAddress, getAddressFromMnemonic, isValidBase58Address, isCounterwalletFormat } from '@/utils/blockchain/bitcoin/address';
 import { AddressFormat } from '@/utils/blockchain/bitcoin';
 import { hexToBytes } from '@noble/hashes/utils';
 
@@ -27,6 +27,10 @@ describe('Bitcoin Address Utilities', () => {
 
     it('should return the correct derivation path for Counterwallet', () => {
       expect(getDerivationPathForAddressFormat(AddressFormat.Counterwallet)).toBe("m/0'/0");
+    });
+
+    it('should return the correct derivation path for CounterwalletSegwit', () => {
+      expect(getDerivationPathForAddressFormat(AddressFormat.CounterwalletSegwit)).toBe("m/0'/0");
     });
 
     it('should throw error for unsupported address type', () => {
@@ -75,6 +79,13 @@ describe('Bitcoin Address Utilities', () => {
       expect(address.startsWith('1')).toBe(true);
       expect(address.length).toBeGreaterThan(25);
       expect(address.length).toBeLessThan(36);
+    });
+
+    it('should encode CounterwalletSegwit address correctly', () => {
+      const address = encodeAddress(testPubKey, AddressFormat.CounterwalletSegwit);
+      expect(typeof address).toBe('string');
+      expect(address.startsWith('bc1')).toBe(true);
+      expect(address.length).toBe(42); // bech32 P2WPKH is always 42 chars
     });
 
     it('should throw error for unsupported address type', () => {
@@ -152,6 +163,13 @@ describe('Bitcoin Address Utilities', () => {
       expect(address.startsWith('1')).toBe(true);
     });
 
+    it('should derive CounterwalletSegwit address from mnemonic', () => {
+      const address = getAddressFromMnemonic(testMnemonic, "m/0'/0", AddressFormat.CounterwalletSegwit);
+      expect(typeof address).toBe('string');
+      expect(address.startsWith('bc1')).toBe(true);
+      expect(address.length).toBe(42); // bech32 P2WPKH is always 42 chars
+    });
+
     it('should generate different addresses for different paths', () => {
       const address1 = getAddressFromMnemonic(testMnemonic, "m/84'/0'/0'/0/0", AddressFormat.P2WPKH);
       const address2 = getAddressFromMnemonic(testMnemonic, "m/84'/0'/0'/0/1", AddressFormat.P2WPKH);
@@ -200,6 +218,17 @@ describe('Bitcoin Address Utilities', () => {
       
       expect(typeof address).toBe('string');
       expect(address.startsWith('bc1')).toBe(true);
+    });
+  });
+
+  describe('isCounterwalletFormat', () => {
+    it('should correctly identify Counterwallet formats', () => {
+      expect(isCounterwalletFormat(AddressFormat.Counterwallet)).toBe(true);
+      expect(isCounterwalletFormat(AddressFormat.CounterwalletSegwit)).toBe(true);
+      expect(isCounterwalletFormat(AddressFormat.P2PKH)).toBe(false);
+      expect(isCounterwalletFormat(AddressFormat.P2WPKH)).toBe(false);
+      expect(isCounterwalletFormat(AddressFormat.P2SH_P2WPKH)).toBe(false);
+      expect(isCounterwalletFormat(AddressFormat.P2TR)).toBe(false);
     });
   });
 

--- a/src/utils/blockchain/bitcoin/__tests__/addressTypeDetector.test.ts
+++ b/src/utils/blockchain/bitcoin/__tests__/addressTypeDetector.test.ts
@@ -18,6 +18,7 @@ describe('Address Type Detector', () => {
     [AddressFormat.P2SH_P2WPKH]: '37VucYSaXLCAsxYyAPfbSi9eh4iEcbShgf',
     [AddressFormat.P2TR]: 'bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr',
     [AddressFormat.Counterwallet]: '1CounterpartyXXXXXXXXXXXXXXXUWLpVr',
+    [AddressFormat.CounterwalletSegwit]: 'bc1qcounterwalletsegwitexampleaddressxxxxxx',
   };
 
   beforeEach(() => {
@@ -209,12 +210,13 @@ describe('Address Type Detector', () => {
       expect(previews[AddressFormat.P2WPKH]).toBe(mockAddresses[AddressFormat.P2WPKH]);
       expect(previews[AddressFormat.P2SH_P2WPKH]).toBe(mockAddresses[AddressFormat.P2SH_P2WPKH]);
       expect(previews[AddressFormat.P2TR]).toBe(mockAddresses[AddressFormat.P2TR]);
-      // Counterwallet generation fails (not in mockAddresses), so it will be undefined
+      // Counterwallet formats generation fails (not in mockAddresses), so they will be undefined
       expect(previews[AddressFormat.Counterwallet]).toBeUndefined();
+      expect(previews[AddressFormat.CounterwalletSegwit]).toBeUndefined();
     });
 
     it('should handle address generation failures gracefully', () => {
-      // The order in getPreviewAddresses is: P2PKH, P2SH_P2WPKH, P2WPKH, P2TR, Counterwallet
+      // The order in getPreviewAddresses is: P2PKH, P2SH_P2WPKH, P2WPKH, P2TR, Counterwallet, CounterwalletSegwit
       vi.mocked(bitcoinAddress.getAddressFromMnemonic)
         .mockImplementationOnce(() => mockAddresses[AddressFormat.P2PKH])  // P2PKH succeeds
         .mockImplementationOnce(() => { throw new Error('Failed to generate'); })  // P2SH_P2WPKH fails

--- a/src/utils/blockchain/bitcoin/__tests__/messageSigner.test.ts
+++ b/src/utils/blockchain/bitcoin/__tests__/messageSigner.test.ts
@@ -94,12 +94,27 @@ describe('messageSign', () => {
         AddressFormat.Counterwallet,
         true
       );
-      
+
       expect(result).toHaveProperty('signature');
       expect(result).toHaveProperty('address');
       expect(result.signature).toBeTruthy();
       // Counterwallet uses P2PKH addresses
       expect(result.address).toMatch(/^1/);
+    });
+
+    it('should sign a message with CounterwalletSegwit address type', async () => {
+      const result = await signMessage(
+        testMessage,
+        testPrivateKey,
+        AddressFormat.CounterwalletSegwit,
+        true
+      );
+
+      expect(result).toHaveProperty('signature');
+      expect(result).toHaveProperty('address');
+      expect(result.signature).toBeTruthy();
+      // CounterwalletSegwit uses Native SegWit addresses
+      expect(result.address).toMatch(/^bc1/);
     });
 
     it('should handle lowercase counterwallet address type', async () => {
@@ -276,6 +291,12 @@ describe('messageSign', () => {
 
     it('should return capabilities for Counterwallet', () => {
       const caps = getSigningCapabilities(AddressFormat.Counterwallet);
+      expect(caps.canSign).toBe(true);
+      expect(caps.method).toContain('BIP-322');
+    });
+
+    it('should return capabilities for CounterwalletSegwit', () => {
+      const caps = getSigningCapabilities(AddressFormat.CounterwalletSegwit);
       expect(caps.canSign).toBe(true);
       expect(caps.method).toContain('BIP-322');
     });

--- a/src/utils/blockchain/bitcoin/address.ts
+++ b/src/utils/blockchain/bitcoin/address.ts
@@ -15,6 +15,8 @@ import { hasAddressActivity } from './balance';
 export const AddressFormat = {
   /** Counterwallet style (P2PKH with custom derivation) */
   Counterwallet: 'counterwallet',
+  /** Counterwallet SegWit (Native SegWit with Counterwallet derivation) */
+  CounterwalletSegwit: 'counterwallet-segwit',
   /** Taproot (Pay-to-Taproot) */
   P2TR: 'p2tr',
   /** Native SegWit (Pay-to-Witness-PubKey-Hash) */
@@ -27,16 +29,17 @@ export const AddressFormat = {
 
 /**
  * Type representing valid address format values.
- * This creates a union type: 'counterwallet' | 'p2tr' | 'p2wpkh' | 'p2sh-p2wpkh' | 'p2pkh'
+ * This creates a union type: 'counterwallet' | 'counterwallet-segwit' | 'p2tr' | 'p2wpkh' | 'p2sh-p2wpkh' | 'p2pkh'
  */
 export type AddressFormat = typeof AddressFormat[keyof typeof AddressFormat];
 
 /**
- * Check if an address format is a SegWit format (P2WPKH, P2SH-P2WPKH, or P2TR).
+ * Check if an address format is a SegWit format (P2WPKH, P2SH-P2WPKH, CounterwalletSegwit, or P2TR).
  */
 export function isSegwitFormat(format: AddressFormat): boolean {
   return format === AddressFormat.P2WPKH ||
          format === AddressFormat.P2SH_P2WPKH ||
+         format === AddressFormat.CounterwalletSegwit ||
          format === AddressFormat.P2TR;
 }
 
@@ -62,6 +65,9 @@ export function getDerivationPathForAddressFormat(addressFormat: AddressFormat):
     case AddressFormat.P2TR:
       return "m/86'/0'/0'/0";
     case AddressFormat.Counterwallet:
+      return "m/0'/0";
+    case AddressFormat.CounterwalletSegwit:
+      // Use Counterwallet derivation path but with SegWit encoding
       return "m/0'/0";
     default:
       throw new Error(`Unsupported address type: ${ addressFormat }`);
@@ -104,6 +110,12 @@ export function encodeAddress(publicKey: Uint8Array, addressFormat: AddressForma
       const words = bech32.toWords(pubKeyHash);
       return bech32.encode('bc', [0, ...words]);
     }
+    case AddressFormat.CounterwalletSegwit: {
+      // CounterwalletSegwit uses Native SegWit (P2WPKH) encoding
+      const pubKeyHash = ripemd160(sha256(publicKey));
+      const words = bech32.toWords(pubKeyHash);
+      return bech32.encode('bc', [0, ...words]);
+    }
     case AddressFormat.P2TR: {
       // For Taproot, use BIP341 tweaking (best practice)
       const xOnlyPubKey = publicKey.slice(1, 33);
@@ -138,9 +150,11 @@ export function getAddressFromMnemonic(
   path: string,
   addressFormat: AddressFormat
 ): string {
-  // Use a specialized seed for Counterwallet; otherwise use standard BIP39 seed.
+  // Use a specialized seed for Counterwallet and CounterwalletSegwit; otherwise use standard BIP39 seed.
   const seed: Uint8Array =
-    addressFormat === AddressFormat.Counterwallet ? getCounterwalletSeed(mnemonic) : mnemonicToSeedSync(mnemonic);
+    (addressFormat === AddressFormat.Counterwallet || addressFormat === AddressFormat.CounterwalletSegwit)
+      ? getCounterwalletSeed(mnemonic)
+      : mnemonicToSeedSync(mnemonic);
   const root = HDKey.fromMasterSeed(seed);
   const child = root.derive(path);
   if (!child.publicKey) {
@@ -211,9 +225,11 @@ export async function detectAddressFormat(
 ): Promise<AddressFormat> {
   // Check these formats for activity (skip Taproot since it's the fallback)
   const addressFormatsToCheck: AddressFormat[] = [
-    AddressFormat.P2PKH,        // Legacy (most common)
-    AddressFormat.P2WPKH,       // Native SegWit (bc1)
-    AddressFormat.P2SH_P2WPKH,  // Nested SegWit (3)
+    AddressFormat.P2PKH,              // Legacy (most common)
+    AddressFormat.P2WPKH,             // Native SegWit (bc1)
+    AddressFormat.P2SH_P2WPKH,        // Nested SegWit (3)
+    AddressFormat.Counterwallet,      // Counterwallet P2PKH
+    AddressFormat.CounterwalletSegwit,// Counterwallet SegWit
   ];
 
   // First, generate all preview addresses (or use cached ones)
@@ -264,6 +280,7 @@ export function getPreviewAddresses(mnemonic: string): Record<AddressFormat, str
     AddressFormat.P2WPKH,
     AddressFormat.P2TR,
     AddressFormat.Counterwallet,
+    AddressFormat.CounterwalletSegwit,
   ];
 
   const previews: Partial<Record<AddressFormat, string>> = {};
@@ -289,9 +306,11 @@ export async function detectAddressFormatFromPreviews(
 ): Promise<AddressFormat> {
   // Check these formats for activity (skip Taproot since it's the fallback)
   const addressFormatsToCheck: AddressFormat[] = [
-    AddressFormat.P2PKH,        // Legacy (most common)
-    AddressFormat.P2WPKH,       // Native SegWit (bc1)
-    AddressFormat.P2SH_P2WPKH,  // Nested SegWit (3)
+    AddressFormat.P2PKH,              // Legacy (most common)
+    AddressFormat.P2WPKH,             // Native SegWit (bc1)
+    AddressFormat.P2SH_P2WPKH,        // Nested SegWit (3)
+    AddressFormat.Counterwallet,      // Counterwallet P2PKH
+    AddressFormat.CounterwalletSegwit,// Counterwallet SegWit
   ];
 
   // Check each preview address for activity

--- a/src/utils/blockchain/bitcoin/messageSigner.ts
+++ b/src/utils/blockchain/bitcoin/messageSigner.ts
@@ -123,9 +123,10 @@ export async function signMessage(
       break;
 
     case AddressFormat.P2WPKH:
-      // Use BIP-322 for P2WPKH
+    case AddressFormat.CounterwalletSegwit:
+      // Use BIP-322 for P2WPKH (Native SegWit)
       signature = await signBIP322P2WPKH(message, privateKey);
-      address = encodeAddress(publicKey, AddressFormat.P2WPKH);
+      address = encodeAddress(publicKey, addressFormat as AddressFormat);
       break;
 
     case AddressFormat.P2SH_P2WPKH:
@@ -193,6 +194,13 @@ export function getSigningCapabilities(addressFormat: AddressFormat | string): {
         canSign: true,
         method: 'BIP-322',
         notes: 'Generic signed message format (BIP-322) with P2PKH virtual transaction'
+      };
+
+    case 'Counterwallet-segwit':
+      return {
+        canSign: true,
+        method: 'BIP-322',
+        notes: 'Generic signed message format (BIP-322) with P2WPKH witness'
       };
 
     default:

--- a/src/utils/blockchain/bitcoin/privateKey.ts
+++ b/src/utils/blockchain/bitcoin/privateKey.ts
@@ -107,7 +107,7 @@ export function getPrivateKeyFromMnemonic(
   addressFormat: AddressFormat
 ): string {
   let seed: Uint8Array;
-  if (addressFormat === AddressFormat.Counterwallet) {
+  if (addressFormat === AddressFormat.Counterwallet || addressFormat === AddressFormat.CounterwalletSegwit) {
     seed = getCounterwalletSeed(mnemonic);
   } else {
     seed = mnemonicToSeedSync(mnemonic);

--- a/src/utils/blockchain/bitcoin/privateKey.ts
+++ b/src/utils/blockchain/bitcoin/privateKey.ts
@@ -5,7 +5,7 @@ import { createBase58check } from '@scure/base';
 import { HDKey } from '@scure/bip32';
 import { generateMnemonic, mnemonicToSeedSync } from '@scure/bip39';
 import { wordlist } from '@scure/bip39/wordlists/english';
-import { encodeAddress } from '@/utils/blockchain/bitcoin/address';
+import { encodeAddress, isCounterwalletFormat } from '@/utils/blockchain/bitcoin/address';
 import { AddressFormat } from '@/utils/blockchain/bitcoin';
 import { getCounterwalletSeed } from '@/utils/blockchain/counterwallet';
 
@@ -106,12 +106,9 @@ export function getPrivateKeyFromMnemonic(
   path: string,
   addressFormat: AddressFormat
 ): string {
-  let seed: Uint8Array;
-  if (addressFormat === AddressFormat.Counterwallet || addressFormat === AddressFormat.CounterwalletSegwit) {
-    seed = getCounterwalletSeed(mnemonic);
-  } else {
-    seed = mnemonicToSeedSync(mnemonic);
-  }
+  const seed: Uint8Array = isCounterwalletFormat(addressFormat)
+    ? getCounterwalletSeed(mnemonic)
+    : mnemonicToSeedSync(mnemonic);
   const root = HDKey.fromMasterSeed(seed);
   const child = root.derive(path);
   if (!child.privateKey) {

--- a/src/utils/blockchain/bitcoin/transactionSigner.ts
+++ b/src/utils/blockchain/bitcoin/transactionSigner.ts
@@ -11,6 +11,7 @@ function paymentScript(pubkeyBytes: Uint8Array, addressFormat: AddressFormat) {
     case AddressFormat.Counterwallet:
       return p2pkh(pubkeyBytes);
     case AddressFormat.P2WPKH:
+    case AddressFormat.CounterwalletSegwit:
       return p2wpkh(pubkeyBytes);
     case AddressFormat.P2SH_P2WPKH:
       return p2sh(p2wpkh(pubkeyBytes));

--- a/src/utils/wallet/walletManager.ts
+++ b/src/utils/wallet/walletManager.ts
@@ -762,7 +762,9 @@ export class WalletManager {
   }
 
   private async generateWalletId(mnemonic: string, addressFormat: AddressFormat): Promise<string> {
-    const seed = addressFormat === AddressFormat.Counterwallet ? getCounterwalletSeed(mnemonic) : mnemonicToSeedSync(mnemonic);
+    const seed = (addressFormat === AddressFormat.Counterwallet || addressFormat === AddressFormat.CounterwalletSegwit)
+      ? getCounterwalletSeed(mnemonic)
+      : mnemonicToSeedSync(mnemonic);
     const derivationPath = getDerivationPathForAddressFormat(addressFormat);
     const pathParts = derivationPath.split('/').slice(0, -1).join('/');
     const root = HDKey.fromMasterSeed(seed);
@@ -788,7 +790,9 @@ export class WalletManager {
   private deriveMnemonicAddress(mnemonic: string, addressFormat: AddressFormat, index: number): Address {
     const path = `${getDerivationPathForAddressFormat(addressFormat)}/${index}`;
     const address = getAddressFromMnemonic(mnemonic, path, addressFormat);
-    const seed = addressFormat === AddressFormat.Counterwallet ? getCounterwalletSeed(mnemonic) : mnemonicToSeedSync(mnemonic);
+    const seed = (addressFormat === AddressFormat.Counterwallet || addressFormat === AddressFormat.CounterwalletSegwit)
+      ? getCounterwalletSeed(mnemonic)
+      : mnemonicToSeedSync(mnemonic);
     const root = HDKey.fromMasterSeed(seed);
     const child = root.derive(path);
     if (!child.publicKey) {

--- a/src/utils/wallet/walletManager.ts
+++ b/src/utils/wallet/walletManager.ts
@@ -6,7 +6,7 @@ import * as sessionManager from '@/utils/auth/sessionManager';
 import { settingsManager } from '@/utils/wallet/settingsManager';
 import { getAllEncryptedWallets, addEncryptedWallet, updateEncryptedWallet, removeEncryptedWallet, EncryptedWalletRecord } from '@/utils/storage/walletStorage';
 import { encryptMnemonic, decryptMnemonic, encryptPrivateKey, decryptPrivateKey, DecryptionError } from '@/utils/encryption';
-import { getAddressFromMnemonic, getPrivateKeyFromMnemonic, getAddressFromPrivateKey, getPublicKeyFromPrivateKey, decodeWIF, isWIF, getDerivationPathForAddressFormat, signMessage } from '@/utils/blockchain/bitcoin';
+import { getAddressFromMnemonic, getPrivateKeyFromMnemonic, getAddressFromPrivateKey, getPublicKeyFromPrivateKey, decodeWIF, isWIF, getDerivationPathForAddressFormat, signMessage, isCounterwalletFormat } from '@/utils/blockchain/bitcoin';
 import { AddressFormat } from '@/utils/blockchain/bitcoin';
 import { getCounterwalletSeed } from '@/utils/blockchain/counterwallet';
 import { KeychainSettings } from '@/utils/storage/settingsStorage';
@@ -762,7 +762,7 @@ export class WalletManager {
   }
 
   private async generateWalletId(mnemonic: string, addressFormat: AddressFormat): Promise<string> {
-    const seed = (addressFormat === AddressFormat.Counterwallet || addressFormat === AddressFormat.CounterwalletSegwit)
+    const seed = isCounterwalletFormat(addressFormat)
       ? getCounterwalletSeed(mnemonic)
       : mnemonicToSeedSync(mnemonic);
     const derivationPath = getDerivationPathForAddressFormat(addressFormat);
@@ -790,7 +790,7 @@ export class WalletManager {
   private deriveMnemonicAddress(mnemonic: string, addressFormat: AddressFormat, index: number): Address {
     const path = `${getDerivationPathForAddressFormat(addressFormat)}/${index}`;
     const address = getAddressFromMnemonic(mnemonic, path, addressFormat);
-    const seed = (addressFormat === AddressFormat.Counterwallet || addressFormat === AddressFormat.CounterwalletSegwit)
+    const seed = isCounterwalletFormat(addressFormat)
       ? getCounterwalletSeed(mnemonic)
       : mnemonicToSeedSync(mnemonic);
     const root = HDKey.fromMasterSeed(seed);


### PR DESCRIPTION
- Add CounterwalletSegwit to AddressFormat enum for bc1 addresses with Counterwallet derivation
- Update address-type-settings to allow Counterwallet users to switch between legacy and Native SegWit
- Use Counterwallet seed derivation (m/0'/0) for CounterwalletSegwit addresses
- Update all relevant functions to handle CounterwalletSegwit format:
  - Address encoding uses P2WPKH (bc1) format
  - Private key derivation uses Counterwallet seed
  - Message signing uses BIP-322 P2WPKH
  - Transaction signing uses witness UTXOs
- Include CounterwalletSegwit in address format detection