### PR TITLE
Gate AMM pool support by core capability

### DIFF
--- a/src/utils/blockchain/counterparty/__tests__/api.test.ts
+++ b/src/utils/blockchain/counterparty/__tests__/api.test.ts
@@ -39,6 +39,9 @@ import { walletManager } from '@/utils/wallet/walletManager';
 vi.mock('@/utils/apiClient');
 vi.mock('@/utils/format');
 vi.mock('@/utils/blockchain/bitcoin/balance');
+vi.mock('@/utils/blockchain/counterparty/capabilities', () => ({
+  requireCounterpartyFeature: vi.fn().mockResolvedValue(undefined),
+}));
 vi.mock('@/utils/wallet/walletManager', () => ({
   walletManager: {
     getSettings: vi.fn().mockReturnValue({

--- a/src/utils/blockchain/counterparty/__tests__/capabilities.test.ts
+++ b/src/utils/blockchain/counterparty/__tests__/capabilities.test.ts
@@ -28,7 +28,7 @@ function mockServerInfo(overrides: Record<string, unknown> = {}) {
         network: 'mainnet',
         version: '11.1.0',
         backend_height: 900000,
-        counterparty_height: 999999999,
+        counterparty_height: 952500,
         ...overrides,
       },
     },
@@ -75,7 +75,7 @@ describe('counterparty capabilities', () => {
     const status = await getCounterpartyFeatureStatus('ammPools');
 
     expect(status.supported).toBe(false);
-    expect(status.reason).toContain('activate at block 999999999');
+    expect(status.reason).toContain('activate at block 952500');
   });
 
   it('allows AMM pools on regtest once the API version supports them', async () => {

--- a/src/utils/blockchain/counterparty/__tests__/capabilities.test.ts
+++ b/src/utils/blockchain/counterparty/__tests__/capabilities.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  clearCounterpartyCapabilityCache,
+  getCounterpartyFeatureStatus,
+  isVersionAtLeast,
+  requireCounterpartyFeature,
+} from '../capabilities';
+import { apiClient } from '@/utils/apiClient';
+import { CounterpartyApiError } from '@/utils/blockchain/errors';
+import { walletManager } from '@/utils/wallet/walletManager';
+
+vi.mock('@/utils/apiClient');
+vi.mock('@/utils/wallet/walletManager', () => ({
+  walletManager: {
+    getSettings: vi.fn(),
+  },
+}));
+
+const mockedApiClient = vi.mocked(apiClient, true);
+const mockedGetSettings = vi.mocked(walletManager.getSettings);
+const mockApiBase = 'https://api.counterparty.io:4000';
+
+function mockServerInfo(overrides: Record<string, unknown> = {}) {
+  mockedApiClient.get.mockResolvedValueOnce({
+    data: {
+      result: {
+        server_ready: true,
+        network: 'mainnet',
+        version: '11.1.0',
+        backend_height: 900000,
+        counterparty_height: 999999999,
+        ...overrides,
+      },
+    },
+    status: 200,
+    statusText: 'OK',
+    headers: {},
+    config: {},
+  } as any);
+}
+
+describe('counterparty capabilities', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearCounterpartyCapabilityCache();
+    mockedGetSettings.mockReturnValue({ counterpartyApiBase: mockApiBase } as any);
+  });
+
+  it('compares semantic versions using numeric components', () => {
+    expect(isVersionAtLeast('11.1.0', '11.1.0')).toBe(true);
+    expect(isVersionAtLeast('11.1.0-alpha.1', '11.1.0')).toBe(true);
+    expect(isVersionAtLeast('11.2.0', '11.1.0')).toBe(true);
+    expect(isVersionAtLeast('11.0.9', '11.1.0')).toBe(false);
+  });
+
+  it('reports AMM pools as supported when version and height are ready', async () => {
+    mockServerInfo();
+
+    const status = await getCounterpartyFeatureStatus('ammPools');
+
+    expect(status.supported).toBe(true);
+    expect(mockedApiClient.get).toHaveBeenCalledWith(`${mockApiBase}/v2/`);
+  });
+
+  it('rejects AMM pools before the minimum API version', async () => {
+    mockServerInfo({ version: '11.0.0' });
+
+    await expect(requireCounterpartyFeature('ammPools')).rejects.toThrow(CounterpartyApiError);
+    await expect(requireCounterpartyFeature('ammPools')).rejects.toThrow('11.1.0');
+  });
+
+  it('rejects AMM pools before activation height', async () => {
+    mockServerInfo({ counterparty_height: 950000 });
+
+    const status = await getCounterpartyFeatureStatus('ammPools');
+
+    expect(status.supported).toBe(false);
+    expect(status.reason).toContain('activate at block 999999999');
+  });
+
+  it('allows AMM pools on regtest once the API version supports them', async () => {
+    mockServerInfo({ network: 'regtest', counterparty_height: 0 });
+
+    const status = await getCounterpartyFeatureStatus('ammPools');
+
+    expect(status.supported).toBe(true);
+  });
+});

--- a/src/utils/blockchain/counterparty/__tests__/compose.specialized.test.ts
+++ b/src/utils/blockchain/counterparty/__tests__/compose.specialized.test.ts
@@ -29,6 +29,9 @@ import {
 
 // Mock dependencies
 vi.mock('@/utils/apiClient');
+vi.mock('@/utils/blockchain/counterparty/capabilities', () => ({
+  requireCounterpartyFeature: vi.fn().mockResolvedValue(undefined),
+}));
 vi.mock('@/utils/wallet/walletManager', () => ({
   walletManager: {
     getSettings: vi.fn(),

--- a/src/utils/blockchain/counterparty/capabilities.ts
+++ b/src/utils/blockchain/counterparty/capabilities.ts
@@ -20,15 +20,33 @@ interface FeatureRequirement {
 
 const CAPABILITY_CACHE_TTL_MS = 60_000;
 
+const AMM_POOLS_PROTOCOL_CHANGE = {
+  minimum_version_major: 11,
+  minimum_version_minor: 1,
+  minimum_version_revision: 0,
+  block_index: 952500,
+  testnet3_block_index: 4961000,
+  testnet4_block_index: 136000,
+  signet_block_index: 310000,
+};
+
+function protocolChangeVersion(change: typeof AMM_POOLS_PROTOCOL_CHANGE): string {
+  return [
+    change.minimum_version_major,
+    change.minimum_version_minor,
+    change.minimum_version_revision,
+  ].join('.');
+}
+
 const FEATURE_REQUIREMENTS: Record<CounterpartyFeature, FeatureRequirement> = {
   ammPools: {
-    minVersion: '11.1.0',
+    minVersion: protocolChangeVersion(AMM_POOLS_PROTOCOL_CHANGE),
     activationHeights: {
-      mainnet: 999999999,
-      testnet: 999999999,
-      testnet3: 999999999,
-      testnet4: 999999999,
-      signet: 0,
+      mainnet: AMM_POOLS_PROTOCOL_CHANGE.block_index,
+      testnet: AMM_POOLS_PROTOCOL_CHANGE.testnet3_block_index,
+      testnet3: AMM_POOLS_PROTOCOL_CHANGE.testnet3_block_index,
+      testnet4: AMM_POOLS_PROTOCOL_CHANGE.testnet4_block_index,
+      signet: AMM_POOLS_PROTOCOL_CHANGE.signet_block_index,
       regtest: 0,
     },
     label: 'AMM pools',

--- a/src/utils/blockchain/counterparty/capabilities.ts
+++ b/src/utils/blockchain/counterparty/capabilities.ts
@@ -1,0 +1,137 @@
+import { apiClient } from '@/utils/apiClient';
+import { CounterpartyApiError } from '@/utils/blockchain/errors';
+import { walletManager } from '@/utils/wallet/walletManager';
+
+export type CounterpartyFeature = 'ammPools';
+
+interface ServerInfo {
+  server_ready: boolean;
+  network: string;
+  version: string;
+  backend_height: number;
+  counterparty_height: number;
+}
+
+interface FeatureRequirement {
+  minVersion: string;
+  activationHeights: Record<string, number>;
+  label: string;
+}
+
+const CAPABILITY_CACHE_TTL_MS = 60_000;
+
+const FEATURE_REQUIREMENTS: Record<CounterpartyFeature, FeatureRequirement> = {
+  ammPools: {
+    minVersion: '11.1.0',
+    activationHeights: {
+      mainnet: 999999999,
+      testnet: 999999999,
+      testnet3: 999999999,
+      testnet4: 999999999,
+      signet: 0,
+      regtest: 0,
+    },
+    label: 'AMM pools',
+  },
+};
+
+let cachedServerInfo: { apiBase: string; serverInfo: ServerInfo; timestamp: number } | null = null;
+
+function getApiBase(): string {
+  return walletManager.getSettings().counterpartyApiBase;
+}
+
+function parseVersion(version: string): [number, number, number] {
+  const match = version.match(/(\d+)\.(\d+)\.(\d+)/);
+  if (!match) return [0, 0, 0];
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+export function isVersionAtLeast(version: string, minimum: string): boolean {
+  const current = parseVersion(version);
+  const required = parseVersion(minimum);
+
+  for (let i = 0; i < required.length; i += 1) {
+    if (current[i] > required[i]) return true;
+    if (current[i] < required[i]) return false;
+  }
+  return true;
+}
+
+async function fetchCapabilityServerInfo(): Promise<ServerInfo> {
+  const apiBase = getApiBase();
+
+  if (
+    cachedServerInfo &&
+    cachedServerInfo.apiBase === apiBase &&
+    Date.now() - cachedServerInfo.timestamp < CAPABILITY_CACHE_TTL_MS
+  ) {
+    return cachedServerInfo.serverInfo;
+  }
+
+  const response = await apiClient.get<{ result?: ServerInfo }>(`${apiBase}/v2/`);
+  if (!response.data.result) {
+    throw new CounterpartyApiError('Invalid API response: missing result', '/v2/');
+  }
+
+  cachedServerInfo = {
+    apiBase,
+    serverInfo: response.data.result,
+    timestamp: Date.now(),
+  };
+
+  return response.data.result;
+}
+
+export async function getCounterpartyFeatureStatus(feature: CounterpartyFeature): Promise<{
+  supported: boolean;
+  serverInfo: ServerInfo;
+  reason?: string;
+}> {
+  const requirement = FEATURE_REQUIREMENTS[feature];
+  const serverInfo = await fetchCapabilityServerInfo();
+
+  if (!serverInfo.server_ready) {
+    return {
+      supported: false,
+      serverInfo,
+      reason: 'API server is not ready',
+    };
+  }
+
+  if (!isVersionAtLeast(serverInfo.version, requirement.minVersion)) {
+    return {
+      supported: false,
+      serverInfo,
+      reason: `${requirement.label} require Counterparty API ${requirement.minVersion} or newer; current API is ${serverInfo.version}`,
+    };
+  }
+
+  const activationHeight =
+    requirement.activationHeights[serverInfo.network] ??
+    requirement.activationHeights.mainnet;
+
+  if (serverInfo.counterparty_height < activationHeight) {
+    return {
+      supported: false,
+      serverInfo,
+      reason: `${requirement.label} activate at block ${activationHeight}; current Counterparty height is ${serverInfo.counterparty_height}`,
+    };
+  }
+
+  return { supported: true, serverInfo };
+}
+
+export async function requireCounterpartyFeature(feature: CounterpartyFeature): Promise<void> {
+  const status = await getCounterpartyFeatureStatus(feature);
+  if (!status.supported) {
+    throw new CounterpartyApiError(
+      status.reason ?? 'Counterparty feature is not supported by this API',
+      '/v2/'
+    );
+  }
+}
+
+export function clearCounterpartyCapabilityCache(): void {
+  cachedServerInfo = null;
+}

--- a/src/utils/blockchain/counterparty/capabilities.ts
+++ b/src/utils/blockchain/counterparty/capabilities.ts
@@ -20,33 +20,15 @@ interface FeatureRequirement {
 
 const CAPABILITY_CACHE_TTL_MS = 60_000;
 
-const AMM_POOLS_PROTOCOL_CHANGE = {
-  minimum_version_major: 11,
-  minimum_version_minor: 1,
-  minimum_version_revision: 0,
-  block_index: 952500,
-  testnet3_block_index: 4961000,
-  testnet4_block_index: 136000,
-  signet_block_index: 310000,
-};
-
-function protocolChangeVersion(change: typeof AMM_POOLS_PROTOCOL_CHANGE): string {
-  return [
-    change.minimum_version_major,
-    change.minimum_version_minor,
-    change.minimum_version_revision,
-  ].join('.');
-}
-
 const FEATURE_REQUIREMENTS: Record<CounterpartyFeature, FeatureRequirement> = {
   ammPools: {
-    minVersion: protocolChangeVersion(AMM_POOLS_PROTOCOL_CHANGE),
+    minVersion: '11.1.0',
     activationHeights: {
-      mainnet: AMM_POOLS_PROTOCOL_CHANGE.block_index,
-      testnet: AMM_POOLS_PROTOCOL_CHANGE.testnet3_block_index,
-      testnet3: AMM_POOLS_PROTOCOL_CHANGE.testnet3_block_index,
-      testnet4: AMM_POOLS_PROTOCOL_CHANGE.testnet4_block_index,
-      signet: AMM_POOLS_PROTOCOL_CHANGE.signet_block_index,
+      mainnet: 952500,
+      testnet: 4961000,
+      testnet3: 4961000,
+      testnet4: 136000,
+      signet: 310000,
       regtest: 0,
     },
     label: 'AMM pools',

--- a/src/utils/blockchain/counterparty/compose.ts
+++ b/src/utils/blockchain/counterparty/compose.ts
@@ -1,6 +1,7 @@
 import { apiClient } from '@/utils/apiClient';
 import { walletManager } from '@/utils/wallet/walletManager';
 import { CounterpartyApiError } from '@/utils/blockchain/errors';
+import { requireCounterpartyFeature } from '@/utils/blockchain/counterparty/capabilities';
 import { selectUtxosForTransaction } from '@/utils/blockchain/counterparty/utxo-selection';
 
 /**
@@ -1020,6 +1021,8 @@ export async function composeFairmint(options: FairmintOptions): Promise<ApiResp
 }
 
 export async function composePoolDeposit(options: PoolDepositOptions): Promise<ApiResponse> {
+  await requireCounterpartyFeature('ammPools');
+
   const {
     sourceAddress,
     asset_a,
@@ -1045,6 +1048,8 @@ export async function composePoolDeposit(options: PoolDepositOptions): Promise<A
 }
 
 export async function getPoolDepositEstimateXcpFee(sourceAddress: string): Promise<number> {
+  await requireCounterpartyFeature('ammPools');
+
   const base = await getApiBase();
   const apiUrl = `${base}/v2/addresses/${sourceAddress}/compose/pooldeposit/estimatexcpfees`;
   const response = await apiClient.get<{ result: number }>(apiUrl);
@@ -1052,6 +1057,8 @@ export async function getPoolDepositEstimateXcpFee(sourceAddress: string): Promi
 }
 
 export async function composePoolWithdraw(options: PoolWithdrawOptions): Promise<ApiResponse> {
+  await requireCounterpartyFeature('ammPools');
+
   const {
     sourceAddress,
     asset_a,
@@ -1077,6 +1084,8 @@ export async function composePoolWithdraw(options: PoolWithdrawOptions): Promise
 }
 
 export async function getPoolWithdrawEstimateXcpFee(sourceAddress: string): Promise<number> {
+  await requireCounterpartyFeature('ammPools');
+
   const base = await getApiBase();
   const apiUrl = `${base}/v2/addresses/${sourceAddress}/compose/poolwithdraw/estimatexcpfees`;
   const response = await apiClient.get<{ result: number }>(apiUrl);


### PR DESCRIPTION
Adds a Counterparty Core capability check before composing AMM pool transactions.

What changed:
- Require Counterparty Core >= 11.1.0 before pool deposit/withdraw compose and XCP fee-estimate calls.
- Require the configured network to be at or past the AMM activation height before those compose/fee-estimate calls.
- Leave pool read/query/quote endpoints ungated. Counterparty Core registers those routes normally in the AMM PR, and pre-activation reads may simply return empty/no-pool results. Older Core versions can fail through the normal API error path.
- Leave unpack/verify alone because those can still inspect historical/user-provided tx data without composing new AMM actions.
- Add focused tests for version comparison, activation-height behavior, and existing compose call coverage.

Activation heights mirror Counterparty Core PR 3288: mainnet = 952500, testnet/testnet3 = 4961000, testnet4 = 136000, signet = 310000, regtest = 0.

Verification:
- npm.cmd run compile
- npx.cmd vitest src/utils/blockchain/counterparty/__tests__/capabilities.test.ts src/utils/blockchain/counterparty/__tests__/api.test.ts src/utils/blockchain/counterparty/__tests__/compose.specialized.test.ts --run