### PR TITLE
Sign/Verify Message UX

### DIFF
--- a/src/pages/actions/sign-message.tsx
+++ b/src/pages/actions/sign-message.tsx
@@ -197,7 +197,7 @@ export default function SignMessage(): ReactElement {
   return (
     <div className="p-4 space-y-4">
       {/* Message Input */}
-      <div className="bg-white rounded-lg shadow-sm p-4">
+      <div className="bg-white rounded-lg shadow-sm p-3 sm:p-4">
         <TextAreaInput
           value={message}
           onChange={(value) => {
@@ -277,58 +277,60 @@ export default function SignMessage(): ReactElement {
             </div>
           )}
         </div>
+
+        {/* Sign Button - only show if not signed */}
+        {!signature && (
+          <div className="mt-4">
+            <Button
+              onClick={() => handleSign()}
+              color="blue"
+              disabled={!signingCapabilities.canSign || !message.trim() || isSigning}
+              fullWidth
+            >
+              {isSigning ? (
+                <div className="flex items-center justify-center gap-2">
+                  <Spinner />
+                  Signing…
+                </div>
+              ) : (
+                <div className="flex items-center justify-center gap-2">
+                  <FaLock className="size-4" aria-hidden="true" />
+                  Sign Message
+                </div>
+              )}
+            </Button>
+          </div>
+        )}
+
+        {/* Actions for Signature - inside container */}
+        {signature && (
+          <div className="flex items-center gap-2 mt-4">
+            <Button
+              onClick={() => {
+                setMessage("");
+                setSignature("");
+                setError(null);
+              }}
+              color="gray"
+            >
+              Reset
+            </Button>
+            <Button
+              onClick={() => handleCopy('', 'json')}
+              color="blue"
+              fullWidth
+            >
+              Download JSON
+            </Button>
+          </div>
+        )}
       </div>
-      
-      {/* Sign Button - only show if not signed */}
-      {!signature && (
-        <Button
-          onClick={() => handleSign()}
-          color="blue"
-          disabled={!signingCapabilities.canSign || !message.trim() || isSigning}
-          fullWidth
-        >
-          {isSigning ? (
-            <div className="flex items-center justify-center gap-2">
-              <Spinner />
-              Signing…
-            </div>
-          ) : (
-            <div className="flex items-center justify-center gap-2">
-              <FaLock className="size-4" aria-hidden="true" />
-              Sign Message
-            </div>
-          )}
-        </Button>
-      )}
-      
+
       {/* Error Display */}
       {error && (
         <ErrorAlert message={error} onClose={() => setError(null)} />
       )}
-      
-      {/* Actions for Signature */}
-      {signature && (
-        <div className="flex items-center gap-2">
-          <Button
-            onClick={() => {
-              setMessage("");
-              setSignature("");
-              setError(null);
-            }}
-            color="gray"
-          >
-            Reset
-          </Button>
-          <Button
-            onClick={() => handleCopy('', 'json')}
-            color="blue"
-            fullWidth
-          >
-            Download JSON
-          </Button>
-        </div>
-      )}
-      
+
       {/* YouTube Tutorial */}
       <Button
         variant="youtube"

--- a/src/utils/validation/__tests__/signatureJson.fuzz.test.ts
+++ b/src/utils/validation/__tests__/signatureJson.fuzz.test.ts
@@ -1,0 +1,527 @@
+/**
+ * Fuzz tests for signature JSON validation
+ * Tests for malformed input, boundary conditions, and security edge cases
+ */
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import {
+  validateSignatureJson,
+  validateJsonText,
+  parseAndValidateSignatureJson,
+  SIGNATURE_JSON_LIMITS,
+} from '../signatureJson';
+
+describe('signatureJson fuzz tests', () => {
+  describe('validateJsonText', () => {
+    it('should handle arbitrary strings without crashing', () => {
+      fc.assert(
+        fc.property(
+          fc.string(),
+          (text) => {
+            expect(() => {
+              validateJsonText(text);
+            }).not.toThrow();
+
+            const result = validateJsonText(text);
+            expect(result).toHaveProperty('valid');
+            expect(typeof result.valid).toBe('boolean');
+          }
+        ),
+        { numRuns: 1000 }
+      );
+    });
+
+    it('should handle unicode and special character strings safely', () => {
+      // Test with various string types including unicode
+      const specialStrings = [
+        '测试文件',
+        'файл',
+        '🎉emoji🚀',
+        'مستند',
+        'line1\nline2',
+        'tab\there',
+        '\x00\x01\x02',
+        '混合mixed內容',
+      ];
+
+      specialStrings.forEach(text => {
+        expect(() => {
+          validateJsonText(text);
+        }).not.toThrow();
+      });
+
+      // Also run property-based tests with random strings
+      fc.assert(
+        fc.property(
+          fc.string(),
+          (text) => {
+            expect(() => {
+              validateJsonText(text);
+            }).not.toThrow();
+          }
+        ),
+        { numRuns: 500 }
+      );
+    });
+  });
+
+  describe('validateSignatureJson', () => {
+    it('should handle arbitrary objects without crashing', () => {
+      fc.assert(
+        fc.property(
+          fc.anything(),
+          (data) => {
+            expect(() => {
+              validateSignatureJson(data);
+            }).not.toThrow();
+
+            const result = validateSignatureJson(data);
+            expect(result).toHaveProperty('valid');
+            expect(typeof result.valid).toBe('boolean');
+          }
+        ),
+        { numRuns: 1000 }
+      );
+    });
+
+    it('should handle deeply nested objects', () => {
+      fc.assert(
+        fc.property(
+          fc.integer({ min: 1, max: 20 }),
+          (depth) => {
+            // Create deeply nested object
+            let nested: any = { value: 'deep' };
+            for (let i = 0; i < depth; i++) {
+              nested = { nested };
+            }
+
+            const data = {
+              address: nested,
+              message: 'test',
+              signature: 'test',
+            };
+
+            expect(() => {
+              validateSignatureJson(data);
+            }).not.toThrow();
+
+            const result = validateSignatureJson(data);
+            expect(result.valid).toBe(false); // Should reject nested address
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('should handle arrays of various types in fields', () => {
+      fc.assert(
+        fc.property(
+          fc.array(fc.anything(), { minLength: 0, maxLength: 10 }),
+          (arr) => {
+            const data = {
+              address: arr,
+              message: 'test',
+              signature: 'test',
+            };
+
+            expect(() => {
+              validateSignatureJson(data);
+            }).not.toThrow();
+
+            const result = validateSignatureJson(data);
+            expect(result.valid).toBe(false); // Arrays should fail
+          }
+        ),
+        { numRuns: 200 }
+      );
+    });
+
+    it('should handle objects with many random extra fields', () => {
+      fc.assert(
+        fc.property(
+          fc.dictionary(fc.string(), fc.anything()),
+          (extraFields) => {
+            const data = {
+              address: 'test',
+              message: 'test',
+              signature: 'test',
+              ...extraFields,
+            };
+
+            expect(() => {
+              validateSignatureJson(data);
+            }).not.toThrow();
+
+            const result = validateSignatureJson(data);
+            // If extra fields exist (beyond our allowed ones), should fail
+            const hasExtraFields = Object.keys(extraFields).some(
+              k => !['address', 'message', 'signature', 'timestamp'].includes(k)
+            );
+            if (hasExtraFields) {
+              expect(result.valid).toBe(false);
+            }
+          }
+        ),
+        { numRuns: 500 }
+      );
+    });
+
+    it('should handle strings of varying lengths in all fields', () => {
+      fc.assert(
+        fc.property(
+          fc.string({ minLength: 0, maxLength: SIGNATURE_JSON_LIMITS.MAX_MESSAGE_LENGTH + 100 }),
+          fc.string({ minLength: 0, maxLength: SIGNATURE_JSON_LIMITS.MAX_ADDRESS_LENGTH + 100 }),
+          fc.string({ minLength: 0, maxLength: SIGNATURE_JSON_LIMITS.MAX_SIGNATURE_LENGTH + 100 }),
+          (message, address, signature) => {
+            const data = { address, message, signature };
+
+            expect(() => {
+              validateSignatureJson(data);
+            }).not.toThrow();
+
+            const result = validateSignatureJson(data);
+            expect(result).toHaveProperty('valid');
+
+            // If all fields are valid strings within limits, should pass
+            // If any field is empty or over limit, should fail
+            if (
+              address.trim().length > 0 &&
+              address.length <= SIGNATURE_JSON_LIMITS.MAX_ADDRESS_LENGTH &&
+              message.trim().length > 0 &&
+              message.length <= SIGNATURE_JSON_LIMITS.MAX_MESSAGE_LENGTH &&
+              signature.trim().length > 0 &&
+              signature.length <= SIGNATURE_JSON_LIMITS.MAX_SIGNATURE_LENGTH
+            ) {
+              expect(result.valid).toBe(true);
+            }
+          }
+        ),
+        { numRuns: 500 }
+      );
+    });
+
+    it('should handle null and undefined values in fields', () => {
+      const nullValues = [null, undefined];
+
+      nullValues.forEach(nullVal => {
+        const testCases = [
+          { address: nullVal, message: 'test', signature: 'test' },
+          { address: 'test', message: nullVal, signature: 'test' },
+          { address: 'test', message: 'test', signature: nullVal },
+          { address: nullVal, message: nullVal, signature: nullVal },
+        ];
+
+        testCases.forEach(data => {
+          expect(() => {
+            validateSignatureJson(data);
+          }).not.toThrow();
+
+          const result = validateSignatureJson(data);
+          expect(result.valid).toBe(false);
+        });
+      });
+    });
+
+    it('should handle special number values', () => {
+      const specialNumbers = [NaN, Infinity, -Infinity, 0, -0, Number.MAX_VALUE, Number.MIN_VALUE];
+
+      specialNumbers.forEach(num => {
+        const data = {
+          address: num,
+          message: 'test',
+          signature: 'test',
+        };
+
+        expect(() => {
+          validateSignatureJson(data);
+        }).not.toThrow();
+
+        const result = validateSignatureJson(data);
+        expect(result.valid).toBe(false); // Numbers should fail
+      });
+    });
+
+    it('should handle boolean values', () => {
+      const data = {
+        address: true,
+        message: false,
+        signature: 'test',
+      };
+
+      expect(() => {
+        validateSignatureJson(data);
+      }).not.toThrow();
+
+      const result = validateSignatureJson(data);
+      expect(result.valid).toBe(false);
+    });
+
+    it('should handle Symbol and BigInt values', () => {
+      const data = {
+        address: 'test',
+        message: 'test',
+        signature: 'test',
+        extra: Symbol('test'),
+      };
+
+      // Symbol won't be enumerated by Object.keys
+      expect(() => {
+        validateSignatureJson(data);
+      }).not.toThrow();
+
+      const bigIntData = {
+        address: BigInt(123),
+        message: 'test',
+        signature: 'test',
+      };
+
+      expect(() => {
+        validateSignatureJson(bigIntData);
+      }).not.toThrow();
+
+      const result = validateSignatureJson(bigIntData);
+      expect(result.valid).toBe(false);
+    });
+  });
+
+  describe('parseAndValidateSignatureJson', () => {
+    it('should handle arbitrary JSON-like strings', () => {
+      fc.assert(
+        fc.property(
+          fc.json(),
+          (jsonString) => {
+            expect(() => {
+              parseAndValidateSignatureJson(jsonString);
+            }).not.toThrow();
+
+            const result = parseAndValidateSignatureJson(jsonString);
+            expect(result).toHaveProperty('valid');
+            expect(typeof result.valid).toBe('boolean');
+          }
+        ),
+        { numRuns: 500 }
+      );
+    });
+
+    it('should handle malformed JSON gracefully', () => {
+      const malformedJsons = [
+        '{',
+        '{"address":}',
+        '{"address": "test"',
+        '[1,2,3',
+        'undefined',
+        'NaN',
+        '{"a": undefined}',
+        '{"a": NaN}',
+        '{a: "b"}', // Unquoted key
+        "{'a': 'b'}", // Single quotes
+        '{"a": \'b\'}', // Mixed quotes
+        '{"a": "b",}', // Trailing comma
+      ];
+
+      malformedJsons.forEach(json => {
+        expect(() => {
+          parseAndValidateSignatureJson(json);
+        }).not.toThrow();
+
+        const result = parseAndValidateSignatureJson(json);
+        expect(result.valid).toBe(false);
+        expect(result.error).toBeDefined();
+      });
+    });
+
+    it('should handle valid JSON with invalid structure', () => {
+      fc.assert(
+        fc.property(
+          fc.oneof(
+            fc.integer(),
+            fc.boolean(),
+            fc.string(),
+            fc.array(fc.anything()),
+            fc.constant(null)
+          ),
+          (value) => {
+            const jsonString = JSON.stringify(value);
+
+            expect(() => {
+              parseAndValidateSignatureJson(jsonString);
+            }).not.toThrow();
+
+            const result = parseAndValidateSignatureJson(jsonString);
+            expect(result.valid).toBe(false); // These are not valid signature objects
+          }
+        ),
+        { numRuns: 200 }
+      );
+    });
+
+    it('should handle JSON with unicode escape sequences', () => {
+      const unicodeJsons = [
+        '{"address": "\\u0041\\u0042\\u0043", "message": "test", "signature": "sig"}',
+        '{"address": "test", "message": "\\u4e2d\\u6587", "signature": "sig"}',
+        '{"address": "\\uD83D\\uDE00", "message": "test", "signature": "sig"}', // Emoji
+      ];
+
+      unicodeJsons.forEach(json => {
+        expect(() => {
+          parseAndValidateSignatureJson(json);
+        }).not.toThrow();
+
+        const result = parseAndValidateSignatureJson(json);
+        // These should be valid as they decode to valid strings
+        expect(result.valid).toBe(true);
+      });
+    });
+  });
+
+  describe('security edge cases', () => {
+    it('should handle JSON with __proto__ in various forms', () => {
+      const protoJsons = [
+        '{"__proto__": {"isAdmin": true}, "address": "a", "message": "m", "signature": "s"}',
+        '{"constructor": {"prototype": {}}, "address": "a", "message": "m", "signature": "s"}',
+        '{"prototype": {}, "address": "a", "message": "m", "signature": "s"}',
+      ];
+
+      protoJsons.forEach(json => {
+        expect(() => {
+          parseAndValidateSignatureJson(json);
+        }).not.toThrow();
+
+        const result = parseAndValidateSignatureJson(json);
+        // Should reject due to unexpected fields
+        // Note: __proto__ may or may not appear depending on JSON.parse behavior
+        if (!result.valid) {
+          expect(result.error).toContain('Unexpected');
+        }
+      });
+    });
+
+    it('should handle extremely long field values', () => {
+      // Generate string just over limit
+      const overLimit = {
+        address: 'a'.repeat(SIGNATURE_JSON_LIMITS.MAX_ADDRESS_LENGTH + 1),
+        message: 'test',
+        signature: 'test',
+      };
+
+      const result = validateSignatureJson(overLimit);
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('exceeds');
+    });
+
+    it('should handle file size limit', () => {
+      // String just over file size limit
+      const hugeJson = JSON.stringify({
+        address: 'test',
+        message: 'x'.repeat(SIGNATURE_JSON_LIMITS.MAX_FILE_SIZE),
+        signature: 'test',
+      });
+
+      const result = parseAndValidateSignatureJson(hugeJson);
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('too large');
+    });
+
+    it('should handle strings with null bytes', () => {
+      const nullByteStrings = [
+        'test\x00string',
+        '\x00',
+        'before\x00after',
+        '\x00\x00\x00',
+      ];
+
+      nullByteStrings.forEach(str => {
+        const data = {
+          address: str,
+          message: 'test',
+          signature: 'test',
+        };
+
+        expect(() => {
+          validateSignatureJson(data);
+        }).not.toThrow();
+
+        // We don't specifically block null bytes, but the function shouldn't crash
+        const result = validateSignatureJson(data);
+        expect(result).toHaveProperty('valid');
+      });
+    });
+
+    it('should handle strings with newlines and special whitespace', () => {
+      // Strings with content plus whitespace should pass
+      const validWhitespaceStrings = [
+        'line1\nline2',
+        'line1\r\nline2',
+        'tab\there',
+        'unicode\u2028line\u2029paragraph',
+      ];
+
+      validWhitespaceStrings.forEach(str => {
+        const data = {
+          address: 'test',
+          message: str,
+          signature: 'test',
+        };
+
+        expect(() => {
+          validateSignatureJson(data);
+        }).not.toThrow();
+
+        const result = validateSignatureJson(data);
+        // These should pass - message has non-whitespace content
+        expect(result.valid).toBe(true);
+      });
+
+      // Strings that are only whitespace should fail (they trim to empty)
+      const whitespaceOnlyStrings = [
+        '\t\n\r ',
+        '   ',
+        '\n\n\n',
+      ];
+
+      whitespaceOnlyStrings.forEach(str => {
+        const data = {
+          address: 'test',
+          message: str,
+          signature: 'test',
+        };
+
+        const result = validateSignatureJson(data);
+        // Should fail - message is effectively empty after trim
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('empty');
+      });
+    });
+  });
+
+  describe('performance', () => {
+    it('should validate quickly even with edge case inputs', () => {
+      const start = Date.now();
+
+      // Run many validations
+      for (let i = 0; i < 1000; i++) {
+        validateSignatureJson({
+          address: 'a'.repeat(SIGNATURE_JSON_LIMITS.MAX_ADDRESS_LENGTH),
+          message: 'm'.repeat(SIGNATURE_JSON_LIMITS.MAX_MESSAGE_LENGTH),
+          signature: 's'.repeat(SIGNATURE_JSON_LIMITS.MAX_SIGNATURE_LENGTH),
+          timestamp: 't'.repeat(SIGNATURE_JSON_LIMITS.MAX_TIMESTAMP_LENGTH),
+        });
+      }
+
+      const elapsed = Date.now() - start;
+      // Should complete 1000 validations in under 1 second
+      expect(elapsed).toBeLessThan(1000);
+    });
+
+    it('should reject oversized input quickly', () => {
+      const hugeString = 'x'.repeat(SIGNATURE_JSON_LIMITS.MAX_FILE_SIZE + 1000);
+
+      const start = Date.now();
+      const result = validateJsonText(hugeString);
+      const elapsed = Date.now() - start;
+
+      expect(result.valid).toBe(false);
+      expect(elapsed).toBeLessThan(10); // Should be nearly instant
+    });
+  });
+});

--- a/src/utils/validation/__tests__/signatureJson.test.ts
+++ b/src/utils/validation/__tests__/signatureJson.test.ts
@@ -1,0 +1,313 @@
+import { describe, it, expect } from 'vitest';
+import {
+  validateSignatureJson,
+  validateJsonText,
+  parseAndValidateSignatureJson,
+  SIGNATURE_JSON_LIMITS,
+  type SignatureJson,
+} from '../signatureJson';
+
+describe('signatureJson validation', () => {
+  describe('validateJsonText', () => {
+    it('should accept valid JSON text within size limits', () => {
+      const result = validateJsonText('{"address": "test"}');
+      expect(result.valid).toBe(true);
+    });
+
+    it('should reject empty text', () => {
+      const result = validateJsonText('');
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('empty');
+    });
+
+    it('should reject whitespace-only text', () => {
+      const result = validateJsonText('   \n\t  ');
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('empty');
+    });
+
+    it('should reject text exceeding max file size', () => {
+      const largeText = 'x'.repeat(SIGNATURE_JSON_LIMITS.MAX_FILE_SIZE + 1);
+      const result = validateJsonText(largeText);
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('too large');
+    });
+  });
+
+  describe('validateSignatureJson', () => {
+    const validData: SignatureJson = {
+      address: 'bc1qtest123',
+      message: 'Hello, world!',
+      signature: 'H1234567890abcdef',
+    };
+
+    it('should accept valid signature JSON', () => {
+      const result = validateSignatureJson(validData);
+      expect(result.valid).toBe(true);
+      expect(result.data).toEqual(validData);
+    });
+
+    it('should accept valid signature JSON with optional timestamp', () => {
+      const dataWithTimestamp = {
+        ...validData,
+        timestamp: '2024-01-01T00:00:00.000Z',
+      };
+      const result = validateSignatureJson(dataWithTimestamp);
+      expect(result.valid).toBe(true);
+      expect(result.data?.timestamp).toBe('2024-01-01T00:00:00.000Z');
+    });
+
+    describe('type validation', () => {
+      it('should reject null', () => {
+        const result = validateSignatureJson(null);
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('expected an object');
+      });
+
+      it('should reject arrays', () => {
+        const result = validateSignatureJson([validData]);
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('expected an object');
+      });
+
+      it('should reject primitives', () => {
+        expect(validateSignatureJson('string').valid).toBe(false);
+        expect(validateSignatureJson(123).valid).toBe(false);
+        expect(validateSignatureJson(true).valid).toBe(false);
+      });
+    });
+
+    describe('required fields', () => {
+      it('should reject missing address', () => {
+        const { address, ...dataWithoutAddress } = validData;
+        const result = validateSignatureJson(dataWithoutAddress);
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('address');
+      });
+
+      it('should reject missing message', () => {
+        const { message, ...dataWithoutMessage } = validData;
+        const result = validateSignatureJson(dataWithoutMessage);
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('message');
+      });
+
+      it('should reject missing signature', () => {
+        const { signature, ...dataWithoutSignature } = validData;
+        const result = validateSignatureJson(dataWithoutSignature);
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('signature');
+      });
+
+      it('should reject empty address', () => {
+        const result = validateSignatureJson({ ...validData, address: '' });
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('cannot be empty');
+      });
+
+      it('should reject whitespace-only address', () => {
+        const result = validateSignatureJson({ ...validData, address: '   ' });
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('cannot be empty');
+      });
+
+      it('should reject empty message', () => {
+        const result = validateSignatureJson({ ...validData, message: '' });
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('cannot be empty');
+      });
+
+      it('should reject empty signature', () => {
+        const result = validateSignatureJson({ ...validData, signature: '' });
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('cannot be empty');
+      });
+    });
+
+    describe('field type validation', () => {
+      it('should reject non-string address', () => {
+        const result = validateSignatureJson({ ...validData, address: 123 });
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('must be a string');
+      });
+
+      it('should reject non-string message', () => {
+        const result = validateSignatureJson({ ...validData, message: { text: 'hi' } });
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('must be a string');
+      });
+
+      it('should reject non-string signature', () => {
+        const result = validateSignatureJson({ ...validData, signature: ['sig'] });
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('must be a string');
+      });
+
+      it('should reject non-string timestamp', () => {
+        const result = validateSignatureJson({ ...validData, timestamp: 1234567890 });
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('must be a string');
+      });
+    });
+
+    describe('field length limits', () => {
+      it('should reject address exceeding max length', () => {
+        const longAddress = 'a'.repeat(SIGNATURE_JSON_LIMITS.MAX_ADDRESS_LENGTH + 1);
+        const result = validateSignatureJson({ ...validData, address: longAddress });
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('exceeds maximum length');
+      });
+
+      it('should accept address at max length', () => {
+        const maxAddress = 'a'.repeat(SIGNATURE_JSON_LIMITS.MAX_ADDRESS_LENGTH);
+        const result = validateSignatureJson({ ...validData, address: maxAddress });
+        expect(result.valid).toBe(true);
+      });
+
+      it('should reject message exceeding max length', () => {
+        const longMessage = 'm'.repeat(SIGNATURE_JSON_LIMITS.MAX_MESSAGE_LENGTH + 1);
+        const result = validateSignatureJson({ ...validData, message: longMessage });
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('exceeds maximum length');
+      });
+
+      it('should accept message at max length', () => {
+        const maxMessage = 'm'.repeat(SIGNATURE_JSON_LIMITS.MAX_MESSAGE_LENGTH);
+        const result = validateSignatureJson({ ...validData, message: maxMessage });
+        expect(result.valid).toBe(true);
+      });
+
+      it('should reject signature exceeding max length', () => {
+        const longSignature = 's'.repeat(SIGNATURE_JSON_LIMITS.MAX_SIGNATURE_LENGTH + 1);
+        const result = validateSignatureJson({ ...validData, signature: longSignature });
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('exceeds maximum length');
+      });
+
+      it('should reject timestamp exceeding max length', () => {
+        const longTimestamp = 't'.repeat(SIGNATURE_JSON_LIMITS.MAX_TIMESTAMP_LENGTH + 1);
+        const result = validateSignatureJson({ ...validData, timestamp: longTimestamp });
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('exceeds maximum length');
+      });
+    });
+
+    describe('unexpected fields', () => {
+      it('should reject objects with unexpected fields', () => {
+        const dataWithExtra = {
+          ...validData,
+          privateKey: 'should-not-be-here',
+        };
+        const result = validateSignatureJson(dataWithExtra);
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('Unexpected fields');
+        expect(result.error).toContain('privateKey');
+      });
+
+      it('should reject multiple unexpected fields', () => {
+        const dataWithExtras = {
+          ...validData,
+          foo: 'bar',
+          baz: 123,
+        };
+        const result = validateSignatureJson(dataWithExtras);
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain('foo');
+        expect(result.error).toContain('baz');
+      });
+    });
+  });
+
+  describe('parseAndValidateSignatureJson', () => {
+    it('should parse and validate valid JSON', () => {
+      const json = JSON.stringify({
+        address: 'bc1qtest',
+        message: 'test message',
+        signature: 'testsig',
+      });
+      const result = parseAndValidateSignatureJson(json);
+      expect(result.valid).toBe(true);
+      expect(result.data?.address).toBe('bc1qtest');
+    });
+
+    it('should reject invalid JSON syntax', () => {
+      const result = parseAndValidateSignatureJson('{ invalid json }');
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('Invalid JSON');
+    });
+
+    it('should reject JSON that parses but fails validation', () => {
+      const json = JSON.stringify({ address: 123 }); // wrong type
+      const result = parseAndValidateSignatureJson(json);
+      expect(result.valid).toBe(false);
+    });
+
+    it('should reject empty input', () => {
+      const result = parseAndValidateSignatureJson('');
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('empty');
+    });
+
+    it('should reject oversized input', () => {
+      const oversized = '{' + ' '.repeat(SIGNATURE_JSON_LIMITS.MAX_FILE_SIZE) + '}';
+      const result = parseAndValidateSignatureJson(oversized);
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('too large');
+    });
+  });
+
+  describe('security scenarios', () => {
+    it('should be safe from prototype pollution because we only extract known fields', () => {
+      // __proto__ in object literals doesn't become an enumerable key in modern JS
+      // Our validation is safe because we only extract specific fields (address, message, signature, timestamp)
+      // and don't iterate or spread the object
+      const malicious = {
+        address: 'test',
+        message: 'test',
+        signature: 'test',
+        __proto__: { isAdmin: true },
+      };
+      const result = validateSignatureJson(malicious);
+      // This passes validation because __proto__ isn't enumerable
+      // But our extraction is safe - we only get the fields we explicitly ask for
+      expect(result.valid).toBe(true);
+      expect(result.data?.address).toBe('test');
+      // Verify no pollution occurred
+      expect((result.data as any).isAdmin).toBeUndefined();
+    });
+
+    it('should not allow constructor pollution', () => {
+      const malicious = {
+        address: 'test',
+        message: 'test',
+        signature: 'test',
+        constructor: { prototype: {} },
+      };
+      const result = validateSignatureJson(malicious);
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('Unexpected fields');
+    });
+
+    it('should handle deeply nested objects in fields', () => {
+      const nested = {
+        address: { nested: { deep: 'value' } },
+        message: 'test',
+        signature: 'test',
+      };
+      const result = validateSignatureJson(nested);
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('must be a string');
+    });
+
+    it('should handle arrays in fields', () => {
+      const withArray = {
+        address: ['addr1', 'addr2'],
+        message: 'test',
+        signature: 'test',
+      };
+      const result = validateSignatureJson(withArray);
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('must be a string');
+    });
+  });
+});

--- a/src/utils/validation/signatureJson.ts
+++ b/src/utils/validation/signatureJson.ts
@@ -1,0 +1,200 @@
+/**
+ * Signature JSON Validation
+ *
+ * Validates JSON files used for importing/exporting message signatures.
+ * Ensures strict schema validation to prevent malformed or malicious input.
+ */
+
+/**
+ * Expected shape of a signature JSON file
+ */
+export interface SignatureJson {
+  address: string;
+  message: string;
+  signature: string;
+  timestamp?: string;
+}
+
+/**
+ * Validation result with typed data or error
+ */
+export interface ValidationResult {
+  valid: boolean;
+  data?: SignatureJson;
+  error?: string;
+}
+
+/**
+ * Maximum allowed lengths for each field
+ */
+export const SIGNATURE_JSON_LIMITS = {
+  /** Maximum Bitcoin address length (bech32m can be up to 90 chars) */
+  MAX_ADDRESS_LENGTH: 100,
+  /** Maximum message length (10KB should be plenty) */
+  MAX_MESSAGE_LENGTH: 10000,
+  /** Maximum signature length (base64 signatures are typically ~88 chars) */
+  MAX_SIGNATURE_LENGTH: 500,
+  /** Maximum timestamp length (ISO format is ~24 chars) */
+  MAX_TIMESTAMP_LENGTH: 50,
+  /** Maximum total JSON file size (50KB) */
+  MAX_FILE_SIZE: 50000,
+} as const;
+
+/**
+ * Allowed keys in a signature JSON file
+ */
+const ALLOWED_KEYS = ['address', 'message', 'signature', 'timestamp'] as const;
+
+/**
+ * Validates that a value is a non-empty string within length limits
+ */
+function validateStringField(
+  value: unknown,
+  fieldName: string,
+  maxLength: number,
+  required: boolean = true
+): string | null {
+  if (value === undefined || value === null) {
+    if (required) {
+      return `Missing required field: ${fieldName}`;
+    }
+    return null;
+  }
+
+  if (typeof value !== 'string') {
+    return `Field '${fieldName}' must be a string, got ${typeof value}`;
+  }
+
+  if (required && value.trim().length === 0) {
+    return `Field '${fieldName}' cannot be empty`;
+  }
+
+  if (value.length > maxLength) {
+    return `Field '${fieldName}' exceeds maximum length of ${maxLength} characters`;
+  }
+
+  return null;
+}
+
+/**
+ * Validates raw JSON text before parsing
+ */
+export function validateJsonText(text: string): ValidationResult {
+  // Check file size
+  if (text.length > SIGNATURE_JSON_LIMITS.MAX_FILE_SIZE) {
+    return {
+      valid: false,
+      error: `File too large. Maximum size is ${SIGNATURE_JSON_LIMITS.MAX_FILE_SIZE} bytes`,
+    };
+  }
+
+  // Check it's not empty
+  if (text.trim().length === 0) {
+    return {
+      valid: false,
+      error: 'File is empty',
+    };
+  }
+
+  return { valid: true };
+}
+
+/**
+ * Validates a parsed JSON object as a signature file
+ */
+export function validateSignatureJson(data: unknown): ValidationResult {
+  // Must be an object
+  if (data === null || typeof data !== 'object' || Array.isArray(data)) {
+    return {
+      valid: false,
+      error: 'Invalid JSON structure: expected an object',
+    };
+  }
+
+  const obj = data as Record<string, unknown>;
+
+  // Check for unexpected fields
+  const keys = Object.keys(obj);
+  const unexpectedKeys = keys.filter(k => !ALLOWED_KEYS.includes(k as typeof ALLOWED_KEYS[number]));
+  if (unexpectedKeys.length > 0) {
+    return {
+      valid: false,
+      error: `Unexpected fields in JSON: ${unexpectedKeys.join(', ')}`,
+    };
+  }
+
+  // Validate required fields
+  const addressError = validateStringField(
+    obj.address,
+    'address',
+    SIGNATURE_JSON_LIMITS.MAX_ADDRESS_LENGTH
+  );
+  if (addressError) {
+    return { valid: false, error: addressError };
+  }
+
+  const messageError = validateStringField(
+    obj.message,
+    'message',
+    SIGNATURE_JSON_LIMITS.MAX_MESSAGE_LENGTH
+  );
+  if (messageError) {
+    return { valid: false, error: messageError };
+  }
+
+  const signatureError = validateStringField(
+    obj.signature,
+    'signature',
+    SIGNATURE_JSON_LIMITS.MAX_SIGNATURE_LENGTH
+  );
+  if (signatureError) {
+    return { valid: false, error: signatureError };
+  }
+
+  // Validate optional timestamp field
+  const timestampError = validateStringField(
+    obj.timestamp,
+    'timestamp',
+    SIGNATURE_JSON_LIMITS.MAX_TIMESTAMP_LENGTH,
+    false // not required
+  );
+  if (timestampError) {
+    return { valid: false, error: timestampError };
+  }
+
+  // All validation passed
+  return {
+    valid: true,
+    data: {
+      address: obj.address as string,
+      message: obj.message as string,
+      signature: obj.signature as string,
+      timestamp: obj.timestamp as string | undefined,
+    },
+  };
+}
+
+/**
+ * Parses and validates a JSON string as a signature file
+ */
+export function parseAndValidateSignatureJson(text: string): ValidationResult {
+  // Validate raw text first
+  const textValidation = validateJsonText(text);
+  if (!textValidation.valid) {
+    return textValidation;
+  }
+
+  // Try to parse JSON
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch (e) {
+    return {
+      valid: false,
+      error: 'Invalid JSON: ' + (e instanceof Error ? e.message : 'parse error'),
+    };
+  }
+
+  // Validate the parsed object
+  return validateSignatureJson(parsed);
+}


### PR DESCRIPTION
## Summary
- Move verify/sign buttons inside the white container to match other forms (like ComposerForm)
- Update container padding to `p-3 sm:p-4` for consistency across forms
- Add strict JSON schema validation for signature file import/export to prevent malformed or malicious input

## Changes
- **src/pages/actions/sign-message.tsx**: Button moved inside container, padding updated, signature actions (Reset/Download JSON) also inside container
- **src/pages/actions/verify-message.tsx**: Verify button moved inside container, padding updated, JSON validation added on import
- **src/utils/validation/signatureJson.ts**: New validation utility with type checking, length limits, and field whitelist
- **src/utils/validation/__tests__/signatureJson.test.ts**: 37 unit tests covering all validation scenarios
- **src/utils/validation/__tests__/signatureJson.fuzz.test.ts**: 22 fuzz tests using fast-check for edge cases

## Test plan
- [x] Unit tests pass (37 tests)
- [x] Fuzz tests pass (22 tests)
- [ ] Manual verification that buttons render inside white container on both pages
- [ ] Test JSON upload with valid signature file
- [ ] Test JSON upload with malformed/oversized files