### PR TITLE
Dropdown Styling

### DIFF
--- a/src/components/inputs/fee-rate-input.tsx
+++ b/src/components/inputs/fee-rate-input.tsx
@@ -203,7 +203,7 @@ export function FeeRateInput({
             aria-label="Custom Fee Rate"
             aria-invalid={!!internalError}
             aria-describedby={internalError ? "sat_per_vbyte-error" : undefined}
-            className="block w-full p-2.5 rounded-md border bg-gray-50 focus:border-blue-500 focus:ring-blue-500"
+            className="block w-full p-2.5 rounded-md border border-gray-200 bg-gray-50 focus:border-blue-500 focus:ring-blue-500"
           />
         </div>
         {showHelpText && (
@@ -241,7 +241,7 @@ export function FeeRateInput({
               aria-label="Custom Fee Rate"
               aria-invalid={!!internalError}
               aria-describedby={internalError ? "sat_per_vbyte-error" : undefined}
-              className="block w-full p-2.5 rounded-md border bg-gray-50 pr-16 focus:border-blue-500 focus:ring-blue-500"
+              className="block w-full p-2.5 rounded-md border border-gray-200 bg-gray-50 pr-16 focus:border-blue-500 focus:ring-blue-500"
             />
             {feeRates && (
               <Button variant="input" onClick={handleEscClick} aria-label="Reset to first preset" {...disabledProps}>
@@ -258,7 +258,7 @@ export function FeeRateInput({
               <div className="relative">
                 <Listbox value={feeOptions.find((opt) => opt.id === selectedOption) || feeOptions[0]} onChange={handleOptionSelect}>
                   <ListboxButton
-                    className="w-full p-2.5 text-left rounded-md border border-gray-300 bg-gray-50 focus:border-blue-500 focus:ring-blue-500 cursor-pointer"
+                    className="w-full p-2.5 text-left rounded-md border border-gray-200 bg-gray-50 focus:border-blue-500 focus:ring-blue-500 cursor-pointer"
                     {...disabledProps}
                   >
                     {({ value }) => (
@@ -270,7 +270,7 @@ export function FeeRateInput({
                       </div>
                     )}
                   </ListboxButton>
-                  <ListboxOptions className="absolute z-10 w-full mt-1 bg-white border rounded-md shadow-lg max-h-60 overflow-auto">
+                  <ListboxOptions className="absolute z-10 w-full mt-1 bg-white border border-gray-200 rounded-md shadow-lg max-h-60 overflow-auto">
                     {feeOptions.map((option) => (
                       <ListboxOption
                         key={option.id}

--- a/src/pages/compose/bet/form.tsx
+++ b/src/pages/compose/bet/form.tsx
@@ -157,15 +157,15 @@ export function BetForm({
             <Label className="text-sm font-medium text-gray-700">
               Bet Type <span className="text-red-500">*</span>
             </Label>
-            <div className="mt-1">
+            <div className="mt-1 relative">
               <Listbox value={selectedBetType} onChange={setSelectedBetType} disabled={pending}>
                 <ListboxButton
-                  className="w-full p-2 text-left rounded-md border border-gray-300 bg-gray-50 focus:border-blue-500 focus:ring-blue-500"
+                  className="w-full p-2 text-left rounded-md border border-gray-200 bg-gray-50 focus:border-blue-500 focus:ring-blue-500"
                   disabled={pending}
                 >
                   <span>{selectedBetType.name}</span>
                 </ListboxButton>
-                <ListboxOptions className="w-full mt-1 bg-white border rounded-md shadow-lg max-h-60 overflow-auto z-10">
+                <ListboxOptions className="absolute z-10 w-full mt-1 bg-white border border-gray-200 rounded-md shadow-lg max-h-60 overflow-auto">
                   {betTypeOptions.map((option) => (
                     <ListboxOption 
                       key={option.id} 

--- a/src/pages/compose/bet/weekly/form.tsx
+++ b/src/pages/compose/bet/weekly/form.tsx
@@ -315,14 +315,14 @@ export function WeeklyBetForm({ formAction }: BetFormProps): ReactElement {
             <Label className="text-sm font-medium text-gray-700">
               Your Prediction <span className="text-red-500">*</span>
             </Label>
-            <div className="mt-1">
+            <div className="mt-1 relative">
               <Listbox value={selectedChoice} onChange={setSelectedChoice} disabled={pending}>
                 <ListboxButton
-                  className="w-full p-2 text-left rounded-md border border-gray-300 bg-gray-50 focus:border-blue-500 focus:ring-blue-500"
+                  className="w-full p-2 text-left rounded-md border border-gray-200 bg-gray-50 focus:border-blue-500 focus:ring-blue-500"
                 >
                   <span>{selectedChoice.name}</span>
                 </ListboxButton>
-                <ListboxOptions className="w-full mt-1 bg-white border rounded-md shadow-lg max-h-60 overflow-auto z-10">
+                <ListboxOptions className="absolute z-10 w-full mt-1 bg-white border border-gray-200 rounded-md shadow-lg max-h-60 overflow-auto">
                   {betChoices.map((choice) => (
                     <ListboxOption
                       key={choice.id}

--- a/src/pages/compose/fairminter/form.tsx
+++ b/src/pages/compose/fairminter/form.tsx
@@ -205,15 +205,15 @@ export function FairminterForm({
             <Label htmlFor="mintMethod" className="block text-sm font-medium text-gray-700">
               Mint Method <span className="text-red-500">*</span>
             </Label>
-            <div className="mt-1">
+            <div className="mt-1 relative">
               <Listbox value={FAIRMINTER_MODEL_OPTIONS.find(option => option.value === selectedMintMethod)} onChange={(option) => setSelectedMintMethod(option.value)} disabled={pending}>
                 <ListboxButton
-                  className="w-full p-2 text-left rounded-md border border-gray-300 bg-gray-50 focus:border-blue-500 focus:ring-blue-500 disabled:bg-gray-100 disabled:cursor-not-allowed"
+                  className="w-full p-2 text-left rounded-md border border-gray-200 bg-gray-50 focus:border-blue-500 focus:ring-blue-500 disabled:bg-gray-100 disabled:cursor-not-allowed"
                   disabled={pending}
                 >
                   <span>{FAIRMINTER_MODEL_OPTIONS.find(option => option.value === selectedMintMethod)?.label}</span>
                 </ListboxButton>
-                <ListboxOptions className="w-full mt-1 bg-white border rounded-md shadow-lg max-h-60 overflow-auto z-10">
+                <ListboxOptions className="absolute z-10 w-full mt-1 bg-white border border-gray-200 rounded-md shadow-lg max-h-60 overflow-auto">
                   {FAIRMINTER_MODEL_OPTIONS.map((option) => (
                     <ListboxOption 
                       key={option.value} 

--- a/src/pages/compose/sweep/form.tsx
+++ b/src/pages/compose/sweep/form.tsx
@@ -80,15 +80,15 @@ export function SweepForm({
         <Label className="block text-sm font-medium text-gray-700">
           Sweep Type <span className="text-red-500">*</span>
         </Label>
-        <div className="mt-1">
+        <div className="mt-1 relative">
           {/* Hidden input for form submission */}
           <input type="hidden" name="flags" value={selectedSweepType.value} />
-          
+
           <Listbox value={selectedSweepType} onChange={setSelectedSweepType}>
-            <ListboxButton className="w-full p-2 text-left rounded-md border border-gray-300 bg-gray-50 focus:border-blue-500 focus:ring-blue-500 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed" {...(pending === true && { disabled: true })}>
+            <ListboxButton className="w-full p-2 text-left rounded-md border border-gray-200 bg-gray-50 focus:border-blue-500 focus:ring-blue-500 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed" {...(pending === true && { disabled: true })}>
               {selectedSweepType.name}
             </ListboxButton>
-            <ListboxOptions className="w-full mt-1 bg-white border rounded-md shadow-lg max-h-60 overflow-auto">
+            <ListboxOptions className="absolute z-10 w-full mt-1 bg-white border border-gray-200 rounded-md shadow-lg max-h-60 overflow-auto">
               {sweepTypeOptions.map((option) => (
                 <ListboxOption 
                   key={option.id} 

--- a/src/pages/wallet/import-private-key.tsx
+++ b/src/pages/wallet/import-private-key.tsx
@@ -154,10 +154,10 @@ const ImportPrivateKey = () => {
               <Label className="block text-sm font-medium text-gray-700">
                 Address Type <span className="text-red-500">*</span>
               </Label>
-              <div className="mt-1">
+              <div className="mt-1 relative">
                 <input type="hidden" name="address-type" value={addressFormat} />
                 <Listbox value={addressFormat} onChange={setAddressFormat} disabled={pending}>
-                  <ListboxButton className="w-full p-2 text-left rounded-md border border-gray-300 bg-white focus:border-blue-500 focus:ring-2 focus:ring-blue-500">
+                  <ListboxButton className="w-full p-2 text-left rounded-md border border-gray-200 bg-white focus:border-blue-500 focus:ring-2 focus:ring-blue-500">
                     {({ value }) => {
                       const selected = ADDRESS_TYPES.find(type => type.value === value);
                       return (
@@ -168,7 +168,7 @@ const ImportPrivateKey = () => {
                       );
                     }}
                   </ListboxButton>
-                  <ListboxOptions className="w-full mt-1 bg-white border border-gray-300 rounded-md shadow-lg max-h-60 overflow-auto z-10">
+                  <ListboxOptions className="absolute z-10 w-full mt-1 bg-white border border-gray-200 rounded-md shadow-lg max-h-60 overflow-auto">
                     {ADDRESS_TYPES.map((type) => (
                       <ListboxOption 
                         key={type.value} 


### PR DESCRIPTION
- Convert all dropdowns from push-down to overlay style using absolute positioning
- Standardize border colors from gray-300 to lighter gray-200 across all dropdowns
- Add relative positioning to dropdown containers for proper overlay behavior
- Ensure consistent styling with existing fee rate input dropdown pattern

Updated components:
- Fee rate input dropdown borders
- Import private key address type dropdown
- Sweep form type selector
- Fairminter mint method dropdown
- Bet form type selector
- Weekly bet prediction choice dropdown

All dropdowns now use overlay behavior instead of pushing content down.