### PR TITLE
Export Private Keys as WIF

### DIFF
--- a/src/contexts/wallet-context.tsx
+++ b/src/contexts/wallet-context.tsx
@@ -95,7 +95,7 @@ interface WalletContextType {
   importTestAddress: (address: string, name?: string) => Promise<Wallet>;
   resetAllWallets: (password: string) => Promise<void>;
   getUnencryptedMnemonic: (walletId: string) => Promise<string>;
-  getPrivateKey: (walletId: string, derivationPath?: string) => Promise<{ key: string; compressed: boolean }>;
+  getPrivateKey: (walletId: string, derivationPath?: string) => Promise<{ wif: string; hex: string; compressed: boolean }>;
   setLastActiveTime: () => Promise<void>;
   verifyPassword: (password: string) => Promise<boolean>;
   updateWalletAddressFormat: (walletId: string, newType: AddressFormat) => Promise<void>;

--- a/src/hooks/__tests__/useConsolidateAndBroadcast.test.ts
+++ b/src/hooks/__tests__/useConsolidateAndBroadcast.test.ts
@@ -61,9 +61,10 @@ describe('useConsolidateAndBroadcast', () => {
     
     vi.mocked(useWallet).mockReturnValue(mockWalletContext as any);
     vi.mocked(consolidateBareMultisig).mockResolvedValue('0x123signed');
-    vi.mocked(mockWalletContext.getPrivateKey).mockResolvedValue({ 
-      key: 'L1234567890',
-      compressed: true 
+    vi.mocked(mockWalletContext.getPrivateKey).mockResolvedValue({
+      wif: 'L1234567890',
+      hex: '1234567890abcdef',
+      compressed: true
     });
   });
 

--- a/src/hooks/useConsolidateAndBroadcast.ts
+++ b/src/hooks/useConsolidateAndBroadcast.ts
@@ -33,7 +33,7 @@ export function useConsolidateAndBroadcast() {
         activeWallet.id,
         activeAddress.path // Use the derivation path from activeAddress
       );
-      const privateKey = privateKeyResult.key;
+      const privateKey = privateKeyResult.hex; // Use hex format for consolidation
 
       // Build consolidation options
       let consolidationOptions: any = {

--- a/src/hooks/useMultiBatchConsolidation.ts
+++ b/src/hooks/useMultiBatchConsolidation.ts
@@ -48,7 +48,7 @@ export function useMultiBatchConsolidation() {
         activeWallet.id,
         activeAddress.path
       );
-      const privateKey = privateKeyResult.key;
+      const privateKey = privateKeyResult.hex; // Use hex format for consolidation
 
       // Process each batch sequentially
       for (let i = 0; i < allBatches.length; i++) {

--- a/src/pages/actions/sign-message.tsx
+++ b/src/pages/actions/sign-message.tsx
@@ -119,9 +119,11 @@ export default function SignMessage(): ReactElement {
         activeWallet.id,
         activeAddress.path
       );
-      const privateKeyHex = privateKeyResult.key;
+
+      // Use the hex format for signing
+      const privateKeyHex = privateKeyResult.hex;
       const compressed = privateKeyResult.compressed;
-      
+
       // Sign the message
       const result = await signMessage(
         message,

--- a/src/pages/secrets/show-private-key.tsx
+++ b/src/pages/secrets/show-private-key.tsx
@@ -91,7 +91,7 @@ export default function ShowPrivateKey(): ReactElement {
           ? await getPrivateKey(walletId)
           : await getPrivateKey(walletId, addressPath);
       if (!privKeyData) throw new Error("Failed to retrieve private key");
-      setPrivateKey(privKeyData.key);
+      setPrivateKey(privKeyData.wif);
       setIsConfirmed(true);
     } catch (err) {
       console.error("Error revealing private key:", err);

--- a/src/pages/secrets/show-private-key.tsx
+++ b/src/pages/secrets/show-private-key.tsx
@@ -146,9 +146,9 @@ export default function ShowPrivateKey(): ReactElement {
         <div className="flex flex-col items-center justify-center flex-grow">
           <div className="w-full max-w-md space-y-4">
             <div className="text-center mb-6">
-              <h3 className="text-2xl font-bold text-gray-800 mb-2">Your Private Key</h3>
+              <h3 className="text-2xl font-bold text-gray-800 mb-2">Your Private Key (WIF)</h3>
               <p className="text-sm text-gray-600">
-                This is your private key. Never share it with anyone.
+                This is your private key in Wallet Import Format. Never share it with anyone.
               </p>
             </div>
             <div

--- a/src/services/walletService.ts
+++ b/src/services/walletService.ts
@@ -34,7 +34,7 @@ interface WalletService {
   updateWalletAddressFormat: (walletId: string, newType: AddressFormat) => Promise<void>;
   updateWalletPinnedAssets: (pinnedAssets: string[]) => Promise<void>;
   getUnencryptedMnemonic: (walletId: string) => Promise<string>;
-  getPrivateKey: (walletId: string, derivationPath?: string) => Promise<{ key: string; compressed: boolean }>;
+  getPrivateKey: (walletId: string, derivationPath?: string) => Promise<{ wif: string; hex: string; compressed: boolean }>;
   removeWallet: (walletId: string) => Promise<void>;
   getPreviewAddressForFormat: (walletId: string, addressFormat: AddressFormat) => Promise<string>;
   signTransaction: (rawTxHex: string, sourceAddress: string) => Promise<string>;

--- a/src/utils/blockchain/bitcoin/__tests__/privateKey.test.ts
+++ b/src/utils/blockchain/bitcoin/__tests__/privateKey.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import {
   generateNewMnemonic,
   decodeWIF,
+  encodeWIF,
   isWIF,
   getPublicKeyFromPrivateKey,
   getAddressFromPrivateKey,
@@ -70,6 +71,59 @@ describe('Private Key Utilities', () => {
       const wif = '5HpHagT65TZzG1PH3CSu63k8DbpvD8s5ip4nEB3kEsreAnchuDf';
       const result = decodeWIF(wif);
       expect(result.privateKey).toHaveLength(64); // 32 bytes = 64 hex chars
+    });
+  });
+
+  describe('encodeWIF', () => {
+    it('should encode a private key to compressed WIF format', () => {
+      const privateKeyHex = '0000000000000000000000000000000000000000000000000000000000000001';
+      const wif = encodeWIF(privateKeyHex, true);
+      expect(wif).toBe('KwDiBf89QgGbjEhKnhXJuH7LrciVrZi3qYjgd9M7rFU73sVHnoWn');
+    });
+
+    it('should encode a private key to uncompressed WIF format', () => {
+      const privateKeyHex = '0000000000000000000000000000000000000000000000000000000000000001';
+      const wif = encodeWIF(privateKeyHex, false);
+      expect(wif).toBe('5HpHagT65TZzG1PH3CSu63k8DbpvD8s5ip4nEB3kEsreAnchuDf');
+    });
+
+    it('should default to compressed format when not specified', () => {
+      const privateKeyHex = '0000000000000000000000000000000000000000000000000000000000000001';
+      const wif = encodeWIF(privateKeyHex);
+      expect(wif).toBe('KwDiBf89QgGbjEhKnhXJuH7LrciVrZi3qYjgd9M7rFU73sVHnoWn');
+    });
+
+    it('should handle a real private key', () => {
+      const privateKeyHex = '1e99423a4ed27608a15a2616a2b0e9e52ced330ac530edcc32c8ffc6a526aedd';
+      const wifCompressed = encodeWIF(privateKeyHex, true);
+      const wifUncompressed = encodeWIF(privateKeyHex, false);
+
+      expect(wifCompressed).toBe('KxFC1jmwwCoACiCAWZ3eXa96mBM6tb3TYzGmf6YwgdGWZgawvrtJ');
+      expect(wifUncompressed).toBe('5J3mBbAH58CpQ3Y5RNJpUKPE62SQ5tfcvU2JpbnkeyhfsYB1Jcn');
+    });
+
+    it('should throw error for invalid private key length', () => {
+      const invalidKeyShort = '00000001';
+      const invalidKeyLong = '00000000000000000000000000000000000000000000000000000000000000001111';
+
+      expect(() => encodeWIF(invalidKeyShort)).toThrow('Private key must be 32 bytes');
+      expect(() => encodeWIF(invalidKeyLong)).toThrow('Private key must be 32 bytes');
+    });
+
+    it('should round-trip correctly with decodeWIF', () => {
+      const privateKeyHex = '1e99423a4ed27608a15a2616a2b0e9e52ced330ac530edcc32c8ffc6a526aedd';
+
+      // Test compressed
+      const wifCompressed = encodeWIF(privateKeyHex, true);
+      const decodedCompressed = decodeWIF(wifCompressed);
+      expect(decodedCompressed.privateKey).toBe(privateKeyHex);
+      expect(decodedCompressed.compressed).toBe(true);
+
+      // Test uncompressed
+      const wifUncompressed = encodeWIF(privateKeyHex, false);
+      const decodedUncompressed = decodeWIF(wifUncompressed);
+      expect(decodedUncompressed.privateKey).toBe(privateKeyHex);
+      expect(decodedUncompressed.compressed).toBe(false);
     });
   });
 

--- a/src/utils/blockchain/bitcoin/privateKey.ts
+++ b/src/utils/blockchain/bitcoin/privateKey.ts
@@ -21,6 +21,27 @@ export function generateNewMnemonic(): string {
 }
 
 /**
+ * Encodes a private key to WIF (Wallet Import Format).
+ *
+ * @param privateKeyHex - The private key in hexadecimal.
+ * @param compressed - Whether the key should be marked as compressed (default true).
+ * @returns The WIF encoded private key string.
+ */
+export function encodeWIF(privateKeyHex: string, compressed = true): string {
+  const privBytes = hexToBytes(privateKeyHex);
+  if (privBytes.length !== 32) {
+    throw new Error('Private key must be 32 bytes');
+  }
+
+  // Build the WIF payload: version byte (0x80) + private key + optional compression flag (0x01)
+  const payload = compressed
+    ? new Uint8Array([0x80, ...privBytes, 0x01])
+    : new Uint8Array([0x80, ...privBytes]);
+
+  return base58check.encode(payload);
+}
+
+/**
  * Decodes a WIF (Wallet Import Format) private key.
  *
  * @param wif - The WIF string.


### PR DESCRIPTION
- Add encodeWIF function to convert hex private keys to WIF format
- Update walletManager.getPrivateKey to return WIF instead of raw hex
- Update show-private-key UI to indicate WIF format
- Add comprehensive tests for WIF encoding/decoding
- Maintain backward compatibility with round-trip encoding/decoding