### PR TITLE
Add AMM pool management and compose flows

### DIFF
--- a/e2e/compose-test-helpers.ts
+++ b/e2e/compose-test-helpers.ts
@@ -17,6 +17,18 @@ import { TEST_ADDRESSES } from './test-data';
 export async function enableValidationBypass(page: Page): Promise<void> {
   const context = page.context();
 
+  const mockPoolPosition = {
+    asset_a: 'XCP',
+    asset_b: 'PEPECASH',
+    lp_asset: 'A95428956661682177',
+    reserve_a: 500000000000,
+    reserve_b: 250000000000,
+    reserve_a_normalized: '5000',
+    reserve_b_normalized: '2500',
+    quantity: 100000000,
+    quantity_normalized: '1',
+  };
+
   // Mock compose response - provides data for review page display
   const mockComposeResponse = {
     result: {
@@ -56,6 +68,78 @@ export async function enableValidationBypass(page: Page): Promise<void> {
     const url = route.request().url();
     const method = route.request().method();
     console.log(`[E2E Debug] ${method} ${url}`);
+
+    if (url.match(/\/v2\/?(\?.*)?$/)) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          result: {
+            server_ready: true,
+            network: 'mainnet',
+            version: '11.1.0',
+            backend_height: 952500,
+            counterparty_height: 952500,
+          },
+        }),
+      });
+      return;
+    }
+
+    if (url.includes('/estimatexcpfees')) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ result: 10000 }),
+      });
+      return;
+    }
+
+    if (url.includes('/v2/addresses/') && url.includes('/pools')) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          result: [mockPoolPosition],
+          result_count: 1,
+        }),
+      });
+      return;
+    }
+
+    if (url.includes('/v2/pools/') && url.includes('/quote/deposit')) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          result: {
+            asset_a: 'XCP',
+            asset_b: 'PEPECASH',
+            pool_exists: true,
+            first_deposit: false,
+            quantity_a_required: 100000000,
+            quantity_b_required: 50000000,
+            quantity_minted_estimate: 2000000,
+          },
+        }),
+      });
+      return;
+    }
+
+    if (url.includes('/v2/pools/') && url.includes('/quote/withdraw')) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          result: {
+            pool_exists: true,
+            quantity_a_estimate: 50000000,
+            quantity_b_estimate: 25000000,
+          },
+        }),
+      });
+      return;
+    }
 
     // Handle compose endpoints - return mock transaction data
     if (url.includes('/compose/')) {
@@ -116,6 +200,36 @@ export async function enableValidationBypass(page: Page): Promise<void> {
         console.log(`[E2E Mock] Order: ${giveQuantity} ${giveAsset} for ${getQuantity} ${getAsset}`);
       }
 
+      if (composeType === 'pooldeposit') {
+        responseParams = {
+          source: mockComposeResponse.result.params.source,
+          asset_a: urlParams.get('asset_a') || 'XCP',
+          asset_b: urlParams.get('asset_b') || 'PEPECASH',
+          quantity_a: parseInt(urlParams.get('quantity_a') || '100000000', 10),
+          quantity_b: parseInt(urlParams.get('quantity_b') || '50000000', 10),
+          min_lp_quantity: parseInt(urlParams.get('min_lp_quantity') || '1900000', 10),
+          lp_asset: urlParams.get('lp_asset') || mockPoolPosition.lp_asset,
+          quantity_a_normalized: '1',
+          quantity_b_normalized: '0.5',
+          min_lp_quantity_normalized: '0.019',
+        };
+      }
+
+      if (composeType === 'poolwithdraw') {
+        responseParams = {
+          source: mockComposeResponse.result.params.source,
+          asset_a: urlParams.get('asset_a') || mockPoolPosition.asset_a,
+          asset_b: urlParams.get('asset_b') || mockPoolPosition.asset_b,
+          lp_asset: urlParams.get('lp_asset') || mockPoolPosition.lp_asset,
+          quantity: parseInt(urlParams.get('quantity') || '10000000', 10),
+          min_quantity_a: parseInt(urlParams.get('min_quantity_a') || '47500000', 10),
+          min_quantity_b: parseInt(urlParams.get('min_quantity_b') || '23750000', 10),
+          quantity_normalized: '0.1',
+          min_quantity_a_normalized: '0.475',
+          min_quantity_b_normalized: '0.2375',
+        };
+      }
+
       // Build dynamic response with params from request
       const dynamicResponse = {
         ...mockComposeResponse,
@@ -144,6 +258,7 @@ export async function enableValidationBypass(page: Page): Promise<void> {
         XCP: { divisible: true, supply: 2648755823622677, locked: true },
         BTC: { divisible: true, supply: 0, locked: true },
         PEPECASH: { divisible: true, supply: 1000000000000000, locked: true },
+        A95428956661682177: { divisible: true, supply: 10000000000, locked: true },
         // TESTUNLOCKED is an unlocked asset for testing issue-supply and lock-supply
         TESTUNLOCKED: { divisible: true, supply: 100000000000, locked: false },
       };

--- a/e2e/pages/assets/[asset]/balance.spec.ts
+++ b/e2e/pages/assets/[asset]/balance.spec.ts
@@ -11,6 +11,7 @@
  */
 
 import { walletTest, expect } from '@e2e/fixtures';
+import { enableValidationBypass } from '../../../compose-test-helpers';
 
 walletTest.describe('View Balance Page (/assets/:asset/balance)', () => {
   // Helper to navigate to balance page and wait for content to load
@@ -149,6 +150,17 @@ walletTest.describe('View Balance Page (/assets/:asset/balance)', () => {
     await dispenserAction.click();
 
     await expect(page).toHaveURL(/compose\/dispenser\/XCP/, { timeout: 5000 });
+  });
+
+  walletTest('LP asset shows Manage Pool action and navigates to pool page', async ({ page }) => {
+    await enableValidationBypass(page);
+    await navigateToBalance(page, 'A95428956661682177');
+
+    const managePoolAction = page.locator('button:has-text("Manage Pool"), div[role="button"]:has-text("Manage Pool")').first();
+    await expect(managePoolAction).toBeVisible({ timeout: 10000 });
+    await managePoolAction.click();
+
+    await expect(page).toHaveURL(/\/pools\/A95428956661682177/, { timeout: 5000 });
   });
 
   walletTest('Attach action navigates to compose/utxo/attach for XCP', async ({ page }) => {

--- a/e2e/pages/compose/pool/deposit.spec.ts
+++ b/e2e/pages/compose/pool/deposit.spec.ts
@@ -1,0 +1,67 @@
+/**
+ * Compose Pool Deposit Page Tests (/compose/pool/deposit)
+ */
+
+import { walletTest, expect } from '@e2e/fixtures';
+import { compose } from '@e2e/selectors';
+import {
+  clickBack,
+  enableDryRun,
+  enableValidationBypass,
+  waitForReview,
+} from '../../../compose-test-helpers';
+
+walletTest.describe('Pool Deposit Flow - Full Compose Flow', () => {
+  walletTest.beforeEach(async ({ page }) => {
+    await enableValidationBypass(page);
+    await enableDryRun(page);
+  });
+
+  walletTest('prefilled pair can quote and reach review', async ({ page }) => {
+    await page.goto(page.url().replace(/\/index.*/, '/compose/pool/deposit/XCP/PEPECASH'));
+    await page.waitForLoadState('networkidle');
+
+    await expect(compose.pool.assetAAmountInput(page)).toBeVisible({ timeout: 10000 });
+    await compose.pool.assetAAmountInput(page).fill('1');
+    await compose.pool.assetBAmountInput(page).fill('0.5');
+
+    await expect(page.getByText(/Quoted partner amount/i)).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText(/Minimum LP tokens/i)).toBeVisible({ timeout: 10000 });
+
+    const submitBtn = compose.pool.depositButton(page);
+    await expect(submitBtn).toBeEnabled({ timeout: 10000 });
+    await submitBtn.click();
+
+    await waitForReview(page);
+    await expect(page.getByText('PEPECASH / XCP')).toBeVisible();
+    await expect(page.getByText(/Minimum LP/i)).toBeVisible();
+  });
+
+  walletTest('form data is preserved after returning from review', async ({ page }) => {
+    await page.goto(page.url().replace(/\/index.*/, '/compose/pool/deposit/XCP/PEPECASH'));
+    await page.waitForLoadState('networkidle');
+
+    await compose.pool.assetAAmountInput(page).fill('1');
+    await compose.pool.assetBAmountInput(page).fill('0.5');
+
+    await expect(compose.pool.depositButton(page)).toBeEnabled({ timeout: 10000 });
+    await compose.pool.depositButton(page).click();
+    await waitForReview(page);
+
+    await clickBack(page);
+
+    await expect(compose.pool.assetAAmountInput(page)).toHaveValue('1');
+    await expect(compose.pool.assetBAmountInput(page)).toHaveValue('0.5');
+  });
+
+  walletTest('Use quote fills the partner asset amount', async ({ page }) => {
+    await page.goto(page.url().replace(/\/index.*/, '/compose/pool/deposit/XCP/PEPECASH'));
+    await page.waitForLoadState('networkidle');
+
+    await compose.pool.assetAAmountInput(page).fill('1');
+    await expect(compose.pool.useQuoteButton(page)).toBeVisible({ timeout: 10000 });
+    await compose.pool.useQuoteButton(page).click();
+
+    await expect(compose.pool.assetBAmountInput(page)).toHaveValue('0.5');
+  });
+});

--- a/e2e/pages/compose/pool/withdraw.spec.ts
+++ b/e2e/pages/compose/pool/withdraw.spec.ts
@@ -1,0 +1,53 @@
+/**
+ * Compose Pool Withdraw Page Tests (/compose/pool/withdraw/:lpAsset)
+ */
+
+import { walletTest, expect } from '@e2e/fixtures';
+import { compose } from '@e2e/selectors';
+import {
+  clickBack,
+  enableDryRun,
+  enableValidationBypass,
+  waitForReview,
+} from '../../../compose-test-helpers';
+
+walletTest.describe('Pool Withdraw Flow - Full Compose Flow', () => {
+  walletTest.beforeEach(async ({ page }) => {
+    await enableValidationBypass(page);
+    await enableDryRun(page);
+  });
+
+  walletTest('LP position can quote and reach review', async ({ page }) => {
+    await page.goto(page.url().replace(/\/index.*/, '/compose/pool/withdraw/A95428956661682177'));
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByText('PEPECASH / XCP')).toBeVisible({ timeout: 10000 });
+    await expect(compose.pool.lpWithdrawInput(page)).toBeVisible({ timeout: 10000 });
+    await compose.pool.lpWithdrawInput(page).fill('0.1');
+
+    await expect(page.getByText(/Estimated receive/i)).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText(/Minimum received/i)).toBeVisible({ timeout: 10000 });
+
+    const submitBtn = compose.pool.withdrawButton(page);
+    await expect(submitBtn).toBeEnabled({ timeout: 10000 });
+    await submitBtn.click();
+
+    await waitForReview(page);
+    await expect(page.getByText('PEPECASH / XCP')).toBeVisible();
+    await expect(page.getByText(/Minimum Receive/i)).toBeVisible();
+  });
+
+  walletTest('form data is preserved after returning from review', async ({ page }) => {
+    await page.goto(page.url().replace(/\/index.*/, '/compose/pool/withdraw/A95428956661682177'));
+    await page.waitForLoadState('networkidle');
+
+    await compose.pool.lpWithdrawInput(page).fill('0.1');
+    await expect(compose.pool.withdrawButton(page)).toBeEnabled({ timeout: 10000 });
+    await compose.pool.withdrawButton(page).click();
+    await waitForReview(page);
+
+    await clickBack(page);
+
+    await expect(compose.pool.lpWithdrawInput(page)).toHaveValue('0.1');
+  });
+});

--- a/e2e/pages/pools/[lpAsset].spec.ts
+++ b/e2e/pages/pools/[lpAsset].spec.ts
@@ -1,0 +1,39 @@
+/**
+ * Pool Position Page Tests (/pools/:lpAsset)
+ */
+
+import { walletTest, expect } from '@e2e/fixtures';
+import { enableValidationBypass } from '../../compose-test-helpers';
+
+walletTest.describe('Pool Position Page (/pools/:lpAsset)', () => {
+  walletTest.beforeEach(async ({ page }) => {
+    await enableValidationBypass(page);
+  });
+
+  walletTest('shows pool details and action buttons', async ({ page }) => {
+    await page.goto(page.url().replace(/\/index.*/, '/pools/A95428956661682177'));
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByRole('heading', { name: 'PEPECASH / XCP' })).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('Reserve PEPECASH')).toBeVisible();
+    await expect(page.getByText('Reserve XCP')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Deposit' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Withdraw' })).toBeVisible();
+  });
+
+  walletTest('Deposit opens the prefilled pool deposit flow', async ({ page }) => {
+    await page.goto(page.url().replace(/\/index.*/, '/pools/A95428956661682177'));
+    await page.waitForLoadState('networkidle');
+
+    await page.getByRole('button', { name: 'Deposit' }).click();
+    await expect(page).toHaveURL(/compose\/pool\/deposit\/XCP\/PEPECASH/, { timeout: 5000 });
+  });
+
+  walletTest('Withdraw opens the pool withdraw flow', async ({ page }) => {
+    await page.goto(page.url().replace(/\/index.*/, '/pools/A95428956661682177'));
+    await page.waitForLoadState('networkidle');
+
+    await page.getByRole('button', { name: 'Withdraw' }).click();
+    await expect(page).toHaveURL(/compose\/pool\/withdraw\/A95428956661682177/, { timeout: 5000 });
+  });
+});

--- a/e2e/pages/pools/index.spec.ts
+++ b/e2e/pages/pools/index.spec.ts
@@ -1,0 +1,44 @@
+/**
+ * Manage Pools Page Tests (/pools)
+ *
+ * Tests the pool entry point and position list using mocked Counterparty pool data.
+ */
+
+import { walletTest, expect, navigateTo } from '@e2e/fixtures';
+import { actions } from '@e2e/selectors';
+import { enableValidationBypass } from '../../compose-test-helpers';
+
+walletTest.describe('Manage Pools Page (/pools)', () => {
+  walletTest.beforeEach(async ({ page }) => {
+    await enableValidationBypass(page);
+  });
+
+  walletTest('can navigate to Manage Pools from actions', async ({ page }) => {
+    await navigateTo(page, 'actions');
+
+    await expect(actions.managePoolsOption(page)).toBeVisible({ timeout: 5000 });
+    await actions.managePoolsOption(page).click();
+
+    await expect(page).toHaveURL(/\/pools/, { timeout: 5000 });
+    await expect(page.getByRole('button', { name: /Enter Pool/i }).first()).toBeVisible();
+  });
+
+  walletTest('lists LP positions and opens the position page', async ({ page }) => {
+    await page.goto(page.url().replace(/\/index.*/, '/pools'));
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByText('PEPECASH / XCP')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('A95428956661682177')).toBeVisible();
+
+    await page.getByRole('button').filter({ hasText: 'PEPECASH / XCP' }).first().click();
+    await expect(page).toHaveURL(/\/pools\/A95428956661682177/, { timeout: 5000 });
+  });
+
+  walletTest('Enter Pool opens the pool deposit flow', async ({ page }) => {
+    await page.goto(page.url().replace(/\/index.*/, '/pools'));
+    await page.waitForLoadState('networkidle');
+
+    await page.getByRole('button', { name: /Enter Pool/i }).first().click();
+    await expect(page).toHaveURL(/compose\/pool\/deposit/, { timeout: 5000 });
+  });
+});

