### PR TITLE
Dispenser Improvements

### DIFF
--- a/src/pages/compose/dispenser/close/form.tsx
+++ b/src/pages/compose/dispenser/close/form.tsx
@@ -122,7 +122,7 @@ export function DispenserCloseForm({
                     disabled={pending}
                   >
                     <div className="relative mt-1">
-                    <ListboxButton className="relative w-full cursor-pointer rounded-lg bg-gray-50 py-2.5 pl-3 pr-10 text-left border border-gray-200 outline-none focus:border-blue-500 focus-visible:ring-2 focus-visible:ring-blue-500 sm:text-sm disabled:bg-gray-100 disabled:cursor-not-allowed">
+                    <ListboxButton className="relative w-full cursor-pointer rounded-lg bg-gray-50 py-2.5 pl-3 pr-10 text-left border border-gray-200 outline-none focus:border-blue-500 focus-visible:ring-2 focus-visible:ring-blue-500 text-base disabled:bg-gray-100 disabled:cursor-not-allowed">
                       <div className="flex items-center">
                         {selectedDispenser?.asset && <AssetIcon asset={selectedDispenser.asset} />}
                         <span className={`block truncate ${selectedDispenser ? "ml-2" : ""}`}>
@@ -167,12 +167,12 @@ export function DispenserCloseForm({
                   {selectedDispenser && (
                     <div className="mt-3 text-sm p-3 bg-gray-50 rounded-md border border-gray-200 space-y-2">
                       <div className="flex justify-between">
-                        <span className="text-gray-500">Price</span>
-                        <span className="font-medium text-gray-900">{selectedDispenser.satoshirate_normalized} BTC</span>
-                      </div>
-                      <div className="flex justify-between">
                         <span className="text-gray-500">Remaining</span>
                         <span className="font-medium text-gray-900">{selectedDispenser.give_remaining_normalized} {selectedDispenser.asset}</span>
+                      </div>
+                      <div className="flex justify-between">
+                        <span className="text-gray-500">Price</span>
+                        <span className="font-medium text-gray-900">{selectedDispenser.satoshirate_normalized} BTC</span>
                       </div>
                       <div className="flex justify-between items-center">
                         <span className="text-gray-500">TX Hash</span>
@@ -189,11 +189,9 @@ export function DispenserCloseForm({
                           )}
                         </button>
                       </div>
+                      <input type="hidden" name="give_remaining_normalized" value={selectedDispenser.give_remaining_normalized} />
                     </div>
                   )}
-                  <p className="mt-3 text-xs text-gray-500">
-                    Dispensers enter a closing state for 5 blocks before fully closing.
-                  </p>
                   {showHelpText && (
                     <Description className="mt-2 text-sm text-gray-500">
                       Select the dispenser you want to close.

--- a/src/pages/compose/dispenser/close/review.tsx
+++ b/src/pages/compose/dispenser/close/review.tsx
@@ -16,9 +16,9 @@ interface ReviewDispenserCloseProps {
 /**
  * Review screen for dispenser close transactions.
  */
-export function ReviewDispenserClose({ 
-  apiResponse, 
-  onSign, 
+export function ReviewDispenserClose({
+  apiResponse,
+  onSign,
   onBack,
   error,
   isSigning
@@ -26,11 +26,16 @@ export function ReviewDispenserClose({
   const { result } = apiResponse;
 
   // Use type assertion for the specific dispenser close params
-  const params = result.params as { asset: string; open_address?: string };
-  
+  const params = result.params as {
+    asset: string;
+    open_address?: string;
+    give_remaining_normalized?: string;
+  };
+
   const customFields = [
     { label: "Asset", value: params.asset },
-    ...(params.open_address ? [{ label: "Dispenser Hash", value: params.open_address }] : []),
+    ...(params.open_address ? [{ label: "Dispenser", value: params.open_address }] : []),
+    ...(params.give_remaining_normalized ? [{ label: "Escrow Returned", value: `${params.give_remaining_normalized} ${params.asset}` }] : []),
   ];
 
   return (

--- a/src/pages/compose/dispenser/dispense/form.tsx
+++ b/src/pages/compose/dispenser/dispense/form.tsx
@@ -307,12 +307,17 @@ export function DispenseForm({
           : "No available balance.";
         setValidationError(message);
       } else {
-        const requiredBTC = selectedDispenser.satoshirate / SATOSHIS_PER_BTC;
+        // Calculate fee for error message
+        const effectiveFeeRate = feeRate ?? 0.1;
+        const estimatedVbytes = estimateVsize(spendableBtc.utxoCount || 1, 1, activeAddress?.address || "");
+        const estimatedFee = Math.ceil(estimatedVbytes * effectiveFeeRate);
+        const requiredSatoshis = selectedDispenser.satoshirate + estimatedFee;
+        const requiredBTC = requiredSatoshis / SATOSHIS_PER_BTC;
         setValidationError(`Insufficient BTC balance. You need at least ${formatAmount({
             value: requiredBTC,
             minimumFractionDigits: 8,
             maximumFractionDigits: 8
-          })} BTC to trigger this dispenser once.`);
+          })} BTC (including ~${estimatedFee} sats fee) to trigger this dispenser once.`);
       }
       return;
     }

--- a/src/pages/compose/dispenser/dispense/review.tsx
+++ b/src/pages/compose/dispenser/dispense/review.tsx
@@ -194,6 +194,14 @@ export function ReviewDispense({
       const satoshirate = dispenser.satoshirate || 0;
       const numberOfDispenses = satoshirate > 0 ? Math.floor(btcQuantity / satoshirate) : 0;
 
+      // Add dispenser TX hash first (after To:)
+      if (dispenser.tx_hash) {
+        customFields.push({
+          label: "Dispenser",
+          value: dispenser.tx_hash
+        });
+      }
+
       customFields.push(
         {
           label: "# of Dispenses",
@@ -209,14 +217,6 @@ export function ReviewDispense({
           rightElement: usdDisplay ? <span className="text-gray-500">{usdDisplay}</span> : undefined
         }
       );
-    }
-    
-    // Add dispenser TX hash only for single dispenser
-    if (allTriggeredDispensers.length === 1 && allTriggeredDispensers[0].tx_hash) {
-      customFields.push({
-        label: "Dispenser TX Hash",
-        value: allTriggeredDispensers[0].tx_hash
-      });
     }
     
     // Add mempool warning if there are competing transactions

--- a/src/pages/compose/dispenser/review.tsx
+++ b/src/pages/compose/dispenser/review.tsx
@@ -1,6 +1,8 @@
 import { ReviewScreen } from "@/components/screens/review-screen";
 import { formatAmount } from "@/utils/format";
 import { fromSatoshis } from "@/utils/numeric";
+import { useMarketPrices } from "@/hooks/useMarketPrices";
+import { useSettings } from "@/contexts/settings-context";
 
 /**
  * Props for the ReviewDispenser component.
@@ -28,36 +30,52 @@ export function ReviewDispenser({
   asset
 }: ReviewDispenserProps) {
   const { result } = apiResponse;
+  const { settings } = useSettings();
+  const { btc: btcPrice } = useMarketPrices(settings.fiat);
 
   // Use normalized values from verbose API response
   const escrowQuantity = result.params.escrow_quantity_normalized;
   const giveQuantity = result.params.give_quantity_normalized;
 
+  // Calculate BTC values for USD display
+  const perDispenseBtc = fromSatoshis(result.params.mainchainrate, true);
+  const bitcoinTotalBtc = (Number(result.params.escrow_quantity) / Number(result.params.give_quantity)) *
+                          fromSatoshis(result.params.mainchainrate, true);
+
+  // Format USD values
+  const perDispenseUsd = btcPrice !== null
+    ? `$${formatAmount({ value: perDispenseBtc * btcPrice, minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+    : null;
+  const bitcoinTotalUsd = btcPrice !== null
+    ? `$${formatAmount({ value: bitcoinTotalBtc * btcPrice, minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+    : null;
+
   const customFields = [
     {
-      label: "Escrow Total",
+      label: "Escrow Amount",
       value: `${escrowQuantity} ${asset}`,
     },
     {
-      label: "Give Amount",
+      label: "Amount per Dispense",
       value: `${giveQuantity} ${asset}`,
     },
     {
       label: "Per Dispense",
       value: `${formatAmount({
-        value: fromSatoshis(result.params.mainchainrate, true),
+        value: perDispenseBtc,
         minimumFractionDigits: 8,
         maximumFractionDigits: 8,
       })} BTC`,
+      rightElement: perDispenseUsd ? <span className="text-gray-500">{perDispenseUsd}</span> : undefined,
     },
     {
       label: "Bitcoin Total",
       value: `${formatAmount({
-        value: (Number(result.params.escrow_quantity) / Number(result.params.give_quantity)) *
-               fromSatoshis(result.params.mainchainrate, true),
+        value: bitcoinTotalBtc,
         minimumFractionDigits: 8,
         maximumFractionDigits: 8,
       })} BTC`,
+      rightElement: bitcoinTotalUsd ? <span className="text-gray-500">{bitcoinTotalUsd}</span> : undefined,
     },
   ];
 

--- a/src/pages/market/dispensers/[asset].tsx
+++ b/src/pages/market/dispensers/[asset].tsx
@@ -75,6 +75,38 @@ function getNextUnit(current: PriceUnit, hasFiat: boolean): PriceUnit {
 }
 
 /**
+ * Copyable stat display with highlight feedback
+ */
+function CopyableStat({
+  label,
+  value,
+  rawValue,
+  onCopy,
+  isCopied,
+}: {
+  label: string;
+  value: string;
+  rawValue: string;
+  onCopy: (value: string) => void;
+  isCopied: boolean;
+}): ReactElement {
+  return (
+    <div>
+      <span className="text-gray-500">{label}</span>
+      <div className="flex items-center gap-2">
+        <div
+          onClick={() => onCopy(rawValue)}
+          className={`font-medium text-gray-900 truncate cursor-pointer rounded px-1 -mx-1 ${isCopied ? "bg-gray-200" : ""}`}
+        >
+          <span>{value}</span>
+        </div>
+        {isCopied && <FaCheck className="size-3 text-green-500 flex-shrink-0" aria-hidden="true" />}
+      </div>
+    </div>
+  );
+}
+
+/**
  * Calculate effective sats per unit from dispenser data
  * satoshirate = total sats per dispense
  * give_quantity_normalized = units given per dispense
@@ -403,26 +435,20 @@ export default function AssetDispensersPage(): ReactElement {
             <div className="flex-1 grid grid-cols-2 gap-4 text-xs">
               {tab === "open" && dispenserStats && (
                 <>
-                  <div>
-                    <span className="text-gray-500">Floor</span>
-                    <div
-                      onClick={() => copy(getRawPrice(dispenserStats.floorPrice, priceUnit, btcPrice, settings.fiat))}
-                      className={`font-medium text-gray-900 truncate cursor-pointer rounded px-1 -mx-1 flex items-center justify-between gap-1 ${isCopied(getRawPrice(dispenserStats.floorPrice, priceUnit, btcPrice, settings.fiat)) ? "bg-gray-200" : ""}`}
-                    >
-                      <span>{formatPrice(dispenserStats.floorPrice, priceUnit, btcPrice, settings.fiat)}</span>
-                      {isCopied(getRawPrice(dispenserStats.floorPrice, priceUnit, btcPrice, settings.fiat)) && <FaCheck className="size-3 text-green-500 flex-shrink-0" aria-hidden="true" />}
-                    </div>
-                  </div>
-                  <div>
-                    <span className="text-gray-500">Avg</span>
-                    <div
-                      onClick={() => copy(getRawPrice(dispenserStats.weightedAvg, priceUnit, btcPrice, settings.fiat))}
-                      className={`font-medium text-gray-900 truncate cursor-pointer rounded px-1 -mx-1 flex items-center justify-between gap-1 ${isCopied(getRawPrice(dispenserStats.weightedAvg, priceUnit, btcPrice, settings.fiat)) ? "bg-gray-200" : ""}`}
-                    >
-                      <span>{formatPrice(dispenserStats.weightedAvg, priceUnit, btcPrice, settings.fiat)}</span>
-                      {isCopied(getRawPrice(dispenserStats.weightedAvg, priceUnit, btcPrice, settings.fiat)) && <FaCheck className="size-3 text-green-500 flex-shrink-0" aria-hidden="true" />}
-                    </div>
-                  </div>
+                  <CopyableStat
+                    label="Floor"
+                    value={formatPrice(dispenserStats.floorPrice, priceUnit, btcPrice, settings.fiat)}
+                    rawValue={getRawPrice(dispenserStats.floorPrice, priceUnit, btcPrice, settings.fiat)}
+                    onCopy={copy}
+                    isCopied={isCopied(getRawPrice(dispenserStats.floorPrice, priceUnit, btcPrice, settings.fiat))}
+                  />
+                  <CopyableStat
+                    label="Avg"
+                    value={formatPrice(dispenserStats.weightedAvg, priceUnit, btcPrice, settings.fiat)}
+                    rawValue={getRawPrice(dispenserStats.weightedAvg, priceUnit, btcPrice, settings.fiat)}
+                    onCopy={copy}
+                    isCopied={isCopied(getRawPrice(dispenserStats.weightedAvg, priceUnit, btcPrice, settings.fiat))}
+                  />
                 </>
               )}
               {tab === "open" && !dispenserStats && (
@@ -439,26 +465,20 @@ export default function AssetDispensersPage(): ReactElement {
               )}
               {tab === "dispensed" && dispenseStats && (
                 <>
-                  <div>
-                    <span className="text-gray-500">Last</span>
-                    <div
-                      onClick={() => copy(getRawPrice(dispenseStats.lastPrice, priceUnit, btcPrice, settings.fiat))}
-                      className={`font-medium text-gray-900 truncate cursor-pointer rounded px-1 -mx-1 flex items-center justify-between gap-1 ${isCopied(getRawPrice(dispenseStats.lastPrice, priceUnit, btcPrice, settings.fiat)) ? "bg-gray-200" : ""}`}
-                    >
-                      <span>{formatPrice(dispenseStats.lastPrice, priceUnit, btcPrice, settings.fiat)}</span>
-                      {isCopied(getRawPrice(dispenseStats.lastPrice, priceUnit, btcPrice, settings.fiat)) && <FaCheck className="size-3 text-green-500 flex-shrink-0" aria-hidden="true" />}
-                    </div>
-                  </div>
-                  <div>
-                    <span className="text-gray-500">Avg</span>
-                    <div
-                      onClick={() => copy(getRawPrice(dispenseStats.avgPrice, priceUnit, btcPrice, settings.fiat))}
-                      className={`font-medium text-gray-900 truncate cursor-pointer rounded px-1 -mx-1 flex items-center justify-between gap-1 ${isCopied(getRawPrice(dispenseStats.avgPrice, priceUnit, btcPrice, settings.fiat)) ? "bg-gray-200" : ""}`}
-                    >
-                      <span>{formatPrice(dispenseStats.avgPrice, priceUnit, btcPrice, settings.fiat)}</span>
-                      {isCopied(getRawPrice(dispenseStats.avgPrice, priceUnit, btcPrice, settings.fiat)) && <FaCheck className="size-3 text-green-500 flex-shrink-0" aria-hidden="true" />}
-                    </div>
-                  </div>
+                  <CopyableStat
+                    label="Last"
+                    value={formatPrice(dispenseStats.lastPrice, priceUnit, btcPrice, settings.fiat)}
+                    rawValue={getRawPrice(dispenseStats.lastPrice, priceUnit, btcPrice, settings.fiat)}
+                    onCopy={copy}
+                    isCopied={isCopied(getRawPrice(dispenseStats.lastPrice, priceUnit, btcPrice, settings.fiat))}
+                  />
+                  <CopyableStat
+                    label="Avg"
+                    value={formatPrice(dispenseStats.avgPrice, priceUnit, btcPrice, settings.fiat)}
+                    rawValue={getRawPrice(dispenseStats.avgPrice, priceUnit, btcPrice, settings.fiat)}
+                    onCopy={copy}
+                    isCopied={isCopied(getRawPrice(dispenseStats.avgPrice, priceUnit, btcPrice, settings.fiat))}
+                  />
                 </>
               )}
               {tab === "dispensed" && !dispenseStats && (
@@ -509,12 +529,12 @@ export default function AssetDispensersPage(): ReactElement {
               Dispensed
             </button>
           </div>
-          <a
-            href="#"
-            className="text-xs text-blue-600 hover:text-blue-800"
+          <button
+            onClick={() => navigate("/market/dispensers/manage")}
+            className="text-xs text-blue-600 hover:text-blue-800 cursor-pointer"
           >
             My Dispensers
-          </a>
+          </button>
         </div>
 
         {/* Content */}


### PR DESCRIPTION
## Summary
- Create dispenser review: rename labels to match form ("Escrow Amount", "Amount per Dispense"), add USD equivalents for BTC fields
- Close dispenser form: reorder details (Remaining → Price → TX Hash), remove 5-block note, increase dropdown font size
- Close dispenser review: show dispenser tx hash and escrow amount being returned
- Dispense review: rename "Dispenser TX Hash" → "Dispenser", reorder fields (dispenser shown before # of dispenses)
- Dispense form: include estimated fee in insufficient balance error message
- Market dispensers page: fix "My Dispensers" link, extract `CopyableStat` component, fix copy highlight to not include checkmark

## Test plan
- [ ] Create dispenser: verify review labels match form, USD shows for BTC fields
- [ ] Close dispenser form: verify Remaining shows before Price, no 5-block note
- [ ] Close dispenser review: verify tx hash and escrow return amount display
- [ ] Dispense review: verify "Dispenser" label and field order
- [ ] Dispense form: test Max button with high fee rate (1200 sat/vB)
- [ ] Market page: test "My Dispensers" navigates, copy highlight is correct