### PR TITLE
Auto-set no_dispense

### DIFF
--- a/src/utils/blockchain/counterparty/compose.ts
+++ b/src/utils/blockchain/counterparty/compose.ts
@@ -200,6 +200,7 @@ export interface SendOptions extends BaseComposeOptions {
   quantity: number;
   memo?: string;
   memo_is_hex?: boolean;
+  no_dispense?: boolean;
 }
 
 export interface SweepOptions extends BaseComposeOptions {
@@ -837,6 +838,7 @@ export async function composeSend(options: SendOptions): Promise<ApiResponse> {
     quantity,
     memo,
     memo_is_hex,
+    no_dispense,
     sat_per_vbyte,
     max_fee,
     encoding,
@@ -847,6 +849,7 @@ export async function composeSend(options: SendOptions): Promise<ApiResponse> {
     quantity: quantity.toString(),
     ...(memo !== undefined ? { memo } : {}),
     ...(memo_is_hex !== undefined ? { memo_is_hex: memo_is_hex.toString() } : {}),
+    ...(no_dispense !== undefined ? { no_dispense: no_dispense.toString() } : {}),
     ...(max_fee !== undefined && { max_fee: max_fee.toString() }),
   };
   return composeTransaction('send', paramsObj, sourceAddress, sat_per_vbyte, encoding);

--- a/src/utils/blockchain/counterparty/normalize.ts
+++ b/src/utils/blockchain/counterparty/normalize.ts
@@ -46,6 +46,7 @@ const NORMALIZATION_CONFIG: Record<string, {
   send: {
     quantityFields: ['quantity'],
     assetFields: { quantity: 'asset' },
+    booleanFields: ['no_dispense'],
     memoConfig: { type: 'boolean', field: 'memo_is_hex' }
   },
   order: {


### PR DESCRIPTION
## Summary
When sending BTC to an address that belongs to the active wallet, automatically set `no_dispense=true` to prevent accidentally triggering dispensers at the destination address.

This solves the issue where sending BTC to yourself triggers unwanted dispenses if you have open dispensers on that address.

## Changes
- Add `no_dispense` option to `SendOptions` interface
- Pass `no_dispense` parameter to compose API in `composeSend`
- Detect own-address BTC sends in composer context and auto-set `no_dispense: true`

## Test plan
- [x] Build passes
- [x] Compose send tests pass (22 tests)
- [x] Composer context tests pass (13 tests)
- [ ] Manual test: Send BTC to own address with dispenser - should NOT trigger dispense
- [ ] Manual test: Send BTC to external dispenser - should still trigger dispense