### PR TITLE
More API Caching

### DIFF
--- a/src/utils/blockchain/bitcoin/__tests__/balance.test.ts
+++ b/src/utils/blockchain/bitcoin/__tests__/balance.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { fetchBTCBalance, hasAddressActivity } from '@/utils/blockchain/bitcoin/balance';
+import { fetchBTCBalance, hasAddressActivity, clearBalanceCache } from '@/utils/blockchain/bitcoin/balance';
 
 describe('Bitcoin Balance Utilities', () => {
   const originalFetch = globalThis.fetch;
@@ -8,6 +8,8 @@ describe('Bitcoin Balance Utilities', () => {
   beforeEach(() => {
     globalThis.fetch = vi.fn();
     vi.clearAllMocks();
+    // Clear all caches to ensure test isolation
+    clearBalanceCache();
   });
 
   afterEach(() => {

--- a/src/utils/blockchain/bitcoin/__tests__/utxo.test.ts
+++ b/src/utils/blockchain/bitcoin/__tests__/utxo.test.ts
@@ -4,7 +4,8 @@ import {
   fetchUTXOs,
   formatInputsSet,
   getUtxoByTxid,
-  fetchPreviousRawTransaction
+  fetchPreviousRawTransaction,
+  clearBitcoinCaches
 } from '@/utils/blockchain/bitcoin/utxo';
 import { apiClient, isCancel } from '@/utils/apiClient';
 import { walletManager } from '@/utils/wallet/walletManager';
@@ -39,6 +40,8 @@ describe('UTXO Utilities', () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    // Clear all caches to ensure test isolation
+    clearBitcoinCaches();
 
     // Setup the settings mock
     mockGetSettings.mockReturnValue({

--- a/src/utils/blockchain/bitcoin/transactionBroadcaster.ts
+++ b/src/utils/blockchain/bitcoin/transactionBroadcaster.ts
@@ -1,6 +1,8 @@
 import { apiClient, withRetry, isApiError, type ApiResponse } from '@/utils/apiClient';
 import { walletManager } from '@/utils/wallet/walletManager';
 import { clearApiCache } from '@/utils/blockchain/counterparty/api';
+import { clearBitcoinCaches } from '@/utils/blockchain/bitcoin/utxo';
+import { clearBalanceCache } from '@/utils/blockchain/bitcoin/balance';
 
 export interface TransactionResponse {
   txid: string;
@@ -88,8 +90,10 @@ export async function broadcastTransaction(signedTxHex: string): Promise<Transac
       throw new Error('Simulated broadcast error for testing');
     }
 
-    // Clear API cache after successful transaction
+    // Clear all caches after successful transaction
     clearApiCache();
+    clearBitcoinCaches();
+    clearBalanceCache();
 
     return {
       txid: generateMockTxid(signedTxHex),
@@ -115,8 +119,10 @@ export async function broadcastTransaction(signedTxHex: string): Promise<Transac
       if (response && response.status >= 200 && response.status < 300) {
         const formatted = formatResponse(endpoint, response);
         if (formatted && formatted.txid) {
-          // Clear API cache after successful transaction
+          // Clear all caches after successful transaction
           clearApiCache();
+          clearBitcoinCaches();
+          clearBalanceCache();
           return formatted;
         }
       }


### PR DESCRIPTION
## Summary

Addresses rate limiting issues (`ERR_CONNECTION_RESET`) from Blockstream.info by adding caching to Bitcoin blockchain API calls.

### Cached endpoints:
- **UTXOs** (`fetchUTXOs`): 30s TTL
- **BTC Balance** (`fetchBTCBalance`): 30s TTL
- **Address Activity** (`hasAddressActivity`): 30s TTL
- **Transaction Details** (`fetchBitcoinTransaction`): 10min TTL (immutable)
- **Raw Transaction Hex** (`fetchPreviousRawTransaction`): 10min TTL (immutable)

### Implementation:
- Added `cachedFetch` helper to `cache.ts` for cache + inflight request deduplication
- Cache invalidation wired to `broadcastTransaction` (clears all caches after successful broadcast)
- Uses existing `CacheTTL` constants (MEDIUM=30s, VERY_LONG=10min)

## Test plan
- [x] Unit tests pass (`npx vitest run src/utils/blockchain/bitcoin/__tests__/`)
- [x] TypeScript compiles (`npm run compile`)
- [ ] Manual test: Open extension, check console for reduced API calls on refresh
- [ ] Manual test: Send transaction, verify fresh data loads after broadcast