### PR TITLE
Support pool message verification

### DIFF
--- a/e2e/inputs/asset-select-input.spec.ts
+++ b/e2e/inputs/asset-select-input.spec.ts
@@ -13,12 +13,15 @@
  */
 
 import { walletTest, expect } from '../fixtures';
+import { enableValidationBypass } from '../compose-test-helpers';
 
 walletTest.describe('AssetSelectInput Component', () => {
   // AssetSelectInput is used on asset-specific pages
   // Navigate to dividend compose page which has AssetSelectInput
 
   walletTest.beforeEach(async ({ page }) => {
+    await enableValidationBypass(page);
+
     // Navigate to dividend page with asset parameter (required for this page)
     const hashIndex = page.url().indexOf('#');
     const baseUrl = hashIndex !== -1 ? page.url().substring(0, hashIndex + 1) : page.url() + '#';

--- a/src/pages/requests/psbt/approve.tsx
+++ b/src/pages/requests/psbt/approve.tsx
@@ -66,6 +66,10 @@ function getTxActionInfo(decodedInfo: DecodedPsbtInfo): { label: string; descrip
       return { label: 'Fairminter', description: `${data.asset}` };
     case 'fairmint':
       return { label: 'Fairmint', description: `${data.quantity} ${data.asset}` };
+    case 'pooldeposit':
+      return { label: 'Pool Deposit', description: `${data.quantityA} ${data.assetA} + ${data.quantityB} ${data.assetB}` };
+    case 'poolwithdraw':
+      return { label: 'Pool Withdraw', description: `Burn ${data.quantity} LP tokens from ${data.assetA}/${data.assetB}` };
     default:
       return { label, description: unpack.messageType };
   }

--- a/src/pages/requests/transaction/approve.tsx
+++ b/src/pages/requests/transaction/approve.tsx
@@ -99,6 +99,10 @@ function getTxActionInfo(decodedInfo: DecodedTransactionInfo): { label: string; 
       return { label: 'Fairminter', description: `${data.asset}` };
     case 'fairmint':
       return { label: 'Fairmint', description: `${normalizeQuantity(data.quantity, data.asset as string)} ${data.asset}` };
+    case 'pooldeposit':
+      return { label: 'Pool Deposit', description: `${normalizeQuantity(data.quantityA, data.assetA as string)} ${data.assetA} + ${normalizeQuantity(data.quantityB, data.assetB as string)} ${data.assetB}` };
+    case 'poolwithdraw':
+      return { label: 'Pool Withdraw', description: `Burn ${String(data.quantity)} LP tokens from ${data.assetA}/${data.assetB}` };
     default:
       return { label, description: unpack.messageType };
   }

--- a/src/utils/blockchain/counterparty/__tests__/api.test.ts
+++ b/src/utils/blockchain/counterparty/__tests__/api.test.ts
@@ -14,6 +14,11 @@ import {
   fetchOwnedAssets,
   fetchOrdersByPair,
   fetchOrderMatches,
+  fetchPools,
+  fetchPool,
+  fetchPoolQuote,
+  fetchPoolDepositQuote,
+  fetchPoolWithdrawQuote,
   fetchServerInfo,
   clearApiCache,
   AssetInfo,
@@ -1129,6 +1134,74 @@ describe('counterparty/api.ts', () => {
       mockedApiClient.get.mockRejectedValue(new Error('Network error'));
 
       await expect(fetchOrderMatches('abc123')).rejects.toThrow(CounterpartyApiError);
+    });
+  });
+
+  describe('AMM pool endpoints', () => {
+    const mockPool = {
+      asset_a: 'XCP',
+      asset_b: 'POOLTEST',
+      reserve_a: 100000000,
+      reserve_b: 500000000,
+      lp_asset: 'A77777777777777777',
+    };
+
+    beforeEach(() => {
+      mockedApiClient.get.mockResolvedValue({
+        data: { result: [mockPool], result_count: 1 },
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {}
+      } as any);
+    });
+
+    it('should fetch pool collection and pair resources', async () => {
+      await fetchPools({ limit: 25, offset: 5 });
+      await fetchPool('XCP', 'POOLTEST');
+
+      expect(mockedApiClient.get).toHaveBeenNthCalledWith(
+        1,
+        `${mockApiBase}/v2/pools`,
+        expect.objectContaining({
+          params: expect.objectContaining({ verbose: true, limit: 25, offset: 5 }),
+        })
+      );
+      expect(mockedApiClient.get).toHaveBeenNthCalledWith(
+        2,
+        `${mockApiBase}/v2/pools/XCP/POOLTEST`,
+        expect.objectContaining({ params: expect.objectContaining({ verbose: true }) })
+      );
+    });
+
+    it('should fetch pool quote endpoints with quantity parameter', async () => {
+      mockedApiClient.get.mockResolvedValue({
+        data: { result: { estimated_output: 123 } },
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {}
+      } as any);
+
+      await fetchPoolQuote('XCP', 'POOLTEST', '100000000');
+      await fetchPoolDepositQuote('XCP', 'POOLTEST', '100000000');
+      await fetchPoolWithdrawQuote('XCP', 'POOLTEST', '1000');
+
+      expect(mockedApiClient.get).toHaveBeenNthCalledWith(
+        1,
+        `${mockApiBase}/v2/pools/XCP/POOLTEST/quote`,
+        expect.objectContaining({ params: { quantity: '100000000' } })
+      );
+      expect(mockedApiClient.get).toHaveBeenNthCalledWith(
+        2,
+        `${mockApiBase}/v2/pools/XCP/POOLTEST/quote/deposit`,
+        expect.objectContaining({ params: { quantity: '100000000' } })
+      );
+      expect(mockedApiClient.get).toHaveBeenNthCalledWith(
+        3,
+        `${mockApiBase}/v2/pools/XCP/POOLTEST/quote/withdraw`,
+        expect.objectContaining({ params: { quantity: '1000' } })
+      );
     });
   });
 

--- a/src/utils/blockchain/counterparty/__tests__/compose.specialized.test.ts
+++ b/src/utils/blockchain/counterparty/__tests__/compose.specialized.test.ts
@@ -5,6 +5,10 @@ import {
   composeMPMA,
   composeFairminter,
   composeFairmint,
+  composePoolDeposit,
+  composePoolWithdraw,
+  getPoolDepositEstimateXcpFee,
+  getPoolWithdrawEstimateXcpFee,
   composeAttach,
   getAttachEstimateXcpFee,
   composeDetach,
@@ -365,6 +369,115 @@ describe('Compose Specialized Operations', () => {
       const actualParams = Object.fromEntries(urlParams.entries());
         expect(url).toContain(`quantity=${quantity}`);
       }
+    });
+  });
+
+  describe('composePoolDeposit', () => {
+    const defaultParams = {
+      asset_a: 'XCP',
+      asset_b: 'POOLTEST',
+      quantity_a: '100000000',
+      quantity_b: '500000000',
+    };
+
+    it('should compose pool deposit transaction', async () => {
+      const result = await composePoolDeposit({
+        sourceAddress: mockAddress,
+        sat_per_vbyte: mockSatPerVbyte,
+        ...defaultParams,
+      });
+
+      expect(result).toEqual(createMockComposeResult());
+      assertComposeUrlCalled(mockedApiClient, 'pooldeposit', {
+        ...defaultParams,
+        min_lp_quantity: '0',
+      });
+    });
+
+    it('should include slippage and LP asset parameters', async () => {
+      await composePoolDeposit({
+        sourceAddress: mockAddress,
+        sat_per_vbyte: mockSatPerVbyte,
+        ...defaultParams,
+        min_lp_quantity: '1000',
+        lp_asset: 'A77777777777777777',
+      });
+
+      const actualCall = mockedApiClient.get.mock.calls[0];
+      const url = actualCall[0] as string;
+      expect(url).toContain('min_lp_quantity=1000');
+      expect(url).toContain('lp_asset=A77777777777777777');
+    });
+  });
+
+  describe('getPoolDepositEstimateXcpFee', () => {
+    it('should get pool deposit fee estimate', async () => {
+      const mockFeeEstimate = 10000;
+      mockedApiClient.get.mockResolvedValueOnce(createMockApiResponse({ result: mockFeeEstimate }));
+
+      const result = await getPoolDepositEstimateXcpFee(mockAddress);
+
+      expect(result).toBe(mockFeeEstimate);
+      expect(mockedApiClient.get.mock.calls[0][0]).toBe(
+        `${mockApiBase}/v2/addresses/${mockAddress}/compose/pooldeposit/estimatexcpfees`
+      );
+    });
+  });
+
+  describe('composePoolWithdraw', () => {
+    const defaultParams = {
+      asset_a: 'XCP',
+      asset_b: 'POOLTEST',
+      quantity: '1000000',
+    };
+
+    it('should compose pool withdraw transaction', async () => {
+      const result = await composePoolWithdraw({
+        sourceAddress: mockAddress,
+        sat_per_vbyte: mockSatPerVbyte,
+        ...defaultParams,
+      });
+
+      expect(result).toEqual(createMockComposeResult());
+      assertComposeUrlCalled(mockedApiClient, 'poolwithdraw', {
+        ...defaultParams,
+        min_quantity_a: '0',
+        min_quantity_b: '0',
+      });
+    });
+
+    it('should compose pool withdraw with LP asset and slippage parameters', async () => {
+      await composePoolWithdraw({
+        sourceAddress: mockAddress,
+        sat_per_vbyte: mockSatPerVbyte,
+        quantity: '1000000',
+        min_quantity_a: '100',
+        min_quantity_b: '200',
+        lp_asset: 'A77777777777777777',
+      });
+
+      const actualCall = mockedApiClient.get.mock.calls[0];
+      const url = actualCall[0] as string;
+      expect(url).toContain('quantity=1000000');
+      expect(url).toContain('min_quantity_a=100');
+      expect(url).toContain('min_quantity_b=200');
+      expect(url).toContain('lp_asset=A77777777777777777');
+      expect(url).not.toContain('asset_a=');
+      expect(url).not.toContain('asset_b=');
+    });
+  });
+
+  describe('getPoolWithdrawEstimateXcpFee', () => {
+    it('should get pool withdraw fee estimate', async () => {
+      const mockFeeEstimate = 11000;
+      mockedApiClient.get.mockResolvedValueOnce(createMockApiResponse({ result: mockFeeEstimate }));
+
+      const result = await getPoolWithdrawEstimateXcpFee(mockAddress);
+
+      expect(result).toBe(mockFeeEstimate);
+      expect(mockedApiClient.get.mock.calls[0][0]).toBe(
+        `${mockApiBase}/v2/addresses/${mockAddress}/compose/poolwithdraw/estimatexcpfees`
+      );
     });
   });
 

--- a/src/utils/blockchain/counterparty/__tests__/transaction.test.ts
+++ b/src/utils/blockchain/counterparty/__tests__/transaction.test.ts
@@ -183,6 +183,28 @@ describe('describeCounterpartyMessage', () => {
     expect(desc).toContain('FAIRTOKEN');
   });
 
+  it('describes pooldeposit', () => {
+    const desc = describeCounterpartyMessage('pooldeposit', {
+      asset_a: 'XCP',
+      asset_b: 'POOLTEST',
+      quantity_a: 100000000,
+      quantity_b: 500000000,
+    });
+    expect(desc).toContain('Deposit liquidity');
+    expect(desc).toContain('XCP');
+    expect(desc).toContain('POOLTEST');
+  });
+
+  it('describes poolwithdraw', () => {
+    const desc = describeCounterpartyMessage('poolwithdraw', {
+      asset_a: 'XCP',
+      asset_b: 'POOLTEST',
+      quantity: 1000000,
+    });
+    expect(desc).toContain('Withdraw liquidity');
+    expect(desc).toContain('XCP/POOLTEST');
+  });
+
   it('describes attach', () => {
     const desc = describeCounterpartyMessage('attach', {
       quantity: 500,

--- a/src/utils/blockchain/counterparty/__tests__/transactionSafety.test.ts
+++ b/src/utils/blockchain/counterparty/__tests__/transactionSafety.test.ts
@@ -126,6 +126,11 @@ describe('message type safety', () => {
     expect(result.warnings).toHaveLength(0);
   });
 
+  it('should allow pool deposit and withdraw without unknown-type warnings', () => {
+    expect(analyzeTransactionSafety('pooldeposit', normalOutputs, SIGNER).warnings).toHaveLength(0);
+    expect(analyzeTransactionSafety('poolwithdraw', normalOutputs, SIGNER).warnings).toHaveLength(0);
+  });
+
   it('should warn about unknown message types', () => {
     const result = analyzeTransactionSafety('totally_new_type', normalOutputs, SIGNER);
     expect(result.blocked).toBe(false);

--- a/src/utils/blockchain/counterparty/api.ts
+++ b/src/utils/blockchain/counterparty/api.ts
@@ -239,6 +239,68 @@ export interface OrderMatch {
 }
 
 // =============================================================================
+// TYPES - AMM Pools
+// =============================================================================
+
+export interface Pool {
+  tx_hash?: string;
+  tx_index?: number;
+  block_index?: number;
+  block_time?: number;
+  source?: string;
+  asset_a: string;
+  asset_b: string;
+  reserve_a: number;
+  reserve_b: number;
+  lp_asset: string;
+  status?: string;
+  reserve_a_normalized?: string;
+  reserve_b_normalized?: string;
+  confirmed?: boolean;
+  [key: string]: unknown;
+}
+
+export interface PoolQuote {
+  estimated_output?: number;
+  pool_output?: number;
+  book_output?: number;
+  book_orders_matched?: number;
+  give_remaining?: number;
+  effective_price?: number;
+  price_impact?: number;
+  pool_exists?: boolean;
+  fee_bps?: number;
+  fee_amount?: number;
+  message?: string;
+  [key: string]: unknown;
+}
+
+export interface PoolDepositQuote {
+  first_deposit: boolean;
+  asset_a?: string;
+  asset_b?: string;
+  quantity_a_required?: number | null;
+  quantity_b_required?: number | null;
+  quantity_minted_estimate?: number | null;
+  message?: string;
+  [key: string]: unknown;
+}
+
+export interface PoolWithdrawQuote {
+  pool_exists: boolean;
+  asset_a?: string;
+  asset_b?: string;
+  quantity?: number;
+  supply?: number;
+  quantity_a_estimate?: number;
+  quantity_b_estimate?: number;
+  reserve_a?: number;
+  reserve_b?: number;
+  message?: string;
+  [key: string]: unknown;
+}
+
+// =============================================================================
 // TYPES - Dispensers
 // =============================================================================
 
@@ -731,6 +793,71 @@ export async function fetchAssetOrders(
     limit: options.limit ?? DEFAULT_LIMIT,
     offset: options.offset ?? 0,
   });
+}
+
+// =============================================================================
+// API - AMM Pools
+// =============================================================================
+
+export async function fetchPools(
+  options: PaginationOptions = {}
+): Promise<PaginatedResponse<Pool>> {
+  return cpApiGet<PaginatedResponse<Pool>>('/v2/pools', {
+    verbose: options.verbose ?? true,
+    limit: options.limit ?? DEFAULT_LIMIT,
+    offset: options.offset ?? 0,
+  });
+}
+
+export async function fetchPool(
+  asset1: string,
+  asset2: string,
+  options: { verbose?: boolean } = {}
+): Promise<Pool | null> {
+  const data = await cpApiGet<{ result: Pool | null }>(
+    `/v2/pools/${encodePath(asset1)}/${encodePath(asset2)}`,
+    { verbose: options.verbose ?? true }
+  );
+  return data.result ?? null;
+}
+
+export async function fetchPoolQuote(
+  asset1: string,
+  asset2: string,
+  quantity: number | string
+): Promise<PoolQuote> {
+  const data = await cpApiGet<{ result: PoolQuote }>(
+    `/v2/pools/${encodePath(asset1)}/${encodePath(asset2)}/quote`,
+    { quantity: quantity.toString() },
+    { skipCache: true }
+  );
+  return data.result;
+}
+
+export async function fetchPoolDepositQuote(
+  asset1: string,
+  asset2: string,
+  quantity: number | string
+): Promise<PoolDepositQuote> {
+  const data = await cpApiGet<{ result: PoolDepositQuote }>(
+    `/v2/pools/${encodePath(asset1)}/${encodePath(asset2)}/quote/deposit`,
+    { quantity: quantity.toString() },
+    { skipCache: true }
+  );
+  return data.result;
+}
+
+export async function fetchPoolWithdrawQuote(
+  asset1: string,
+  asset2: string,
+  quantity: number | string
+): Promise<PoolWithdrawQuote> {
+  const data = await cpApiGet<{ result: PoolWithdrawQuote }>(
+    `/v2/pools/${encodePath(asset1)}/${encodePath(asset2)}/quote/withdraw`,
+    { quantity: quantity.toString() },
+    { skipCache: true }
+  );
+  return data.result;
 }
 
 // =============================================================================

--- a/src/utils/blockchain/counterparty/compose.ts
+++ b/src/utils/blockchain/counterparty/compose.ts
@@ -237,6 +237,24 @@ export interface FairmintOptions extends BaseComposeOptions {
   quantity?: number;
 }
 
+export interface PoolDepositOptions extends BaseComposeOptions {
+  asset_a: string;
+  asset_b: string;
+  quantity_a: number | string;
+  quantity_b: number | string;
+  min_lp_quantity?: number | string;
+  lp_asset?: string;
+}
+
+export interface PoolWithdrawOptions extends BaseComposeOptions {
+  asset_a?: string;
+  asset_b?: string;
+  quantity: number | string;
+  min_quantity_a?: number | string;
+  min_quantity_b?: number | string;
+  lp_asset?: string;
+}
+
 export interface AttachOptions extends BaseComposeOptions {
   asset: string;
   quantity: number;
@@ -999,6 +1017,70 @@ export async function composeFairmint(options: FairmintOptions): Promise<ApiResp
     ...(max_fee !== undefined && { max_fee: max_fee.toString() }),
   };
   return composeTransaction('fairmint', paramsObj, sourceAddress, sat_per_vbyte, encoding);
+}
+
+export async function composePoolDeposit(options: PoolDepositOptions): Promise<ApiResponse> {
+  const {
+    sourceAddress,
+    asset_a,
+    asset_b,
+    quantity_a,
+    quantity_b,
+    min_lp_quantity = 0,
+    lp_asset,
+    sat_per_vbyte,
+    max_fee,
+    encoding,
+  } = options;
+  const paramsObj = {
+    asset_a,
+    asset_b,
+    quantity_a: quantity_a.toString(),
+    quantity_b: quantity_b.toString(),
+    min_lp_quantity: min_lp_quantity.toString(),
+    ...(lp_asset && { lp_asset }),
+    ...(max_fee !== undefined && { max_fee: max_fee.toString() }),
+  };
+  return composeTransaction('pooldeposit', paramsObj, sourceAddress, sat_per_vbyte, encoding);
+}
+
+export async function getPoolDepositEstimateXcpFee(sourceAddress: string): Promise<number> {
+  const base = await getApiBase();
+  const apiUrl = `${base}/v2/addresses/${sourceAddress}/compose/pooldeposit/estimatexcpfees`;
+  const response = await apiClient.get<{ result: number }>(apiUrl);
+  return response.data.result;
+}
+
+export async function composePoolWithdraw(options: PoolWithdrawOptions): Promise<ApiResponse> {
+  const {
+    sourceAddress,
+    asset_a,
+    asset_b,
+    quantity,
+    min_quantity_a = 0,
+    min_quantity_b = 0,
+    lp_asset,
+    sat_per_vbyte,
+    max_fee,
+    encoding,
+  } = options;
+  const paramsObj = {
+    ...(asset_a && { asset_a }),
+    ...(asset_b && { asset_b }),
+    quantity: quantity.toString(),
+    min_quantity_a: min_quantity_a.toString(),
+    min_quantity_b: min_quantity_b.toString(),
+    ...(lp_asset && { lp_asset }),
+    ...(max_fee !== undefined && { max_fee: max_fee.toString() }),
+  };
+  return composeTransaction('poolwithdraw', paramsObj, sourceAddress, sat_per_vbyte, encoding);
+}
+
+export async function getPoolWithdrawEstimateXcpFee(sourceAddress: string): Promise<number> {
+  const base = await getApiBase();
+  const apiUrl = `${base}/v2/addresses/${sourceAddress}/compose/poolwithdraw/estimatexcpfees`;
+  const response = await apiClient.get<{ result: number }>(apiUrl);
+  return response.data.result;
 }
 
 export async function composeAttach(options: AttachOptions): Promise<ApiResponse> {

--- a/src/utils/blockchain/counterparty/transaction.ts
+++ b/src/utils/blockchain/counterparty/transaction.ts
@@ -257,6 +257,10 @@ export function describeCounterpartyMessage(
       return `Create Fairminter: ${displayName('asset')}`;
     case 'fairmint':
       return `Mint from Fairminter: ${displayName('asset')}`;
+    case 'pooldeposit':
+      return `Deposit liquidity: ${q('quantity_a', 'asset_a')} ${displayName('asset_a')} and ${q('quantity_b', 'asset_b')} ${displayName('asset_b')}`;
+    case 'poolwithdraw':
+      return `Withdraw liquidity: burn ${q('quantity')} LP tokens from ${displayName('asset_a')}/${displayName('asset_b')}`;
     case 'attach':
       return `Attach ${q('quantity', 'asset')} ${displayName('asset')} to UTXO`;
     case 'detach':

--- a/src/utils/blockchain/counterparty/transactionSafety.ts
+++ b/src/utils/blockchain/counterparty/transactionSafety.ts
@@ -69,6 +69,8 @@ const SAFE_MESSAGE_TYPES = new Set([
   'detach',
   'mpma_send',
   'btcpay',
+  'pooldeposit',
+  'poolwithdraw',
 ]);
 
 /**

--- a/src/utils/blockchain/counterparty/unpack/index.ts
+++ b/src/utils/blockchain/counterparty/unpack/index.ts
@@ -32,6 +32,7 @@ import { unpackDividend, type DividendData } from './messages/dividend';
 import { unpackFairminter, type FairminterData } from './messages/fairminter';
 import { unpackFairmint, type FairmintData } from './messages/fairmint';
 import { unpackAttach, unpackDetach, type AttachData, type DetachData } from './messages/attach';
+import { unpackPoolDeposit, unpackPoolWithdraw, type PoolDepositData, type PoolWithdrawData } from './messages/pool';
 
 /**
  * Union type of all possible unpacked message data
@@ -54,6 +55,8 @@ export type UnpackedMessageData =
   | FairmintData
   | AttachData
   | DetachData
+  | PoolDepositData
+  | PoolWithdrawData
   | Record<string, unknown>; // Fallback for unsupported types
 
 /**
@@ -171,6 +174,14 @@ export function unpackCounterpartyMessage(data: string | Uint8Array): UnpackResu
           unpackedData = unpackDestroy(rawPayload);
           break;
 
+        case MessageTypeId.POOL_DEPOSIT:
+          unpackedData = unpackPoolDeposit(rawPayload);
+          break;
+
+        case MessageTypeId.POOL_WITHDRAW:
+          unpackedData = unpackPoolWithdraw(rawPayload);
+          break;
+
         case MessageTypeId.SWEEP:
           unpackedData = unpackSweep(rawPayload);
           break;
@@ -286,6 +297,7 @@ export type { DividendData } from './messages/dividend';
 export type { FairminterData } from './messages/fairminter';
 export type { FairmintData } from './messages/fairmint';
 export type { AttachData } from './messages/attach';
+export type { PoolDepositData, PoolWithdrawData } from './messages/pool';
 
 // Re-export verification utilities
 export {

--- a/src/utils/blockchain/counterparty/unpack/messageTypes.ts
+++ b/src/utils/blockchain/counterparty/unpack/messageTypes.ts
@@ -29,6 +29,8 @@ export const MessageTypeId = {
   UTXO_ATTACH: 101,     // Attach assets to UTXO
   UTXO_DETACH: 102,     // Detach assets from UTXO (move to address)
   DESTROY: 110,         // Destroy assets
+  POOL_DEPOSIT: 120,    // Deposit liquidity into AMM pool
+  POOL_WITHDRAW: 121,   // Withdraw liquidity from AMM pool
 } as const;
 
 export type MessageTypeId = typeof MessageTypeId[keyof typeof MessageTypeId];
@@ -57,6 +59,8 @@ export const MessageTypeName: Record<number, string> = {
   [MessageTypeId.UTXO_ATTACH]: 'attach',
   [MessageTypeId.UTXO_DETACH]: 'detach',
   [MessageTypeId.DESTROY]: 'destroy',
+  [MessageTypeId.POOL_DEPOSIT]: 'pooldeposit',
+  [MessageTypeId.POOL_WITHDRAW]: 'poolwithdraw',
 };
 
 /** The "CNTRPRTY" prefix as bytes */

--- a/src/utils/blockchain/counterparty/unpack/messages/pool.ts
+++ b/src/utils/blockchain/counterparty/unpack/messages/pool.ts
@@ -1,0 +1,67 @@
+import { BinaryReader } from '../binary';
+import { assetIdToName } from '../assetId';
+
+export interface PoolDepositData {
+  assetA: string;
+  assetAId: bigint;
+  assetB: string;
+  assetBId: bigint;
+  quantityA: bigint;
+  quantityB: bigint;
+  minLpQuantity: bigint;
+  lpAssetId: bigint;
+  lpAsset?: string;
+}
+
+export interface PoolWithdrawData {
+  assetA: string;
+  assetAId: bigint;
+  assetB: string;
+  assetBId: bigint;
+  quantity: bigint;
+  minQuantityA: bigint;
+  minQuantityB: bigint;
+}
+
+export function unpackPoolDeposit(payload: Uint8Array): PoolDepositData {
+  const reader = new BinaryReader(payload);
+
+  const assetAId = reader.readUint64BE();
+  const assetBId = reader.readUint64BE();
+  const quantityA = reader.readUint64BE();
+  const quantityB = reader.readUint64BE();
+  const minLpQuantity = reader.readUint64BE();
+  const lpAssetId = reader.readUint64BE();
+
+  return {
+    assetA: assetIdToName(assetAId),
+    assetAId,
+    assetB: assetIdToName(assetBId),
+    assetBId,
+    quantityA,
+    quantityB,
+    minLpQuantity,
+    lpAssetId,
+    ...(lpAssetId > 0n ? { lpAsset: assetIdToName(lpAssetId) } : {}),
+  };
+}
+
+export function unpackPoolWithdraw(payload: Uint8Array): PoolWithdrawData {
+  const reader = new BinaryReader(payload);
+
+  const assetAId = reader.readUint64BE();
+  const assetBId = reader.readUint64BE();
+  const quantity = reader.readUint64BE();
+  const minQuantityA = reader.readUint64BE();
+  const minQuantityB = reader.readUint64BE();
+
+  return {
+    assetA: assetIdToName(assetAId),
+    assetAId,
+    assetB: assetIdToName(assetBId),
+    assetBId,
+    quantity,
+    minQuantityA,
+    minQuantityB,
+  };
+}

--- a/src/utils/blockchain/counterparty/unpack/paramSchema.ts
+++ b/src/utils/blockchain/counterparty/unpack/paramSchema.ts
@@ -383,6 +383,64 @@ export const MESSAGE_SCHEMAS: Record<string, MessageSchema> = {
       },
     },
   },
+
+  pooldeposit: {
+    messageType: 'pooldeposit',
+    messageTypeIds: [120],
+    params: {
+      asset_a: {
+        criticality: 'critical',
+        riskDescription: 'Wrong asset = depositing wrong tokens',
+      },
+      asset_b: {
+        criticality: 'critical',
+        riskDescription: 'Wrong asset = depositing wrong tokens',
+      },
+      quantity_a: {
+        criticality: 'critical',
+        riskDescription: 'Wrong amount = depositing more than intended',
+      },
+      quantity_b: {
+        criticality: 'critical',
+        riskDescription: 'Wrong amount = depositing more than intended',
+      },
+      min_lp_quantity: {
+        criticality: 'dangerous',
+        riskDescription: 'Lower minimum = weaker slippage protection',
+      },
+      lp_asset: {
+        criticality: 'dangerous',
+        riskDescription: 'Wrong LP asset = creates or references an unintended pool token',
+      },
+    },
+  },
+
+  poolwithdraw: {
+    messageType: 'poolwithdraw',
+    messageTypeIds: [121],
+    params: {
+      asset_a: {
+        criticality: 'critical',
+        riskDescription: 'Wrong asset = withdrawing from wrong pool',
+      },
+      asset_b: {
+        criticality: 'critical',
+        riskDescription: 'Wrong asset = withdrawing from wrong pool',
+      },
+      quantity: {
+        criticality: 'critical',
+        riskDescription: 'Wrong amount = burning more LP tokens than intended',
+      },
+      min_quantity_a: {
+        criticality: 'dangerous',
+        riskDescription: 'Lower minimum = weaker slippage protection',
+      },
+      min_quantity_b: {
+        criticality: 'dangerous',
+        riskDescription: 'Lower minimum = weaker slippage protection',
+      },
+    },
+  },
 };
 
 /**

--- a/src/utils/blockchain/counterparty/unpack/providerVerify.ts
+++ b/src/utils/blockchain/counterparty/unpack/providerVerify.ts
@@ -23,6 +23,7 @@ import type { DividendData } from './messages/dividend';
 import type { FairminterData } from './messages/fairminter';
 import type { FairmintData } from './messages/fairmint';
 import type { AttachData, DetachData } from './messages/attach';
+import type { PoolDepositData, PoolWithdrawData } from './messages/pool';
 
 /**
  * API-decoded Counterparty message (from decodeCounterpartyMessage)
@@ -492,6 +493,73 @@ function verifyAttach(
   return mismatches;
 }
 
+function verifyPoolDeposit(
+  local: PoolDepositData,
+  api: Record<string, unknown>
+): string[] {
+  const mismatches: string[] = [];
+
+  const apiAssetA = getApiValue(api, 'asset_a', 'assetA') as string | undefined;
+  if (apiAssetA && !assetsEqual(local.assetA, apiAssetA)) {
+    mismatches.push(`Asset A: local="${local.assetA}", API="${apiAssetA}"`);
+  }
+
+  const apiAssetB = getApiValue(api, 'asset_b', 'assetB') as string | undefined;
+  if (apiAssetB && !assetsEqual(local.assetB, apiAssetB)) {
+    mismatches.push(`Asset B: local="${local.assetB}", API="${apiAssetB}"`);
+  }
+
+  const apiQuantityA = getApiValue(api, 'quantity_a', 'quantityA');
+  if (apiQuantityA !== undefined && !quantitiesEqual(local.quantityA, apiQuantityA)) {
+    mismatches.push(`Quantity A: local=${local.quantityA}, API=${apiQuantityA}`);
+  }
+
+  const apiQuantityB = getApiValue(api, 'quantity_b', 'quantityB');
+  if (apiQuantityB !== undefined && !quantitiesEqual(local.quantityB, apiQuantityB)) {
+    mismatches.push(`Quantity B: local=${local.quantityB}, API=${apiQuantityB}`);
+  }
+
+  const apiMinLp = getApiValue(api, 'min_lp_quantity', 'minLpQuantity');
+  if (apiMinLp !== undefined && !quantitiesEqual(local.minLpQuantity, apiMinLp)) {
+    mismatches.push(`Min LP quantity: local=${local.minLpQuantity}, API=${apiMinLp}`);
+  }
+
+  return mismatches;
+}
+
+function verifyPoolWithdraw(
+  local: PoolWithdrawData,
+  api: Record<string, unknown>
+): string[] {
+  const mismatches: string[] = [];
+
+  const apiAssetA = getApiValue(api, 'asset_a', 'assetA') as string | undefined;
+  if (apiAssetA && !assetsEqual(local.assetA, apiAssetA)) {
+    mismatches.push(`Asset A: local="${local.assetA}", API="${apiAssetA}"`);
+  }
+
+  const apiAssetB = getApiValue(api, 'asset_b', 'assetB') as string | undefined;
+  if (apiAssetB && !assetsEqual(local.assetB, apiAssetB)) {
+    mismatches.push(`Asset B: local="${local.assetB}", API="${apiAssetB}"`);
+  }
+
+  if (api.quantity !== undefined && !quantitiesEqual(local.quantity, api.quantity)) {
+    mismatches.push(`Quantity: local=${local.quantity}, API=${api.quantity}`);
+  }
+
+  const apiMinA = getApiValue(api, 'min_quantity_a', 'minQuantityA');
+  if (apiMinA !== undefined && !quantitiesEqual(local.minQuantityA, apiMinA)) {
+    mismatches.push(`Min quantity A: local=${local.minQuantityA}, API=${apiMinA}`);
+  }
+
+  const apiMinB = getApiValue(api, 'min_quantity_b', 'minQuantityB');
+  if (apiMinB !== undefined && !quantitiesEqual(local.minQuantityB, apiMinB)) {
+    mismatches.push(`Min quantity B: local=${local.minQuantityB}, API=${apiMinB}`);
+  }
+
+  return mismatches;
+}
+
 /**
  * Verify a provider transaction by comparing local unpack against API decode.
  *
@@ -615,6 +683,14 @@ export function verifyProviderTransaction(
 
     case 'attach':
       mismatches.push(...verifyAttach(localUnpack.data as AttachData, apiData));
+      break;
+
+    case 'pooldeposit':
+      mismatches.push(...verifyPoolDeposit(localUnpack.data as PoolDepositData, apiData));
+      break;
+
+    case 'poolwithdraw':
+      mismatches.push(...verifyPoolWithdraw(localUnpack.data as PoolWithdrawData, apiData));
       break;
 
     case 'detach':

--- a/src/utils/blockchain/counterparty/unpack/verify.ts
+++ b/src/utils/blockchain/counterparty/unpack/verify.ts
@@ -18,6 +18,7 @@ import type { DestroyData } from './messages/destroy';
 import type { SweepData } from './messages/sweep';
 import type { SendData } from './messages/send';
 import type { IssuanceData } from './messages/issuance';
+import type { PoolDepositData, PoolWithdrawData } from './messages/pool';
 import { addressesEqual } from './address';
 import { getMessageSchema, type Criticality } from './paramSchema';
 
@@ -30,6 +31,8 @@ import type {
   DestroyOptions,
   SweepOptions,
   IssuanceOptions,
+  PoolDepositOptions,
+  PoolWithdrawOptions,
 } from '@/utils/blockchain/counterparty/compose';
 
 /**
@@ -43,7 +46,9 @@ export type VerifiableComposeType =
   | 'cancel'
   | 'destroy'
   | 'sweep'
-  | 'issuance';
+  | 'issuance'
+  | 'pooldeposit'
+  | 'poolwithdraw';
 
 /**
  * Compose params - the params object from compose options
@@ -56,7 +61,9 @@ export type ComposeParams =
   | Pick<CancelOptions, 'offer_hash'>
   | Pick<DestroyOptions, 'asset' | 'quantity' | 'tag'>
   | Pick<SweepOptions, 'destination' | 'flags' | 'memo'>
-  | Pick<IssuanceOptions, 'asset' | 'quantity' | 'divisible' | 'lock' | 'reset' | 'transfer_destination' | 'description'>;
+  | Pick<IssuanceOptions, 'asset' | 'quantity' | 'divisible' | 'lock' | 'reset' | 'transfer_destination' | 'description'>
+  | Pick<PoolDepositOptions, 'asset_a' | 'asset_b' | 'quantity_a' | 'quantity_b' | 'min_lp_quantity' | 'lp_asset'>
+  | Pick<PoolWithdrawOptions, 'asset_a' | 'asset_b' | 'quantity' | 'min_quantity_a' | 'min_quantity_b' | 'lp_asset'>;
 
 /**
  * A mismatch found during verification
@@ -479,6 +486,73 @@ function verifyIssuance(
   }
 }
 
+function verifyPoolDeposit(
+  data: PoolDepositData,
+  params: Record<string, unknown>,
+  result: VerificationResult
+): void {
+  if (!valuesEqual(data.assetA, params.asset_a)) {
+    addMismatch(result, 'asset_a', params.asset_a, data.assetA, 'critical',
+      'Wrong asset = depositing wrong tokens');
+  }
+
+  if (!valuesEqual(data.assetB, params.asset_b)) {
+    addMismatch(result, 'asset_b', params.asset_b, data.assetB, 'critical',
+      'Wrong asset = depositing wrong tokens');
+  }
+
+  if (!valuesEqual(data.quantityA, params.quantity_a)) {
+    addMismatch(result, 'quantity_a', params.quantity_a, data.quantityA, 'critical',
+      'Wrong amount = depositing more than intended');
+  }
+
+  if (!valuesEqual(data.quantityB, params.quantity_b)) {
+    addMismatch(result, 'quantity_b', params.quantity_b, data.quantityB, 'critical',
+      'Wrong amount = depositing more than intended');
+  }
+
+  if (params.min_lp_quantity !== undefined && !valuesEqual(data.minLpQuantity, params.min_lp_quantity)) {
+    addMismatch(result, 'min_lp_quantity', params.min_lp_quantity, data.minLpQuantity, 'dangerous',
+      'Lower minimum = weaker slippage protection');
+  }
+
+  if (params.lp_asset !== undefined && data.lpAsset && !valuesEqual(data.lpAsset, params.lp_asset)) {
+    addMismatch(result, 'lp_asset', params.lp_asset, data.lpAsset, 'dangerous',
+      'Wrong LP asset = creates or references an unintended pool token');
+  }
+}
+
+function verifyPoolWithdraw(
+  data: PoolWithdrawData,
+  params: Record<string, unknown>,
+  result: VerificationResult
+): void {
+  if (params.asset_a !== undefined && !valuesEqual(data.assetA, params.asset_a)) {
+    addMismatch(result, 'asset_a', params.asset_a, data.assetA, 'critical',
+      'Wrong asset = withdrawing from wrong pool');
+  }
+
+  if (params.asset_b !== undefined && !valuesEqual(data.assetB, params.asset_b)) {
+    addMismatch(result, 'asset_b', params.asset_b, data.assetB, 'critical',
+      'Wrong asset = withdrawing from wrong pool');
+  }
+
+  if (!valuesEqual(data.quantity, params.quantity)) {
+    addMismatch(result, 'quantity', params.quantity, data.quantity, 'critical',
+      'Wrong amount = burning more LP tokens than intended');
+  }
+
+  if (params.min_quantity_a !== undefined && !valuesEqual(data.minQuantityA, params.min_quantity_a)) {
+    addMismatch(result, 'min_quantity_a', params.min_quantity_a, data.minQuantityA, 'dangerous',
+      'Lower minimum = weaker slippage protection');
+  }
+
+  if (params.min_quantity_b !== undefined && !valuesEqual(data.minQuantityB, params.min_quantity_b)) {
+    addMismatch(result, 'min_quantity_b', params.min_quantity_b, data.minQuantityB, 'dangerous',
+      'Lower minimum = weaker slippage protection');
+  }
+}
+
 /**
  * Verify a composed transaction matches the request params.
  *
@@ -594,6 +668,22 @@ export function verifyTransaction(
         return result;
       }
       verifyIssuance(unpacked.data as IssuanceData, actualParams, result);
+      break;
+
+    case 'pooldeposit':
+      if (unpacked.messageTypeId !== MessageTypeId.POOL_DEPOSIT) {
+        result.errors.push(`Message type mismatch: expected pooldeposit, got ${unpacked.messageType}`);
+        return result;
+      }
+      verifyPoolDeposit(unpacked.data as PoolDepositData, actualParams, result);
+      break;
+
+    case 'poolwithdraw':
+      if (unpacked.messageTypeId !== MessageTypeId.POOL_WITHDRAW) {
+        result.errors.push(`Message type mismatch: expected poolwithdraw, got ${unpacked.messageType}`);
+        return result;
+      }
+      verifyPoolWithdraw(unpacked.data as PoolWithdrawData, actualParams, result);
       break;
 
     default:


### PR DESCRIPTION
## Summary
- add local unpack support for Counterparty pooldeposit and poolwithdraw messages
- register message IDs 120 and 121 in message type/schema metadata
- verify pool deposit/withdraw fields during local/provider transaction verification

## Tests
- pnpm.cmd compile
- pnpm.cmd vitest run src/utils/blockchain/counterparty/unpack/__tests__/providerVerify.test.ts src/services/__tests__/providerService.test.ts