### PR TITLE
Memo Hex Refactor

### DIFF
--- a/src/pages/compose/send/index.tsx
+++ b/src/pages/compose/send/index.tsx
@@ -2,71 +2,17 @@ import { useParams } from "react-router-dom";
 import { SendForm } from "./form";
 import { ReviewSend } from "./review";
 import { Composer } from "@/components/composer/composer";
-import { composeSend, composeMPMA } from "@/utils/blockchain/counterparty/compose";
-import { isHexMemo, stripHexPrefix } from "@/utils/blockchain/counterparty/memo";
-import type { SendOptions, MPMAOptions, ApiResponse } from "@/utils/blockchain/counterparty/compose";
-
-interface ExtendedSendOptions extends SendOptions {
-  destinations?: string; // Comma-separated list for MPMA
-}
+import { composeSendOrMPMA } from "@/utils/blockchain/counterparty/compose";
+import type { SendOrMPMAOptions } from "@/utils/blockchain/counterparty/compose";
 
 function ComposeSendPage() {
   const { asset } = useParams<{ asset?: string }>();
 
-  // Wrapper function that determines which compose function to use
-  const composeTransaction = async (data: ExtendedSendOptions): Promise<ApiResponse> => {
-    // Auto-detect hex memo and process it
-    let processedMemo = data.memo;
-    let memoIsHex = false;
-
-    if (data.memo && isHexMemo(data.memo)) {
-      processedMemo = stripHexPrefix(data.memo);
-      memoIsHex = true;
-    }
-
-    // Check if we have multiple destinations (MPMA)
-    if (data.destinations && data.destinations.includes(',')) {
-      // Parse multiple destinations
-      const destArray = data.destinations.split(',').map((d: string) => d.trim());
-
-      // Create MPMA options
-      const mpmaOptions: MPMAOptions = {
-        sourceAddress: data.sourceAddress,
-        assets: destArray.map(() => data.asset), // Same asset for all
-        destinations: destArray,
-        quantities: destArray.map(() => data.quantity.toString()), // Same quantity for all
-        sat_per_vbyte: data.sat_per_vbyte,
-        ...(processedMemo && {
-          memos: destArray.map(() => processedMemo as string),
-          memos_are_hex: destArray.map(() => memoIsHex)
-        })
-      };
-
-      // Compose MPMA transaction
-      const response = await composeMPMA(mpmaOptions);
-      // Mark as MPMA for review component
-      response.result.name = 'mpma';
-      return response;
-    } else {
-      // Single destination - use regular send with processed memo
-      const sendOptions = {
-        ...data,
-        ...(processedMemo && {
-          memo: processedMemo,
-          memo_is_hex: memoIsHex
-        })
-      };
-      const response = await composeSend(sendOptions);
-      response.result.name = 'send';
-      return response;
-    }
-  };
-
   return (
     <div className="p-4">
-      <Composer<ExtendedSendOptions>
+      <Composer<SendOrMPMAOptions>
         composeType="send"
-        composeApiMethod={composeTransaction}
+        composeApiMethod={composeSendOrMPMA}
         initialTitle="Send"
         FormComponent={(props) => <SendForm {...props} initialAsset={asset || "BTC"} />}
         ReviewComponent={ReviewSend}

--- a/src/pages/compose/sweep/form.tsx
+++ b/src/pages/compose/sweep/form.tsx
@@ -18,6 +18,7 @@ import type { SweepOptions } from "@/utils/blockchain/counterparty/compose";
 import type { ReactElement } from "react";
 
 // Define sweep type options
+// Note: FLAG_BINARY_MEMO (4) is handled automatically by normalize.ts based on memo content
 const FLAG_BALANCES = 1;
 const FLAG_OWNERSHIP = 2;
 

--- a/src/utils/blockchain/counterparty/__tests__/compose.send.test.ts
+++ b/src/utils/blockchain/counterparty/__tests__/compose.send.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { composeSend, composeSweep, getSweepEstimateXcpFee, composeMove } from '../compose';
+import { composeSend, composeSendOrMPMA, composeMPMA, composeSweep, getSweepEstimateXcpFee, composeMove } from '../compose';
 import * as apiClientUtils from '@/utils/apiClient';
 import { walletManager } from '@/utils/wallet/walletManager';
 import {
@@ -124,6 +124,135 @@ describe('Compose Send Operations', () => {
         ...btcParams,
       });
       assertComposeUrlCalled(mockedApiClient, 'send', btcParams);
+    });
+  });
+
+  describe('composeSendOrMPMA', () => {
+    const defaultParams = {
+      destination: mockDestAddress,
+      asset: testAssets.XCP,
+      quantity: testQuantities.MEDIUM,
+    };
+
+    // composeSendOrMPMA accesses response.result.name, so we need proper ApiResponse structure
+    const createApiResponseWithResult = () => ({
+      data: { result: createMockComposeResult() },
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      config: { headers: {} as any },
+    });
+
+    it('should use composeSend for single destination and set result.name to "send"', async () => {
+      mockedApiClient.get.mockResolvedValue(createApiResponseWithResult());
+
+      const result = await composeSendOrMPMA({
+        sourceAddress: mockAddress,
+        sat_per_vbyte: mockSatPerVbyte,
+        ...defaultParams,
+      });
+
+      expect(result.result.name).toBe('send');
+      assertComposeUrlCalled(mockedApiClient, 'send', defaultParams);
+    });
+
+    it('should use composeMPMA for multiple destinations and set result.name to "mpma"', async () => {
+      mockedApiClient.get.mockResolvedValue(createApiResponseWithResult());
+      const destinations = `${mockDestAddress}, bc1qanother, bc1qthird`;
+
+      const result = await composeSendOrMPMA({
+        sourceAddress: mockAddress,
+        sat_per_vbyte: mockSatPerVbyte,
+        asset: testAssets.XCP,
+        quantity: testQuantities.MEDIUM,
+        destination: mockDestAddress, // ignored when destinations provided
+        destinations,
+      });
+
+      expect(result.result.name).toBe('mpma');
+
+      const actualUrl = mockedApiClient.get.mock.calls[0][0] as string;
+      expect(actualUrl).toContain('/compose/mpma');
+      // MPMA uses comma-separated destinations
+      expect(actualUrl).toContain('destinations=');
+      expect(actualUrl).toContain('bc1qanother');
+      expect(actualUrl).toContain('bc1qthird');
+    });
+
+    it('should duplicate asset and quantity for each destination in MPMA', async () => {
+      mockedApiClient.get.mockResolvedValue(createApiResponseWithResult());
+      const destinations = `${mockDestAddress}, bc1qsecond`;
+
+      await composeSendOrMPMA({
+        sourceAddress: mockAddress,
+        sat_per_vbyte: mockSatPerVbyte,
+        asset: testAssets.XCP,
+        quantity: testQuantities.MEDIUM,
+        destination: mockDestAddress,
+        destinations,
+      });
+
+      const actualUrl = mockedApiClient.get.mock.calls[0][0] as string;
+      // Should have same asset for both destinations
+      expect(actualUrl).toContain(`assets=${testAssets.XCP}%2C${testAssets.XCP}`);
+      // Should have same quantity for both destinations
+      expect(actualUrl).toContain(`quantities=${testQuantities.MEDIUM}%2C${testQuantities.MEDIUM}`);
+    });
+
+    it('should include memo for each destination in MPMA', async () => {
+      mockedApiClient.get.mockResolvedValue(createApiResponseWithResult());
+      const destinations = `${mockDestAddress}, bc1qsecond`;
+
+      await composeSendOrMPMA({
+        sourceAddress: mockAddress,
+        sat_per_vbyte: mockSatPerVbyte,
+        asset: testAssets.XCP,
+        quantity: testQuantities.MEDIUM,
+        destination: mockDestAddress,
+        destinations,
+        memo: testMemos.TEXT,
+        memo_is_hex: false,
+      });
+
+      const actualUrl = mockedApiClient.get.mock.calls[0][0] as string;
+      // Should have memo arrays
+      expect(actualUrl).toContain(`memos[]=${encodeURIComponent(testMemos.TEXT)}`);
+      expect(actualUrl).toContain('memos_are_hex[]=false');
+    });
+
+    it('should treat single destination without comma as regular send', async () => {
+      mockedApiClient.get.mockResolvedValue(createApiResponseWithResult());
+
+      const result = await composeSendOrMPMA({
+        sourceAddress: mockAddress,
+        sat_per_vbyte: mockSatPerVbyte,
+        ...defaultParams,
+        destinations: mockDestAddress, // Single destination, no comma
+      });
+
+      expect(result.result.name).toBe('send');
+      const actualUrl = mockedApiClient.get.mock.calls[0][0] as string;
+      expect(actualUrl).toContain('/compose/send');
+    });
+
+    it('should trim whitespace from destinations', async () => {
+      mockedApiClient.get.mockResolvedValue(createApiResponseWithResult());
+      const destinations = `  ${mockDestAddress}  ,  bc1qsecond  `;
+
+      await composeSendOrMPMA({
+        sourceAddress: mockAddress,
+        sat_per_vbyte: mockSatPerVbyte,
+        asset: testAssets.XCP,
+        quantity: testQuantities.MEDIUM,
+        destination: mockDestAddress,
+        destinations,
+      });
+
+      const actualUrl = mockedApiClient.get.mock.calls[0][0] as string;
+      // Destinations should be trimmed (MPMA uses comma-separated, not array syntax)
+      expect(actualUrl).toContain(`destinations=${encodeURIComponent(mockDestAddress)}%2Cbc1qsecond`);
+      // Should not contain extra whitespace
+      expect(actualUrl).not.toContain('%20%20');
     });
   });
 