--- a/e2e/selectors.ts
+++ b/e2e/selectors.ts
@@ -168,6 +168,7 @@ export const actions = {
   cancelOrderOption: (page: Page) => page.getByText('Cancel Order'),
   closeDispenserOption: (page: Page) => page.getByText('Close Dispenser', { exact: true }),
   recoverBitcoinOption: (page: Page) => page.getByText('Recover Bitcoin'),
+  managePoolsOption: (page: Page) => page.getByText('Manage Pools'),
   toolsSection: (page: Page) => page.getByText('Tools'),
   assetsSection: (page: Page) => page.locator('text=Assets').first(),
   addressSection: (page: Page) => page.locator('text=Address').first(),
@@ -355,6 +356,17 @@ export const compose = {
   fairmint: {
     mintButton: (page: Page) => page.locator('button:has-text("Mint"), button:has-text("Participate")').first(),
     quantityInput: (page: Page) => page.locator('input[name*="quantity"], input[type="number"]').first(),
+  },
+
+  // AMM pool operations (/compose/pool/*)
+  pool: {
+    assetAAmountInput: (page: Page) => page.locator('input[name="quantity_a_display"]'),
+    assetBAmountInput: (page: Page) => page.locator('input[name="quantity_b_display"]'),
+    lpWithdrawInput: (page: Page) => page.locator('input[name="quantity_display"]'),
+    depositButton: (page: Page) => page.getByRole('button', { name: /Review Deposit/i }),
+    withdrawButton: (page: Page) => page.getByRole('button', { name: /Review Withdrawal/i }),
+    useQuoteButton: (page: Page) => page.getByRole('button', { name: /Use quote/i }),
+    slippageInput: (page: Page) => page.locator('input[name="slippage"]'),
   },
 
   // UTXO operations (/compose/utxo/*)

--- a/src/components/composer/composer.tsx
+++ b/src/components/composer/composer.tsx
@@ -16,7 +16,7 @@ export type ComposeType =
   | 'cancel' | 'dispenser-close-by-hash' | 'broadcast'
   | 'attach' | 'detach' | 'move-utxo' | 'move' | 'destroy' | 'issue-supply'
   | 'lock-supply' | 'reset-supply' | 'transfer' | 'update-description'
-  | 'lock-description' | 'issuance';
+  | 'lock-description' | 'issuance' | 'pooldeposit' | 'poolwithdraw';
 
 /**
  * Props for the Composer component.

--- a/src/components/ui/headers/pool-header.tsx
+++ b/src/components/ui/headers/pool-header.tsx
@@ -1,0 +1,32 @@
+import { type ReactElement } from "react";
+import { AssetIcon } from "@/components/domain/asset/asset-icon";
+import { formatAmount } from "@/utils/format";
+import { getCanonicalPoolPair } from "@/utils/blockchain/counterparty/pool";
+import type { PoolPosition } from "@/utils/blockchain/counterparty/api";
+
+interface PoolHeaderProps {
+  pool: PoolPosition;
+  className?: string;
+}
+
+export function PoolHeader({ pool, className = "" }: PoolHeaderProps): ReactElement {
+  const pair = getCanonicalPoolPair(pool.asset_a, pool.asset_b);
+  const balance = pool.quantity_normalized
+    ? formatAmount({
+        value: Number(pool.quantity_normalized),
+        minimumFractionDigits: 8,
+        maximumFractionDigits: 8,
+        useGrouping: true,
+      })
+    : "0";
+
+  return (
+    <div className={`flex items-center ${className}`}>
+      <AssetIcon asset={pool.lp_asset} size="lg" className="mr-4" />
+      <div className="min-w-0">
+        <h2 className="text-xl font-bold break-words">{pair}</h2>
+        <p className="text-sm text-gray-600">Balance: {balance}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/entrypoints/popup/app.tsx
+++ b/src/entrypoints/popup/app.tsx
@@ -65,6 +65,7 @@ import AssetsPage from '@/pages/assets';
 import AssetPage from '@/pages/assets/[asset]';
 import AssetBalancePage from '@/pages/assets/[asset]/balance';
 import UtxoPage from '@/pages/assets/utxos/[txHash]';
+import ManagePoolsPage from '@/pages/pools';
 import PoolPositionPage from '@/pages/pools/[lpAsset]';
 import TransactionPage from '@/pages/transactions/[txHash]';
 
@@ -101,6 +102,8 @@ import ComposeBroadcastAddressOptionsPage from '@/pages/compose/broadcast/addres
 import ComposeUtxoAttachPage from '@/pages/compose/utxo/attach';
 import ComposeUtxoDetachPage from '@/pages/compose/utxo/detach';
 import ComposeUtxoMovePage from '@/pages/compose/utxo/move';
+import ComposePoolDepositPage from '@/pages/compose/pool/deposit';
+import ComposePoolWithdrawPage from '@/pages/compose/pool/withdraw';
 
 import NotFoundPage from '@/pages/not-found';
 
@@ -206,6 +209,7 @@ export default function App() {
             <Route path="/assets/utxos/:txHash" element={<UtxoPage />} />
             <Route path="/assets/:asset/balance" element={<AssetBalancePage />} />
             <Route path="/assets/:asset" element={<AssetPage />} />
+            <Route path="/pools" element={<ManagePoolsPage />} />
             <Route path="/pools/:lpAsset" element={<PoolPositionPage />} />
 
             <Route path="/transactions/:txHash" element={<TransactionPage />} />
@@ -233,6 +237,9 @@ export default function App() {
             <Route path="/compose/dividend/:asset" element={<ComposeDividendPage />} />
             <Route path="/compose/broadcast/address-options" element={<ComposeBroadcastAddressOptionsPage />} />
             <Route path="/compose/broadcast" element={<ComposeBroadcastPage />} />
+            <Route path="/compose/pool/deposit" element={<ComposePoolDepositPage />} />
+            <Route path="/compose/pool/deposit/:assetA/:assetB" element={<ComposePoolDepositPage />} />
+            <Route path="/compose/pool/withdraw/:lpAsset" element={<ComposePoolWithdrawPage />} />
             <Route path="/market/swaps/list" element={<SwapListPage />} />
             <Route path="/market/swaps/manage" element={<SwapManagePage />} />
             <Route path="/market/swaps/buy/:id" element={<SwapBuyPage />} />

--- a/src/entrypoints/popup/app.tsx
+++ b/src/entrypoints/popup/app.tsx
@@ -65,6 +65,7 @@ import AssetsPage from '@/pages/assets';
 import AssetPage from '@/pages/assets/[asset]';
 import AssetBalancePage from '@/pages/assets/[asset]/balance';
 import UtxoPage from '@/pages/assets/utxos/[txHash]';
+import PoolPositionPage from '@/pages/pools/[lpAsset]';
 import TransactionPage from '@/pages/transactions/[txHash]';
 
 // Market - Swaps
@@ -205,6 +206,7 @@ export default function App() {
             <Route path="/assets/utxos/:txHash" element={<UtxoPage />} />
             <Route path="/assets/:asset/balance" element={<AssetBalancePage />} />
             <Route path="/assets/:asset" element={<AssetPage />} />
+            <Route path="/pools/:lpAsset" element={<PoolPositionPage />} />
 
             <Route path="/transactions/:txHash" element={<TransactionPage />} />
 

--- a/src/hooks/__tests__/useLpAssetPool.test.ts
+++ b/src/hooks/__tests__/useLpAssetPool.test.ts
@@ -1,0 +1,115 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useLpAssetPool } from '../useLpAssetPool';
+import { fetchAddressPoolByLpAsset } from '@/utils/blockchain/counterparty/api';
+
+const mocks = vi.hoisted(() => ({
+  activeAddress: { address: 'bc1qtest123' },
+}));
+
+vi.mock('@/contexts/wallet-context', () => ({
+  useWallet: () => ({
+    activeAddress: mocks.activeAddress,
+  }),
+}));
+
+vi.mock('@/utils/blockchain/counterparty/api', () => ({
+  fetchAddressPoolByLpAsset: vi.fn(),
+}));
+
+const mockedFetchAddressPoolByLpAsset = vi.mocked(fetchAddressPoolByLpAsset);
+
+const poolA = {
+  asset_a: 'XCP',
+  asset_b: 'POOLTEST',
+  reserve_a: 100000000,
+  reserve_b: 200000000,
+  lp_asset: 'A11111111111111111',
+  quantity: 100000000,
+  quantity_normalized: '1',
+};
+
+const poolB = {
+  asset_a: 'XCP',
+  asset_b: 'OTHER',
+  reserve_a: 300000000,
+  reserve_b: 400000000,
+  lp_asset: 'A22222222222222222',
+  quantity: 200000000,
+  quantity_normalized: '2',
+};
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('useLpAssetPool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.activeAddress = { address: 'bc1qtest123' };
+  });
+
+  it('fetches a pool position for the active address and LP asset', async () => {
+    mockedFetchAddressPoolByLpAsset.mockResolvedValue(poolA);
+
+    const { result } = renderHook(() => useLpAssetPool('A11111111111111111'));
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.data).toBeNull();
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.data).toEqual(poolA);
+    expect(mockedFetchAddressPoolByLpAsset).toHaveBeenCalledWith(
+      'bc1qtest123',
+      'A11111111111111111',
+      { limit: 100 },
+    );
+  });
+
+  it('clears stale pool data while a different LP asset is loading', async () => {
+    mockedFetchAddressPoolByLpAsset.mockResolvedValueOnce(poolA);
+
+    const { result, rerender } = renderHook(
+      ({ asset }) => useLpAssetPool(asset),
+      { initialProps: { asset: 'A11111111111111111' } },
+    );
+
+    await waitFor(() => expect(result.current.data).toEqual(poolA));
+
+    const nextLookup = deferred<typeof poolB>();
+    mockedFetchAddressPoolByLpAsset.mockReturnValueOnce(nextLookup.promise);
+
+    rerender({ asset: 'A22222222222222222' });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(true);
+      expect(result.current.data).toBeNull();
+    });
+
+    nextLookup.resolve(poolB);
+
+    await waitFor(() => expect(result.current.data).toEqual(poolB));
+  });
+
+  it('does not fetch for BTC or a missing asset', () => {
+    const { result, rerender } = renderHook(
+      ({ asset }) => useLpAssetPool(asset),
+      { initialProps: { asset: 'BTC' as string | undefined } },
+    );
+
+    expect(result.current).toEqual({ data: null, isLoading: false, error: null });
+    expect(mockedFetchAddressPoolByLpAsset).not.toHaveBeenCalled();
+
+    rerender({ asset: undefined });
+
+    expect(result.current).toEqual({ data: null, isLoading: false, error: null });
+    expect(mockedFetchAddressPoolByLpAsset).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useInView.ts
+++ b/src/hooks/useInView.ts
@@ -17,12 +17,6 @@ export function useInView(options?: IntersectionObserverInit) {
     // Create and start observing immediately
     const observer = new IntersectionObserver(
       ([entry]) => {
-        console.log('[useInView] Intersection:', {
-          isIntersecting: entry.isIntersecting,
-          intersectionRatio: entry.intersectionRatio,
-          boundingClientRect: entry.boundingClientRect,
-          rootBounds: entry.rootBounds
-        });
         setInView(entry.isIntersecting);
       },
       {

--- a/src/hooks/useLpAssetPool.ts
+++ b/src/hooks/useLpAssetPool.ts
@@ -5,29 +5,34 @@ import { fetchAddressPoolByLpAsset, type PoolPosition } from "@/utils/blockchain
 interface LpAssetPoolState {
   data: PoolPosition | null;
   isLoading: boolean;
+  error: Error | null;
 }
 
 export function useLpAssetPool(asset: string | undefined): LpAssetPoolState {
   const { activeAddress } = useWallet();
-  const [state, setState] = useState<LpAssetPoolState>({ data: null, isLoading: false });
+  const [state, setState] = useState<LpAssetPoolState>({ data: null, isLoading: false, error: null });
 
   useEffect(() => {
     if (!asset || !activeAddress?.address || asset === "BTC") {
-      setState({ data: null, isLoading: false });
+      setState({ data: null, isLoading: false, error: null });
       return;
     }
 
     let cancelled = false;
-    setState((current) => ({ ...current, isLoading: true }));
+    setState((current) => ({ ...current, isLoading: true, error: null }));
 
     fetchAddressPoolByLpAsset(activeAddress.address, asset, { limit: 100 })
       .then((response) => {
         if (cancelled) return;
-        setState({ data: response, isLoading: false });
+        setState({ data: response, isLoading: false, error: null });
       })
-      .catch(() => {
+      .catch((err) => {
         if (!cancelled) {
-          setState({ data: null, isLoading: false });
+          setState({
+            data: null,
+            isLoading: false,
+            error: err instanceof Error ? err : new Error("Failed to check pool position"),
+          });
         }
       });
 

--- a/src/hooks/useLpAssetPool.ts
+++ b/src/hooks/useLpAssetPool.ts
@@ -19,7 +19,7 @@ export function useLpAssetPool(asset: string | undefined): LpAssetPoolState {
     }
 
     let cancelled = false;
-    setState((current) => ({ ...current, isLoading: true, error: null }));
+    setState({ data: null, isLoading: true, error: null });
 
     fetchAddressPoolByLpAsset(activeAddress.address, asset, { limit: 100 })
       .then((response) => {

--- a/src/hooks/useLpAssetPool.ts
+++ b/src/hooks/useLpAssetPool.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState } from "react";
+import { useWallet } from "@/contexts/wallet-context";
+import { fetchAddressPoolByLpAsset, type PoolPosition } from "@/utils/blockchain/counterparty/api";
+
+interface LpAssetPoolState {
+  data: PoolPosition | null;
+  isLoading: boolean;
+}
+
+export function useLpAssetPool(asset: string | undefined): LpAssetPoolState {
+  const { activeAddress } = useWallet();
+  const [state, setState] = useState<LpAssetPoolState>({ data: null, isLoading: false });
+
+  useEffect(() => {
+    if (!asset || !activeAddress?.address || asset === "BTC") {
+      setState({ data: null, isLoading: false });
+      return;
+    }
+
+    let cancelled = false;
+    setState((current) => ({ ...current, isLoading: true }));
+
+    fetchAddressPoolByLpAsset(activeAddress.address, asset, { limit: 100 })
+      .then((response) => {
+        if (cancelled) return;
+        setState({ data: response, isLoading: false });
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setState({ data: null, isLoading: false });
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeAddress?.address, asset]);
+
+  return state;
+}

--- a/src/hooks/usePoolQuotes.ts
+++ b/src/hooks/usePoolQuotes.ts
@@ -5,16 +5,12 @@ import {
   type PoolDepositQuote,
   type PoolWithdrawQuote,
 } from "@/utils/blockchain/counterparty/api";
-import { toBigNumber, toSatoshis } from "@/utils/numeric";
+import { roundDown, toSatoshis } from "@/utils/numeric";
 
 interface PoolQuoteState<T> {
   data: T | null;
   isLoading: boolean;
   error: string | null;
-}
-
-function toRawQuantity(value: string, divisible: boolean): string {
-  return divisible ? toSatoshis(value) : toBigNumber(value).integerValue().toString();
 }
 
 export function usePoolDepositQuote({
@@ -46,7 +42,11 @@ export function usePoolDepositQuote({
     setState({ data: null, isLoading: true, error: null });
 
     const timer = setTimeout(() => {
-      fetchPoolDepositQuote(assetA, assetB, toRawQuantity(quantityA, isAssetADivisible))
+      fetchPoolDepositQuote(
+        assetA,
+        assetB,
+        isAssetADivisible ? toSatoshis(quantityA) : roundDown(quantityA).toString()
+      )
         .then((data) => {
           if (!cancelled) setState({ data, isLoading: false, error: null });
         })

--- a/src/hooks/usePoolQuotes.ts
+++ b/src/hooks/usePoolQuotes.ts
@@ -1,0 +1,122 @@
+import { useEffect, useState } from "react";
+import {
+  fetchPoolDepositQuote,
+  fetchPoolWithdrawQuote,
+  type PoolDepositQuote,
+  type PoolWithdrawQuote,
+} from "@/utils/blockchain/counterparty/api";
+import { toBigNumber, toSatoshis } from "@/utils/numeric";
+
+interface PoolQuoteState<T> {
+  data: T | null;
+  isLoading: boolean;
+  error: string | null;
+}
+
+function toRawQuantity(value: string, divisible: boolean): string {
+  return divisible ? toSatoshis(value) : toBigNumber(value).integerValue().toString();
+}
+
+export function usePoolDepositQuote({
+  assetA,
+  assetB,
+  quantityA,
+  isAssetADivisible,
+  enabled,
+}: {
+  assetA: string;
+  assetB: string;
+  quantityA: string;
+  isAssetADivisible: boolean;
+  enabled: boolean;
+}): PoolQuoteState<PoolDepositQuote> {
+  const [state, setState] = useState<PoolQuoteState<PoolDepositQuote>>({
+    data: null,
+    isLoading: false,
+    error: null,
+  });
+
+  useEffect(() => {
+    if (!enabled) {
+      setState({ data: null, isLoading: false, error: null });
+      return;
+    }
+
+    let cancelled = false;
+    setState({ data: null, isLoading: true, error: null });
+
+    const timer = setTimeout(() => {
+      fetchPoolDepositQuote(assetA, assetB, toRawQuantity(quantityA, isAssetADivisible))
+        .then((data) => {
+          if (!cancelled) setState({ data, isLoading: false, error: null });
+        })
+        .catch((err) => {
+          if (!cancelled) {
+            setState({
+              data: null,
+              isLoading: false,
+              error: err instanceof Error ? err.message : "Unable to load pool quote.",
+            });
+          }
+        });
+    }, 300);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [assetA, assetB, enabled, isAssetADivisible, quantityA]);
+
+  return state;
+}
+
+export function usePoolWithdrawQuote({
+  assetA,
+  assetB,
+  quantity,
+  enabled,
+}: {
+  assetA: string;
+  assetB: string;
+  quantity: string;
+  enabled: boolean;
+}): PoolQuoteState<PoolWithdrawQuote> {
+  const [state, setState] = useState<PoolQuoteState<PoolWithdrawQuote>>({
+    data: null,
+    isLoading: false,
+    error: null,
+  });
+
+  useEffect(() => {
+    if (!enabled) {
+      setState({ data: null, isLoading: false, error: null });
+      return;
+    }
+
+    let cancelled = false;
+    setState({ data: null, isLoading: true, error: null });
+
+    const timer = setTimeout(() => {
+      fetchPoolWithdrawQuote(assetA, assetB, toSatoshis(quantity))
+        .then((data) => {
+          if (!cancelled) setState({ data, isLoading: false, error: null });
+        })
+        .catch((err) => {
+          if (!cancelled) {
+            setState({
+              data: null,
+              isLoading: false,
+              error: err instanceof Error ? err.message : "Unable to load withdrawal quote.",
+            });
+          }
+        });
+    }, 300);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [assetA, assetB, enabled, quantity]);
+
+  return state;
+}

--- a/src/pages/actions/index.tsx
+++ b/src/pages/actions/index.tsx
@@ -115,6 +115,12 @@ const getActionSections = (
           description: "Close a dispenser using its transaction hash",
           onClick: () => navigate("/compose/dispenser/close-by-hash"),
         },
+        {
+          id: "manage-pools",
+          title: "Manage Pools",
+          description: "View liquidity positions and enter pools",
+          onClick: () => navigate("/pools"),
+        },
       ],
     },
   ];

--- a/src/pages/assets/[asset]/balance.tsx
+++ b/src/pages/assets/[asset]/balance.tsx
@@ -5,6 +5,7 @@ import { BalanceHeader } from "@/components/ui/headers/balance-header";
 import { ActionList } from "@/components/ui/lists/action-list";
 import { useHeader } from "@/contexts/header-context";
 import { useAssetDetails } from "@/hooks/useAssetDetails";
+import { useLpAssetPool } from "@/hooks/useLpAssetPool";
 
 import type { TokenBalance } from "@/utils/blockchain/counterparty/api";
 import type { ReactElement } from "react";
@@ -37,6 +38,7 @@ export default function AssetBalancePage(): ReactElement {
   const navigate = useNavigate();
   const { setHeaderProps, getCachedBalance } = useHeader();
   const { data: assetDetails, isLoading, error } = useAssetDetails(asset || "");
+  const { data: lpPool } = useLpAssetPool(asset);
 
   // Get cached data for instant display
   const cachedBalance = useMemo(() => getCachedBalance(asset || ""), [getCachedBalance, asset]);
@@ -168,6 +170,22 @@ export default function AssetBalancePage(): ReactElement {
             className: "!border !border-red-500",
           },
         ];
+    if (lpPool) {
+      return [
+        {
+          title: "Liquidity Pool",
+          items: [
+            {
+              id: "manage-pool",
+              title: "Manage Pool",
+              description: `${lpPool.asset_a} / ${lpPool.asset_b}`,
+              onClick: () => navigate(`/pools/${encodeURIComponent(lpPool.lp_asset)}`),
+            },
+          ],
+        },
+        { items },
+      ];
+    }
     return [{ items }];
   };
 

--- a/src/pages/compose/pool/deposit/form.tsx
+++ b/src/pages/compose/pool/deposit/form.tsx
@@ -283,7 +283,7 @@ export function PoolDepositForm({
 
       {isZeroSupplyRestart && (
         <div className="rounded border border-yellow-200 bg-yellow-50 p-3 text-sm text-yellow-800">
-          LP supply is zero. This deposit re-seeds the pool with the amounts entered.
+          LP supply is zero. This deposit restarts the pool and may claim existing reserves.
         </div>
       )}
 

--- a/src/pages/compose/pool/deposit/form.tsx
+++ b/src/pages/compose/pool/deposit/form.tsx
@@ -51,6 +51,27 @@ function applySlippage(value: number | string | null | undefined, slippagePercen
     .toString();
 }
 
+function getLimitingLpEstimate(
+  mintedEstimate: number | string | null | undefined,
+  partnerRequired: number | string | null | undefined,
+  partnerProvided: string
+): string {
+  if (mintedEstimate === null || mintedEstimate === undefined) return "0";
+  if (partnerRequired === null || partnerRequired === undefined) return mintedEstimate.toString();
+
+  const required = toBigNumber(partnerRequired);
+  const provided = toBigNumber(partnerProvided);
+  if (!required.isGreaterThan(0) || provided.isGreaterThanOrEqualTo(required)) {
+    return mintedEstimate.toString();
+  }
+
+  return toBigNumber(mintedEstimate)
+    .times(provided)
+    .div(required)
+    .integerValue(BigNumber.ROUND_DOWN)
+    .toString();
+}
+
 export function PoolDepositForm({
   formAction,
   initialFormData,
@@ -114,11 +135,16 @@ export function PoolDepositForm({
   const quantityBRaw = quantityB ? toRawQuantity(quantityB, isAssetBDivisible) : "0";
   const partnerQuantityMatches = partnerQuantityRaw === undefined || partnerQuantityRaw === null
     || toBigNumber(quantityBRaw).isEqualTo(partnerQuantityRaw);
+  const partnerQuantityIsLow = partnerQuantityRaw !== undefined && partnerQuantityRaw !== null
+    && toBigNumber(quantityBRaw).isLessThan(partnerQuantityRaw);
+  const partnerQuantityIsHigh = partnerQuantityRaw !== undefined && partnerQuantityRaw !== null
+    && toBigNumber(quantityBRaw).isGreaterThan(partnerQuantityRaw);
   const isZeroSupplyRestart = !isFirstDeposit && quote?.quantity_minted_estimate === 0;
   const [canonicalAssetA, canonicalAssetB] = getCanonicalPair(assetA, assetB, quote);
   const canonicalQuantityA = canonicalAssetA === assetA ? quantityA : quantityB;
   const canonicalQuantityB = canonicalAssetB === assetB ? quantityB : quantityA;
-  const minLpQuantity = applySlippage(quote?.quantity_minted_estimate, slippage);
+  const limitingLpEstimate = getLimitingLpEstimate(quote?.quantity_minted_estimate, partnerQuantityRaw, quantityBRaw);
+  const minLpQuantity = applySlippage(limitingLpEstimate, slippage);
   const hasLpMinimum = toBigNumber(minLpQuantity).isGreaterThan(0);
   const isSlippageValid = isValidPositiveNumber(slippage, { allowZero: true, maxDecimals: 2 })
     && toBigNumber(slippage).isLessThanOrEqualTo(50);
@@ -127,11 +153,10 @@ export function PoolDepositForm({
     if (!assetA || !assetB || assetA === assetB) return true;
     if (!toBigNumber(quantityA || 0).isGreaterThan(0)) return true;
     if (!toBigNumber(quantityB || 0).isGreaterThan(0)) return true;
-    if (!partnerQuantityMatches) return true;
     if (isFirstDeposit && lpAsset && !isLpAssetValid) return true;
     if (!isSlippageValid) return true;
     return false;
-  }, [assetA, assetB, quantityA, quantityB, partnerQuantityMatches, isFirstDeposit, lpAsset, isLpAssetValid, isSlippageValid]);
+  }, [assetA, assetB, quantityA, quantityB, isFirstDeposit, lpAsset, isLpAssetValid, isSlippageValid]);
 
   const handleFormAction = (formData: FormData) => {
     if (assetA === assetB) {
@@ -237,7 +262,11 @@ export function PoolDepositForm({
 
       {partnerQuantity && !isFirstDeposit && !partnerQuantityMatches && (
         <div className="rounded border border-yellow-200 bg-yellow-50 p-3 text-sm text-yellow-800">
-          Existing pool deposits must match the pool ratio. Use quote to continue.
+          {partnerQuantityIsHigh
+            ? "Only the pool-ratio amount will be deposited; extra is left unused."
+            : partnerQuantityIsLow
+              ? "This deposits less than the quoted ratio allows."
+              : "Pool deposits use the current pool ratio."}
         </div>
       )}
 

--- a/src/pages/compose/pool/deposit/form.tsx
+++ b/src/pages/compose/pool/deposit/form.tsx
@@ -9,7 +9,6 @@ import { AssetSelectInput } from "@/components/ui/inputs/asset-select-input";
 import { useComposer } from "@/contexts/composer-context";
 import { useAssetDetails } from "@/hooks/useAssetDetails";
 import { usePoolDepositQuote } from "@/hooks/usePoolQuotes";
-import type { PoolDepositQuote } from "@/utils/blockchain/counterparty/api";
 import {
   applyPoolSlippage,
   calculateInitialLpEstimate,
@@ -29,16 +28,6 @@ interface PoolDepositFormProps {
   initialFormData: PoolDepositOptions | null;
   initialAssetA?: string;
   initialAssetB?: string;
-}
-
-function getCanonicalPair(firstAsset: string, secondAsset: string, quote: PoolDepositQuote | null) {
-  if (quote?.asset_a && quote?.asset_b) {
-    return [quote.asset_a, quote.asset_b] as const;
-  }
-
-  return firstAsset > secondAsset
-    ? [secondAsset, firstAsset] as const
-    : [firstAsset, secondAsset] as const;
 }
 
 function toRawQuantity(value: string, divisible: boolean): string {
@@ -95,12 +84,7 @@ export function PoolDepositForm({
   const partnerQuantityIsHigh = partnerQuantityRaw !== undefined && partnerQuantityRaw !== null
     && toBigNumber(quantityBRaw).isGreaterThan(partnerQuantityRaw);
   const isZeroSupplyRestart = !isFirstDeposit && quote?.quantity_minted_estimate === 0;
-  const [canonicalAssetA, canonicalAssetB] = getCanonicalPair(assetA, assetB, quote);
-  const canonicalQuantityA = canonicalAssetA === assetA ? quantityA : quantityB;
-  const canonicalQuantityB = canonicalAssetB === assetB ? quantityB : quantityA;
-  const canonicalQuantityARaw = canonicalAssetA === assetA ? quantityARaw : quantityBRaw;
-  const canonicalQuantityBRaw = canonicalAssetB === assetB ? quantityBRaw : quantityARaw;
-  const initialLpEstimate = calculateInitialLpEstimate(canonicalQuantityARaw, canonicalQuantityBRaw);
+  const initialLpEstimate = calculateInitialLpEstimate(quantityARaw, quantityBRaw);
   const limitingLpEstimate = calculateLimitingLpEstimate(quote?.quantity_minted_estimate, partnerQuantityRaw, quantityBRaw);
   const lpEstimateForMinimum = isFirstDeposit || isZeroSupplyRestart ? initialLpEstimate : limitingLpEstimate;
   const minLpQuantity = applyPoolSlippage(lpEstimateForMinimum, slippage);
@@ -124,10 +108,10 @@ export function PoolDepositForm({
       return;
     }
 
-    formData.set("asset_a", canonicalAssetA);
-    formData.set("asset_b", canonicalAssetB);
-    formData.set("quantity_a", canonicalQuantityA);
-    formData.set("quantity_b", canonicalQuantityB);
+    formData.set("asset_a", assetA);
+    formData.set("asset_b", assetB);
+    formData.set("quantity_a", quantityA);
+    formData.set("quantity_b", quantityB);
     formData.set("min_lp_quantity", minLpQuantity);
     if (lpAsset.trim()) {
       formData.set("lp_asset", lpAsset.trim());
@@ -280,10 +264,10 @@ export function PoolDepositForm({
         </Field>
       )}
 
-      <input type="hidden" name="asset_a" value={canonicalAssetA} />
-      <input type="hidden" name="asset_b" value={canonicalAssetB} />
-      <input type="hidden" name="quantity_a" value={canonicalQuantityA} />
-      <input type="hidden" name="quantity_b" value={canonicalQuantityB} />
+      <input type="hidden" name="asset_a" value={assetA} />
+      <input type="hidden" name="asset_b" value={assetB} />
+      <input type="hidden" name="quantity_a" value={quantityA} />
+      <input type="hidden" name="quantity_b" value={quantityB} />
       <input type="hidden" name="min_lp_quantity" value={minLpQuantity} />
       <input type="hidden" name="slippage" value={slippage} />
       {lpAsset && <input type="hidden" name="lp_asset" value={lpAsset} />}

--- a/src/pages/compose/pool/deposit/form.tsx
+++ b/src/pages/compose/pool/deposit/form.tsx
@@ -3,6 +3,7 @@ import { useFormStatus } from "react-dom";
 import { Field, Description } from "@headlessui/react";
 import { ComposerForm } from "@/components/composer/composer-form";
 import { ErrorAlert } from "@/components/ui/error-alert";
+import { BalanceHeader } from "@/components/ui/headers/balance-header";
 import { AmountWithMaxInput } from "@/components/ui/inputs/amount-with-max-input";
 import { AssetNameInput } from "@/components/ui/inputs/asset-name-input";
 import { AssetSelectInput } from "@/components/ui/inputs/asset-select-input";
@@ -25,6 +26,7 @@ import {
   toSatoshis,
 } from "@/utils/numeric";
 import type { PoolDepositOptions } from "@/utils/blockchain/counterparty/compose";
+import type { TokenBalance } from "@/utils/blockchain/counterparty/api";
 import { DEFAULT_POOL_SLIPPAGE, SlippageInput } from "../slippage-input";
 
 interface PoolDepositFormProps {
@@ -97,6 +99,20 @@ export function PoolDepositForm({
   const hasLpMinimum = isGreaterThan(minLpQuantity, 0);
   const isSlippageValid = isValidPositiveNumber(slippage, { allowZero: true, maxDecimals: 2 })
     && isLessThanOrEqualTo(slippage, 50);
+  const assetABalanceHeader: TokenBalance | null = assetADetailsReady && assetADetails
+    ? {
+        asset: assetA,
+        quantity_normalized: assetADetails.availableBalance,
+        asset_info: assetADetails.assetInfo ? {
+          asset_longname: assetADetails.assetInfo.asset_longname,
+          description: assetADetails.assetInfo.description || "",
+          issuer: assetADetails.assetInfo.issuer || "",
+          divisible: assetADetails.assetInfo.divisible,
+          locked: assetADetails.assetInfo.locked,
+          supply: assetADetails.assetInfo.supply,
+        } : undefined,
+      }
+    : null;
 
   const submitDisabled = useMemo(() => {
     if (!assetA || !assetB || assetA === assetB) return true;
@@ -131,6 +147,7 @@ export function PoolDepositForm({
   return (
     <ComposerForm
       formAction={handleFormAction}
+      header={assetABalanceHeader ? <BalanceHeader balance={assetABalanceHeader} className="mt-1 mb-5" /> : null}
       submitText="Review Deposit"
       submitDisabled={pending || submitDisabled}
     >

--- a/src/pages/compose/pool/deposit/form.tsx
+++ b/src/pages/compose/pool/deposit/form.tsx
@@ -10,9 +10,11 @@ import { useComposer } from "@/contexts/composer-context";
 import { useAssetDetails } from "@/hooks/useAssetDetails";
 import { fetchPoolDepositQuote, type PoolDepositQuote } from "@/utils/blockchain/counterparty/api";
 import {
-  applySlippage,
+  applyPoolSlippage,
   calculateInitialLpEstimate,
   calculateLimitingLpEstimate,
+} from "@/utils/blockchain/counterparty/pool";
+import {
   fromSatoshis,
   isValidPositiveNumber,
   toBigNumber,
@@ -133,7 +135,7 @@ export function PoolDepositForm({
   const initialLpEstimate = calculateInitialLpEstimate(canonicalQuantityARaw, canonicalQuantityBRaw);
   const limitingLpEstimate = calculateLimitingLpEstimate(quote?.quantity_minted_estimate, partnerQuantityRaw, quantityBRaw);
   const lpEstimateForMinimum = isFirstDeposit || isZeroSupplyRestart ? initialLpEstimate : limitingLpEstimate;
-  const minLpQuantity = applySlippage(lpEstimateForMinimum, slippage);
+  const minLpQuantity = applyPoolSlippage(lpEstimateForMinimum, slippage);
   const hasLpMinimum = toBigNumber(minLpQuantity).isGreaterThan(0);
   const isSlippageValid = isValidPositiveNumber(slippage, { allowZero: true, maxDecimals: 2 })
     && toBigNumber(slippage).isLessThanOrEqualTo(50);

--- a/src/pages/compose/pool/deposit/form.tsx
+++ b/src/pages/compose/pool/deposit/form.tsx
@@ -94,6 +94,7 @@ export function PoolDepositForm({
   const [isLpAssetValid, setIsLpAssetValid] = useState(false);
   const [slippage, setSlippage] = useState((initialFormData as PoolDepositOptions & { slippage?: string })?.slippage || DEFAULT_POOL_SLIPPAGE);
   const [localError, setLocalError] = useState<string | null>(null);
+  const [quoteError, setQuoteError] = useState<string | null>(null);
   const [quote, setQuote] = useState<PoolDepositQuote | null>(null);
   const [isLoadingQuote, setIsLoadingQuote] = useState(false);
 
@@ -108,18 +109,28 @@ export function PoolDepositForm({
   useEffect(() => {
     if (!canQuote) {
       setQuote(null);
+      setQuoteError(null);
+      setIsLoadingQuote(false);
       return;
     }
 
     let cancelled = false;
+    setQuote(null);
+    setQuoteError(null);
+    setIsLoadingQuote(true);
     const timer = setTimeout(() => {
-      setIsLoadingQuote(true);
       fetchPoolDepositQuote(assetA, assetB, toRawQuantity(quantityA, isAssetADivisible))
         .then((result) => {
-          if (!cancelled) setQuote(result);
+          if (!cancelled) {
+            setQuote(result);
+            setQuoteError(null);
+          }
         })
-        .catch(() => {
-          if (!cancelled) setQuote(null);
+        .catch((err) => {
+          if (!cancelled) {
+            setQuote(null);
+            setQuoteError(err instanceof Error ? err.message : "Unable to load pool quote.");
+          }
         })
         .finally(() => {
           if (!cancelled) setIsLoadingQuote(false);
@@ -259,6 +270,10 @@ export function PoolDepositForm({
 
       {isLoadingQuote && (
         <p className="text-sm text-gray-500">Loading pool quote...</p>
+      )}
+
+      {quoteError && (
+        <ErrorAlert message={quoteError} onClose={() => setQuoteError(null)} />
       )}
 
       {quote?.message && (

--- a/src/pages/compose/pool/deposit/form.tsx
+++ b/src/pages/compose/pool/deposit/form.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type ReactElement } from "react";
+import { useMemo, useState, type ReactElement } from "react";
 import { useFormStatus } from "react-dom";
 import { Field, Description } from "@headlessui/react";
 import { ComposerForm } from "@/components/composer/composer-form";
@@ -8,7 +8,8 @@ import { AssetNameInput } from "@/components/ui/inputs/asset-name-input";
 import { AssetSelectInput } from "@/components/ui/inputs/asset-select-input";
 import { useComposer } from "@/contexts/composer-context";
 import { useAssetDetails } from "@/hooks/useAssetDetails";
-import { fetchPoolDepositQuote, type PoolDepositQuote } from "@/utils/blockchain/counterparty/api";
+import { usePoolDepositQuote } from "@/hooks/usePoolQuotes";
+import type { PoolDepositQuote } from "@/utils/blockchain/counterparty/api";
 import {
   applyPoolSlippage,
   calculateInitialLpEstimate,
@@ -60,9 +61,6 @@ export function PoolDepositForm({
   const [isLpAssetValid, setIsLpAssetValid] = useState(false);
   const [slippage, setSlippage] = useState((initialFormData as PoolDepositOptions & { slippage?: string })?.slippage || DEFAULT_POOL_SLIPPAGE);
   const [localError, setLocalError] = useState<string | null>(null);
-  const [quoteError, setQuoteError] = useState<string | null>(null);
-  const [quote, setQuote] = useState<PoolDepositQuote | null>(null);
-  const [isLoadingQuote, setIsLoadingQuote] = useState(false);
 
   const { data: assetADetails } = useAssetDetails(assetA);
   const { data: assetBDetails } = useAssetDetails(assetB);
@@ -71,43 +69,13 @@ export function PoolDepositForm({
   const isAssetBDivisible = assetBDetails?.isDivisible ?? true;
   const canQuote = assetA && assetB && assetA !== assetB && toBigNumber(quantityA || 0).isGreaterThan(0);
   const needsQuote = canQuote && toBigNumber(quantityB || 0).isGreaterThan(0);
-
-  useEffect(() => {
-    if (!canQuote) {
-      setQuote(null);
-      setQuoteError(null);
-      setIsLoadingQuote(false);
-      return;
-    }
-
-    let cancelled = false;
-    setQuote(null);
-    setQuoteError(null);
-    setIsLoadingQuote(true);
-    const timer = setTimeout(() => {
-      fetchPoolDepositQuote(assetA, assetB, toRawQuantity(quantityA, isAssetADivisible))
-        .then((result) => {
-          if (!cancelled) {
-            setQuote(result);
-            setQuoteError(null);
-          }
-        })
-        .catch((err) => {
-          if (!cancelled) {
-            setQuote(null);
-            setQuoteError(err instanceof Error ? err.message : "Unable to load pool quote.");
-          }
-        })
-        .finally(() => {
-          if (!cancelled) setIsLoadingQuote(false);
-        });
-    }, 300);
-
-    return () => {
-      cancelled = true;
-      clearTimeout(timer);
-    };
-  }, [assetA, assetB, quantityA, canQuote, isAssetADivisible]);
+  const { data: quote, isLoading: isLoadingQuote, error: quoteError } = usePoolDepositQuote({
+    assetA,
+    assetB,
+    quantityA,
+    isAssetADivisible,
+    enabled: Boolean(canQuote),
+  });
 
   const isFirstDeposit = quote?.first_deposit === true;
   const partnerQuantityRaw = quote?.asset_a === assetA
@@ -241,7 +209,7 @@ export function PoolDepositForm({
       )}
 
       {quoteError && (
-        <ErrorAlert message={quoteError} onClose={() => setQuoteError(null)} />
+        <ErrorAlert message={quoteError} />
       )}
 
       {quote?.message && (

--- a/src/pages/compose/pool/deposit/form.tsx
+++ b/src/pages/compose/pool/deposit/form.tsx
@@ -92,7 +92,7 @@ export function PoolDepositForm({
   const [quantityB, setQuantityB] = useState(initialFormData?.quantity_b?.toString() || "");
   const [lpAsset, setLpAsset] = useState(initialFormData?.lp_asset || "");
   const [isLpAssetValid, setIsLpAssetValid] = useState(false);
-  const [slippage, setSlippage] = useState("1");
+  const [slippage, setSlippage] = useState((initialFormData as PoolDepositOptions & { slippage?: string })?.slippage || "1");
   const [localError, setLocalError] = useState<string | null>(null);
   const [quote, setQuote] = useState<PoolDepositQuote | null>(null);
   const [isLoadingQuote, setIsLoadingQuote] = useState(false);
@@ -332,6 +332,7 @@ export function PoolDepositForm({
       <input type="hidden" name="quantity_a" value={canonicalQuantityA} />
       <input type="hidden" name="quantity_b" value={canonicalQuantityB} />
       <input type="hidden" name="min_lp_quantity" value={minLpQuantity} />
+      <input type="hidden" name="slippage" value={slippage} />
       {lpAsset && <input type="hidden" name="lp_asset" value={lpAsset} />}
     </ComposerForm>
   );

--- a/src/pages/compose/pool/deposit/form.tsx
+++ b/src/pages/compose/pool/deposit/form.tsx
@@ -103,6 +103,7 @@ export function PoolDepositForm({
   const isAssetADivisible = assetADetails?.isDivisible ?? true;
   const isAssetBDivisible = assetBDetails?.isDivisible ?? true;
   const canQuote = assetA && assetB && assetA !== assetB && toBigNumber(quantityA || 0).isGreaterThan(0);
+  const needsQuote = canQuote && toBigNumber(quantityB || 0).isGreaterThan(0);
 
   useEffect(() => {
     if (!canQuote) {
@@ -164,10 +165,11 @@ export function PoolDepositForm({
     if (!assetA || !assetB || assetA === assetB) return true;
     if (!toBigNumber(quantityA || 0).isGreaterThan(0)) return true;
     if (!toBigNumber(quantityB || 0).isGreaterThan(0)) return true;
+    if (needsQuote && (isLoadingQuote || !quote)) return true;
     if (isFirstDeposit && lpAsset && !isLpAssetValid) return true;
     if (!isSlippageValid) return true;
     return false;
-  }, [assetA, assetB, quantityA, quantityB, isFirstDeposit, lpAsset, isLpAssetValid, isSlippageValid]);
+  }, [assetA, assetB, quantityA, quantityB, needsQuote, isLoadingQuote, quote, isFirstDeposit, lpAsset, isLpAssetValid, isSlippageValid]);
 
   const handleFormAction = (formData: FormData) => {
     if (assetA === assetB) {

--- a/src/pages/compose/pool/deposit/form.tsx
+++ b/src/pages/compose/pool/deposit/form.tsx
@@ -9,7 +9,15 @@ import { AssetSelectInput } from "@/components/ui/inputs/asset-select-input";
 import { useComposer } from "@/contexts/composer-context";
 import { useAssetDetails } from "@/hooks/useAssetDetails";
 import { fetchPoolDepositQuote, type PoolDepositQuote } from "@/utils/blockchain/counterparty/api";
-import { BigNumber, fromSatoshis, isValidPositiveNumber, toBigNumber, toSatoshis } from "@/utils/numeric";
+import {
+  applySlippage,
+  calculateInitialLpEstimate,
+  calculateLimitingLpEstimate,
+  fromSatoshis,
+  isValidPositiveNumber,
+  toBigNumber,
+  toSatoshis,
+} from "@/utils/numeric";
 import type { PoolDepositOptions } from "@/utils/blockchain/counterparty/compose";
 import { DEFAULT_POOL_SLIPPAGE, SlippageInput } from "../slippage-input";
 
@@ -18,14 +26,6 @@ interface PoolDepositFormProps {
   initialFormData: PoolDepositOptions | null;
   initialAssetA?: string;
   initialAssetB?: string;
-}
-
-function toRawQuantity(value: string, divisible: boolean): string {
-  return divisible ? toSatoshis(value) : toBigNumber(value).integerValue().toString();
-}
-
-function fromRawQuantity(value: number | string, divisible: boolean): string {
-  return divisible ? fromSatoshis(value, { removeTrailingZeros: true }) : value.toString();
 }
 
 function getCanonicalPair(firstAsset: string, secondAsset: string, quote: PoolDepositQuote | null) {
@@ -38,44 +38,8 @@ function getCanonicalPair(firstAsset: string, secondAsset: string, quote: PoolDe
     : [firstAsset, secondAsset] as const;
 }
 
-function applySlippage(value: number | string | null | undefined, slippagePercent: string): string {
-  if (value === null || value === undefined) return "0";
-
-  const bps = toBigNumber(slippagePercent || "0").times(100);
-  const multiplier = BigNumber.maximum(0, toBigNumber(10000).minus(bps));
-
-  return toBigNumber(value)
-    .times(multiplier)
-    .div(10000)
-    .integerValue(BigNumber.ROUND_DOWN)
-    .toString();
-}
-
-function getLimitingLpEstimate(
-  mintedEstimate: number | string | null | undefined,
-  partnerRequired: number | string | null | undefined,
-  partnerProvided: string
-): string {
-  if (mintedEstimate === null || mintedEstimate === undefined) return "0";
-  if (partnerRequired === null || partnerRequired === undefined) return mintedEstimate.toString();
-
-  const required = toBigNumber(partnerRequired);
-  const provided = toBigNumber(partnerProvided);
-  if (!required.isGreaterThan(0) || provided.isGreaterThanOrEqualTo(required)) {
-    return mintedEstimate.toString();
-  }
-
-  return toBigNumber(mintedEstimate)
-    .times(provided)
-    .div(required)
-    .integerValue(BigNumber.ROUND_DOWN)
-    .toString();
-}
-
-function getInitialLpEstimate(quantityA: string, quantityB: string): string {
-  const product = toBigNumber(quantityA).times(quantityB);
-  if (!product.isGreaterThan(0)) return "0";
-  return product.sqrt().integerValue(BigNumber.ROUND_DOWN).toString();
+function toRawQuantity(value: string, divisible: boolean): string {
+  return divisible ? toSatoshis(value) : toBigNumber(value).integerValue().toString();
 }
 
 export function PoolDepositForm({
@@ -148,7 +112,9 @@ export function PoolDepositForm({
     ? quote?.quantity_b_required
     : quote?.quantity_a_required;
   const partnerQuantity = partnerQuantityRaw !== undefined && partnerQuantityRaw !== null
-    ? fromRawQuantity(partnerQuantityRaw, isAssetBDivisible)
+    ? isAssetBDivisible
+      ? fromSatoshis(partnerQuantityRaw, { removeTrailingZeros: true })
+      : partnerQuantityRaw.toString()
     : null;
   const quantityARaw = quantityA ? toRawQuantity(quantityA, isAssetADivisible) : "0";
   const quantityBRaw = quantityB ? toRawQuantity(quantityB, isAssetBDivisible) : "0";
@@ -164,8 +130,8 @@ export function PoolDepositForm({
   const canonicalQuantityB = canonicalAssetB === assetB ? quantityB : quantityA;
   const canonicalQuantityARaw = canonicalAssetA === assetA ? quantityARaw : quantityBRaw;
   const canonicalQuantityBRaw = canonicalAssetB === assetB ? quantityBRaw : quantityARaw;
-  const initialLpEstimate = getInitialLpEstimate(canonicalQuantityARaw, canonicalQuantityBRaw);
-  const limitingLpEstimate = getLimitingLpEstimate(quote?.quantity_minted_estimate, partnerQuantityRaw, quantityBRaw);
+  const initialLpEstimate = calculateInitialLpEstimate(canonicalQuantityARaw, canonicalQuantityBRaw);
+  const limitingLpEstimate = calculateLimitingLpEstimate(quote?.quantity_minted_estimate, partnerQuantityRaw, quantityBRaw);
   const lpEstimateForMinimum = isFirstDeposit || isZeroSupplyRestart ? initialLpEstimate : limitingLpEstimate;
   const minLpQuantity = applySlippage(lpEstimateForMinimum, slippage);
   const hasLpMinimum = toBigNumber(minLpQuantity).isGreaterThan(0);
@@ -316,7 +282,7 @@ export function PoolDepositForm({
             <div className="rounded border border-gray-200 bg-gray-50 p-3 text-sm text-gray-600">
               Minimum LP tokens:{" "}
               <span className="font-medium text-gray-900">
-                {fromRawQuantity(minLpQuantity, true)}
+                {fromSatoshis(minLpQuantity, { removeTrailingZeros: true })}
               </span>{" "}
               after {slippage || "0"}% slippage.
             </div>

--- a/src/pages/compose/pool/deposit/form.tsx
+++ b/src/pages/compose/pool/deposit/form.tsx
@@ -28,6 +28,16 @@ function fromRawQuantity(value: number | string, divisible: boolean): string {
   return divisible ? fromSatoshis(value, { removeTrailingZeros: true }) : value.toString();
 }
 
+function getCanonicalPair(firstAsset: string, secondAsset: string, quote: PoolDepositQuote | null) {
+  if (quote?.asset_a && quote?.asset_b) {
+    return [quote.asset_a, quote.asset_b] as const;
+  }
+
+  return firstAsset > secondAsset
+    ? [secondAsset, firstAsset] as const
+    : [firstAsset, secondAsset] as const;
+}
+
 function applySlippage(value: number | string | null | undefined, slippagePercent: string): string {
   if (value === null || value === undefined) return "0";
 
@@ -101,6 +111,9 @@ export function PoolDepositForm({
   const partnerQuantity = partnerQuantityRaw !== undefined && partnerQuantityRaw !== null
     ? fromRawQuantity(partnerQuantityRaw, isAssetBDivisible)
     : null;
+  const [canonicalAssetA, canonicalAssetB] = getCanonicalPair(assetA, assetB, quote);
+  const canonicalQuantityA = canonicalAssetA === assetA ? quantityA : quantityB;
+  const canonicalQuantityB = canonicalAssetB === assetB ? quantityB : quantityA;
   const minLpQuantity = applySlippage(quote?.quantity_minted_estimate, slippage);
   const hasLpMinimum = toBigNumber(minLpQuantity).isGreaterThan(0);
   const isSlippageValid = isValidPositiveNumber(slippage, { allowZero: true, maxDecimals: 2 })
@@ -121,10 +134,10 @@ export function PoolDepositForm({
       return;
     }
 
-    formData.set("asset_a", assetA);
-    formData.set("asset_b", assetB);
-    formData.set("quantity_a", quantityA);
-    formData.set("quantity_b", quantityB);
+    formData.set("asset_a", canonicalAssetA);
+    formData.set("asset_b", canonicalAssetB);
+    formData.set("quantity_a", canonicalQuantityA);
+    formData.set("quantity_b", canonicalQuantityB);
     formData.set("min_lp_quantity", minLpQuantity);
     if (lpAsset.trim()) {
       formData.set("lp_asset", lpAsset.trim());
@@ -257,10 +270,10 @@ export function PoolDepositForm({
         </Field>
       )}
 
-      <input type="hidden" name="asset_a" value={assetA} />
-      <input type="hidden" name="asset_b" value={assetB} />
-      <input type="hidden" name="quantity_a" value={quantityA} />
-      <input type="hidden" name="quantity_b" value={quantityB} />
+      <input type="hidden" name="asset_a" value={canonicalAssetA} />
+      <input type="hidden" name="asset_b" value={canonicalAssetB} />
+      <input type="hidden" name="quantity_a" value={canonicalQuantityA} />
+      <input type="hidden" name="quantity_b" value={canonicalQuantityB} />
       <input type="hidden" name="min_lp_quantity" value={minLpQuantity} />
       {lpAsset && <input type="hidden" name="lp_asset" value={lpAsset} />}
     </ComposerForm>

--- a/src/pages/compose/pool/deposit/form.tsx
+++ b/src/pages/compose/pool/deposit/form.tsx
@@ -72,6 +72,12 @@ function getLimitingLpEstimate(
     .toString();
 }
 
+function getInitialLpEstimate(quantityA: string, quantityB: string): string {
+  const product = toBigNumber(quantityA).times(quantityB);
+  if (!product.isGreaterThan(0)) return "0";
+  return product.sqrt().integerValue(BigNumber.ROUND_DOWN).toString();
+}
+
 export function PoolDepositForm({
   formAction,
   initialFormData,
@@ -132,6 +138,7 @@ export function PoolDepositForm({
   const partnerQuantity = partnerQuantityRaw !== undefined && partnerQuantityRaw !== null
     ? fromRawQuantity(partnerQuantityRaw, isAssetBDivisible)
     : null;
+  const quantityARaw = quantityA ? toRawQuantity(quantityA, isAssetADivisible) : "0";
   const quantityBRaw = quantityB ? toRawQuantity(quantityB, isAssetBDivisible) : "0";
   const partnerQuantityMatches = partnerQuantityRaw === undefined || partnerQuantityRaw === null
     || toBigNumber(quantityBRaw).isEqualTo(partnerQuantityRaw);
@@ -143,8 +150,12 @@ export function PoolDepositForm({
   const [canonicalAssetA, canonicalAssetB] = getCanonicalPair(assetA, assetB, quote);
   const canonicalQuantityA = canonicalAssetA === assetA ? quantityA : quantityB;
   const canonicalQuantityB = canonicalAssetB === assetB ? quantityB : quantityA;
+  const canonicalQuantityARaw = canonicalAssetA === assetA ? quantityARaw : quantityBRaw;
+  const canonicalQuantityBRaw = canonicalAssetB === assetB ? quantityBRaw : quantityARaw;
+  const initialLpEstimate = getInitialLpEstimate(canonicalQuantityARaw, canonicalQuantityBRaw);
   const limitingLpEstimate = getLimitingLpEstimate(quote?.quantity_minted_estimate, partnerQuantityRaw, quantityBRaw);
-  const minLpQuantity = applySlippage(limitingLpEstimate, slippage);
+  const lpEstimateForMinimum = isFirstDeposit || isZeroSupplyRestart ? initialLpEstimate : limitingLpEstimate;
+  const minLpQuantity = applySlippage(lpEstimateForMinimum, slippage);
   const hasLpMinimum = toBigNumber(minLpQuantity).isGreaterThan(0);
   const isSlippageValid = isValidPositiveNumber(slippage, { allowZero: true, maxDecimals: 2 })
     && toBigNumber(slippage).isLessThanOrEqualTo(50);
@@ -272,11 +283,11 @@ export function PoolDepositForm({
 
       {isZeroSupplyRestart && (
         <div className="rounded border border-yellow-200 bg-yellow-50 p-3 text-sm text-yellow-800">
-          LP supply is zero. This deposit restarts the pool at the current reserve ratio.
+          LP supply is zero. This deposit re-seeds the pool with the amounts entered.
         </div>
       )}
 
-      {!isZeroSupplyRestart && !isFirstDeposit && quote?.quantity_minted_estimate !== undefined && quote.quantity_minted_estimate !== null && (
+      {(isFirstDeposit || isZeroSupplyRestart || (quote?.quantity_minted_estimate !== undefined && quote.quantity_minted_estimate !== null)) && (
         <>
           <SlippageInput
             value={slippage}

--- a/src/pages/compose/pool/deposit/form.tsx
+++ b/src/pages/compose/pool/deposit/form.tsx
@@ -11,7 +11,7 @@ import { useAssetDetails } from "@/hooks/useAssetDetails";
 import { fetchPoolDepositQuote, type PoolDepositQuote } from "@/utils/blockchain/counterparty/api";
 import { BigNumber, fromSatoshis, isValidPositiveNumber, toBigNumber, toSatoshis } from "@/utils/numeric";
 import type { PoolDepositOptions } from "@/utils/blockchain/counterparty/compose";
-import { SlippageInput } from "../slippage-input";
+import { DEFAULT_POOL_SLIPPAGE, SlippageInput } from "../slippage-input";
 
 interface PoolDepositFormProps {
   formAction: (formData: FormData) => void;
@@ -92,7 +92,7 @@ export function PoolDepositForm({
   const [quantityB, setQuantityB] = useState(initialFormData?.quantity_b?.toString() || "");
   const [lpAsset, setLpAsset] = useState(initialFormData?.lp_asset || "");
   const [isLpAssetValid, setIsLpAssetValid] = useState(false);
-  const [slippage, setSlippage] = useState((initialFormData as PoolDepositOptions & { slippage?: string })?.slippage || "1");
+  const [slippage, setSlippage] = useState((initialFormData as PoolDepositOptions & { slippage?: string })?.slippage || DEFAULT_POOL_SLIPPAGE);
   const [localError, setLocalError] = useState<string | null>(null);
   const [quote, setQuote] = useState<PoolDepositQuote | null>(null);
   const [isLoadingQuote, setIsLoadingQuote] = useState(false);

--- a/src/pages/compose/pool/deposit/form.tsx
+++ b/src/pages/compose/pool/deposit/form.tsx
@@ -16,8 +16,12 @@ import {
 } from "@/utils/blockchain/counterparty/pool";
 import {
   fromSatoshis,
+  isEqualTo,
+  isGreaterThan,
+  isLessThan,
+  isLessThanOrEqualTo,
   isValidPositiveNumber,
-  toBigNumber,
+  roundDown,
   toSatoshis,
 } from "@/utils/numeric";
 import type { PoolDepositOptions } from "@/utils/blockchain/counterparty/compose";
@@ -28,10 +32,6 @@ interface PoolDepositFormProps {
   initialFormData: PoolDepositOptions | null;
   initialAssetA?: string;
   initialAssetB?: string;
-}
-
-function toRawQuantity(value: string, divisible: boolean): string {
-  return divisible ? toSatoshis(value) : toBigNumber(value).integerValue().toString();
 }
 
 export function PoolDepositForm({
@@ -54,10 +54,12 @@ export function PoolDepositForm({
   const { data: assetADetails } = useAssetDetails(assetA);
   const { data: assetBDetails } = useAssetDetails(assetB);
 
-  const isAssetADivisible = assetADetails?.isDivisible ?? true;
-  const isAssetBDivisible = assetBDetails?.isDivisible ?? true;
-  const canQuote = assetA && assetB && assetA !== assetB && toBigNumber(quantityA || 0).isGreaterThan(0);
-  const needsQuote = canQuote && toBigNumber(quantityB || 0).isGreaterThan(0);
+  const assetADetailsReady = assetADetails?.assetInfo?.asset === assetA;
+  const assetBDetailsReady = assetB ? assetBDetails?.assetInfo?.asset === assetB : false;
+  const isAssetADivisible = assetADetailsReady ? assetADetails.isDivisible : true;
+  const isAssetBDivisible = assetBDetailsReady && assetBDetails ? assetBDetails.isDivisible : true;
+  const canQuote = assetA && assetB && assetA !== assetB && assetADetailsReady && isGreaterThan(quantityA || 0, 0);
+  const needsQuote = canQuote && isGreaterThan(quantityB || 0, 0);
   const { data: quote, isLoading: isLoadingQuote, error: quoteError } = usePoolDepositQuote({
     assetA,
     assetB,
@@ -75,32 +77,37 @@ export function PoolDepositForm({
       ? fromSatoshis(partnerQuantityRaw, { removeTrailingZeros: true })
       : partnerQuantityRaw.toString()
     : null;
-  const quantityARaw = quantityA ? toRawQuantity(quantityA, isAssetADivisible) : "0";
-  const quantityBRaw = quantityB ? toRawQuantity(quantityB, isAssetBDivisible) : "0";
+  const quantityARaw = quantityA
+    ? isAssetADivisible ? toSatoshis(quantityA) : roundDown(quantityA).toString()
+    : "0";
+  const quantityBRaw = quantityB
+    ? isAssetBDivisible ? toSatoshis(quantityB) : roundDown(quantityB).toString()
+    : "0";
   const partnerQuantityMatches = partnerQuantityRaw === undefined || partnerQuantityRaw === null
-    || toBigNumber(quantityBRaw).isEqualTo(partnerQuantityRaw);
+    || isEqualTo(quantityBRaw, partnerQuantityRaw);
   const partnerQuantityIsLow = partnerQuantityRaw !== undefined && partnerQuantityRaw !== null
-    && toBigNumber(quantityBRaw).isLessThan(partnerQuantityRaw);
+    && isLessThan(quantityBRaw, partnerQuantityRaw);
   const partnerQuantityIsHigh = partnerQuantityRaw !== undefined && partnerQuantityRaw !== null
-    && toBigNumber(quantityBRaw).isGreaterThan(partnerQuantityRaw);
+    && isGreaterThan(quantityBRaw, partnerQuantityRaw);
   const isZeroSupplyRestart = !isFirstDeposit && quote?.quantity_minted_estimate === 0;
   const initialLpEstimate = calculateInitialLpEstimate(quantityARaw, quantityBRaw);
   const limitingLpEstimate = calculateLimitingLpEstimate(quote?.quantity_minted_estimate, partnerQuantityRaw, quantityBRaw);
   const lpEstimateForMinimum = isFirstDeposit || isZeroSupplyRestart ? initialLpEstimate : limitingLpEstimate;
   const minLpQuantity = applyPoolSlippage(lpEstimateForMinimum, slippage);
-  const hasLpMinimum = toBigNumber(minLpQuantity).isGreaterThan(0);
+  const hasLpMinimum = isGreaterThan(minLpQuantity, 0);
   const isSlippageValid = isValidPositiveNumber(slippage, { allowZero: true, maxDecimals: 2 })
-    && toBigNumber(slippage).isLessThanOrEqualTo(50);
+    && isLessThanOrEqualTo(slippage, 50);
 
   const submitDisabled = useMemo(() => {
     if (!assetA || !assetB || assetA === assetB) return true;
-    if (!toBigNumber(quantityA || 0).isGreaterThan(0)) return true;
-    if (!toBigNumber(quantityB || 0).isGreaterThan(0)) return true;
+    if (!assetADetailsReady || !assetBDetailsReady) return true;
+    if (!isGreaterThan(quantityA || 0, 0)) return true;
+    if (!isGreaterThan(quantityB || 0, 0)) return true;
     if (needsQuote && (isLoadingQuote || !quote)) return true;
     if (isFirstDeposit && lpAsset && !isLpAssetValid) return true;
     if (!isSlippageValid) return true;
     return false;
-  }, [assetA, assetB, quantityA, quantityB, needsQuote, isLoadingQuote, quote, isFirstDeposit, lpAsset, isLpAssetValid, isSlippageValid]);
+  }, [assetA, assetB, assetADetailsReady, assetBDetailsReady, quantityA, quantityB, needsQuote, isLoadingQuote, quote, isFirstDeposit, lpAsset, isLpAssetValid, isSlippageValid]);
 
   const handleFormAction = (formData: FormData) => {
     if (assetA === assetB) {

--- a/src/pages/compose/pool/deposit/form.tsx
+++ b/src/pages/compose/pool/deposit/form.tsx
@@ -111,6 +111,10 @@ export function PoolDepositForm({
   const partnerQuantity = partnerQuantityRaw !== undefined && partnerQuantityRaw !== null
     ? fromRawQuantity(partnerQuantityRaw, isAssetBDivisible)
     : null;
+  const quantityBRaw = quantityB ? toRawQuantity(quantityB, isAssetBDivisible) : "0";
+  const partnerQuantityMatches = partnerQuantityRaw === undefined || partnerQuantityRaw === null
+    || toBigNumber(quantityBRaw).isEqualTo(partnerQuantityRaw);
+  const isZeroSupplyRestart = !isFirstDeposit && quote?.quantity_minted_estimate === 0;
   const [canonicalAssetA, canonicalAssetB] = getCanonicalPair(assetA, assetB, quote);
   const canonicalQuantityA = canonicalAssetA === assetA ? quantityA : quantityB;
   const canonicalQuantityB = canonicalAssetB === assetB ? quantityB : quantityA;
@@ -123,10 +127,11 @@ export function PoolDepositForm({
     if (!assetA || !assetB || assetA === assetB) return true;
     if (!toBigNumber(quantityA || 0).isGreaterThan(0)) return true;
     if (!toBigNumber(quantityB || 0).isGreaterThan(0)) return true;
+    if (!partnerQuantityMatches) return true;
     if (isFirstDeposit && lpAsset && !isLpAssetValid) return true;
     if (!isSlippageValid) return true;
     return false;
-  }, [assetA, assetB, quantityA, quantityB, isFirstDeposit, lpAsset, isLpAssetValid, isSlippageValid]);
+  }, [assetA, assetB, quantityA, quantityB, partnerQuantityMatches, isFirstDeposit, lpAsset, isLpAssetValid, isSlippageValid]);
 
   const handleFormAction = (formData: FormData) => {
     if (assetA === assetB) {
@@ -230,7 +235,19 @@ export function PoolDepositForm({
         </div>
       )}
 
-      {!isFirstDeposit && quote?.quantity_minted_estimate !== undefined && quote.quantity_minted_estimate !== null && (
+      {partnerQuantity && !isFirstDeposit && !partnerQuantityMatches && (
+        <div className="rounded border border-yellow-200 bg-yellow-50 p-3 text-sm text-yellow-800">
+          Existing pool deposits must match the pool ratio. Use quote to continue.
+        </div>
+      )}
+
+      {isZeroSupplyRestart && (
+        <div className="rounded border border-yellow-200 bg-yellow-50 p-3 text-sm text-yellow-800">
+          LP supply is zero. This deposit restarts the pool at the current reserve ratio.
+        </div>
+      )}
+
+      {!isZeroSupplyRestart && !isFirstDeposit && quote?.quantity_minted_estimate !== undefined && quote.quantity_minted_estimate !== null && (
         <>
           <SlippageInput
             value={slippage}

--- a/src/pages/compose/pool/deposit/form.tsx
+++ b/src/pages/compose/pool/deposit/form.tsx
@@ -1,0 +1,268 @@
+import { useEffect, useMemo, useState, type ReactElement } from "react";
+import { useFormStatus } from "react-dom";
+import { Field, Description } from "@headlessui/react";
+import { ComposerForm } from "@/components/composer/composer-form";
+import { ErrorAlert } from "@/components/ui/error-alert";
+import { AmountWithMaxInput } from "@/components/ui/inputs/amount-with-max-input";
+import { AssetNameInput } from "@/components/ui/inputs/asset-name-input";
+import { AssetSelectInput } from "@/components/ui/inputs/asset-select-input";
+import { useComposer } from "@/contexts/composer-context";
+import { useAssetDetails } from "@/hooks/useAssetDetails";
+import { fetchPoolDepositQuote, type PoolDepositQuote } from "@/utils/blockchain/counterparty/api";
+import { BigNumber, fromSatoshis, isValidPositiveNumber, toBigNumber, toSatoshis } from "@/utils/numeric";
+import type { PoolDepositOptions } from "@/utils/blockchain/counterparty/compose";
+import { SlippageInput } from "../slippage-input";
+
+interface PoolDepositFormProps {
+  formAction: (formData: FormData) => void;
+  initialFormData: PoolDepositOptions | null;
+  initialAssetA?: string;
+  initialAssetB?: string;
+}
+
+function toRawQuantity(value: string, divisible: boolean): string {
+  return divisible ? toSatoshis(value) : toBigNumber(value).integerValue().toString();
+}
+
+function fromRawQuantity(value: number | string, divisible: boolean): string {
+  return divisible ? fromSatoshis(value, { removeTrailingZeros: true }) : value.toString();
+}
+
+function applySlippage(value: number | string | null | undefined, slippagePercent: string): string {
+  if (value === null || value === undefined) return "0";
+
+  const bps = toBigNumber(slippagePercent || "0").times(100);
+  const multiplier = BigNumber.maximum(0, toBigNumber(10000).minus(bps));
+
+  return toBigNumber(value)
+    .times(multiplier)
+    .div(10000)
+    .integerValue(BigNumber.ROUND_DOWN)
+    .toString();
+}
+
+export function PoolDepositForm({
+  formAction,
+  initialFormData,
+  initialAssetA,
+  initialAssetB,
+}: PoolDepositFormProps): ReactElement {
+  const { activeAddress, showHelpText, feeRate } = useComposer<PoolDepositOptions>();
+  const { pending } = useFormStatus();
+  const [assetA, setAssetA] = useState(initialFormData?.asset_a || initialAssetA || "XCP");
+  const [assetB, setAssetB] = useState(initialFormData?.asset_b || initialAssetB || "");
+  const [quantityA, setQuantityA] = useState(initialFormData?.quantity_a?.toString() || "");
+  const [quantityB, setQuantityB] = useState(initialFormData?.quantity_b?.toString() || "");
+  const [lpAsset, setLpAsset] = useState(initialFormData?.lp_asset || "");
+  const [isLpAssetValid, setIsLpAssetValid] = useState(false);
+  const [slippage, setSlippage] = useState("1");
+  const [localError, setLocalError] = useState<string | null>(null);
+  const [quote, setQuote] = useState<PoolDepositQuote | null>(null);
+  const [isLoadingQuote, setIsLoadingQuote] = useState(false);
+
+  const { data: assetADetails } = useAssetDetails(assetA);
+  const { data: assetBDetails } = useAssetDetails(assetB);
+
+  const isAssetADivisible = assetADetails?.isDivisible ?? true;
+  const isAssetBDivisible = assetBDetails?.isDivisible ?? true;
+  const canQuote = assetA && assetB && assetA !== assetB && toBigNumber(quantityA || 0).isGreaterThan(0);
+
+  useEffect(() => {
+    if (!canQuote) {
+      setQuote(null);
+      return;
+    }
+
+    let cancelled = false;
+    const timer = setTimeout(() => {
+      setIsLoadingQuote(true);
+      fetchPoolDepositQuote(assetA, assetB, toRawQuantity(quantityA, isAssetADivisible))
+        .then((result) => {
+          if (!cancelled) setQuote(result);
+        })
+        .catch(() => {
+          if (!cancelled) setQuote(null);
+        })
+        .finally(() => {
+          if (!cancelled) setIsLoadingQuote(false);
+        });
+    }, 300);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [assetA, assetB, quantityA, canQuote, isAssetADivisible]);
+
+  const isFirstDeposit = quote?.first_deposit === true;
+  const partnerQuantityRaw = quote?.asset_a === assetA
+    ? quote?.quantity_b_required
+    : quote?.quantity_a_required;
+  const partnerQuantity = partnerQuantityRaw !== undefined && partnerQuantityRaw !== null
+    ? fromRawQuantity(partnerQuantityRaw, isAssetBDivisible)
+    : null;
+  const minLpQuantity = applySlippage(quote?.quantity_minted_estimate, slippage);
+  const hasLpMinimum = toBigNumber(minLpQuantity).isGreaterThan(0);
+  const isSlippageValid = isValidPositiveNumber(slippage, { allowZero: true, maxDecimals: 2 })
+    && toBigNumber(slippage).isLessThanOrEqualTo(50);
+
+  const submitDisabled = useMemo(() => {
+    if (!assetA || !assetB || assetA === assetB) return true;
+    if (!toBigNumber(quantityA || 0).isGreaterThan(0)) return true;
+    if (!toBigNumber(quantityB || 0).isGreaterThan(0)) return true;
+    if (isFirstDeposit && lpAsset && !isLpAssetValid) return true;
+    if (!isSlippageValid) return true;
+    return false;
+  }, [assetA, assetB, quantityA, quantityB, isFirstDeposit, lpAsset, isLpAssetValid, isSlippageValid]);
+
+  const handleFormAction = (formData: FormData) => {
+    if (assetA === assetB) {
+      setLocalError("Pool assets must be different.");
+      return;
+    }
+
+    formData.set("asset_a", assetA);
+    formData.set("asset_b", assetB);
+    formData.set("quantity_a", quantityA);
+    formData.set("quantity_b", quantityB);
+    formData.set("min_lp_quantity", minLpQuantity);
+    if (lpAsset.trim()) {
+      formData.set("lp_asset", lpAsset.trim());
+    } else {
+      formData.delete("lp_asset");
+    }
+    formAction(formData);
+  };
+
+  return (
+    <ComposerForm
+      formAction={handleFormAction}
+      submitText="Review Deposit"
+      submitDisabled={pending || submitDisabled}
+    >
+      {localError && <ErrorAlert message={localError} onClose={() => setLocalError(null)} />}
+
+      <AssetSelectInput
+        selectedAsset={assetA}
+        onChange={setAssetA}
+        label="First Asset"
+        required
+        showHelpText={showHelpText}
+      />
+
+      <AmountWithMaxInput
+        asset={assetA}
+        availableBalance={assetADetails?.availableBalance || "0"}
+        value={quantityA}
+        onChange={setQuantityA}
+        feeRate={feeRate}
+        setError={setLocalError}
+        showHelpText={showHelpText}
+        sourceAddress={activeAddress}
+        maxAmount={assetADetails?.availableBalance || "0"}
+        label={`${assetA || "Asset"} Amount`}
+        name="quantity_a_display"
+        disabled={pending || !assetA}
+        isDivisible={isAssetADivisible}
+      />
+
+      <AssetSelectInput
+        selectedAsset={assetB}
+        onChange={setAssetB}
+        label="Second Asset"
+        required
+        showHelpText={showHelpText}
+      />
+
+      <AmountWithMaxInput
+        asset={assetB}
+        availableBalance={assetBDetails?.availableBalance || "0"}
+        value={quantityB}
+        onChange={setQuantityB}
+        feeRate={feeRate}
+        setError={setLocalError}
+        showHelpText={showHelpText}
+        sourceAddress={activeAddress}
+        maxAmount={assetBDetails?.availableBalance || "0"}
+        label={`${assetB || "Asset"} Amount`}
+        name="quantity_b_display"
+        disabled={pending || !assetB}
+        isDivisible={isAssetBDivisible}
+        labelRight={
+          partnerQuantity && !isFirstDeposit ? (
+            <button
+              type="button"
+              className="text-xs text-blue-600 hover:text-blue-800"
+              onClick={() => setQuantityB(partnerQuantity.toString())}
+            >
+              Use quote
+            </button>
+          ) : null
+        }
+      />
+
+      {isLoadingQuote && (
+        <p className="text-sm text-gray-500">Loading pool quote...</p>
+      )}
+
+      {quote?.message && (
+        <div className="rounded border border-gray-200 bg-gray-50 p-3 text-sm text-gray-600">
+          {quote.message}
+        </div>
+      )}
+
+      {partnerQuantity && !isFirstDeposit && (
+        <div className="rounded border border-gray-200 bg-gray-50 p-3 text-sm text-gray-600">
+          Quoted partner amount: {partnerQuantity.toString()} {assetB}
+        </div>
+      )}
+
+      {!isFirstDeposit && quote?.quantity_minted_estimate !== undefined && quote.quantity_minted_estimate !== null && (
+        <>
+          <SlippageInput
+            value={slippage}
+            onChange={setSlippage}
+            showHelpText={showHelpText}
+          />
+
+          {hasLpMinimum && (
+            <div className="rounded border border-gray-200 bg-gray-50 p-3 text-sm text-gray-600">
+              Minimum LP tokens:{" "}
+              <span className="font-medium text-gray-900">
+                {fromRawQuantity(minLpQuantity, true)}
+              </span>{" "}
+              after {slippage || "0"}% slippage.
+            </div>
+          )}
+        </>
+      )}
+
+      {isFirstDeposit && (
+        <Field>
+          <AssetNameInput
+            value={lpAsset}
+            onChange={setLpAsset}
+            onValidationChange={setIsLpAssetValid}
+            label="LP Asset"
+            required={false}
+            showRandomNumeric
+            showHelpText={showHelpText}
+            helpText="Optional. Leave blank to auto-generate the LP asset."
+          />
+          {showHelpText && (
+            <Description className="mt-2 text-sm text-gray-500">
+              The LP asset represents your share of the pool.
+            </Description>
+          )}
+        </Field>
+      )}
+
+      <input type="hidden" name="asset_a" value={assetA} />
+      <input type="hidden" name="asset_b" value={assetB} />
+      <input type="hidden" name="quantity_a" value={quantityA} />
+      <input type="hidden" name="quantity_b" value={quantityB} />
+      <input type="hidden" name="min_lp_quantity" value={minLpQuantity} />
+      {lpAsset && <input type="hidden" name="lp_asset" value={lpAsset} />}
+    </ComposerForm>
+  );
+}

--- a/src/pages/compose/pool/deposit/index.tsx
+++ b/src/pages/compose/pool/deposit/index.tsx
@@ -1,0 +1,27 @@
+import { useParams } from "react-router-dom";
+import { Composer } from "@/components/composer/composer";
+import { composePoolDeposit, type PoolDepositOptions } from "@/utils/blockchain/counterparty/compose";
+import { PoolDepositForm } from "./form";
+import { ReviewPoolDeposit } from "./review";
+
+export default function ComposePoolDepositPage() {
+  const { assetA, assetB } = useParams<{ assetA?: string; assetB?: string }>();
+
+  return (
+    <div className="p-4">
+      <Composer<PoolDepositOptions>
+        composeType="pooldeposit"
+        composeApiMethod={composePoolDeposit}
+        initialTitle="Pool Deposit"
+        FormComponent={(props) => (
+          <PoolDepositForm
+            {...props}
+            initialAssetA={assetA ? decodeURIComponent(assetA) : undefined}
+            initialAssetB={assetB ? decodeURIComponent(assetB) : undefined}
+          />
+        )}
+        ReviewComponent={ReviewPoolDeposit}
+      />
+    </div>
+  );
+}

--- a/src/pages/compose/pool/deposit/review.tsx
+++ b/src/pages/compose/pool/deposit/review.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useState } from "react";
+import { ReviewScreen } from "@/components/screens/review-screen";
+import { useMarketPrices } from "@/hooks/useMarketPrices";
+import { useSettings } from "@/contexts/settings-context";
+import { getPoolDepositEstimateXcpFee } from "@/utils/blockchain/counterparty/compose";
+import { formatAmount } from "@/utils/format";
+import { fromSatoshis } from "@/utils/numeric";
+
+interface ReviewPoolDepositProps {
+  apiResponse: any;
+  onSign: () => void;
+  onBack: () => void;
+  error: string | null;
+  isSigning: boolean;
+}
+
+export function ReviewPoolDeposit({
+  apiResponse,
+  onSign,
+  onBack,
+  error,
+  isSigning,
+}: ReviewPoolDepositProps) {
+  const { result } = apiResponse;
+  const params = result.params;
+  const { settings } = useSettings();
+  const { xcp: xcpPrice } = useMarketPrices(settings.fiat);
+  const [xcpFeeEstimate, setXcpFeeEstimate] = useState<number | null>(null);
+  const [feeLoading, setFeeLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchFeeEstimate = async () => {
+      try {
+        const sourceAddress = params.source;
+        if (sourceAddress) {
+          const fee = await getPoolDepositEstimateXcpFee(sourceAddress);
+          setXcpFeeEstimate(fee);
+        }
+      } catch (err) {
+        console.error("Failed to fetch pool deposit XCP fee estimate:", err);
+      } finally {
+        setFeeLoading(false);
+      }
+    };
+
+    fetchFeeEstimate();
+  }, [params.source]);
+
+  const xcpFeeInXcp = xcpFeeEstimate !== null ? fromSatoshis(xcpFeeEstimate, true) : null;
+  const xcpFeeInFiat = xcpFeeInXcp !== null && xcpPrice ? xcpFeeInXcp * xcpPrice : null;
+
+  const customFields = [
+    {
+      label: "Pool",
+      value: `${params.asset_a} / ${params.asset_b}`,
+    },
+    {
+      label: "Deposit",
+      value: `${params.quantity_a_normalized ?? params.quantity_a} ${params.asset_a}\n${params.quantity_b_normalized ?? params.quantity_b} ${params.asset_b}`,
+    },
+    ...(params.min_lp_quantity && params.min_lp_quantity !== "0"
+      ? [{ label: "Minimum LP", value: params.min_lp_quantity_normalized ?? params.min_lp_quantity }]
+      : []),
+    ...(params.lp_asset ? [{ label: "LP Asset", value: params.lp_asset }] : []),
+    {
+      label: "XCP Fee",
+      value: feeLoading
+        ? "Loading..."
+        : xcpFeeEstimate !== null
+          ? `${formatAmount({
+              value: xcpFeeInXcp!,
+              minimumFractionDigits: 8,
+              maximumFractionDigits: 8,
+            })} XCP`
+          : "Unable to estimate",
+      rightElement: !feeLoading && xcpFeeInFiat !== null
+        ? <span className="text-gray-500">${formatAmount({ value: xcpFeeInFiat, minimumFractionDigits: 2, maximumFractionDigits: 2 })}</span>
+        : undefined,
+    },
+  ];
+
+  return (
+    <ReviewScreen
+      apiResponse={apiResponse}
+      onSign={onSign}
+      onBack={onBack}
+      customFields={customFields}
+      error={error}
+      isSigning={isSigning}
+    />
+  );
+}

--- a/src/pages/compose/pool/deposit/review.tsx
+++ b/src/pages/compose/pool/deposit/review.tsx
@@ -3,6 +3,7 @@ import { ReviewScreen } from "@/components/screens/review-screen";
 import { useMarketPrices } from "@/hooks/useMarketPrices";
 import { useSettings } from "@/contexts/settings-context";
 import { getPoolDepositEstimateXcpFee } from "@/utils/blockchain/counterparty/compose";
+import { getCanonicalPoolPair } from "@/utils/blockchain/counterparty/pool";
 import { formatAmount } from "@/utils/format";
 import { fromSatoshis } from "@/utils/numeric";
 
@@ -54,7 +55,7 @@ export function ReviewPoolDeposit({
   const customFields = [
     {
       label: "Pool",
-      value: `${params.asset_a} / ${params.asset_b}`,
+      value: getCanonicalPoolPair(params.asset_a, params.asset_b),
     },
     {
       label: "Deposit",

--- a/src/pages/compose/pool/deposit/review.tsx
+++ b/src/pages/compose/pool/deposit/review.tsx
@@ -48,6 +48,8 @@ export function ReviewPoolDeposit({
 
   const xcpFeeInXcp = xcpFeeEstimate !== null ? fromSatoshis(xcpFeeEstimate, true) : null;
   const xcpFeeInFiat = xcpFeeInXcp !== null && xcpPrice ? xcpFeeInXcp * xcpPrice : null;
+  const minimumLpDisplay = params.min_lp_quantity_normalized
+    ?? fromSatoshis(params.min_lp_quantity ?? 0, { removeTrailingZeros: true });
 
   const customFields = [
     {
@@ -59,7 +61,7 @@ export function ReviewPoolDeposit({
       value: `${params.quantity_a_normalized ?? params.quantity_a} ${params.asset_a}\n${params.quantity_b_normalized ?? params.quantity_b} ${params.asset_b}`,
     },
     ...(params.min_lp_quantity && params.min_lp_quantity !== "0"
-      ? [{ label: "Minimum LP", value: params.min_lp_quantity_normalized ?? params.min_lp_quantity }]
+      ? [{ label: "Minimum LP", value: minimumLpDisplay }]
       : []),
     ...(params.lp_asset ? [{ label: "LP Asset", value: params.lp_asset }] : []),
     {

--- a/src/pages/compose/pool/slippage-input.tsx
+++ b/src/pages/compose/pool/slippage-input.tsx
@@ -1,8 +1,11 @@
 import { Field, Label, Description, Input } from "@headlessui/react";
 import { Button } from "@/components/ui/button";
+import { toBigNumber } from "@/utils/numeric";
 import type { ReactElement } from "react";
 
 const PRESET_SLIPPAGE = ["0.5", "1", "2", "3"];
+const LOW_SLIPPAGE_THRESHOLD = "0.05";
+const HIGH_SLIPPAGE_THRESHOLD = "20";
 
 interface SlippageInputProps {
   value: string;
@@ -16,6 +19,10 @@ export function SlippageInput({
   showHelpText = false,
 }: SlippageInputProps): ReactElement {
   const isPreset = PRESET_SLIPPAGE.includes(value);
+  const slippageValue = toBigNumber(value);
+  const isLowSlippage = slippageValue.isGreaterThanOrEqualTo(0)
+    && slippageValue.isLessThan(LOW_SLIPPAGE_THRESHOLD);
+  const isHighSlippage = slippageValue.isGreaterThanOrEqualTo(HIGH_SLIPPAGE_THRESHOLD);
 
   return (
     <Field>
@@ -47,6 +54,16 @@ export function SlippageInput({
         <Description className="mt-2 text-sm text-gray-500">
           Sets how far the pool quote may move before the transaction fails.
         </Description>
+      )}
+      {isLowSlippage && (
+        <div className="mt-2 rounded border border-yellow-200 bg-yellow-50 p-2 text-sm text-yellow-800">
+          Low slippage may fail if the pool changes before confirmation.
+        </div>
+      )}
+      {isHighSlippage && (
+        <div className="mt-2 rounded border border-yellow-200 bg-yellow-50 p-2 text-sm text-yellow-800">
+          High slippage allows a worse result before failing.
+        </div>
       )}
     </Field>
   );

--- a/src/pages/compose/pool/slippage-input.tsx
+++ b/src/pages/compose/pool/slippage-input.tsx
@@ -10,7 +10,11 @@ import {
   ListboxOptions,
 } from "@headlessui/react";
 import { Button } from "@/components/ui/button";
-import { BigNumber } from "@/utils/numeric";
+import {
+  isFiniteNumber,
+  isGreaterThanOrEqualTo,
+  isLessThan,
+} from "@/utils/numeric";
 import type { ReactElement } from "react";
 
 export const DEFAULT_POOL_SLIPPAGE = "2.5";
@@ -57,13 +61,12 @@ export function SlippageInput({
     { id: "custom" as const, name: "Custom", value: customInput || DEFAULT_POOL_SLIPPAGE },
   ];
 
-  const slippageValue = new BigNumber(value);
-  const showSlippageWarning = value.trim() !== "" && slippageValue.isFinite();
+  const showSlippageWarning = value.trim() !== "" && isFiniteNumber(value);
   const isLowSlippage = showSlippageWarning
-    && slippageValue.isGreaterThanOrEqualTo(0)
-    && slippageValue.isLessThan(LOW_SLIPPAGE_THRESHOLD);
+    && isGreaterThanOrEqualTo(value, 0)
+    && isLessThan(value, LOW_SLIPPAGE_THRESHOLD);
   const isHighSlippage = showSlippageWarning
-    && slippageValue.isGreaterThanOrEqualTo(HIGH_SLIPPAGE_THRESHOLD);
+    && isGreaterThanOrEqualTo(value, HIGH_SLIPPAGE_THRESHOLD);
 
   const handleOptionSelect = (option: typeof options[number] | null) => {
     if (!option) return;
@@ -79,14 +82,14 @@ export function SlippageInput({
     const nextValue = event.target.value.trim();
     const parts = nextValue.split(".");
     if (parts.length > 2) return;
-    if (nextValue !== "" && !new BigNumber(nextValue).isFinite()) return;
+    if (nextValue !== "" && !isFiniteNumber(nextValue)) return;
 
     setCustomInput(nextValue);
     onChange(nextValue);
   };
 
   const handleCustomInputBlur = () => {
-    if (!customInput || new BigNumber(customInput).isLessThan(0)) {
+    if (!customInput || isLessThan(customInput, 0)) {
       setCustomInput(DEFAULT_POOL_SLIPPAGE);
       onChange(DEFAULT_POOL_SLIPPAGE);
     }

--- a/src/pages/compose/pool/slippage-input.tsx
+++ b/src/pages/compose/pool/slippage-input.tsx
@@ -1,0 +1,53 @@
+import { Field, Label, Description, Input } from "@headlessui/react";
+import { Button } from "@/components/ui/button";
+import type { ReactElement } from "react";
+
+const PRESET_SLIPPAGE = ["0.5", "1", "2", "3"];
+
+interface SlippageInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  showHelpText?: boolean;
+}
+
+export function SlippageInput({
+  value,
+  onChange,
+  showHelpText = false,
+}: SlippageInputProps): ReactElement {
+  const isPreset = PRESET_SLIPPAGE.includes(value);
+
+  return (
+    <Field>
+      <Label className="block text-sm font-medium text-gray-700">
+        Slippage Tolerance <span className="text-red-500">*</span>
+      </Label>
+      <div className="mt-1 grid grid-cols-4 gap-2">
+        {PRESET_SLIPPAGE.map((preset) => (
+          <Button
+            key={preset}
+            type="button"
+            color={value === preset ? "blue" : "gray"}
+            className="py-2 px-2 text-sm"
+            onClick={() => onChange(preset)}
+          >
+            {preset}%
+          </Button>
+        ))}
+      </div>
+      <Input
+        type="text"
+        inputMode="decimal"
+        value={isPreset ? "" : value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder="Custom %"
+        className="mt-2 block w-full p-2.5 rounded-md border border-gray-300 bg-gray-50 outline-none focus:border-blue-500 focus-visible:ring-2 focus-visible:ring-blue-500"
+      />
+      {showHelpText && (
+        <Description className="mt-2 text-sm text-gray-500">
+          Sets how far the pool quote may move before the transaction fails.
+        </Description>
+      )}
+    </Field>
+  );
+}

--- a/src/pages/compose/pool/slippage-input.tsx
+++ b/src/pages/compose/pool/slippage-input.tsx
@@ -1,9 +1,29 @@
-import { Field, Label, Description, Input } from "@headlessui/react";
+import { useEffect, useState } from "react";
+import {
+  Field,
+  Label,
+  Description,
+  Input,
+  Listbox,
+  ListboxButton,
+  ListboxOption,
+  ListboxOptions,
+} from "@headlessui/react";
 import { Button } from "@/components/ui/button";
-import { toBigNumber } from "@/utils/numeric";
+import { BigNumber } from "@/utils/numeric";
 import type { ReactElement } from "react";
 
-const PRESET_SLIPPAGE = ["0.5", "1", "2", "3"];
+export const DEFAULT_POOL_SLIPPAGE = "2.5";
+
+const PRESET_OPTIONS = [
+  { id: "tight", name: "Tight", value: "0.5" },
+  { id: "standard", name: "Standard", value: DEFAULT_POOL_SLIPPAGE },
+  { id: "loose", name: "Loose", value: "5" },
+] as const;
+
+type PresetId = typeof PRESET_OPTIONS[number]["id"];
+type OptionId = PresetId | "custom";
+
 const LOW_SLIPPAGE_THRESHOLD = "0.05";
 const HIGH_SLIPPAGE_THRESHOLD = "20";
 
@@ -18,38 +38,126 @@ export function SlippageInput({
   onChange,
   showHelpText = false,
 }: SlippageInputProps): ReactElement {
-  const isPreset = PRESET_SLIPPAGE.includes(value);
-  const slippageValue = toBigNumber(value);
-  const isLowSlippage = slippageValue.isGreaterThanOrEqualTo(0)
+  const [selectedOption, setSelectedOption] = useState<OptionId>("standard");
+  const [customInput, setCustomInput] = useState(value);
+
+  useEffect(() => {
+    const matchingPreset = PRESET_OPTIONS.find((option) => option.value === value);
+    if (matchingPreset) {
+      setSelectedOption(matchingPreset.id);
+      setCustomInput(value);
+    } else {
+      setSelectedOption("custom");
+      setCustomInput(value);
+    }
+  }, [value]);
+
+  const options = [
+    ...PRESET_OPTIONS,
+    { id: "custom" as const, name: "Custom", value: customInput || DEFAULT_POOL_SLIPPAGE },
+  ];
+
+  const slippageValue = new BigNumber(value);
+  const showSlippageWarning = value.trim() !== "" && slippageValue.isFinite();
+  const isLowSlippage = showSlippageWarning
+    && slippageValue.isGreaterThanOrEqualTo(0)
     && slippageValue.isLessThan(LOW_SLIPPAGE_THRESHOLD);
-  const isHighSlippage = slippageValue.isGreaterThanOrEqualTo(HIGH_SLIPPAGE_THRESHOLD);
+  const isHighSlippage = showSlippageWarning
+    && slippageValue.isGreaterThanOrEqualTo(HIGH_SLIPPAGE_THRESHOLD);
+
+  const handleOptionSelect = (option: typeof options[number] | null) => {
+    if (!option) return;
+
+    setSelectedOption(option.id);
+    if (option.id !== "custom") {
+      setCustomInput(option.value);
+      onChange(option.value);
+    }
+  };
+
+  const handleCustomInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const nextValue = event.target.value.trim();
+    const parts = nextValue.split(".");
+    if (parts.length > 2) return;
+    if (nextValue !== "" && !new BigNumber(nextValue).isFinite()) return;
+
+    setCustomInput(nextValue);
+    onChange(nextValue);
+  };
+
+  const handleCustomInputBlur = () => {
+    if (!customInput || new BigNumber(customInput).isLessThan(0)) {
+      setCustomInput(DEFAULT_POOL_SLIPPAGE);
+      onChange(DEFAULT_POOL_SLIPPAGE);
+    }
+  };
+
+  const handleEscClick = () => {
+    const standard = PRESET_OPTIONS.find((option) => option.id === "standard") ?? PRESET_OPTIONS[0];
+    setSelectedOption(standard.id);
+    setCustomInput(standard.value);
+    onChange(standard.value);
+  };
 
   return (
     <Field>
       <Label className="block text-sm font-medium text-gray-700">
         Slippage Tolerance <span className="text-red-500">*</span>
       </Label>
-      <div className="mt-1 grid grid-cols-4 gap-2">
-        {PRESET_SLIPPAGE.map((preset) => (
-          <Button
-            key={preset}
-            type="button"
-            color={value === preset ? "blue" : "gray"}
-            className="py-2 px-2 text-sm"
-            onClick={() => onChange(preset)}
-          >
-            {preset}%
-          </Button>
-        ))}
+      <div className="mt-1">
+        {selectedOption === "custom" ? (
+          <div className="relative">
+            <Input
+              type="text"
+              inputMode="decimal"
+              value={customInput}
+              onChange={handleCustomInputChange}
+              onBlur={handleCustomInputBlur}
+              placeholder="Custom %"
+              className="block w-full p-2.5 rounded-md border border-gray-200 bg-gray-50 pr-16 outline-none focus:border-blue-500 focus-visible:ring-2 focus-visible:ring-blue-500"
+            />
+            <Button type="button" variant="input" onClick={handleEscClick} aria-label="Reset to standard slippage">
+              Esc
+            </Button>
+          </div>
+        ) : (
+          <div className="relative">
+            <Listbox
+              value={options.find((option) => option.id === selectedOption) || options[1]}
+              onChange={handleOptionSelect}
+            >
+              <ListboxButton className="w-full p-2.5 text-left rounded-md border border-gray-200 bg-gray-50 outline-none focus:border-blue-500 focus-visible:ring-2 focus-visible:ring-blue-500 cursor-pointer">
+                {({ value }) => (
+                  <div className="flex justify-between">
+                    <span>{value?.name}</span>
+                    {value?.id !== "custom" && <span className="text-gray-500">{value?.value}%</span>}
+                  </div>
+                )}
+              </ListboxButton>
+              <ListboxOptions className="absolute z-10 w-full mt-1 bg-white border border-gray-200 rounded-md shadow-lg max-h-60 overflow-auto">
+                {options.map((option) => (
+                  <ListboxOption
+                    key={option.id}
+                    value={option}
+                    className={({ focus }) =>
+                      `p-2.5 cursor-pointer select-none ${focus ? "bg-blue-500 text-white" : "text-gray-900"}`
+                    }
+                  >
+                    {({ selected, focus }) => (
+                      <div className="flex justify-between">
+                        <span className={selected ? "font-medium" : ""}>{option.name}</span>
+                        {option.id !== "custom" && (
+                          <span className={focus ? "text-blue-100" : "text-gray-500"}>{option.value}%</span>
+                        )}
+                      </div>
+                    )}
+                  </ListboxOption>
+                ))}
+              </ListboxOptions>
+            </Listbox>
+          </div>
+        )}
       </div>
-      <Input
-        type="text"
-        inputMode="decimal"
-        value={isPreset ? "" : value}
-        onChange={(event) => onChange(event.target.value)}
-        placeholder="Custom %"
-        className="mt-2 block w-full p-2.5 rounded-md border border-gray-300 bg-gray-50 outline-none focus:border-blue-500 focus-visible:ring-2 focus-visible:ring-blue-500"
-      />
       {showHelpText && (
         <Description className="mt-2 text-sm text-gray-500">
           Sets how far the pool quote may move before the transaction fails.

--- a/src/pages/compose/pool/withdraw/form.tsx
+++ b/src/pages/compose/pool/withdraw/form.tsx
@@ -8,7 +8,8 @@ import { useComposer } from "@/contexts/composer-context";
 import { useAssetDetails } from "@/hooks/useAssetDetails";
 import { useLpAssetPool } from "@/hooks/useLpAssetPool";
 import { fetchPoolWithdrawQuote, type PoolWithdrawQuote } from "@/utils/blockchain/counterparty/api";
-import { applySlippage, fromSatoshis, isValidPositiveNumber, toBigNumber, toSatoshis } from "@/utils/numeric";
+import { applyPoolSlippage } from "@/utils/blockchain/counterparty/pool";
+import { fromSatoshis, isValidPositiveNumber, toBigNumber, toSatoshis } from "@/utils/numeric";
 import type { PoolWithdrawOptions } from "@/utils/blockchain/counterparty/compose";
 import { DEFAULT_POOL_SLIPPAGE, SlippageInput } from "../slippage-input";
 
@@ -44,8 +45,8 @@ export function PoolWithdrawForm({
     return divisible ? fromSatoshis(value.toString(), { removeTrailingZeros: true }) : value.toString();
   };
 
-  const minQuantityA = applySlippage(quote?.quantity_a_estimate, slippage);
-  const minQuantityB = applySlippage(quote?.quantity_b_estimate, slippage);
+  const minQuantityA = applyPoolSlippage(quote?.quantity_a_estimate, slippage);
+  const minQuantityB = applyPoolSlippage(quote?.quantity_b_estimate, slippage);
   const hasMinimums = toBigNumber(minQuantityA).isGreaterThan(0) || toBigNumber(minQuantityB).isGreaterThan(0);
   const isSlippageValid = isValidPositiveNumber(slippage, { allowZero: true, maxDecimals: 2 })
     && toBigNumber(slippage).isLessThanOrEqualTo(50);

--- a/src/pages/compose/pool/withdraw/form.tsx
+++ b/src/pages/compose/pool/withdraw/form.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState, type ReactElement } from "react";
 import { useFormStatus } from "react-dom";
 import { ComposerForm } from "@/components/composer/composer-form";
 import { ErrorAlert } from "@/components/ui/error-alert";
+import { PoolHeader } from "@/components/ui/headers/pool-header";
 import { AmountWithMaxInput } from "@/components/ui/inputs/amount-with-max-input";
 import { Spinner } from "@/components/ui/spinner";
 import { useComposer } from "@/contexts/composer-context";
@@ -92,16 +93,11 @@ export function PoolWithdrawForm({
   return (
     <ComposerForm
       formAction={handleFormAction}
+      header={<PoolHeader pool={pool} className="mt-1 mb-5" />}
       submitText="Review Withdrawal"
       submitDisabled={pending || submitDisabled}
     >
       {localError && <ErrorAlert message={localError} onClose={() => setLocalError(null)} />}
-
-      <div className="rounded border border-gray-200 bg-gray-50 p-3 text-sm text-gray-700">
-        <div className="font-semibold text-gray-900">{pool.asset_a} / {pool.asset_b}</div>
-        <div className="mt-1 text-gray-600">LP Asset: {pool.lp_asset}</div>
-        <div className="mt-1 text-gray-600">Available: {pool.quantity_normalized ?? pool.quantity}</div>
-      </div>
 
       <AmountWithMaxInput
         asset={pool.lp_asset}

--- a/src/pages/compose/pool/withdraw/form.tsx
+++ b/src/pages/compose/pool/withdraw/form.tsx
@@ -93,9 +93,10 @@ export function PoolWithdrawForm({
     if (!pool) return true;
     if (!toBigNumber(quantity || 0).isGreaterThan(0)) return true;
     if (toBigNumber(quantity).isGreaterThan(pool.quantity_normalized ?? pool.quantity)) return true;
+    if (canQuote && (isLoadingQuote || !quote?.pool_exists)) return true;
     if (!isSlippageValid) return true;
     return false;
-  }, [pool, quantity, isSlippageValid]);
+  }, [pool, quantity, canQuote, isLoadingQuote, quote?.pool_exists, isSlippageValid]);
 
   const handleFormAction = (formData: FormData) => {
     if (!pool) return;

--- a/src/pages/compose/pool/withdraw/form.tsx
+++ b/src/pages/compose/pool/withdraw/form.tsx
@@ -10,7 +10,7 @@ import { useLpAssetPool } from "@/hooks/useLpAssetPool";
 import { fetchPoolWithdrawQuote, type PoolWithdrawQuote } from "@/utils/blockchain/counterparty/api";
 import { BigNumber, isValidPositiveNumber, toBigNumber, toSatoshis, fromSatoshis } from "@/utils/numeric";
 import type { PoolWithdrawOptions } from "@/utils/blockchain/counterparty/compose";
-import { SlippageInput } from "../slippage-input";
+import { DEFAULT_POOL_SLIPPAGE, SlippageInput } from "../slippage-input";
 
 interface PoolWithdrawFormProps {
   formAction: (formData: FormData) => void;
@@ -42,7 +42,7 @@ export function PoolWithdrawForm({
   const { data: assetADetails } = useAssetDetails(pool?.asset_a || "");
   const { data: assetBDetails } = useAssetDetails(pool?.asset_b || "");
   const [quantity, setQuantity] = useState(initialFormData?.quantity?.toString() || "");
-  const [slippage, setSlippage] = useState((initialFormData as PoolWithdrawOptions & { slippage?: string })?.slippage || "1");
+  const [slippage, setSlippage] = useState((initialFormData as PoolWithdrawOptions & { slippage?: string })?.slippage || DEFAULT_POOL_SLIPPAGE);
   const [localError, setLocalError] = useState<string | null>(null);
   const [quote, setQuote] = useState<PoolWithdrawQuote | null>(null);
   const [isLoadingQuote, setIsLoadingQuote] = useState(false);

--- a/src/pages/compose/pool/withdraw/form.tsx
+++ b/src/pages/compose/pool/withdraw/form.tsx
@@ -9,7 +9,7 @@ import { useAssetDetails } from "@/hooks/useAssetDetails";
 import { useLpAssetPool } from "@/hooks/useLpAssetPool";
 import { usePoolWithdrawQuote } from "@/hooks/usePoolQuotes";
 import { applyPoolSlippage } from "@/utils/blockchain/counterparty/pool";
-import { fromSatoshis, isValidPositiveNumber, toBigNumber } from "@/utils/numeric";
+import { fromSatoshis, isGreaterThan, isLessThanOrEqualTo, isValidPositiveNumber } from "@/utils/numeric";
 import type { PoolWithdrawOptions } from "@/utils/blockchain/counterparty/compose";
 import { DEFAULT_POOL_SLIPPAGE, SlippageInput } from "../slippage-input";
 
@@ -33,7 +33,7 @@ export function PoolWithdrawForm({
   const [slippage, setSlippage] = useState((initialFormData as PoolWithdrawOptions & { slippage?: string })?.slippage || DEFAULT_POOL_SLIPPAGE);
   const [localError, setLocalError] = useState<string | null>(null);
 
-  const canQuote = !!pool && toBigNumber(quantity || 0).isGreaterThan(0);
+  const canQuote = !!pool && isGreaterThan(quantity || 0, 0);
   const isAssetADivisible = assetADetails?.isDivisible ?? true;
   const isAssetBDivisible = assetBDetails?.isDivisible ?? true;
   const { data: quote, isLoading: isLoadingQuote, error: quoteError } = usePoolWithdrawQuote({
@@ -50,14 +50,14 @@ export function PoolWithdrawForm({
 
   const minQuantityA = applyPoolSlippage(quote?.quantity_a_estimate, slippage);
   const minQuantityB = applyPoolSlippage(quote?.quantity_b_estimate, slippage);
-  const hasMinimums = toBigNumber(minQuantityA).isGreaterThan(0) || toBigNumber(minQuantityB).isGreaterThan(0);
+  const hasMinimums = isGreaterThan(minQuantityA, 0) || isGreaterThan(minQuantityB, 0);
   const isSlippageValid = isValidPositiveNumber(slippage, { allowZero: true, maxDecimals: 2 })
-    && toBigNumber(slippage).isLessThanOrEqualTo(50);
+    && isLessThanOrEqualTo(slippage, 50);
 
   const submitDisabled = useMemo(() => {
     if (!pool) return true;
-    if (!toBigNumber(quantity || 0).isGreaterThan(0)) return true;
-    if (toBigNumber(quantity).isGreaterThan(pool.quantity_normalized ?? pool.quantity)) return true;
+    if (!isGreaterThan(quantity || 0, 0)) return true;
+    if (isGreaterThan(quantity, pool.quantity_normalized ?? pool.quantity)) return true;
     if (canQuote && (isLoadingQuote || !quote?.pool_exists)) return true;
     if (!isSlippageValid) return true;
     return false;

--- a/src/pages/compose/pool/withdraw/form.tsx
+++ b/src/pages/compose/pool/withdraw/form.tsx
@@ -38,12 +38,13 @@ export function PoolWithdrawForm({
 }: PoolWithdrawFormProps): ReactElement {
   const { activeAddress, showHelpText, feeRate } = useComposer<PoolWithdrawOptions>();
   const { pending } = useFormStatus();
-  const { data: pool, isLoading } = useLpAssetPool(lpAsset);
+  const { data: pool, isLoading, error: poolError } = useLpAssetPool(lpAsset);
   const { data: assetADetails } = useAssetDetails(pool?.asset_a || "");
   const { data: assetBDetails } = useAssetDetails(pool?.asset_b || "");
   const [quantity, setQuantity] = useState(initialFormData?.quantity?.toString() || "");
   const [slippage, setSlippage] = useState((initialFormData as PoolWithdrawOptions & { slippage?: string })?.slippage || DEFAULT_POOL_SLIPPAGE);
   const [localError, setLocalError] = useState<string | null>(null);
+  const [quoteError, setQuoteError] = useState<string | null>(null);
   const [quote, setQuote] = useState<PoolWithdrawQuote | null>(null);
   const [isLoadingQuote, setIsLoadingQuote] = useState(false);
 
@@ -65,18 +66,28 @@ export function PoolWithdrawForm({
   useEffect(() => {
     if (!pool || !canQuote) {
       setQuote(null);
+      setQuoteError(null);
+      setIsLoadingQuote(false);
       return;
     }
 
     let cancelled = false;
+    setQuote(null);
+    setQuoteError(null);
+    setIsLoadingQuote(true);
     const timer = setTimeout(() => {
-      setIsLoadingQuote(true);
       fetchPoolWithdrawQuote(pool.asset_a, pool.asset_b, toSatoshis(quantity))
         .then((result) => {
-          if (!cancelled) setQuote(result);
+          if (!cancelled) {
+            setQuote(result);
+            setQuoteError(null);
+          }
         })
-        .catch(() => {
-          if (!cancelled) setQuote(null);
+        .catch((err) => {
+          if (!cancelled) {
+            setQuote(null);
+            setQuoteError(err instanceof Error ? err.message : "Unable to load withdrawal quote.");
+          }
         })
         .finally(() => {
           if (!cancelled) setIsLoadingQuote(false);
@@ -114,6 +125,13 @@ export function PoolWithdrawForm({
   }
 
   if (!pool) {
+    if (poolError) {
+      return (
+        <div className="p-4">
+          <ErrorAlert message={poolError.message} />
+        </div>
+      );
+    }
     return <div className="p-4 text-center text-gray-600">Pool position not found</div>;
   }
 
@@ -149,6 +167,10 @@ export function PoolWithdrawForm({
 
       {isLoadingQuote && (
         <p className="text-sm text-gray-500">Loading withdrawal quote...</p>
+      )}
+
+      {quoteError && (
+        <ErrorAlert message={quoteError} onClose={() => setQuoteError(null)} />
       )}
 
       {quote?.pool_exists && (

--- a/src/pages/compose/pool/withdraw/form.tsx
+++ b/src/pages/compose/pool/withdraw/form.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type ReactElement } from "react";
+import { useMemo, useState, type ReactElement } from "react";
 import { useFormStatus } from "react-dom";
 import { ComposerForm } from "@/components/composer/composer-form";
 import { ErrorAlert } from "@/components/ui/error-alert";
@@ -7,9 +7,9 @@ import { Spinner } from "@/components/ui/spinner";
 import { useComposer } from "@/contexts/composer-context";
 import { useAssetDetails } from "@/hooks/useAssetDetails";
 import { useLpAssetPool } from "@/hooks/useLpAssetPool";
-import { fetchPoolWithdrawQuote, type PoolWithdrawQuote } from "@/utils/blockchain/counterparty/api";
+import { usePoolWithdrawQuote } from "@/hooks/usePoolQuotes";
 import { applyPoolSlippage } from "@/utils/blockchain/counterparty/pool";
-import { fromSatoshis, isValidPositiveNumber, toBigNumber, toSatoshis } from "@/utils/numeric";
+import { fromSatoshis, isValidPositiveNumber, toBigNumber } from "@/utils/numeric";
 import type { PoolWithdrawOptions } from "@/utils/blockchain/counterparty/compose";
 import { DEFAULT_POOL_SLIPPAGE, SlippageInput } from "../slippage-input";
 
@@ -32,13 +32,16 @@ export function PoolWithdrawForm({
   const [quantity, setQuantity] = useState(initialFormData?.quantity?.toString() || "");
   const [slippage, setSlippage] = useState((initialFormData as PoolWithdrawOptions & { slippage?: string })?.slippage || DEFAULT_POOL_SLIPPAGE);
   const [localError, setLocalError] = useState<string | null>(null);
-  const [quoteError, setQuoteError] = useState<string | null>(null);
-  const [quote, setQuote] = useState<PoolWithdrawQuote | null>(null);
-  const [isLoadingQuote, setIsLoadingQuote] = useState(false);
 
   const canQuote = !!pool && toBigNumber(quantity || 0).isGreaterThan(0);
   const isAssetADivisible = assetADetails?.isDivisible ?? true;
   const isAssetBDivisible = assetBDetails?.isDivisible ?? true;
+  const { data: quote, isLoading: isLoadingQuote, error: quoteError } = usePoolWithdrawQuote({
+    assetA: pool?.asset_a || "",
+    assetB: pool?.asset_b || "",
+    quantity,
+    enabled: canQuote,
+  });
 
   const formatReceived = (value: number | string | undefined, divisible: boolean): string => {
     if (value === undefined) return "0";
@@ -50,43 +53,6 @@ export function PoolWithdrawForm({
   const hasMinimums = toBigNumber(minQuantityA).isGreaterThan(0) || toBigNumber(minQuantityB).isGreaterThan(0);
   const isSlippageValid = isValidPositiveNumber(slippage, { allowZero: true, maxDecimals: 2 })
     && toBigNumber(slippage).isLessThanOrEqualTo(50);
-
-  useEffect(() => {
-    if (!pool || !canQuote) {
-      setQuote(null);
-      setQuoteError(null);
-      setIsLoadingQuote(false);
-      return;
-    }
-
-    let cancelled = false;
-    setQuote(null);
-    setQuoteError(null);
-    setIsLoadingQuote(true);
-    const timer = setTimeout(() => {
-      fetchPoolWithdrawQuote(pool.asset_a, pool.asset_b, toSatoshis(quantity))
-        .then((result) => {
-          if (!cancelled) {
-            setQuote(result);
-            setQuoteError(null);
-          }
-        })
-        .catch((err) => {
-          if (!cancelled) {
-            setQuote(null);
-            setQuoteError(err instanceof Error ? err.message : "Unable to load withdrawal quote.");
-          }
-        })
-        .finally(() => {
-          if (!cancelled) setIsLoadingQuote(false);
-        });
-    }, 300);
-
-    return () => {
-      cancelled = true;
-      clearTimeout(timer);
-    };
-  }, [pool, quantity, canQuote]);
 
   const submitDisabled = useMemo(() => {
     if (!pool) return true;
@@ -158,7 +124,7 @@ export function PoolWithdrawForm({
       )}
 
       {quoteError && (
-        <ErrorAlert message={quoteError} onClose={() => setQuoteError(null)} />
+        <ErrorAlert message={quoteError} />
       )}
 
       {quote?.pool_exists && (

--- a/src/pages/compose/pool/withdraw/form.tsx
+++ b/src/pages/compose/pool/withdraw/form.tsx
@@ -1,0 +1,201 @@
+import { useEffect, useMemo, useState, type ReactElement } from "react";
+import { useFormStatus } from "react-dom";
+import { ComposerForm } from "@/components/composer/composer-form";
+import { ErrorAlert } from "@/components/ui/error-alert";
+import { AmountWithMaxInput } from "@/components/ui/inputs/amount-with-max-input";
+import { Spinner } from "@/components/ui/spinner";
+import { useComposer } from "@/contexts/composer-context";
+import { useAssetDetails } from "@/hooks/useAssetDetails";
+import { useLpAssetPool } from "@/hooks/useLpAssetPool";
+import { fetchPoolWithdrawQuote, type PoolWithdrawQuote } from "@/utils/blockchain/counterparty/api";
+import { BigNumber, isValidPositiveNumber, toBigNumber, toSatoshis, fromSatoshis } from "@/utils/numeric";
+import type { PoolWithdrawOptions } from "@/utils/blockchain/counterparty/compose";
+import { SlippageInput } from "../slippage-input";
+
+interface PoolWithdrawFormProps {
+  formAction: (formData: FormData) => void;
+  initialFormData: PoolWithdrawOptions | null;
+  lpAsset: string;
+}
+
+function applySlippage(value: number | string | null | undefined, slippagePercent: string): string {
+  if (value === null || value === undefined) return "0";
+
+  const bps = toBigNumber(slippagePercent || "0").times(100);
+  const multiplier = BigNumber.maximum(0, toBigNumber(10000).minus(bps));
+
+  return toBigNumber(value)
+    .times(multiplier)
+    .div(10000)
+    .integerValue(BigNumber.ROUND_DOWN)
+    .toString();
+}
+
+export function PoolWithdrawForm({
+  formAction,
+  initialFormData,
+  lpAsset,
+}: PoolWithdrawFormProps): ReactElement {
+  const { activeAddress, showHelpText, feeRate } = useComposer<PoolWithdrawOptions>();
+  const { pending } = useFormStatus();
+  const { data: pool, isLoading } = useLpAssetPool(lpAsset);
+  const { data: assetADetails } = useAssetDetails(pool?.asset_a || "");
+  const { data: assetBDetails } = useAssetDetails(pool?.asset_b || "");
+  const [quantity, setQuantity] = useState(initialFormData?.quantity?.toString() || "");
+  const [slippage, setSlippage] = useState("1");
+  const [localError, setLocalError] = useState<string | null>(null);
+  const [quote, setQuote] = useState<PoolWithdrawQuote | null>(null);
+  const [isLoadingQuote, setIsLoadingQuote] = useState(false);
+
+  const canQuote = !!pool && toBigNumber(quantity || 0).isGreaterThan(0);
+  const isAssetADivisible = assetADetails?.isDivisible ?? true;
+  const isAssetBDivisible = assetBDetails?.isDivisible ?? true;
+
+  const formatReceived = (value: number | string | undefined, divisible: boolean): string => {
+    if (value === undefined) return "0";
+    return divisible ? fromSatoshis(value.toString(), { removeTrailingZeros: true }) : value.toString();
+  };
+
+  const minQuantityA = applySlippage(quote?.quantity_a_estimate, slippage);
+  const minQuantityB = applySlippage(quote?.quantity_b_estimate, slippage);
+  const hasMinimums = toBigNumber(minQuantityA).isGreaterThan(0) || toBigNumber(minQuantityB).isGreaterThan(0);
+  const isSlippageValid = isValidPositiveNumber(slippage, { allowZero: true, maxDecimals: 2 })
+    && toBigNumber(slippage).isLessThanOrEqualTo(50);
+
+  useEffect(() => {
+    if (!pool || !canQuote) {
+      setQuote(null);
+      return;
+    }
+
+    let cancelled = false;
+    const timer = setTimeout(() => {
+      setIsLoadingQuote(true);
+      fetchPoolWithdrawQuote(pool.asset_a, pool.asset_b, toSatoshis(quantity))
+        .then((result) => {
+          if (!cancelled) setQuote(result);
+        })
+        .catch(() => {
+          if (!cancelled) setQuote(null);
+        })
+        .finally(() => {
+          if (!cancelled) setIsLoadingQuote(false);
+        });
+    }, 300);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [pool, quantity, canQuote]);
+
+  const submitDisabled = useMemo(() => {
+    if (!pool) return true;
+    if (!toBigNumber(quantity || 0).isGreaterThan(0)) return true;
+    if (toBigNumber(quantity).isGreaterThan(pool.quantity_normalized ?? pool.quantity)) return true;
+    if (!isSlippageValid) return true;
+    return false;
+  }, [pool, quantity, isSlippageValid]);
+
+  const handleFormAction = (formData: FormData) => {
+    if (!pool) return;
+    formData.set("lp_asset", pool.lp_asset);
+    formData.set("asset_a", pool.asset_a);
+    formData.set("asset_b", pool.asset_b);
+    formData.set("quantity", quantity);
+    formData.set("min_quantity_a", minQuantityA);
+    formData.set("min_quantity_b", minQuantityB);
+    formAction(formData);
+  };
+
+  if (isLoading) {
+    return <Spinner message="Loading pool position..." className="min-h-[240px]" />;
+  }
+
+  if (!pool) {
+    return <div className="p-4 text-center text-gray-600">Pool position not found</div>;
+  }
+
+  return (
+    <ComposerForm
+      formAction={handleFormAction}
+      submitText="Review Withdrawal"
+      submitDisabled={pending || submitDisabled}
+    >
+      {localError && <ErrorAlert message={localError} onClose={() => setLocalError(null)} />}
+
+      <div className="rounded border border-gray-200 bg-gray-50 p-3 text-sm text-gray-700">
+        <div className="font-semibold text-gray-900">{pool.asset_a} / {pool.asset_b}</div>
+        <div className="mt-1 text-gray-600">LP Asset: {pool.lp_asset}</div>
+        <div className="mt-1 text-gray-600">Available: {pool.quantity_normalized ?? pool.quantity}</div>
+      </div>
+
+      <AmountWithMaxInput
+        asset={pool.lp_asset}
+        availableBalance={pool.quantity_normalized ?? pool.quantity.toString()}
+        value={quantity}
+        onChange={setQuantity}
+        feeRate={feeRate}
+        setError={setLocalError}
+        showHelpText={showHelpText}
+        sourceAddress={activeAddress}
+        maxAmount={pool.quantity_normalized ?? pool.quantity.toString()}
+        label="LP Tokens to Withdraw"
+        name="quantity_display"
+        disabled={pending}
+        isDivisible
+      />
+
+      {isLoadingQuote && (
+        <p className="text-sm text-gray-500">Loading withdrawal quote...</p>
+      )}
+
+      {quote?.pool_exists && (
+        <div className="rounded border border-gray-200 bg-gray-50 p-3 text-sm text-gray-600">
+          Estimated receive:
+          <div className="mt-1 font-medium text-gray-900">
+            {formatReceived(quote.quantity_a_estimate, isAssetADivisible)} {pool.asset_a}
+          </div>
+          <div className="font-medium text-gray-900">
+            {formatReceived(quote.quantity_b_estimate, isAssetBDivisible)} {pool.asset_b}
+          </div>
+        </div>
+      )}
+
+      {quote?.pool_exists && (
+        <>
+          <SlippageInput
+            value={slippage}
+            onChange={setSlippage}
+            showHelpText={showHelpText}
+          />
+
+          {hasMinimums && (
+            <div className="rounded border border-gray-200 bg-gray-50 p-3 text-sm text-gray-600">
+              Minimum received after {slippage || "0"}% slippage:
+              <div className="mt-1 font-medium text-gray-900">
+                {formatReceived(minQuantityA, isAssetADivisible)} {pool.asset_a}
+              </div>
+              <div className="font-medium text-gray-900">
+                {formatReceived(minQuantityB, isAssetBDivisible)} {pool.asset_b}
+              </div>
+            </div>
+          )}
+        </>
+      )}
+
+      {quote?.message && (
+        <div className="rounded border border-gray-200 bg-gray-50 p-3 text-sm text-gray-600">
+          {quote.message}
+        </div>
+      )}
+
+      <input type="hidden" name="lp_asset" value={pool.lp_asset} />
+      <input type="hidden" name="asset_a" value={pool.asset_a} />
+      <input type="hidden" name="asset_b" value={pool.asset_b} />
+      <input type="hidden" name="quantity" value={quantity} />
+      <input type="hidden" name="min_quantity_a" value={minQuantityA} />
+      <input type="hidden" name="min_quantity_b" value={minQuantityB} />
+    </ComposerForm>
+  );
+}

--- a/src/pages/compose/pool/withdraw/form.tsx
+++ b/src/pages/compose/pool/withdraw/form.tsx
@@ -8,7 +8,7 @@ import { useComposer } from "@/contexts/composer-context";
 import { useAssetDetails } from "@/hooks/useAssetDetails";
 import { useLpAssetPool } from "@/hooks/useLpAssetPool";
 import { fetchPoolWithdrawQuote, type PoolWithdrawQuote } from "@/utils/blockchain/counterparty/api";
-import { BigNumber, isValidPositiveNumber, toBigNumber, toSatoshis, fromSatoshis } from "@/utils/numeric";
+import { applySlippage, fromSatoshis, isValidPositiveNumber, toBigNumber, toSatoshis } from "@/utils/numeric";
 import type { PoolWithdrawOptions } from "@/utils/blockchain/counterparty/compose";
 import { DEFAULT_POOL_SLIPPAGE, SlippageInput } from "../slippage-input";
 
@@ -16,19 +16,6 @@ interface PoolWithdrawFormProps {
   formAction: (formData: FormData) => void;
   initialFormData: PoolWithdrawOptions | null;
   lpAsset: string;
-}
-
-function applySlippage(value: number | string | null | undefined, slippagePercent: string): string {
-  if (value === null || value === undefined) return "0";
-
-  const bps = toBigNumber(slippagePercent || "0").times(100);
-  const multiplier = BigNumber.maximum(0, toBigNumber(10000).minus(bps));
-
-  return toBigNumber(value)
-    .times(multiplier)
-    .div(10000)
-    .integerValue(BigNumber.ROUND_DOWN)
-    .toString();
 }
 
 export function PoolWithdrawForm({

--- a/src/pages/compose/pool/withdraw/form.tsx
+++ b/src/pages/compose/pool/withdraw/form.tsx
@@ -42,7 +42,7 @@ export function PoolWithdrawForm({
   const { data: assetADetails } = useAssetDetails(pool?.asset_a || "");
   const { data: assetBDetails } = useAssetDetails(pool?.asset_b || "");
   const [quantity, setQuantity] = useState(initialFormData?.quantity?.toString() || "");
-  const [slippage, setSlippage] = useState("1");
+  const [slippage, setSlippage] = useState((initialFormData as PoolWithdrawOptions & { slippage?: string })?.slippage || "1");
   const [localError, setLocalError] = useState<string | null>(null);
   const [quote, setQuote] = useState<PoolWithdrawQuote | null>(null);
   const [isLoadingQuote, setIsLoadingQuote] = useState(false);
@@ -196,6 +196,7 @@ export function PoolWithdrawForm({
       <input type="hidden" name="quantity" value={quantity} />
       <input type="hidden" name="min_quantity_a" value={minQuantityA} />
       <input type="hidden" name="min_quantity_b" value={minQuantityB} />
+      <input type="hidden" name="slippage" value={slippage} />
     </ComposerForm>
   );
 }

--- a/src/pages/compose/pool/withdraw/index.tsx
+++ b/src/pages/compose/pool/withdraw/index.tsx
@@ -1,0 +1,22 @@
+import { useParams } from "react-router-dom";
+import { Composer } from "@/components/composer/composer";
+import { composePoolWithdraw, type PoolWithdrawOptions } from "@/utils/blockchain/counterparty/compose";
+import { PoolWithdrawForm } from "./form";
+import { ReviewPoolWithdraw } from "./review";
+
+export default function ComposePoolWithdrawPage() {
+  const { lpAsset } = useParams<{ lpAsset: string }>();
+  const asset = lpAsset ? decodeURIComponent(lpAsset) : "";
+
+  return (
+    <div className="p-4">
+      <Composer<PoolWithdrawOptions>
+        composeType="poolwithdraw"
+        composeApiMethod={composePoolWithdraw}
+        initialTitle="Pool Withdraw"
+        FormComponent={(props) => <PoolWithdrawForm {...props} lpAsset={asset} />}
+        ReviewComponent={ReviewPoolWithdraw}
+      />
+    </div>
+  );
+}

--- a/src/pages/compose/pool/withdraw/review.tsx
+++ b/src/pages/compose/pool/withdraw/review.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useState } from "react";
+import { ReviewScreen } from "@/components/screens/review-screen";
+import { useMarketPrices } from "@/hooks/useMarketPrices";
+import { useSettings } from "@/contexts/settings-context";
+import { getPoolWithdrawEstimateXcpFee } from "@/utils/blockchain/counterparty/compose";
+import { formatAmount } from "@/utils/format";
+import { fromSatoshis } from "@/utils/numeric";
+
+interface ReviewPoolWithdrawProps {
+  apiResponse: any;
+  onSign: () => void;
+  onBack: () => void;
+  error: string | null;
+  isSigning: boolean;
+}
+
+export function ReviewPoolWithdraw({
+  apiResponse,
+  onSign,
+  onBack,
+  error,
+  isSigning,
+}: ReviewPoolWithdrawProps) {
+  const { result } = apiResponse;
+  const params = result.params;
+  const { settings } = useSettings();
+  const { xcp: xcpPrice } = useMarketPrices(settings.fiat);
+  const [xcpFeeEstimate, setXcpFeeEstimate] = useState<number | null>(null);
+  const [feeLoading, setFeeLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchFeeEstimate = async () => {
+      try {
+        const sourceAddress = params.source;
+        if (sourceAddress) {
+          const fee = await getPoolWithdrawEstimateXcpFee(sourceAddress);
+          setXcpFeeEstimate(fee);
+        }
+      } catch (err) {
+        console.error("Failed to fetch pool withdraw XCP fee estimate:", err);
+      } finally {
+        setFeeLoading(false);
+      }
+    };
+
+    fetchFeeEstimate();
+  }, [params.source]);
+
+  const xcpFeeInXcp = xcpFeeEstimate !== null ? fromSatoshis(xcpFeeEstimate, true) : null;
+  const xcpFeeInFiat = xcpFeeInXcp !== null && xcpPrice ? xcpFeeInXcp * xcpPrice : null;
+
+  const customFields = [
+    {
+      label: "Pool",
+      value: params.asset_a && params.asset_b ? `${params.asset_a} / ${params.asset_b}` : params.lp_asset,
+    },
+    {
+      label: "Withdraw",
+      value: `${params.quantity_normalized ?? params.quantity} ${params.lp_asset ?? "LP"}`,
+    },
+    ...(params.min_quantity_a || params.min_quantity_b
+      ? [{
+          label: "Minimum Receive",
+          value: `${params.min_quantity_a_normalized ?? params.min_quantity_a ?? "0"} ${params.asset_a ?? ""}\n${params.min_quantity_b_normalized ?? params.min_quantity_b ?? "0"} ${params.asset_b ?? ""}`,
+        }]
+      : []),
+    {
+      label: "XCP Fee",
+      value: feeLoading
+        ? "Loading..."
+        : xcpFeeEstimate !== null
+          ? `${formatAmount({
+              value: xcpFeeInXcp!,
+              minimumFractionDigits: 8,
+              maximumFractionDigits: 8,
+            })} XCP`
+          : "Unable to estimate",
+      rightElement: !feeLoading && xcpFeeInFiat !== null
+        ? <span className="text-gray-500">${formatAmount({ value: xcpFeeInFiat, minimumFractionDigits: 2, maximumFractionDigits: 2 })}</span>
+        : undefined,
+    },
+  ];
+
+  return (
+    <ReviewScreen
+      apiResponse={apiResponse}
+      onSign={onSign}
+      onBack={onBack}
+      customFields={customFields}
+      error={error}
+      isSigning={isSigning}
+    />
+  );
+}

--- a/src/pages/compose/pool/withdraw/review.tsx
+++ b/src/pages/compose/pool/withdraw/review.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { ReviewScreen } from "@/components/screens/review-screen";
 import { useMarketPrices } from "@/hooks/useMarketPrices";
 import { useSettings } from "@/contexts/settings-context";
+import { useAssetInfo } from "@/hooks/useAssetInfo";
 import { getPoolWithdrawEstimateXcpFee } from "@/utils/blockchain/counterparty/compose";
 import { formatAmount } from "@/utils/format";
 import { fromSatoshis } from "@/utils/numeric";
@@ -25,6 +26,8 @@ export function ReviewPoolWithdraw({
   const params = result.params;
   const { settings } = useSettings();
   const { xcp: xcpPrice } = useMarketPrices(settings.fiat);
+  const { data: assetAInfo, isLoading: isLoadingAssetA } = useAssetInfo(params.asset_a || "");
+  const { data: assetBInfo, isLoading: isLoadingAssetB } = useAssetInfo(params.asset_b || "");
   const [xcpFeeEstimate, setXcpFeeEstimate] = useState<number | null>(null);
   const [feeLoading, setFeeLoading] = useState(true);
 
@@ -48,6 +51,19 @@ export function ReviewPoolWithdraw({
 
   const xcpFeeInXcp = xcpFeeEstimate !== null ? fromSatoshis(xcpFeeEstimate, true) : null;
   const xcpFeeInFiat = xcpFeeInXcp !== null && xcpPrice ? xcpFeeInXcp * xcpPrice : null;
+  const formatMinimum = (
+    normalized: string | undefined,
+    raw: string | number | undefined,
+    divisible: boolean | undefined,
+    isLoadingAsset: boolean
+  ) => {
+    if (normalized !== undefined) return normalized;
+    if (raw === undefined) return "0";
+    if (divisible === undefined && isLoadingAsset) return "Loading...";
+    return divisible ? fromSatoshis(raw, { removeTrailingZeros: true }) : raw.toString();
+  };
+  const minQuantityADisplay = formatMinimum(params.min_quantity_a_normalized, params.min_quantity_a, assetAInfo?.divisible, isLoadingAssetA);
+  const minQuantityBDisplay = formatMinimum(params.min_quantity_b_normalized, params.min_quantity_b, assetBInfo?.divisible, isLoadingAssetB);
 
   const customFields = [
     {
@@ -61,7 +77,7 @@ export function ReviewPoolWithdraw({
     ...(params.min_quantity_a || params.min_quantity_b
       ? [{
           label: "Minimum Receive",
-          value: `${params.min_quantity_a_normalized ?? params.min_quantity_a ?? "0"} ${params.asset_a ?? ""}\n${params.min_quantity_b_normalized ?? params.min_quantity_b ?? "0"} ${params.asset_b ?? ""}`,
+          value: `${minQuantityADisplay} ${params.asset_a ?? ""}\n${minQuantityBDisplay} ${params.asset_b ?? ""}`,
         }]
       : []),
     {

--- a/src/pages/compose/pool/withdraw/review.tsx
+++ b/src/pages/compose/pool/withdraw/review.tsx
@@ -64,6 +64,8 @@ export function ReviewPoolWithdraw({
   };
   const minQuantityADisplay = formatMinimum(params.min_quantity_a_normalized, params.min_quantity_a, assetAInfo?.divisible, isLoadingAssetA);
   const minQuantityBDisplay = formatMinimum(params.min_quantity_b_normalized, params.min_quantity_b, assetBInfo?.divisible, isLoadingAssetB);
+  const quantityDisplay = params.quantity_normalized
+    ?? fromSatoshis(params.quantity ?? 0, { removeTrailingZeros: true });
 
   const customFields = [
     {
@@ -72,7 +74,7 @@ export function ReviewPoolWithdraw({
     },
     {
       label: "Withdraw",
-      value: `${params.quantity_normalized ?? params.quantity} ${params.lp_asset ?? "LP"}`,
+      value: `${quantityDisplay} ${params.lp_asset ?? "LP"}`,
     },
     ...(params.min_quantity_a || params.min_quantity_b
       ? [{

--- a/src/pages/compose/pool/withdraw/review.tsx
+++ b/src/pages/compose/pool/withdraw/review.tsx
@@ -4,6 +4,7 @@ import { useMarketPrices } from "@/hooks/useMarketPrices";
 import { useSettings } from "@/contexts/settings-context";
 import { useAssetInfo } from "@/hooks/useAssetInfo";
 import { getPoolWithdrawEstimateXcpFee } from "@/utils/blockchain/counterparty/compose";
+import { getCanonicalPoolPair } from "@/utils/blockchain/counterparty/pool";
 import { formatAmount } from "@/utils/format";
 import { fromSatoshis } from "@/utils/numeric";
 
@@ -70,7 +71,7 @@ export function ReviewPoolWithdraw({
   const customFields = [
     {
       label: "Pool",
-      value: params.asset_a && params.asset_b ? `${params.asset_a} / ${params.asset_b}` : params.lp_asset,
+      value: params.asset_a && params.asset_b ? getCanonicalPoolPair(params.asset_a, params.asset_b) : params.lp_asset,
     },
     {
       label: "Withdraw",

--- a/src/pages/pools/[lpAsset].tsx
+++ b/src/pages/pools/[lpAsset].tsx
@@ -3,10 +3,12 @@ import { useNavigate, useParams } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { ErrorAlert } from "@/components/ui/error-alert";
+import { PoolHeader } from "@/components/ui/headers/pool-header";
 import { ActionList } from "@/components/ui/lists/action-list";
 import { useHeader } from "@/contexts/header-context";
 import { useAssetInfo } from "@/hooks/useAssetInfo";
 import { useLpAssetPool } from "@/hooks/useLpAssetPool";
+import { getCanonicalPoolAssets, getCanonicalPoolPair } from "@/utils/blockchain/counterparty/pool";
 import { divide, formatDecimal, isGreaterThan, multiply, toBigNumber } from "@/utils/numeric";
 
 import type { ReactElement } from "react";
@@ -42,10 +44,15 @@ export default function PoolPositionPage(): ReactElement {
     return <div className="p-4 text-center text-gray-600">Pool position not found</div>;
   }
 
-  const pair = `${pool.asset_a} / ${pool.asset_b}`;
-  const lpBalance = toBigNumber(pool.quantity_normalized ?? pool.quantity);
+  const pair = getCanonicalPoolPair(pool.asset_a, pool.asset_b);
+  const [firstReserveAsset, secondReserveAsset] = getCanonicalPoolAssets(pool.asset_a, pool.asset_b);
+  const reserveByAsset = {
+    [pool.asset_a]: pool.reserve_a_normalized ?? pool.reserve_a,
+    [pool.asset_b]: pool.reserve_b_normalized ?? pool.reserve_b,
+  };
+  const lpBalanceValue = toBigNumber(pool.quantity_normalized ?? pool.quantity);
   const lpSupply = toBigNumber(lpAssetInfo?.supply_normalized);
-  const poolShare = isGreaterThan(lpSupply, 0) ? divide(lpBalance, lpSupply) : null;
+  const poolShare = isGreaterThan(lpSupply, 0) ? divide(lpBalanceValue, lpSupply) : null;
   const poolSharePercent = poolShare ? formatDecimal(multiply(poolShare, 100), 4) : null;
   const underlyingA = poolShare
     ? formatDecimal(multiply(poolShare, pool.reserve_a_normalized ?? pool.reserve_a))
@@ -55,32 +62,29 @@ export default function PoolPositionPage(): ReactElement {
     : null;
 
   return (
-    <div className="p-4 space-y-6" role="main" aria-labelledby="pool-title">
-      <section className="space-y-4">
+    <div className="p-4 space-y-6" role="main" aria-label={pair}>
+      <section className="space-y-5">
         <div>
-          <h1 id="pool-title" className="text-xl font-semibold text-gray-900">{pair}</h1>
-          <p className="mt-1 text-sm text-gray-500">{pool.lp_asset}</p>
+          <PoolHeader pool={pool} className="mt-1 mb-5" />
         </div>
 
         <div className="rounded border border-gray-200 bg-white">
+          <div className="border-b border-gray-200 p-4">
+            <div className="text-xs font-medium uppercase text-gray-500">LP Asset</div>
+            <div className="mt-1 break-all text-sm font-semibold text-gray-900">{pool.lp_asset}</div>
+          </div>
           <div className="grid grid-cols-2 divide-x divide-gray-200 border-b border-gray-200">
             <div className="p-4">
-              <div className="text-xs font-medium uppercase text-gray-500">Reserve {pool.asset_a}</div>
+              <div className="text-xs font-medium uppercase text-gray-500">Reserve {firstReserveAsset}</div>
               <div className="mt-1 text-sm font-semibold text-gray-900">
-                {pool.reserve_a_normalized ?? pool.reserve_a}
+                {reserveByAsset[firstReserveAsset]}
               </div>
             </div>
             <div className="p-4">
-              <div className="text-xs font-medium uppercase text-gray-500">Reserve {pool.asset_b}</div>
+              <div className="text-xs font-medium uppercase text-gray-500">Reserve {secondReserveAsset}</div>
               <div className="mt-1 text-sm font-semibold text-gray-900">
-                {pool.reserve_b_normalized ?? pool.reserve_b}
+                {reserveByAsset[secondReserveAsset]}
               </div>
-            </div>
-          </div>
-          <div className="p-4">
-            <div className="text-xs font-medium uppercase text-gray-500">Your LP balance</div>
-            <div className="mt-1 text-sm font-semibold text-gray-900">
-              {pool.quantity_normalized ?? pool.quantity}
             </div>
           </div>
           {poolSharePercent && underlyingA && underlyingB && (

--- a/src/pages/pools/[lpAsset].tsx
+++ b/src/pages/pools/[lpAsset].tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
+import { ErrorAlert } from "@/components/ui/error-alert";
 import { ActionList } from "@/components/ui/lists/action-list";
 import { useHeader } from "@/contexts/header-context";
 import { useAssetInfo } from "@/hooks/useAssetInfo";
@@ -15,7 +16,7 @@ export default function PoolPositionPage(): ReactElement {
   const navigate = useNavigate();
   const { setHeaderProps } = useHeader();
   const asset = lpAsset ? decodeURIComponent(lpAsset) : undefined;
-  const { data: pool, isLoading } = useLpAssetPool(asset);
+  const { data: pool, isLoading, error } = useLpAssetPool(asset);
   const { data: lpAssetInfo } = useAssetInfo(pool?.lp_asset || "");
 
   useEffect(() => {
@@ -31,6 +32,13 @@ export default function PoolPositionPage(): ReactElement {
   }
 
   if (!pool) {
+    if (error) {
+      return (
+        <div className="p-4">
+          <ErrorAlert message={error.message} />
+        </div>
+      );
+    }
     return <div className="p-4 text-center text-gray-600">Pool position not found</div>;
   }
 

--- a/src/pages/pools/[lpAsset].tsx
+++ b/src/pages/pools/[lpAsset].tsx
@@ -7,7 +7,7 @@ import { ActionList } from "@/components/ui/lists/action-list";
 import { useHeader } from "@/contexts/header-context";
 import { useAssetInfo } from "@/hooks/useAssetInfo";
 import { useLpAssetPool } from "@/hooks/useLpAssetPool";
-import { formatDecimal, toBigNumber } from "@/utils/numeric";
+import { divide, formatDecimal, isGreaterThan, multiply, toBigNumber } from "@/utils/numeric";
 
 import type { ReactElement } from "react";
 
@@ -45,13 +45,13 @@ export default function PoolPositionPage(): ReactElement {
   const pair = `${pool.asset_a} / ${pool.asset_b}`;
   const lpBalance = toBigNumber(pool.quantity_normalized ?? pool.quantity);
   const lpSupply = toBigNumber(lpAssetInfo?.supply_normalized);
-  const poolShare = lpSupply.isGreaterThan(0) ? lpBalance.div(lpSupply) : null;
-  const poolSharePercent = poolShare ? formatDecimal(poolShare.times(100), 4) : null;
+  const poolShare = isGreaterThan(lpSupply, 0) ? divide(lpBalance, lpSupply) : null;
+  const poolSharePercent = poolShare ? formatDecimal(multiply(poolShare, 100), 4) : null;
   const underlyingA = poolShare
-    ? formatDecimal(poolShare.times(toBigNumber(pool.reserve_a_normalized ?? pool.reserve_a)))
+    ? formatDecimal(multiply(poolShare, pool.reserve_a_normalized ?? pool.reserve_a))
     : null;
   const underlyingB = poolShare
-    ? formatDecimal(poolShare.times(toBigNumber(pool.reserve_b_normalized ?? pool.reserve_b)))
+    ? formatDecimal(multiply(poolShare, pool.reserve_b_normalized ?? pool.reserve_b))
     : null;
 
   return (

--- a/src/pages/pools/[lpAsset].tsx
+++ b/src/pages/pools/[lpAsset].tsx
@@ -1,0 +1,99 @@
+import { useEffect } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import { ActionList } from "@/components/ui/lists/action-list";
+import { useHeader } from "@/contexts/header-context";
+import { useLpAssetPool } from "@/hooks/useLpAssetPool";
+
+import type { ReactElement } from "react";
+
+export default function PoolPositionPage(): ReactElement {
+  const { lpAsset } = useParams<{ lpAsset: string }>();
+  const navigate = useNavigate();
+  const { setHeaderProps } = useHeader();
+  const asset = lpAsset ? decodeURIComponent(lpAsset) : undefined;
+  const { data: pool, isLoading } = useLpAssetPool(asset);
+
+  useEffect(() => {
+    setHeaderProps({
+      title: "Pool",
+      onBack: () => navigate(-1),
+    });
+    return () => setHeaderProps(null);
+  }, [navigate, setHeaderProps]);
+
+  if (isLoading) {
+    return <Spinner message="Loading pool position..." />;
+  }
+
+  if (!pool) {
+    return <div className="p-4 text-center text-gray-600">Pool position not found</div>;
+  }
+
+  const pair = `${pool.asset_a} / ${pool.asset_b}`;
+
+  return (
+    <div className="p-4 space-y-6" role="main" aria-labelledby="pool-title">
+      <section className="space-y-4">
+        <div>
+          <h1 id="pool-title" className="text-xl font-semibold text-gray-900">{pair}</h1>
+          <p className="mt-1 text-sm text-gray-500">{pool.lp_asset}</p>
+        </div>
+
+        <div className="rounded border border-gray-200 bg-white">
+          <div className="grid grid-cols-2 divide-x divide-gray-200 border-b border-gray-200">
+            <div className="p-4">
+              <div className="text-xs font-medium uppercase text-gray-500">Reserve {pool.asset_a}</div>
+              <div className="mt-1 text-sm font-semibold text-gray-900">
+                {pool.reserve_a_normalized ?? pool.reserve_a}
+              </div>
+            </div>
+            <div className="p-4">
+              <div className="text-xs font-medium uppercase text-gray-500">Reserve {pool.asset_b}</div>
+              <div className="mt-1 text-sm font-semibold text-gray-900">
+                {pool.reserve_b_normalized ?? pool.reserve_b}
+              </div>
+            </div>
+          </div>
+          <div className="p-4">
+            <div className="text-xs font-medium uppercase text-gray-500">Your LP balance</div>
+            <div className="mt-1 text-sm font-semibold text-gray-900">
+              {pool.quantity_normalized ?? pool.quantity}
+            </div>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <Button fullWidth disabled title="Pool deposit compose UI is not available yet">
+            Deposit
+          </Button>
+          <Button fullWidth disabled title="Pool withdrawal compose UI is not available yet">
+            Withdraw
+          </Button>
+        </div>
+      </section>
+
+      <ActionList
+        sections={[
+          {
+            items: [
+              {
+                id: "trade-a",
+                title: `Trade ${pool.asset_a}`,
+                description: `Open DEX order flow for ${pool.asset_a}`,
+                onClick: () => navigate(`/compose/order/${encodeURIComponent(pool.asset_a)}`),
+              },
+              {
+                id: "trade-b",
+                title: `Trade ${pool.asset_b}`,
+                description: `Open DEX order flow for ${pool.asset_b}`,
+                onClick: () => navigate(`/compose/order/${encodeURIComponent(pool.asset_b)}`),
+              },
+            ],
+          },
+        ]}
+      />
+    </div>
+  );
+}

--- a/src/pages/pools/[lpAsset].tsx
+++ b/src/pages/pools/[lpAsset].tsx
@@ -4,7 +4,9 @@ import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { ActionList } from "@/components/ui/lists/action-list";
 import { useHeader } from "@/contexts/header-context";
+import { useAssetInfo } from "@/hooks/useAssetInfo";
 import { useLpAssetPool } from "@/hooks/useLpAssetPool";
+import { formatDecimal, toBigNumber } from "@/utils/numeric";
 
 import type { ReactElement } from "react";
 
@@ -14,6 +16,7 @@ export default function PoolPositionPage(): ReactElement {
   const { setHeaderProps } = useHeader();
   const asset = lpAsset ? decodeURIComponent(lpAsset) : undefined;
   const { data: pool, isLoading } = useLpAssetPool(asset);
+  const { data: lpAssetInfo } = useAssetInfo(pool?.lp_asset || "");
 
   useEffect(() => {
     setHeaderProps({
@@ -32,6 +35,16 @@ export default function PoolPositionPage(): ReactElement {
   }
 
   const pair = `${pool.asset_a} / ${pool.asset_b}`;
+  const lpBalance = toBigNumber(pool.quantity_normalized ?? pool.quantity);
+  const lpSupply = toBigNumber(lpAssetInfo?.supply_normalized);
+  const poolShare = lpSupply.isGreaterThan(0) ? lpBalance.div(lpSupply) : null;
+  const poolSharePercent = poolShare ? formatDecimal(poolShare.times(100), 4) : null;
+  const underlyingA = poolShare
+    ? formatDecimal(poolShare.times(toBigNumber(pool.reserve_a_normalized ?? pool.reserve_a)))
+    : null;
+  const underlyingB = poolShare
+    ? formatDecimal(poolShare.times(toBigNumber(pool.reserve_b_normalized ?? pool.reserve_b)))
+    : null;
 
   return (
     <div className="p-4 space-y-6" role="main" aria-labelledby="pool-title">
@@ -62,13 +75,36 @@ export default function PoolPositionPage(): ReactElement {
               {pool.quantity_normalized ?? pool.quantity}
             </div>
           </div>
+          {poolSharePercent && underlyingA && underlyingB && (
+            <div className="grid grid-cols-2 divide-x divide-gray-200 border-t border-gray-200">
+              <div className="p-4">
+                <div className="text-xs font-medium uppercase text-gray-500">Pool share</div>
+                <div className="mt-1 text-sm font-semibold text-gray-900">{poolSharePercent}%</div>
+              </div>
+              <div className="p-4">
+                <div className="text-xs font-medium uppercase text-gray-500">Underlying</div>
+                <div className="mt-1 text-sm font-semibold text-gray-900">
+                  {underlyingA} {pool.asset_a}
+                </div>
+                <div className="text-sm font-semibold text-gray-900">
+                  {underlyingB} {pool.asset_b}
+                </div>
+              </div>
+            </div>
+          )}
         </div>
 
         <div className="grid grid-cols-2 gap-3">
-          <Button fullWidth disabled title="Pool deposit compose UI is not available yet">
+          <Button
+            fullWidth
+            onClick={() => navigate(`/compose/pool/deposit/${encodeURIComponent(pool.asset_a)}/${encodeURIComponent(pool.asset_b)}`)}
+          >
             Deposit
           </Button>
-          <Button fullWidth disabled title="Pool withdrawal compose UI is not available yet">
+          <Button
+            fullWidth
+            onClick={() => navigate(`/compose/pool/withdraw/${encodeURIComponent(pool.lp_asset)}`)}
+          >
             Withdraw
           </Button>
         </div>

--- a/src/pages/pools/index.tsx
+++ b/src/pages/pools/index.tsx
@@ -1,0 +1,109 @@
+import { useEffect, useState, type ReactElement } from "react";
+import { useNavigate } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import { ErrorAlert } from "@/components/ui/error-alert";
+import { ActionList, type ActionSection } from "@/components/ui/lists/action-list";
+import { useHeader } from "@/contexts/header-context";
+import { useWallet } from "@/contexts/wallet-context";
+import { fetchAddressPools, type PoolPosition } from "@/utils/blockchain/counterparty/api";
+
+export default function ManagePoolsPage(): ReactElement {
+  const navigate = useNavigate();
+  const { setHeaderProps } = useHeader();
+  const { activeAddress } = useWallet();
+  const [positions, setPositions] = useState<PoolPosition[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setHeaderProps({
+      title: "Pools",
+      onBack: () => navigate("/actions"),
+    });
+    return () => setHeaderProps(null);
+  }, [navigate, setHeaderProps]);
+
+  useEffect(() => {
+    if (!activeAddress?.address) {
+      setPositions([]);
+      return;
+    }
+
+    let cancelled = false;
+    setIsLoading(true);
+    setError(null);
+
+    fetchAddressPools(activeAddress.address, { limit: 100 })
+      .then((response) => {
+        if (cancelled) return;
+        setPositions(response.result);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : "Failed to load pool positions");
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeAddress?.address]);
+
+  const sections: ActionSection[] = [
+    {
+      title: "Pools",
+      items: [
+        {
+          id: "enter-pool",
+          title: "Enter Pool",
+          description: "Deposit assets into a liquidity pool",
+          onClick: () => navigate("/compose/pool/deposit"),
+        },
+      ],
+    },
+  ];
+
+  if (positions.length > 0) {
+    sections.push({
+      title: "Your Positions",
+      items: positions.map((position) => ({
+        id: position.lp_asset,
+        title: `${position.asset_a} / ${position.asset_b}`,
+        description: `${position.quantity_normalized ?? position.quantity} ${position.lp_asset}`,
+        onClick: () => navigate(`/pools/${encodeURIComponent(position.lp_asset)}`),
+      })),
+    });
+  }
+
+  return (
+    <div className="flex flex-col h-full" role="main" aria-labelledby="pools-title">
+      <h2 id="pools-title" className="sr-only">Manage Pools</h2>
+      <div className="flex-1 overflow-auto no-scrollbar p-4 space-y-4">
+        {error && <ErrorAlert message={error} onClose={() => setError(null)} />}
+        {isLoading ? (
+          <Spinner message="Loading pools..." className="min-h-[240px]" />
+        ) : (
+          <>
+            <ActionList sections={sections} />
+            {positions.length === 0 && (
+              <div className="rounded border border-gray-200 bg-white p-4 text-sm text-gray-600">
+                <p>No LP positions were found for this address.</p>
+                <Button
+                  type="button"
+                  fullWidth
+                  className="mt-4"
+                  onClick={() => navigate("/compose/pool/deposit")}
+                >
+                  Enter Pool
+                </Button>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/pools/index.tsx
+++ b/src/pages/pools/index.tsx
@@ -8,6 +8,7 @@ import { useHeader } from "@/contexts/header-context";
 import { useWallet } from "@/contexts/wallet-context";
 import { useInView } from "@/hooks/useInView";
 import { fetchAddressPools, type PoolPosition } from "@/utils/blockchain/counterparty/api";
+import { getCanonicalPoolPair } from "@/utils/blockchain/counterparty/pool";
 
 const PAGE_SIZE = 20;
 
@@ -133,7 +134,7 @@ export default function ManagePoolsPage(): ReactElement {
       title: "Your Positions",
       items: positions.map((position) => ({
         id: position.lp_asset,
-        title: `${position.asset_a} / ${position.asset_b}`,
+        title: getCanonicalPoolPair(position.asset_a, position.asset_b),
         description: `${position.quantity_normalized ?? position.quantity} ${position.lp_asset}`,
         onClick: () => navigate(`/pools/${encodeURIComponent(position.lp_asset)}`),
       })),

--- a/src/pages/pools/index.tsx
+++ b/src/pages/pools/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type ReactElement } from "react";
+import { useCallback, useEffect, useState, type ReactElement } from "react";
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
@@ -6,7 +6,10 @@ import { ErrorAlert } from "@/components/ui/error-alert";
 import { ActionList, type ActionSection } from "@/components/ui/lists/action-list";
 import { useHeader } from "@/contexts/header-context";
 import { useWallet } from "@/contexts/wallet-context";
+import { useInView } from "@/hooks/useInView";
 import { fetchAddressPools, type PoolPosition } from "@/utils/blockchain/counterparty/api";
+
+const PAGE_SIZE = 20;
 
 export default function ManagePoolsPage(): ReactElement {
   const navigate = useNavigate();
@@ -14,7 +17,12 @@ export default function ManagePoolsPage(): ReactElement {
   const { activeAddress } = useWallet();
   const [positions, setPositions] = useState<PoolPosition[]>([]);
   const [isLoading, setIsLoading] = useState(false);
+  const [isFetchingMore, setIsFetchingMore] = useState(false);
+  const [offset, setOffset] = useState(0);
+  const [hasMore, setHasMore] = useState(true);
+  const [initialLoaded, setInitialLoaded] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const { ref: loadMoreRef, inView } = useInView({ rootMargin: "300px", threshold: 0 });
 
   useEffect(() => {
     setHeaderProps({
@@ -27,21 +35,32 @@ export default function ManagePoolsPage(): ReactElement {
   useEffect(() => {
     if (!activeAddress?.address) {
       setPositions([]);
+      setOffset(0);
+      setHasMore(true);
+      setInitialLoaded(false);
       return;
     }
 
     let cancelled = false;
+    setPositions([]);
+    setOffset(0);
+    setHasMore(true);
+    setInitialLoaded(false);
     setIsLoading(true);
     setError(null);
 
-    fetchAddressPools(activeAddress.address, { limit: 100 })
+    fetchAddressPools(activeAddress.address, { limit: PAGE_SIZE, offset: 0 })
       .then((response) => {
         if (cancelled) return;
         setPositions(response.result);
+        setOffset(PAGE_SIZE);
+        setHasMore(response.result.length === PAGE_SIZE && response.result.length < response.result_count);
+        setInitialLoaded(true);
       })
       .catch((err) => {
         if (cancelled) return;
         setError(err instanceof Error ? err.message : "Failed to load pool positions");
+        setInitialLoaded(true);
       })
       .finally(() => {
         if (!cancelled) setIsLoading(false);
@@ -51,6 +70,49 @@ export default function ManagePoolsPage(): ReactElement {
       cancelled = true;
     };
   }, [activeAddress?.address]);
+
+  const appendPositions = useCallback((newPositions: PoolPosition[]) => {
+    setPositions((current) => {
+      const existing = new Set(current.map((position) => position.lp_asset));
+      const unique = newPositions.filter((position) => !existing.has(position.lp_asset));
+      return [...current, ...unique];
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!activeAddress?.address || !inView || !hasMore || isFetchingMore || isLoading || !initialLoaded) {
+      return;
+    }
+
+    let cancelled = false;
+
+    const loadMore = async () => {
+      setIsFetchingMore(true);
+      setError(null);
+
+      try {
+        const response = await fetchAddressPools(activeAddress.address, { limit: PAGE_SIZE, offset });
+        if (cancelled) return;
+
+        appendPositions(response.result);
+        setOffset((current) => current + PAGE_SIZE);
+        setHasMore(response.result.length === PAGE_SIZE && offset + response.result.length < response.result_count);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Failed to load more pool positions");
+          setHasMore(false);
+        }
+      } finally {
+        if (!cancelled) setIsFetchingMore(false);
+      }
+    };
+
+    loadMore();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeAddress?.address, appendPositions, hasMore, inView, initialLoaded, isFetchingMore, isLoading, offset]);
 
   const sections: ActionSection[] = [
     {
@@ -99,6 +161,17 @@ export default function ManagePoolsPage(): ReactElement {
                 >
                   Enter Pool
                 </Button>
+              </div>
+            )}
+            {positions.length > 0 && (
+              <div ref={loadMoreRef} className="flex flex-col justify-center items-center py-1">
+                {hasMore ? (
+                  isFetchingMore ? (
+                    <Spinner className="py-4" />
+                  ) : (
+                    <div className="text-sm text-gray-500">Scroll to load more...</div>
+                  )
+                ) : null}
               </div>
             )}
           </>

--- a/src/pages/requests/psbt/approve.tsx
+++ b/src/pages/requests/psbt/approve.tsx
@@ -12,6 +12,11 @@ import { useSignPsbtRequest } from '@/hooks/useSignPsbtRequest';
 import { getWalletService } from '@/services/walletService';
 import type { DecodedPsbtInfo } from '@/hooks/useSignPsbtRequest';
 
+function normalizeLpQuantity(quantity: unknown): string {
+  if (quantity == null) return '?';
+  return fromSatoshis(String(quantity), { removeTrailingZeros: true });
+}
+
 /**
  * Build a human-readable label and description from PSBT decoded info.
  * Uses the API counterpartyMessage if available, otherwise falls back
@@ -69,7 +74,7 @@ function getTxActionInfo(decodedInfo: DecodedPsbtInfo): { label: string; descrip
     case 'pooldeposit':
       return { label: 'Pool Deposit', description: `${data.quantityA} ${data.assetA} + ${data.quantityB} ${data.assetB}` };
     case 'poolwithdraw':
-      return { label: 'Pool Withdraw', description: `Burn ${data.quantity} LP tokens from ${data.assetA}/${data.assetB}` };
+      return { label: 'Pool Withdraw', description: `Burn ${normalizeLpQuantity(data.quantity)} LP tokens from ${data.assetA}/${data.assetB}` };
     default:
       return { label, description: unpack.messageType };
   }

--- a/src/pages/requests/transaction/approve.tsx
+++ b/src/pages/requests/transaction/approve.tsx
@@ -44,6 +44,11 @@ function normalizeQuantity(quantity: unknown, asset: string, messageData?: Recor
   return val.toLocaleString();
 }
 
+function normalizeLpQuantity(quantity: unknown): string {
+  if (quantity == null) return '?';
+  return fromSatoshis(String(quantity), { removeTrailingZeros: true });
+}
+
 /**
  * Build a human-readable label and description from transaction data.
  * Uses the API counterpartyMessage if available, otherwise falls back
@@ -102,7 +107,7 @@ function getTxActionInfo(decodedInfo: DecodedTransactionInfo): { label: string; 
     case 'pooldeposit':
       return { label: 'Pool Deposit', description: `${normalizeQuantity(data.quantityA, data.assetA as string)} ${data.assetA} + ${normalizeQuantity(data.quantityB, data.assetB as string)} ${data.assetB}` };
     case 'poolwithdraw':
-      return { label: 'Pool Withdraw', description: `Burn ${String(data.quantity)} LP tokens from ${data.assetA}/${data.assetB}` };
+      return { label: 'Pool Withdraw', description: `Burn ${normalizeLpQuantity(data.quantity)} LP tokens from ${data.assetA}/${data.assetB}` };
     default:
       return { label, description: unpack.messageType };
   }

--- a/src/utils/__tests__/numeric.test.ts
+++ b/src/utils/__tests__/numeric.test.ts
@@ -13,6 +13,9 @@ import {
   isLessThanOrEqualToSatoshis,
   normalizeAssetSupply,
   calculateMaxDividendPerUnit,
+  applySlippage,
+  calculateInitialLpEstimate,
+  calculateLimitingLpEstimate,
 } from '../numeric';
 
 describe('numeric utilities', () => {
@@ -488,6 +491,27 @@ describe('numeric utilities', () => {
       expect(normalizeAssetSupply('100', false)).toBe(100);
       expect(normalizeAssetSupply('1', false)).toBe(1);
       expect(normalizeAssetSupply('1000000', false)).toBe(1000000);
+    });
+  });
+
+  describe('slippage calculations', () => {
+    it('applies percentage slippage to raw integer quantities', () => {
+      expect(applySlippage('100000000', '2.5')).toBe('97500000');
+      expect(applySlippage('100', '0.5')).toBe('99');
+      expect(applySlippage(undefined, '1')).toBe('0');
+    });
+  });
+
+  describe('LP estimate calculations', () => {
+    it('estimates initial LP supply from the geometric mean', () => {
+      expect(calculateInitialLpEstimate('100', '400')).toBe('200');
+      expect(calculateInitialLpEstimate('0', '400')).toBe('0');
+    });
+
+    it('uses the limiting side when a deposit is below the quoted ratio', () => {
+      expect(calculateLimitingLpEstimate('1000', '500', '250')).toBe('500');
+      expect(calculateLimitingLpEstimate('1000', '500', '500')).toBe('1000');
+      expect(calculateLimitingLpEstimate('1000', null, '250')).toBe('1000');
     });
   });
 

--- a/src/utils/__tests__/numeric.test.ts
+++ b/src/utils/__tests__/numeric.test.ts
@@ -13,9 +13,6 @@ import {
   isLessThanOrEqualToSatoshis,
   normalizeAssetSupply,
   calculateMaxDividendPerUnit,
-  applySlippage,
-  calculateInitialLpEstimate,
-  calculateLimitingLpEstimate,
 } from '../numeric';
 
 describe('numeric utilities', () => {
@@ -491,27 +488,6 @@ describe('numeric utilities', () => {
       expect(normalizeAssetSupply('100', false)).toBe(100);
       expect(normalizeAssetSupply('1', false)).toBe(1);
       expect(normalizeAssetSupply('1000000', false)).toBe(1000000);
-    });
-  });
-
-  describe('slippage calculations', () => {
-    it('applies percentage slippage to raw integer quantities', () => {
-      expect(applySlippage('100000000', '2.5')).toBe('97500000');
-      expect(applySlippage('100', '0.5')).toBe('99');
-      expect(applySlippage(undefined, '1')).toBe('0');
-    });
-  });
-
-  describe('LP estimate calculations', () => {
-    it('estimates initial LP supply from the geometric mean', () => {
-      expect(calculateInitialLpEstimate('100', '400')).toBe('200');
-      expect(calculateInitialLpEstimate('0', '400')).toBe('0');
-    });
-
-    it('uses the limiting side when a deposit is below the quoted ratio', () => {
-      expect(calculateLimitingLpEstimate('1000', '500', '250')).toBe('500');
-      expect(calculateLimitingLpEstimate('1000', '500', '500')).toBe('1000');
-      expect(calculateLimitingLpEstimate('1000', null, '250')).toBe('1000');
     });
   });
 

--- a/src/utils/__tests__/numeric.test.ts
+++ b/src/utils/__tests__/numeric.test.ts
@@ -11,6 +11,12 @@ import {
   divideSatoshis,
   isLessThanSatoshis,
   isLessThanOrEqualToSatoshis,
+  isFiniteNumber,
+  isEqualTo,
+  isLessThan,
+  isGreaterThan,
+  isGreaterThanOrEqualTo,
+  isLessThanOrEqualTo,
   normalizeAssetSupply,
   calculateMaxDividendPerUnit,
 } from '../numeric';
@@ -247,6 +253,18 @@ describe('numeric utilities', () => {
 
     it('should maintain precision', () => {
       expect(fromSatoshis('12345678')).toBe('0.12345678');
+    });
+  });
+
+  describe('generic comparisons', () => {
+    it('compares mixed numeric inputs safely', () => {
+      expect(isFiniteNumber('1.25')).toBe(true);
+      expect(isFiniteNumber('Infinity')).toBe(false);
+      expect(isEqualTo('100', 100)).toBe(true);
+      expect(isLessThan('99.99999999', 100)).toBe(true);
+      expect(isLessThanOrEqualTo('100', 100)).toBe(true);
+      expect(isGreaterThan('100.00000001', 100)).toBe(true);
+      expect(isGreaterThanOrEqualTo('100', 100)).toBe(true);
     });
   });
 

--- a/src/utils/blockchain/counterparty/__tests__/api.test.ts
+++ b/src/utils/blockchain/counterparty/__tests__/api.test.ts
@@ -19,6 +19,8 @@ import {
   fetchPoolQuote,
   fetchPoolDepositQuote,
   fetchPoolWithdrawQuote,
+  fetchAddressPools,
+  fetchAddressPoolByLpAsset,
   fetchServerInfo,
   clearApiCache,
   AssetInfo,
@@ -1204,6 +1206,29 @@ describe('counterparty/api.ts', () => {
         3,
         `${mockApiBase}/v2/pools/XCP/POOLTEST/quote/withdraw`,
         expect.objectContaining({ params: { quantity: '1000' } })
+      );
+    });
+
+    it('should fetch address LP pool positions', async () => {
+      await fetchAddressPools(mockAddress, { limit: 50, offset: 10 });
+
+      expect(mockedApiClient.get).toHaveBeenCalledWith(
+        `${mockApiBase}/v2/addresses/${mockAddress}/pools`,
+        expect.objectContaining({
+          params: expect.objectContaining({ verbose: true, limit: 50, offset: 10 }),
+        })
+      );
+    });
+
+    it('should find an address LP pool position by LP asset', async () => {
+      const result = await fetchAddressPoolByLpAsset(mockAddress, 'A77777777777777777');
+
+      expect(result).toEqual(mockPool);
+      expect(mockedApiClient.get).toHaveBeenCalledWith(
+        `${mockApiBase}/v2/addresses/${mockAddress}/pools`,
+        expect.objectContaining({
+          params: expect.objectContaining({ verbose: true, limit: 100, offset: 0 }),
+        })
       );
     });
   });

--- a/src/utils/blockchain/counterparty/__tests__/compose.specialized.test.ts
+++ b/src/utils/blockchain/counterparty/__tests__/compose.specialized.test.ts
@@ -450,7 +450,11 @@ describe('Compose Specialized Operations', () => {
     });
 
     it('should compose pool withdraw with LP asset and slippage parameters', async () => {
-      await composePoolWithdraw({
+      mockedApiClient.get.mockResolvedValueOnce(createMockApiResponse({
+        result: createMockComposeResult(),
+      }));
+
+      const result = await composePoolWithdraw({
         sourceAddress: mockAddress,
         sat_per_vbyte: mockSatPerVbyte,
         quantity: '1000000',
@@ -467,6 +471,7 @@ describe('Compose Specialized Operations', () => {
       expect(url).toContain('lp_asset=A77777777777777777');
       expect(url).not.toContain('asset_a=');
       expect(url).not.toContain('asset_b=');
+      expect(result.result.params.lp_asset).toBe('A77777777777777777');
     });
   });
 

--- a/src/utils/blockchain/counterparty/__tests__/normalize.test.ts
+++ b/src/utils/blockchain/counterparty/__tests__/normalize.test.ts
@@ -91,6 +91,25 @@ describe('normalize.ts', () => {
       expect(getComposeType(formData)).toBe('movetoutxo');
     });
 
+    it('should detect pool deposit type from pool deposit fields', () => {
+      const formData = {
+        asset_a: 'XCP',
+        asset_b: 'POOLTEST',
+        quantity_a: '1',
+        quantity_b: '2',
+      };
+      expect(getComposeType(formData)).toBe('pooldeposit');
+    });
+
+    it('should detect pool withdraw type from LP asset withdraw fields', () => {
+      const formData = {
+        lp_asset: 'A77777777777777777',
+        quantity: '1',
+        min_quantity_a: '0',
+      };
+      expect(getComposeType(formData)).toBe('poolwithdraw');
+    });
+
     it('should use explicit type mapping from __type field', () => {
       const formData = { __type: 'SendOptions' };
       expect(getComposeType(formData)).toBe('send');
@@ -204,6 +223,65 @@ describe('normalize.ts', () => {
         expect(result.normalizedData.give_quantity).toBe('250000000');
         expect(result.normalizedData.get_quantity).toBe('100000');
         expect(result.assetInfoCache.size).toBe(2);
+      });
+
+      it('should normalize pool deposit asset quantities', async () => {
+        const formData = new FormData();
+        formData.set('asset_a', 'XCP');
+        formData.set('asset_b', 'POOLTEST');
+        formData.set('quantity_a', '1.5');
+        formData.set('quantity_b', '2');
+        formData.set('min_lp_quantity', '0');
+
+        const mockPoolAsset: AssetInfo = {
+          asset: 'POOLTEST',
+          asset_longname: null,
+          divisible: true,
+          locked: false,
+          supply_normalized: '1000000.00000000'
+        };
+
+        mockFetchAssetDetails
+          .mockResolvedValueOnce(mockDivisibleAsset)
+          .mockResolvedValueOnce(mockPoolAsset);
+
+        mockToSatoshis
+          .mockReturnValueOnce('150000000')
+          .mockReturnValueOnce('200000000');
+
+        const result = await normalizeFormData(formData, 'pooldeposit');
+
+        expect(mockFetchAssetDetails).toHaveBeenCalledWith('XCP');
+        expect(mockFetchAssetDetails).toHaveBeenCalledWith('POOLTEST');
+        expect(result.normalizedData.quantity_a).toBe('150000000');
+        expect(result.normalizedData.quantity_b).toBe('200000000');
+        expect(result.normalizedData.min_lp_quantity).toBe('0');
+      });
+
+      it('should normalize pool withdraw LP quantity', async () => {
+        const formData = new FormData();
+        formData.set('lp_asset', 'A77777777777777777');
+        formData.set('quantity', '3.25');
+        formData.set('min_quantity_a', '0');
+        formData.set('min_quantity_b', '0');
+
+        const mockLpAsset: AssetInfo = {
+          asset: 'A77777777777777777',
+          asset_longname: null,
+          divisible: true,
+          locked: false,
+          supply_normalized: '1000000.00000000'
+        };
+
+        mockFetchAssetDetails.mockResolvedValue(mockLpAsset);
+        mockToSatoshis.mockReturnValue('325000000');
+
+        const result = await normalizeFormData(formData, 'poolwithdraw');
+
+        expect(mockFetchAssetDetails).toHaveBeenCalledWith('A77777777777777777');
+        expect(result.normalizedData.quantity).toBe('325000000');
+        expect(result.normalizedData.min_quantity_a).toBe('0');
+        expect(result.normalizedData.min_quantity_b).toBe('0');
       });
     });
 

--- a/src/utils/blockchain/counterparty/__tests__/pool.test.ts
+++ b/src/utils/blockchain/counterparty/__tests__/pool.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyPoolSlippage,
+  calculateInitialLpEstimate,
+  calculateLimitingLpEstimate,
+} from "../pool";
+
+describe("counterparty pool utilities", () => {
+  it("applies pool slippage to raw integer quantities", () => {
+    expect(applyPoolSlippage("100000000", "2.5")).toBe("97500000");
+    expect(applyPoolSlippage("100", "0.5")).toBe("99");
+    expect(applyPoolSlippage(undefined, "1")).toBe("0");
+  });
+
+  it("estimates initial LP supply from the geometric mean", () => {
+    expect(calculateInitialLpEstimate("100", "400")).toBe("200");
+    expect(calculateInitialLpEstimate("0", "400")).toBe("0");
+  });
+
+  it("uses the limiting side when a deposit is below the quoted ratio", () => {
+    expect(calculateLimitingLpEstimate("1000", "500", "250")).toBe("500");
+    expect(calculateLimitingLpEstimate("1000", "500", "500")).toBe("1000");
+    expect(calculateLimitingLpEstimate("1000", null, "250")).toBe("1000");
+  });
+});

--- a/src/utils/blockchain/counterparty/__tests__/pool.test.ts
+++ b/src/utils/blockchain/counterparty/__tests__/pool.test.ts
@@ -3,9 +3,17 @@ import {
   applyPoolSlippage,
   calculateInitialLpEstimate,
   calculateLimitingLpEstimate,
+  getCanonicalPoolAssets,
+  getCanonicalPoolPair,
 } from "../pool";
 
 describe("counterparty pool utilities", () => {
+  it("formats pool pairs in canonical Counterparty asset order", () => {
+    expect(getCanonicalPoolAssets("XCP", "PEPECASH")).toEqual(["PEPECASH", "XCP"]);
+    expect(getCanonicalPoolPair("XCP", "PEPECASH")).toBe("PEPECASH / XCP");
+    expect(getCanonicalPoolPair("A111111111111111111", "XCP")).toBe("A111111111111111111 / XCP");
+  });
+
   it("applies pool slippage to raw integer quantities", () => {
     expect(applyPoolSlippage("100000000", "2.5")).toBe("97500000");
     expect(applyPoolSlippage("100", "0.5")).toBe("99");

--- a/src/utils/blockchain/counterparty/api.ts
+++ b/src/utils/blockchain/counterparty/api.ts
@@ -260,6 +260,11 @@ export interface Pool {
   [key: string]: unknown;
 }
 
+export interface PoolPosition extends Pool {
+  quantity: number;
+  quantity_normalized?: string;
+}
+
 export interface PoolQuote {
   estimated_output?: number;
   pool_output?: number;
@@ -858,6 +863,40 @@ export async function fetchPoolWithdrawQuote(
     { skipCache: true }
   );
   return data.result;
+}
+
+export async function fetchAddressPools(
+  address: string,
+  options: PaginationOptions = {}
+): Promise<PaginatedResponse<PoolPosition>> {
+  return cpApiGet<PaginatedResponse<PoolPosition>>(
+    `/v2/addresses/${encodePath(address)}/pools`,
+    {
+      verbose: options.verbose ?? true,
+      limit: options.limit ?? 100,
+      offset: options.offset ?? 0,
+    }
+  );
+}
+
+export async function fetchAddressPoolByLpAsset(
+  address: string,
+  lpAsset: string,
+  options: PaginationOptions = {}
+): Promise<PoolPosition | null> {
+  const limit = options.limit ?? 100;
+  let offset = options.offset ?? 0;
+
+  while (true) {
+    const page = await fetchAddressPools(address, { ...options, limit, offset });
+    const pool = page.result.find((position) => position.lp_asset === lpAsset);
+    if (pool) return pool;
+
+    offset += limit;
+    if (page.result.length < limit || offset >= page.result_count) {
+      return null;
+    }
+  }
 }
 
 // =============================================================================

--- a/src/utils/blockchain/counterparty/compose.ts
+++ b/src/utils/blockchain/counterparty/compose.ts
@@ -79,6 +79,7 @@ export interface ComposeParams {
   asset_info: ComposeAssetInfo;
   quantity_normalized: string;
   more_outputs?: string;
+  lp_asset?: string;
 }
 
 export interface ComposeResult {
@@ -1080,7 +1081,11 @@ export async function composePoolWithdraw(options: PoolWithdrawOptions): Promise
     ...(lp_asset && { lp_asset }),
     ...(max_fee !== undefined && { max_fee: max_fee.toString() }),
   };
-  return composeTransaction('poolwithdraw', paramsObj, sourceAddress, sat_per_vbyte, encoding);
+  const response = await composeTransaction('poolwithdraw', paramsObj, sourceAddress, sat_per_vbyte, encoding);
+  if (lp_asset && response.result?.params) {
+    response.result.params.lp_asset = lp_asset;
+  }
+  return response;
 }
 
 export async function getPoolWithdrawEstimateXcpFee(sourceAddress: string): Promise<number> {

--- a/src/utils/blockchain/counterparty/normalize.ts
+++ b/src/utils/blockchain/counterparty/normalize.ts
@@ -132,6 +132,17 @@ const NORMALIZATION_CONFIG: Record<string, {
   cancel: {
     quantityFields: [],
     assetFields: {}
+  },
+  pooldeposit: {
+    quantityFields: ['quantity_a', 'quantity_b'],
+    assetFields: {
+      quantity_a: 'asset_a',
+      quantity_b: 'asset_b'
+    }
+  },
+  poolwithdraw: {
+    quantityFields: ['quantity'],
+    assetFields: { quantity: 'lp_asset' }
   }
 };
 
@@ -161,6 +172,8 @@ export function getComposeType(formData: Record<string, any>): string | undefine
     'CancelOptions': 'cancel',
     'MPMAOptions': 'mpma',
     'MPMAData': 'mpma',
+    'PoolDepositOptions': 'pooldeposit',
+    'PoolWithdrawOptions': 'poolwithdraw',
   };
   
   // Try to detect based on presence of specific fields
@@ -175,6 +188,8 @@ export function getComposeType(formData: Record<string, any>): string | undefine
   if ('quantity' in formData && 'asset_name' in formData) return 'issuance';
   if ('destination' in formData && 'asset' in formData) return 'attach';
   if ('utxo_address' in formData) return 'movetoutxo';
+  if ('asset_a' in formData && 'asset_b' in formData && 'quantity_a' in formData && 'quantity_b' in formData) return 'pooldeposit';
+  if ('lp_asset' in formData && 'quantity' in formData && ('min_quantity_a' in formData || 'min_quantity_b' in formData)) return 'poolwithdraw';
   
   // Fallback: check if type is explicitly provided
   const typeName = formData.__type || formData.type;

--- a/src/utils/blockchain/counterparty/pool.ts
+++ b/src/utils/blockchain/counterparty/pool.ts
@@ -1,0 +1,41 @@
+import { BigNumber, toBigNumber } from "@/utils/numeric";
+
+export function applyPoolSlippage(value: number | string | null | undefined, slippagePercent: string): string {
+  if (value === null || value === undefined) return "0";
+
+  const bps = toBigNumber(slippagePercent || "0").times(100);
+  const multiplier = BigNumber.maximum(0, toBigNumber(10000).minus(bps));
+
+  return toBigNumber(value)
+    .times(multiplier)
+    .div(10000)
+    .integerValue(BigNumber.ROUND_DOWN)
+    .toString();
+}
+
+export function calculateInitialLpEstimate(quantityA: string, quantityB: string): string {
+  const product = toBigNumber(quantityA).times(quantityB);
+  if (!product.isGreaterThan(0)) return "0";
+  return product.sqrt().integerValue(BigNumber.ROUND_DOWN).toString();
+}
+
+export function calculateLimitingLpEstimate(
+  mintedEstimate: number | string | null | undefined,
+  partnerRequired: number | string | null | undefined,
+  partnerProvided: string
+): string {
+  if (mintedEstimate === null || mintedEstimate === undefined) return "0";
+  if (partnerRequired === null || partnerRequired === undefined) return mintedEstimate.toString();
+
+  const required = toBigNumber(partnerRequired);
+  const provided = toBigNumber(partnerProvided);
+  if (!required.isGreaterThan(0) || provided.isGreaterThanOrEqualTo(required)) {
+    return mintedEstimate.toString();
+  }
+
+  return toBigNumber(mintedEstimate)
+    .times(provided)
+    .div(required)
+    .integerValue(BigNumber.ROUND_DOWN)
+    .toString();
+}

--- a/src/utils/blockchain/counterparty/pool.ts
+++ b/src/utils/blockchain/counterparty/pool.ts
@@ -1,5 +1,13 @@
 import { BigNumber, toBigNumber } from "@/utils/numeric";
 
+export function getCanonicalPoolAssets(assetA: string, assetB: string): [string, string] {
+  return assetA <= assetB ? [assetA, assetB] : [assetB, assetA];
+}
+
+export function getCanonicalPoolPair(assetA: string, assetB: string): string {
+  return getCanonicalPoolAssets(assetA, assetB).join(" / ");
+}
+
 export function applyPoolSlippage(value: number | string | null | undefined, slippagePercent: string): string {
   if (value === null || value === undefined) return "0";
 

--- a/src/utils/fathom.ts
+++ b/src/utils/fathom.ts
@@ -81,6 +81,7 @@ const SENSITIVE_PATH_PATTERNS: Array<{ prefix: string; sanitized: string }> = [
   // ═══════════════════════════════════════════════════════════════════════════
   { prefix: '/transactions/', sanitized: '/transactions' },
   { prefix: '/assets/utxos/', sanitized: '/assets/utxos' },
+  { prefix: '/pools/', sanitized: '/pools' },
 
   // ═══════════════════════════════════════════════════════════════════════════
   // ASSET VIEWING (asset names - must come after /assets/utxos/)

--- a/src/utils/fathom.ts
+++ b/src/utils/fathom.ts
@@ -121,6 +121,9 @@ const SENSITIVE_PATH_PATTERNS: Array<{ prefix: string; sanitized: string }> = [
   { prefix: '/compose/order/btcpay', sanitized: '/compose/order/btcpay' }, // static
   { prefix: '/compose/order/cancel/', sanitized: '/compose/order/cancel' },
   { prefix: '/compose/order/', sanitized: '/compose/order' },
+  { prefix: '/compose/pool/deposit/', sanitized: '/compose/pool/deposit' },
+  { prefix: '/compose/pool/deposit', sanitized: '/compose/pool/deposit' },
+  { prefix: '/compose/pool/withdraw/', sanitized: '/compose/pool/withdraw' },
 
   // ═══════════════════════════════════════════════════════════════════════════
   // COMPOSE - UTXO OPERATIONS (asset names, tx hashes)

--- a/src/utils/numeric.ts
+++ b/src/utils/numeric.ts
@@ -170,6 +170,55 @@ export function fromSatoshis(satoshis: BigNumber | string | number, optionsOrAsN
 }
 
 /**
+ * Applies percentage slippage to a raw integer quantity and rounds down.
+ */
+export function applySlippage(value: number | string | null | undefined, slippagePercent: string): string {
+  if (value === null || value === undefined) return "0";
+
+  const bps = toBigNumber(slippagePercent || "0").times(100);
+  const multiplier = BigNumber.maximum(0, toBigNumber(10000).minus(bps));
+
+  return toBigNumber(value)
+    .times(multiplier)
+    .div(10000)
+    .integerValue(BigNumber.ROUND_DOWN)
+    .toString();
+}
+
+/**
+ * Estimates initial LP token supply as floor(sqrt(quantityA * quantityB)).
+ */
+export function calculateInitialLpEstimate(quantityA: string, quantityB: string): string {
+  const product = toBigNumber(quantityA).times(quantityB);
+  if (!product.isGreaterThan(0)) return "0";
+  return product.sqrt().integerValue(BigNumber.ROUND_DOWN).toString();
+}
+
+/**
+ * Adjusts an LP estimate when the partner side is below the quoted pool ratio.
+ */
+export function calculateLimitingLpEstimate(
+  mintedEstimate: number | string | null | undefined,
+  partnerRequired: number | string | null | undefined,
+  partnerProvided: string
+): string {
+  if (mintedEstimate === null || mintedEstimate === undefined) return "0";
+  if (partnerRequired === null || partnerRequired === undefined) return mintedEstimate.toString();
+
+  const required = toBigNumber(partnerRequired);
+  const provided = toBigNumber(partnerProvided);
+  if (!required.isGreaterThan(0) || provided.isGreaterThanOrEqualTo(required)) {
+    return mintedEstimate.toString();
+  }
+
+  return toBigNumber(mintedEstimate)
+    .times(provided)
+    .div(required)
+    .integerValue(BigNumber.ROUND_DOWN)
+    .toString();
+}
+
+/**
  * Subtracts one satoshi value from another, returning an integer result
  *
  * @param minuend - The value to subtract from (in satoshis)

--- a/src/utils/numeric.ts
+++ b/src/utils/numeric.ts
@@ -142,6 +142,14 @@ export const toSatoshis = (value: BigNumber | string | number): string => {
 };
 
 /**
+ * Converts a display quantity to the integer quantity expected by Counterparty APIs.
+ * Divisible assets use satoshi-style 1e8 precision; indivisible assets are whole units.
+ *
+ * @param value - The display quantity
+ * @param isDivisible - Whether the asset is divisible
+ * @returns Integer quantity as a string
+ */
+/**
  * Converts satoshis to BTC (divides by 1e8)
  *
  * @param satoshis - The value in satoshis
@@ -210,6 +218,86 @@ export const isLessThanSatoshis = (value: string | number, threshold: string | n
  * @returns Boolean indicating if value is less than or equal to threshold
  */
 export const isLessThanOrEqualToSatoshis = (value: string | number, threshold: string | number): boolean => {
+  return toBigNumber(value).isLessThanOrEqualTo(toBigNumber(threshold));
+};
+
+/**
+ * Checks if a numeric value is finite.
+ *
+ * @param value - The value to check
+ * @returns Boolean indicating if the value is finite
+ */
+export const isFiniteNumber = (value: string | number | BigNumber | null | undefined): boolean => {
+  return toBigNumber(value).isFinite();
+};
+
+/**
+ * Checks if a numeric value is equal to another.
+ *
+ * @param value - The value to compare
+ * @param threshold - The threshold to compare against
+ * @returns Boolean indicating if value is equal to threshold
+ */
+export const isEqualTo = (
+  value: string | number | BigNumber | null | undefined,
+  threshold: string | number | BigNumber | null | undefined
+): boolean => {
+  return toBigNumber(value).isEqualTo(toBigNumber(threshold));
+};
+
+/**
+ * Checks if a numeric value is less than another.
+ *
+ * @param value - The value to compare
+ * @param threshold - The threshold to compare against
+ * @returns Boolean indicating if value is less than threshold
+ */
+export const isLessThan = (
+  value: string | number | BigNumber | null | undefined,
+  threshold: string | number | BigNumber | null | undefined
+): boolean => {
+  return toBigNumber(value).isLessThan(toBigNumber(threshold));
+};
+
+/**
+ * Checks if a numeric value is greater than another.
+ *
+ * @param value - The value to compare
+ * @param threshold - The threshold to compare against
+ * @returns Boolean indicating if value is greater than threshold
+ */
+export const isGreaterThan = (
+  value: string | number | BigNumber | null | undefined,
+  threshold: string | number | BigNumber | null | undefined
+): boolean => {
+  return toBigNumber(value).isGreaterThan(toBigNumber(threshold));
+};
+
+/**
+ * Checks if a numeric value is greater than or equal to another.
+ *
+ * @param value - The value to compare
+ * @param threshold - The threshold to compare against
+ * @returns Boolean indicating if value is greater than or equal to threshold
+ */
+export const isGreaterThanOrEqualTo = (
+  value: string | number | BigNumber | null | undefined,
+  threshold: string | number | BigNumber | null | undefined
+): boolean => {
+  return toBigNumber(value).isGreaterThanOrEqualTo(toBigNumber(threshold));
+};
+
+/**
+ * Checks if a numeric value is less than or equal to another.
+ *
+ * @param value - The value to compare
+ * @param threshold - The threshold to compare against
+ * @returns Boolean indicating if value is less than or equal to threshold
+ */
+export const isLessThanOrEqualTo = (
+  value: string | number | BigNumber | null | undefined,
+  threshold: string | number | BigNumber | null | undefined
+): boolean => {
   return toBigNumber(value).isLessThanOrEqualTo(toBigNumber(threshold));
 };
 

--- a/src/utils/numeric.ts
+++ b/src/utils/numeric.ts
@@ -170,55 +170,6 @@ export function fromSatoshis(satoshis: BigNumber | string | number, optionsOrAsN
 }
 
 /**
- * Applies percentage slippage to a raw integer quantity and rounds down.
- */
-export function applySlippage(value: number | string | null | undefined, slippagePercent: string): string {
-  if (value === null || value === undefined) return "0";
-
-  const bps = toBigNumber(slippagePercent || "0").times(100);
-  const multiplier = BigNumber.maximum(0, toBigNumber(10000).minus(bps));
-
-  return toBigNumber(value)
-    .times(multiplier)
-    .div(10000)
-    .integerValue(BigNumber.ROUND_DOWN)
-    .toString();
-}
-
-/**
- * Estimates initial LP token supply as floor(sqrt(quantityA * quantityB)).
- */
-export function calculateInitialLpEstimate(quantityA: string, quantityB: string): string {
-  const product = toBigNumber(quantityA).times(quantityB);
-  if (!product.isGreaterThan(0)) return "0";
-  return product.sqrt().integerValue(BigNumber.ROUND_DOWN).toString();
-}
-
-/**
- * Adjusts an LP estimate when the partner side is below the quoted pool ratio.
- */
-export function calculateLimitingLpEstimate(
-  mintedEstimate: number | string | null | undefined,
-  partnerRequired: number | string | null | undefined,
-  partnerProvided: string
-): string {
-  if (mintedEstimate === null || mintedEstimate === undefined) return "0";
-  if (partnerRequired === null || partnerRequired === undefined) return mintedEstimate.toString();
-
-  const required = toBigNumber(partnerRequired);
-  const provided = toBigNumber(partnerProvided);
-  if (!required.isGreaterThan(0) || provided.isGreaterThanOrEqualTo(required)) {
-    return mintedEstimate.toString();
-  }
-
-  return toBigNumber(mintedEstimate)
-    .times(provided)
-    .div(required)
-    .integerValue(BigNumber.ROUND_DOWN)
-    .toString();
-}
-
-/**
  * Subtracts one satoshi value from another, returning an integer result
  *
  * @param minuend - The value to subtract from (in satoshis)


### PR DESCRIPTION
Adds full AMM pool management and compose support for LP assets.

What changed:
- Add Counterparty pool API helpers for pool list/detail, address LP positions, quotes, compose, and XCP fee estimates.
- Detect LP asset balances using Core's address pool-position model and show Manage Pool from LP balance views.
- Add Manage Pools and Pool Position pages with reserves, LP balance, pool share, underlying estimates, and Deposit/Withdraw actions.
- Add pool deposit and withdrawal compose flows using the existing Composer and ReviewScreen patterns.
- Use quote-backed previews for pool ratios, estimated withdrawal receive amounts, and slippage-derived hidden minimum fields.
- Keep outbound compose quantity conversion in the existing normalizeFormData path; read/query display uses Core verbose *_normalized fields.
- Preserve LP asset display context for pool withdrawal reviews when Core resolves it to pair params.
- Add tests for pool API helpers, compose endpoints, normalization, pool math, and LP review handling.

Notes:
- Quote endpoints return raw current-state estimate fields, so the form converts those locally for previews and minimum calculations.
- Pool list/detail/address queries and compose responses request verbose=true and prefer *_normalized values for display.
- Fees-earned/PnL is not shown because the current API provides current reserves, LP balances, and quotes, but not a per-position historical basis.

Verification:
- npm.cmd run compile
- npx.cmd vitest src/utils/blockchain/counterparty/__tests__/compose.specialized.test.ts src/utils/blockchain/counterparty/__tests__/normalize.test.ts src/utils/blockchain/counterparty/__tests__/pool.test.ts src/utils/blockchain/counterparty/__tests__/api.test.ts --run