### PR DESCRIPTION
## Summary

- Sweep transactions with hex memos now correctly set `FLAG_BINARY_MEMO` (4) in the flags field, matching counterparty-core behavior
- Centralized memo hex detection in `normalize.ts` for both send and sweep
- Added `composeSendOrMPMA` function for cleaner send/MPMA routing
- Simplified `send/index.tsx` to match the pattern of other index files

## Problem

Counterparty-core uses `FLAG_BINARY_MEMO = 4` in the flags field to indicate a hex memo for sweep transactions. The extension was not setting this flag, causing hex memos to be incorrectly encoded as UTF-8 text.

## Changes

| File | Change |
|------|--------|
| `normalize.ts` | Add memo hex detection with configurable output (boolean for send, flag for sweep) |
| `compose.ts` | Add `composeSendOrMPMA` to handle send vs MPMA routing |
| `send/index.tsx` | Simplify to use new compose function (-62 lines) |
| `sweep/form.tsx` | Add clarifying comment |

## Test plan

- [x] Added 8 tests for memo normalization in `normalize.test.ts`
- [x] Added 6 tests for `composeSendOrMPMA` in `compose.send.test.ts`
- [x] All 244 related tests passing
- [ ] Manual test: send with hex memo (0xdeadbeef)
- [ ] Manual test: sweep with hex memo