### PR TITLE
Release 0.4.0 — pools, order expiration, and provider hardening

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -14,7 +14,8 @@ jobs:
   full-test-suite:
     name: Full Test Suite
     runs-on: ubuntu-latest
-    
+    timeout-minutes: 120  # Hard backstop so a stalled setup can't burn the 6h job cap
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -47,10 +48,32 @@ jobs:
           NODE_OPTIONS: --max-old-space-size=6144
         run: npx vitest run src --config vitest.fuzz.config.ts
       
+      - name: Cache Playwright browsers
+        id: pw-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+
       - name: Install Playwright browsers
-        run: npx playwright install chromium
-      
-      - name: Install system dependencies
+        if: steps.pw-cache.outputs.cache-hit != 'true'
+        timeout-minutes: 16
+        run: |
+          # The browser download can stall on the CDN; cap each attempt and retry
+          # so a stall fails in minutes instead of hanging to the job timeout.
+          for attempt in 1 2 3; do
+            echo "Installing Playwright Chromium (attempt $attempt)..."
+            if timeout 300 npx playwright install chromium; then
+              exit 0
+            fi
+            echo "Attempt $attempt stalled or failed; retrying."
+            sleep 5
+          done
+          echo "Playwright browser install failed after 3 attempts" >&2
+          exit 1
+
+      - name: Install Playwright system dependencies
+        timeout-minutes: 5
         run: npx playwright install-deps chromium
       
       - name: Run all E2E tests

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -107,6 +107,7 @@ jobs:
   e2e-tests:
     name: E2E Tests (Batch ${{ matrix.batch }})
     runs-on: ubuntu-latest
+    timeout-minutes: 30  # Hard backstop so a stalled setup can't burn the 6h job cap
     needs: lint-and-type-check
     strategy:
       fail-fast: false
@@ -131,10 +132,32 @@ jobs:
       - name: Build extension
         run: npm run build
 
-      - name: Install Playwright browsers
-        run: npx playwright install chromium
+      - name: Cache Playwright browsers
+        id: pw-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
 
-      - name: Install system dependencies
+      - name: Install Playwright browsers
+        if: steps.pw-cache.outputs.cache-hit != 'true'
+        timeout-minutes: 16
+        run: |
+          # The browser download can stall on the CDN; cap each attempt and retry
+          # so a stall fails in minutes instead of hanging to the job timeout.
+          for attempt in 1 2 3; do
+            echo "Installing Playwright Chromium (attempt $attempt)..."
+            if timeout 300 npx playwright install chromium; then
+              exit 0
+            fi
+            echo "Attempt $attempt stalled or failed; retrying."
+            sleep 5
+          done
+          echo "Playwright browser install failed after 3 attempts" >&2
+          exit 1
+
+      - name: Install Playwright system dependencies
+        timeout-minutes: 5
         run: npx playwright install-deps chromium
 
       - name: Configure Xvfb (MetaMask style)

--- a/.github/workflows/trezor-emulator-tests.yml
+++ b/.github/workflows/trezor-emulator-tests.yml
@@ -25,6 +25,7 @@ jobs:
   trezor-emulator-tests:
     name: Trezor Emulator Integration Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 45  # Hard backstop so a stalled setup can't burn the 6h job cap
 
     # Use the same Docker service configuration as Trezor's own tests
     # Reference: https://github.com/trezor/connect/blob/develop/.github/workflows/test_with_trezor-user-env.yml
@@ -97,8 +98,29 @@ jobs:
           TREZOR_TEST_MODE: 'true'
         run: npm run build
 
+      - name: Cache Playwright browsers
+        id: pw-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+
       - name: Install Playwright browsers
-        run: npx playwright install chromium
+        if: steps.pw-cache.outputs.cache-hit != 'true'
+        timeout-minutes: 16
+        run: |
+          # The browser download can stall on the CDN; cap each attempt and retry
+          # so a stall fails in minutes instead of hanging to the job timeout.
+          for attempt in 1 2 3; do
+            echo "Installing Playwright Chromium (attempt $attempt)..."
+            if timeout 300 npx playwright install chromium; then
+              exit 0
+            fi
+            echo "Attempt $attempt stalled or failed; retrying."
+            sleep 5
+          done
+          echo "Playwright browser install failed after 3 attempts" >&2
+          exit 1
 
       - name: Verify bridge before tests
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ scripts/ralph/
 e2e-notes.local.md
 MANUAL_TEST_PLAN.txt
 *.tsbuildinfo
+
+test-results.json

--- a/PROVIDER.md
+++ b/PROVIDER.md
@@ -178,16 +178,44 @@ await xcpwallet.request({ method: 'xcp_getNetwork' });
 ## Events
 
 ```js
-// Account changed (address switch or connect/disconnect)
+// Account changed: address switch, connect, lock/unlock
 xcpwallet.on('accountsChanged', (accounts) => {
-  // accounts: string[] — empty on disconnect
+  // accounts: string[]
+  // [address] — connected / unlocked
+  // []        — locked or no active account; the connection is RETAINED and a
+  //             later unlock re-emits [address] (no need to reconnect)
 });
 
-// Wallet disconnected this site
+// Wallet revoked this site's connection (explicit disconnect only)
 xcpwallet.on('disconnect', () => {
-  // Connection revoked
+  // Connection revoked — call xcp_requestAccounts to reconnect
 });
 ```
+
+A lock emits `accountsChanged []`, not `disconnect`. Treat an empty array as "temporarily unavailable," and only `disconnect` as "must reconnect."
+
+## Errors
+
+`request()` rejects with an `Error` carrying a numeric `code` (JSON-RPC / EIP-1193 style). Branch on the `code`, not the message — messages are for display and may change.
+
+```js
+try {
+  await xcpwallet.request({ method: 'xcp_signTransaction', params: [{ hex }] });
+} catch (err) {
+  if (err.code === 4001) return;  // user cancelled — not a failure to report
+  throw err;
+}
+```
+
+| Code | Meaning | What to do |
+|------|---------|------------|
+| `4001` | User rejected the request (declined or closed the popup) | Treat as a cancellation |
+| `4100` | Not connected, or the wallet is locked / not set up | Call `xcp_requestAccounts`, or prompt to unlock |
+| `4200` | Method not supported | Stop calling it |
+| `4900` | Wallet background was momentarily unavailable | Transient — retry (the SDK retries signing automatically) |
+| `-32603` | Internal error | Generic failure; internal details are intentionally masked |
+
+Only these codes carry a meaningful message; any other failure surfaces as `-32603` with `"Request failed"`.
 
 ## SDK
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "xcp-wallet",
   "description": "Counterparty Web3 Wallet",
   "private": true,
-  "version": "0.3.2",
+  "version": "0.4.0",
   "type": "module",
   "engines": {
     "node": ">=24 <25",

--- a/src/components/ui/inputs/fairminter-select-input.tsx
+++ b/src/components/ui/inputs/fairminter-select-input.tsx
@@ -7,7 +7,7 @@ import {
   ComboboxOption,
 } from "@headlessui/react";
 import { FaCheck, FiChevronDown } from '@/components/icons';
-import { walletManager } from '@/utils/wallet/walletManager';
+import { useSettings } from '@/contexts/settings-context';
 import { formatAmount } from '@/utils/format';
 
 export interface Fairminter {
@@ -48,6 +48,7 @@ export function FairminterSelectInput({
   required = false,
   currencyFilter,
 }: FairminterSelectInputProps): ReactElement {
+  const { settings } = useSettings();
   const [query, setQuery] = useState("");
   const [fairminters, setFairminters] = useState<Fairminter[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -59,7 +60,6 @@ export function FairminterSelectInput({
       setError(null);
       
       try {
-        const settings = walletManager.getSettings();
         // Fetch fairminters with status "open"
         const response = await fetch(`${settings.counterpartyApiBase}/v2/fairminters?status=open&verbose=true`);
         

--- a/src/contexts/wallet-context.tsx
+++ b/src/contexts/wallet-context.tsx
@@ -46,7 +46,6 @@ import {
 } from "react";
 import { onMessage } from 'webext-bridge/popup'; // Import for popup context
 import { getWalletService } from "@/services/walletService";
-import { walletManager } from "@/utils/wallet/walletManager";
 import { keychainExists as checkKeychainExists } from "@/utils/storage/walletStorage";
 import { AddressFormat } from '@/utils/blockchain/bitcoin/address';
 import { withStateLock } from "@/utils/wallet/stateLockManager";
@@ -467,8 +466,8 @@ export function WalletProvider({ children }: { children: ReactNode }): ReactElem
 
       // Handle address switch - emit accountsChanged to all connected sites
       if (oldAddress && newAddress && oldAddress !== newAddress) {
-        // Get connected sites from settings
-        const settings = walletManager.getSettings();
+        // Get connected sites from settings (via the service seam, not the singleton)
+        const settings = await walletService.getSettings();
 
         // Emit accountsChanged event to each connected site with new address
         // The wallet service proxy will handle the communication to background

--- a/src/entrypoints/__tests__/content.test.ts
+++ b/src/entrypoints/__tests__/content.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { fakeBrowser } from 'wxt/testing';
+import { ProviderError, PROVIDER_ERROR_CODES } from '@/utils/errors';
 
 // Mock WXT injectScript function
 const mockInjectScript = vi.fn();
@@ -275,8 +276,9 @@ describe('Content Script', () => {
     });
 
     it('should pass through user-facing error messages', async () => {
-      // User rejection errors should be passed through
-      mockProviderService.handleRequest.mockRejectedValue(new Error('User denied the request'));
+      // A coded ProviderError is surfaced to the dApp with its code intact.
+      mockProviderService.handleRequest.mockRejectedValue(
+        new ProviderError(PROVIDER_ERROR_CODES.USER_REJECTED, 'User denied the request'));
 
       const event = {
         source: window,
@@ -302,7 +304,40 @@ describe('Content Script', () => {
           id: '790',
           error: {
             message: 'User denied the request',
-            code: -32603
+            code: 4001 // USER_REJECTED — carried from the ProviderError
+          }
+        },
+        mockWindow.location.origin
+      );
+    });
+
+    it('surfaces a coded sign cancellation so dApps can branch', async () => {
+      // The wallet rejects a cancelled sign with a coded ProviderError; it must reach
+      // the dApp intact with code 4001, not masked to a generic 'Request failed'.
+      mockProviderService.handleRequest.mockRejectedValue(
+        new ProviderError(PROVIDER_ERROR_CODES.USER_REJECTED, 'User cancelled transaction signing request'));
+
+      const event = {
+        source: window,
+        origin: mockWindow.location.origin,
+        data: {
+          target: 'xcp-wallet-content',
+          type: 'XCP_WALLET_REQUEST',
+          id: '791',
+          data: { method: 'xcp_signTransaction', params: ['00'] }
+        }
+      };
+
+      await messageListener(event);
+
+      expect(mockWindow.postMessage).toHaveBeenCalledWith(
+        {
+          target: 'xcp-wallet-injected',
+          type: 'XCP_WALLET_RESPONSE',
+          id: '791',
+          error: {
+            message: 'User cancelled transaction signing request',
+            code: 4001
           }
         },
         mockWindow.location.origin

--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -7,7 +7,7 @@ import { ServiceRegistry } from '@/services/core/ServiceRegistry';
 import { MessageBus, type ProviderMessage, type ApprovalMessage, type EventMessage } from '@/services/core/MessageBus';
 import { checkSessionRecovery, SessionRecoveryState } from '@/utils/auth/sessionManager';
 import { serviceKeepAlive } from '@/utils/storage/serviceStateStorage';
-import { JSON_RPC_ERROR_CODES, PROVIDER_ERROR_CODES, createJsonRpcError } from '@/utils/errors';
+import { JSON_RPC_ERROR_CODES, createJsonRpcError, classifyProviderError } from '@/utils/errors';
 import { broadcastToTabs } from '@/utils/browser';
 import { getUpdateService } from '@/services/updateService';
 import { getPopupMonitorService } from '@/services/popupMonitorService';
@@ -311,37 +311,8 @@ export default defineBackground(() => {
       };
     } catch (error: any) {
       console.error('[Background] Provider request failed:', error);
-
-      // Determine appropriate error code and message
-      // ISSUE 1 FIX: Use generic messages for internal errors, only pass through user-facing errors
-      let errorCode: number = JSON_RPC_ERROR_CODES.INTERNAL_ERROR;
-      let errorMessage: string = 'Request failed'; // Generic default
-
-      if (error.message?.includes('User denied') || error.message?.includes('User rejected')) {
-        errorCode = PROVIDER_ERROR_CODES.USER_REJECTED;
-        errorMessage = error.message; // User-facing, safe to pass through
-      } else if (error.message?.includes('not connected') || error.message?.includes('Unauthorized')) {
-        errorCode = PROVIDER_ERROR_CODES.UNAUTHORIZED;
-        errorMessage = error.message; // User-facing, safe to pass through
-      } else if (error.message?.includes('Wallet is locked')) {
-        errorCode = PROVIDER_ERROR_CODES.UNAUTHORIZED;
-        errorMessage = error.message; // User-facing, safe to pass through
-      } else if (error.message?.includes('not supported') || error.message?.includes('not found')) {
-        errorCode = JSON_RPC_ERROR_CODES.METHOD_NOT_FOUND;
-        errorMessage = 'Method not supported'; // Generic
-      } else if (error.message?.includes('Invalid params')) {
-        errorCode = JSON_RPC_ERROR_CODES.INVALID_PARAMS;
-        errorMessage = 'Invalid parameters'; // Generic
-      }
-      // All other errors get the generic "Request failed" message
-
-      return {
-        success: false,
-        error: createJsonRpcError(
-          error.code || errorCode,
-          errorMessage
-        )
-      };
+      const { code, message } = classifyProviderError(error);
+      return { success: false, error: createJsonRpcError(code, message) };
     }
   });
 

--- a/src/entrypoints/content.ts
+++ b/src/entrypoints/content.ts
@@ -1,6 +1,7 @@
 import { defineContentScript, injectScript } from '#imports';
 import { MESSAGE_TARGETS, MESSAGE_TYPES } from '@/constants/messaging';
 import { disconnectAllPorts } from '@/utils/proxy';
+import { classifyProviderError } from '@/utils/errors';
 
 // Always include localhost for local dApp testing (safe - only accessible locally)
 // HTTPS for all other sites
@@ -120,20 +121,9 @@ export default defineContentScript({
             };
           } catch (error: any) {
             console.debug('Provider service request failed:', error);
-            // ISSUE 1 FIX: Use generic error messages to prevent information leakage
-            // Only pass through user-facing error messages, not internal details
-            const isUserFacingError = error?.message?.includes('User denied') ||
-                                       error?.message?.includes('User rejected') ||
-                                       error?.message?.includes('not connected') ||
-                                       error?.message?.includes('Wallet is locked') ||
-                                       error?.message?.includes('wallet setup');
-            response = {
-              success: false,
-              error: {
-                message: isUserFacingError ? error.message : 'Request failed',
-                code: error?.code || -32603
-              }
-            };
+            // The proxy delivers only the message, so the structured code a dApp
+            // branches on is derived from it here at the boundary.
+            response = { success: false, error: classifyProviderError(error) };
           }
           
           // Handle the response properly

--- a/src/entrypoints/injected.ts
+++ b/src/entrypoints/injected.ts
@@ -116,7 +116,12 @@ export default defineUnlistedScript(() => {
     pendingRequests.delete(id);
 
     if (error) {
-      pending.reject(new Error(formatErrorMessage(error?.message || error)));
+      const rejection = new Error(formatErrorMessage(error?.message || error));
+      // Preserve the JSON-RPC error code so dApps can branch (e.g. 4001 = user rejected).
+      if (error && typeof error === 'object' && typeof error.code === 'number') {
+        (rejection as { code?: number }).code = error.code;
+      }
+      pending.reject(rejection);
       return;
     }
 

--- a/src/hooks/usePopupLifecycle.ts
+++ b/src/hooks/usePopupLifecycle.ts
@@ -1,0 +1,26 @@
+import { useEffect } from 'react';
+
+export type SignRequestKind = 'sign-transaction' | 'sign-psbt' | 'sign-message';
+
+/**
+ * Connects the 'popup-lifecycle' port so the background can promptly cancel this
+ * request if the popup is closed without a decision. The background only cancels
+ * flows still marked 'pending', so completing/cancelling first is safe.
+ */
+export function usePopupLifecycle(requestId: string | null | undefined, requestType: SignRequestKind): void {
+  useEffect(() => {
+    if (!requestId) return;
+
+    let port: chrome.runtime.Port | null = null;
+    try {
+      port = chrome.runtime.connect({ name: 'popup-lifecycle' });
+      port.postMessage({ type: 'request-active', requestId, requestType });
+    } catch {
+      // Background may be unavailable; cancellation falls back to the timeout.
+    }
+
+    return () => {
+      try { port?.disconnect(); } catch { /* already gone */ }
+    };
+  }, [requestId, requestType]);
+}

--- a/src/hooks/useSignMessageRequest.ts
+++ b/src/hooks/useSignMessageRequest.ts
@@ -11,6 +11,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { signMessageRequestStorage, type SignMessageRequest } from '@/utils/storage/signMessageRequestStorage';
+import { recordSignOutcome } from '@/utils/provider/signFlow';
 
 /**
  * Send an event to the background script's EventEmitterService.
@@ -89,6 +90,8 @@ export function useSignMessageRequest() {
   // Handle completion for provider requests
   const handleSuccess = useCallback(async (result: { signature: string }) => {
     if (requestId) {
+      // Persist the outcome so the dApp can recover it after a worker restart.
+      await recordSignOutcome(requestId, 'completed', result);
       // Notify the background that the sign message is complete
       emitToBackground(`sign-message-complete-${requestId}`, result);
 
@@ -100,6 +103,7 @@ export function useSignMessageRequest() {
   // Handle cancellation for provider requests
   const handleCancel = useCallback(async () => {
     if (requestId) {
+      await recordSignOutcome(requestId, 'cancelled');
       // Notify the background that the sign message was cancelled
       emitToBackground(`sign-message-cancel-${requestId}`, { reason: 'User cancelled' });
 

--- a/src/hooks/useSignPsbtRequest.ts
+++ b/src/hooks/useSignPsbtRequest.ts
@@ -13,6 +13,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { signPsbtRequestStorage, type SignPsbtRequest } from '@/utils/storage/signPsbtRequestStorage';
+import { recordSignOutcome } from '@/utils/provider/signFlow';
 import { extractPsbtDetails, type PsbtDetails } from '@/utils/blockchain/bitcoin/psbt';
 import {
   decodeRawTransaction,
@@ -198,6 +199,8 @@ export function useSignPsbtRequest(signerAddress?: string) {
   // Handle completion - called when user approves and signs
   const handleSuccess = useCallback(async (signedPsbtHex: string) => {
     if (requestId) {
+      // Persist the outcome so the dApp can recover it after a worker restart.
+      await recordSignOutcome(requestId, 'completed', { signedPsbtHex });
       // Notify the background that PSBT signing is complete
       emitToBackground(`sign-psbt-complete-${requestId}`, { signedPsbtHex });
 
@@ -209,6 +212,7 @@ export function useSignPsbtRequest(signerAddress?: string) {
   // Handle cancellation
   const handleCancel = useCallback(async () => {
     if (requestId) {
+      await recordSignOutcome(requestId, 'cancelled');
       // Notify the background that PSBT signing was cancelled
       emitToBackground(`sign-psbt-cancel-${requestId}`, { reason: 'User cancelled' });
 

--- a/src/hooks/useSignTransactionRequest.ts
+++ b/src/hooks/useSignTransactionRequest.ts
@@ -12,6 +12,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { signTransactionRequestStorage, type SignTransactionRequest } from '@/utils/storage/signTransactionRequestStorage';
+import { recordSignOutcome } from '@/utils/provider/signFlow';
 import {
   decodeRawTransaction,
   decodeCounterpartyMessage,
@@ -243,6 +244,8 @@ export function useSignTransactionRequest(signerAddress?: string) {
   // Handle completion - called when user approves and signs
   const handleSuccess = useCallback(async (signedTxHex: string) => {
     if (requestId) {
+      // Persist the outcome so the dApp can recover it after a worker restart.
+      await recordSignOutcome(requestId, 'completed', { signedTxHex });
       // Notify the background that transaction signing is complete
       emitToBackground(`sign-tx-complete-${requestId}`, { signedTxHex });
 
@@ -254,6 +257,7 @@ export function useSignTransactionRequest(signerAddress?: string) {
   // Handle cancellation
   const handleCancel = useCallback(async () => {
     if (requestId) {
+      await recordSignOutcome(requestId, 'cancelled');
       // Notify the background that transaction signing was cancelled
       emitToBackground(`sign-tx-cancel-${requestId}`, { reason: 'User cancelled' });
 

--- a/src/pages/compose/dispenser/__tests__/review.test.tsx
+++ b/src/pages/compose/dispenser/__tests__/review.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { ReviewDispenser } from '../review';
+
+// Capture the customFields handed to the shared review screen.
+vi.mock('@/components/screens/review-screen', () => ({
+  ReviewScreen: ({ customFields }: any) => (
+    <div data-testid="review-screen">
+      {customFields.map((field: any, idx: number) => (
+        <div key={idx}>
+          <span>{field.label}</span>
+          {field.value && <span>{field.value}</span>}
+        </div>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock('@/hooks/useMarketPrices', () => ({
+  useMarketPrices: () => ({ btc: null }),
+}));
+
+vi.mock('@/contexts/settings-context', () => ({
+  useSettings: () => ({ settings: { fiat: 'USD' } }),
+}));
+
+describe('ReviewDispenser', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  const baseParams = {
+    asset: 'PEPECASH',
+    escrow_quantity_normalized: '5',
+    give_quantity_normalized: '1',
+    escrow_quantity: 5,
+    give_quantity: 1,
+    mainchainrate: 100000,
+  };
+
+  const renderWith = (params: Record<string, unknown>, assetProp: string) =>
+    render(
+      <ReviewDispenser
+        apiResponse={{ result: { params } }}
+        onSign={vi.fn()}
+        onBack={vi.fn()}
+        error={null}
+        isSigning={false}
+        asset={assetProp}
+      />
+    );
+
+  it('labels amounts with the signed result.params.asset, not the route prop', () => {
+    // The in-form asset-select path leaves the route prop empty; the displayed
+    // asset must still match the asset actually being composed/signed.
+    renderWith(baseParams, '');
+
+    expect(screen.getByText('5 PEPECASH')).toBeInTheDocument();
+    expect(screen.getByText('1 PEPECASH')).toBeInTheDocument();
+  });
+
+  it('prefers asset_longname when present', () => {
+    renderWith({ ...baseParams, asset: 'A123', asset_longname: 'MYPROJECT.TOKEN' }, '');
+
+    expect(screen.getByText('5 MYPROJECT.TOKEN')).toBeInTheDocument();
+  });
+
+  it('falls back to the prop only when params omit the asset', () => {
+    const { asset: _omit, ...paramsWithoutAsset } = baseParams;
+    renderWith(paramsWithoutAsset, 'FALLBACKASSET');
+
+    expect(screen.getByText('5 FALLBACKASSET')).toBeInTheDocument();
+  });
+});

--- a/src/pages/compose/dispenser/review.tsx
+++ b/src/pages/compose/dispenser/review.tsx
@@ -1,5 +1,5 @@
 import { ReviewScreen } from "@/components/screens/review-screen";
-import { formatAmount } from "@/utils/format";
+import { formatAmount, formatAsset } from "@/utils/format";
 import { fromSatoshis } from "@/utils/numeric";
 import { useMarketPrices } from "@/hooks/useMarketPrices";
 import { useSettings } from "@/contexts/settings-context";
@@ -33,6 +33,12 @@ export function ReviewDispenser({
   const { settings } = useSettings();
   const { btc: btcPrice } = useMarketPrices(settings.fiat);
 
+  // Asset label from the signed params, not the route prop (empty on the
+  // in-form asset-select path); fall back to the prop only if params omit it.
+  const displayAsset = formatAsset(result.params.asset ?? asset, {
+    assetInfo: { asset_longname: result.params.asset_longname ?? null },
+  });
+
   // Use normalized values from verbose API response
   const escrowQuantity = result.params.escrow_quantity_normalized;
   const giveQuantity = result.params.give_quantity_normalized;
@@ -53,11 +59,11 @@ export function ReviewDispenser({
   const customFields = [
     {
       label: "Escrow Amount",
-      value: `${escrowQuantity} ${asset}`,
+      value: `${escrowQuantity} ${displayAsset}`,
     },
     {
       label: "Amount per Dispense",
-      value: `${giveQuantity} ${asset}`,
+      value: `${giveQuantity} ${displayAsset}`,
     },
     {
       label: "Per Dispense",

--- a/src/pages/compose/fairminter/form.tsx
+++ b/src/pages/compose/fairminter/form.tsx
@@ -82,6 +82,7 @@ export function FairminterForm({
 
   // Quantity field state (controlled for decimal enforcement)
   const [maxMintPerTx, setMaxMintPerTx] = useState(initialFormData?.max_mint_per_tx?.toString() || "");
+  const [maxMintPerAddress, setMaxMintPerAddress] = useState(initialFormData?.max_mint_per_address?.toString() || "");
   const [lotSize, setLotSize] = useState(initialFormData?.lot_size?.toString() || "");
   const [hardCap, setHardCap] = useState(initialFormData?.hard_cap?.toString() || "");
   const [premintQuantity, setPremintQuantity] = useState(initialFormData?.premint_quantity?.toString() || "0");
@@ -165,6 +166,7 @@ export function FairminterForm({
 
     // Set controlled quantity fields from state
     if (maxMintPerTx) processedFormData.set('max_mint_per_tx', maxMintPerTx);
+    if (maxMintPerAddress) processedFormData.set('max_mint_per_address', maxMintPerAddress);
     if (lotSize) processedFormData.set('lot_size', lotSize);
     if (hardCap) processedFormData.set('hard_cap', hardCap);
     if (premintQuantity) processedFormData.set('premint_quantity', premintQuantity);
@@ -289,6 +291,29 @@ export function FairminterForm({
               )}
             </Field>
           )}
+
+          <Field>
+            <Label htmlFor="max_mint_per_address" className="block text-sm font-medium text-gray-700">
+              Mint per Address
+            </Label>
+            <Input
+              id="max_mint_per_address"
+              name="max_mint_per_address"
+              type="text"
+              inputMode="decimal"
+              value={maxMintPerAddress}
+              onChange={handleQuantityChange(setMaxMintPerAddress)}
+              step={getInputStep()}
+              placeholder="No limit"
+              className="mt-1 block w-full p-2.5 rounded-md border border-gray-300 bg-gray-50 outline-none focus:border-blue-500 focus-visible:ring-2 focus-visible:ring-blue-500"
+              disabled={pending}
+            />
+            {showHelpText && (
+              <Description className="mt-2 text-sm text-gray-500">
+                Optional maximum amount each address can mint. Leave blank for no per-address limit.
+              </Description>
+            )}
+          </Field>
           {selectedMintMethod !== FAIRMINTER_MODELS.MINER_FEE_ONLY && (
             <>
               <Field>

--- a/src/pages/compose/fairminter/review.tsx
+++ b/src/pages/compose/fairminter/review.tsx
@@ -29,6 +29,9 @@ export function ReviewFairminter({
     { label: "Asset", value: result.params.asset },
     { label: "Lot Price", value: result.params.lot_price },
     { label: "Lot Size", value: result.params.lot_size },
+    ...(Number(result.params.max_mint_per_address ?? 0) > 0
+      ? [{ label: "Mint per Address", value: result.params.max_mint_per_address }]
+      : []),
     { label: "Hard Cap", value: result.params.hard_cap },
     ...(result.params.description ? [{ label: "Description", value: result.params.description }] : []),
   ];

--- a/src/pages/compose/order/form.tsx
+++ b/src/pages/compose/order/form.tsx
@@ -12,6 +12,7 @@ import { useAssetDetails } from "@/hooks/useAssetDetails";
 import { useTradingPair } from "@/hooks/useTradingPair";
 import { toBigNumber } from "@/utils/numeric";
 import { formatAmount } from "@/utils/format";
+import { DEFAULT_ORDER_EXPIRATION } from "@/utils/settings";
 import { ErrorAlert } from "@/components/ui/error-alert";
 import type { OrderOptions } from "@/utils/blockchain/counterparty/compose";
 import type { ReactElement } from "react";
@@ -91,7 +92,7 @@ export function OrderForm({
   // Form state - priority: initialFormData > urlParams > empty
   const [price, setPrice] = useState<string>(initialFormData?.price || urlParams?.price || "");
   const [amount, setAmount] = useState<string>(initialFormData?.amount || urlParams?.amount || "");
-  const [customExpiration, setCustomExpiration] = useState<number | undefined>(initialFormData?.expiration || undefined);
+  const [customExpiration, setCustomExpiration] = useState<number | undefined>(initialFormData?.expiration ?? undefined);
   const [customFeeRequired, setCustomFeeRequired] = useState<number>(initialFormData?.fee_required || 0);
   // Note: quoteAsset state is defined above the data fetching hooks for proper reactivity
   
@@ -320,7 +321,11 @@ export function OrderForm({
             )}
             <input type="hidden" name="give_asset" value={isBuy ? quoteAsset : baseAsset} />
             <input type="hidden" name="get_asset" value={isBuy ? baseAsset : quoteAsset} />
-            <input type="hidden" name="expiration" value={customExpiration || settings?.defaultOrderExpiration || 8064} />
+            <input
+              type="hidden"
+              name="expiration"
+              value={customExpiration ?? settings?.defaultOrderExpiration ?? DEFAULT_ORDER_EXPIRATION}
+            />
             {isBuy && baseAsset === "BTC" && (
               <input type="hidden" name="fee_required" value={customFeeRequired} />
             )}

--- a/src/pages/compose/order/review.tsx
+++ b/src/pages/compose/order/review.tsx
@@ -2,6 +2,12 @@ import { useState } from "react";
 import { FaExchangeAlt } from "@/components/icons";
 import { ReviewScreen } from "@/components/screens/review-screen";
 import { formatPriceRatio } from "@/utils/format";
+import { DEFAULT_ORDER_EXPIRATION } from "@/utils/settings";
+
+const formatExpiration = (expiration: unknown) => {
+  const blocks = Number(expiration ?? DEFAULT_ORDER_EXPIRATION);
+  return blocks === 0 ? "Never expires" : `${blocks.toLocaleString()} blocks`;
+};
 
 /**
  * Props for the ReviewOrder component.
@@ -72,9 +78,7 @@ export function ReviewOrder({
         </button>
       ),
     },
-    ...(result.params.expiration !== 8064
-      ? [{ label: "Expiration", value: `${result.params.expiration} blocks` }]
-      : []),
+    { label: "Expiration", value: formatExpiration(result.params.expiration) },
     ...(result.params.fee_required && Number(result.params.fee_required) > 0
       ? [{ label: "Fee Required", value: `${result.params.fee_required} satoshis` }]
       : []),

--- a/src/pages/compose/send/mpma/__tests__/review.test.tsx
+++ b/src/pages/compose/send/mpma/__tests__/review.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, cleanup, waitFor } from '@testing-library/react';
 import { ReviewMPMA } from '../review';
+import { fetchAssetDetails } from '@/utils/blockchain/counterparty/api';
 
 // Mock the ReviewScreen component
 vi.mock('@/components/screens/review-screen', () => ({
@@ -21,26 +22,10 @@ vi.mock('@/components/screens/review-screen', () => ({
   )
 }));
 
-// Mock the fetchAssetDetails function
+// The review must NOT independently re-fetch divisibility; it renders the
+// server-normalized quantities echoed in the (signed) compose response.
 vi.mock('@/utils/blockchain/counterparty/api', () => ({
-  fetchAssetDetails: vi.fn((asset: string) => {
-    // XCP and BTC are divisible, PEPE is indivisible
-    if (asset === 'XCP' || asset === 'BTC') {
-      return Promise.resolve({ divisible: true });
-    }
-    return Promise.resolve({ divisible: false });
-  })
-}));
-
-// Mock fromSatoshis
-vi.mock('@/utils/numeric', () => ({
-  fromSatoshis: (value: string) => {
-    const num = BigInt(value);
-    const divisor = BigInt(100000000);
-    const whole = num / divisor;
-    const fraction = num % divisor;
-    return `${whole}.${fraction.toString().padStart(8, '0')}`;
-  }
+  fetchAssetDetails: vi.fn(() => Promise.resolve({ divisible: true })),
 }));
 
 describe('ReviewMPMA', () => {
@@ -49,16 +34,23 @@ describe('ReviewMPMA', () => {
 
   afterEach(() => {
     cleanup();
+    vi.clearAllMocks();
   });
 
-  // The API returns asset_dest_quant_list with raw quantities (satoshis for divisible)
+  // The verbose API echoes asset_dest_quant_list_normalized: the same normalized
+  // amounts encoded into the signed transaction.
   const mockApiResponse = {
     result: {
       params: {
         asset_dest_quant_list: [
-          ['XCP', 'bc1qaddress1', 100000000], // 1 XCP in satoshis
-          ['BTC', 'bc1qaddress2', 50000],     // 0.0005 BTC in satoshis
-          ['PEPE', 'bc1qaddress3', 1000],     // 1000 PEPE (indivisible)
+          ['XCP', 'bc1qaddress1', 100000000],
+          ['BTC', 'bc1qaddress2', 50000],
+          ['PEPE', 'bc1qaddress3', 1000],
+        ],
+        asset_dest_quant_list_normalized: [
+          ['XCP', 'bc1qaddress1', '1.00000000'],
+          ['BTC', 'bc1qaddress2', '0.00050000'],
+          ['PEPE', 'bc1qaddress3', '1000'],
         ],
         memos: ['Memo 1', 'Memo 2', 'Memo 3']
       }
@@ -76,12 +68,10 @@ describe('ReviewMPMA', () => {
       />
     );
 
-    await waitFor(() => {
-      expect(screen.getByText('Send')).toBeInTheDocument();
-    });
+    expect(screen.getByText('Send')).toBeInTheDocument();
   });
 
-  it('displays normalized quantities for divisible assets', async () => {
+  it('renders the server-normalized quantities (matching the signed amounts)', () => {
     render(
       <ReviewMPMA
         apiResponse={mockApiResponse}
@@ -92,15 +82,15 @@ describe('ReviewMPMA', () => {
       />
     );
 
-    await waitFor(() => {
-      // XCP: 100000000 satoshis = 1.00000000 XCP
-      expect(screen.getByText(/1\.00000000 XCP/)).toBeInTheDocument();
-      // BTC: 50000 satoshis = 0.00050000 BTC
-      expect(screen.getByText(/0\.00050000 BTC/)).toBeInTheDocument();
-    });
+    expect(screen.getByText(/1\.00000000 XCP/)).toBeInTheDocument();
+    expect(screen.getByText(/0\.00050000 BTC/)).toBeInTheDocument();
+    expect(screen.getByText(/1000 PEPE/)).toBeInTheDocument();
   });
 
-  it('displays raw quantities for indivisible assets', async () => {
+  it('does not independently re-fetch divisibility (WYSIWYS guard)', async () => {
+    // Guards the "what you see is what you sign" invariant: the displayed amount
+    // must come from the signed compose echo, never a separate client lookup
+    // that could disagree with what was signed.
     render(
       <ReviewMPMA
         apiResponse={mockApiResponse}
@@ -111,13 +101,12 @@ describe('ReviewMPMA', () => {
       />
     );
 
-    await waitFor(() => {
-      // PEPE is indivisible, displayed as-is
-      expect(screen.getByText(/1000 PEPE/)).toBeInTheDocument();
-    });
+    // Give any (unwanted) async fetch a chance to fire.
+    await waitFor(() => expect(screen.getByText(/1\.00000000 XCP/)).toBeInTheDocument());
+    expect(fetchAssetDetails).not.toHaveBeenCalled();
   });
 
-  it('displays destination addresses', async () => {
+  it('displays destination addresses', () => {
     render(
       <ReviewMPMA
         apiResponse={mockApiResponse}
@@ -128,14 +117,12 @@ describe('ReviewMPMA', () => {
       />
     );
 
-    await waitFor(() => {
-      expect(screen.getByText(/to bc1qaddress1/)).toBeInTheDocument();
-      expect(screen.getByText(/to bc1qaddress2/)).toBeInTheDocument();
-      expect(screen.getByText(/to bc1qaddress3/)).toBeInTheDocument();
-    });
+    expect(screen.getByText(/to bc1qaddress1/)).toBeInTheDocument();
+    expect(screen.getByText(/to bc1qaddress2/)).toBeInTheDocument();
+    expect(screen.getByText(/to bc1qaddress3/)).toBeInTheDocument();
   });
 
-  it('displays memos when present', async () => {
+  it('displays memos when present', () => {
     render(
       <ReviewMPMA
         apiResponse={mockApiResponse}
@@ -146,19 +133,17 @@ describe('ReviewMPMA', () => {
       />
     );
 
-    await waitFor(() => {
-      expect(screen.getByText(/Memo: Memo 1/)).toBeInTheDocument();
-      expect(screen.getByText(/Memo: Memo 2/)).toBeInTheDocument();
-      expect(screen.getByText(/Memo: Memo 3/)).toBeInTheDocument();
-    });
+    expect(screen.getByText(/Memo: Memo 1/)).toBeInTheDocument();
+    expect(screen.getByText(/Memo: Memo 2/)).toBeInTheDocument();
+    expect(screen.getByText(/Memo: Memo 3/)).toBeInTheDocument();
   });
 
-  it('handles missing memos', async () => {
+  it('handles missing memos', () => {
     const responseWithoutMemos = {
       result: {
         params: {
-          asset_dest_quant_list: [
-            ['XCP', 'bc1qaddress1', 100000000],
+          asset_dest_quant_list_normalized: [
+            ['XCP', 'bc1qaddress1', '1.00000000'],
           ]
         }
       }
@@ -174,12 +159,10 @@ describe('ReviewMPMA', () => {
       />
     );
 
-    await waitFor(() => {
-      expect(screen.queryByText(/Memo:/)).not.toBeInTheDocument();
-    });
+    expect(screen.queryByText(/Memo:/)).not.toBeInTheDocument();
   });
 
-  it('displays send numbers', async () => {
+  it('displays send numbers', () => {
     render(
       <ReviewMPMA
         apiResponse={mockApiResponse}
@@ -190,14 +173,12 @@ describe('ReviewMPMA', () => {
       />
     );
 
-    await waitFor(() => {
-      expect(screen.getByText(/Send #1:/)).toBeInTheDocument();
-      expect(screen.getByText(/Send #2:/)).toBeInTheDocument();
-      expect(screen.getByText(/Send #3:/)).toBeInTheDocument();
-    });
+    expect(screen.getByText(/Send #1:/)).toBeInTheDocument();
+    expect(screen.getByText(/Send #2:/)).toBeInTheDocument();
+    expect(screen.getByText(/Send #3:/)).toBeInTheDocument();
   });
 
-  it('passes error to review screen', async () => {
+  it('passes error to review screen', () => {
     const error = 'Transaction failed';
 
     render(
@@ -213,7 +194,7 @@ describe('ReviewMPMA', () => {
     expect(screen.getByText(error)).toBeInTheDocument();
   });
 
-  it('shows signing state', async () => {
+  it('shows signing state', () => {
     render(
       <ReviewMPMA
         apiResponse={mockApiResponse}
@@ -227,11 +208,11 @@ describe('ReviewMPMA', () => {
     expect(screen.getByText('Signing...')).toBeInTheDocument();
   });
 
-  it('handles empty asset list', async () => {
+  it('handles empty asset list', () => {
     const emptyResponse = {
       result: {
         params: {
-          asset_dest_quant_list: []
+          asset_dest_quant_list_normalized: []
         }
       }
     };
@@ -246,22 +227,6 @@ describe('ReviewMPMA', () => {
       />
     );
 
-    await waitFor(() => {
-      expect(screen.getByText('No sends')).toBeInTheDocument();
-    });
-  });
-
-  it('shows loading state initially', () => {
-    render(
-      <ReviewMPMA
-        apiResponse={mockApiResponse}
-        onSign={mockOnSign}
-        onBack={mockOnBack}
-        error={null}
-        isSigning={false}
-      />
-    );
-
-    expect(screen.getByText('Loading...')).toBeInTheDocument();
+    expect(screen.getByText('No sends')).toBeInTheDocument();
   });
 });

--- a/src/pages/compose/send/mpma/review.tsx
+++ b/src/pages/compose/send/mpma/review.tsx
@@ -1,7 +1,5 @@
-import { type ReactElement, useState, useEffect } from "react";
+import { type ReactElement } from "react";
 import { ReviewScreen } from "@/components/screens/review-screen";
-import { fetchAssetDetails } from "@/utils/blockchain/counterparty/api";
-import { fromSatoshis } from "@/utils/numeric";
 
 interface ReviewMPMAProps {
   apiResponse: any;
@@ -9,14 +7,6 @@ interface ReviewMPMAProps {
   onBack: () => void;
   error: string | null;
   isSigning: boolean;
-}
-
-interface Transaction {
-  asset: string;
-  destination: string;
-  quantity: string | number;
-  quantityNormalized: string;
-  memo?: string;
 }
 
 export function ReviewMPMA({
@@ -27,66 +17,20 @@ export function ReviewMPMA({
   isSigning,
 }: ReviewMPMAProps): ReactElement {
   const { result } = apiResponse;
-  const [transactions, setTransactions] = useState<Transaction[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
 
-  // The API returns asset_dest_quant_list with [asset, destination, quantity] tuples
-  const assetDestQuantList = result.params.asset_dest_quant_list || [];
-
-  useEffect(() => {
-    async function normalizeQuantities() {
-      if (assetDestQuantList.length === 0) {
-        setTransactions([]);
-        setIsLoading(false);
-        return;
-      }
-
-      // Get unique assets
-      const assetNames: string[] = assetDestQuantList.map((item: any[]) => String(item[0]));
-      const uniqueAssets: string[] = Array.from(new Set<string>(assetNames));
-
-      // Fetch divisibility for each asset (BTC and XCP are known divisible)
-      const divisibilityMap: Record<string, boolean> = { BTC: true, XCP: true };
-
-      // Fetch divisibility for unknown assets
-      const unknownAssets = uniqueAssets.filter((asset) => !(asset in divisibilityMap));
-      await Promise.all(
-        unknownAssets.map(async (asset) => {
-          try {
-            const info = await fetchAssetDetails(asset);
-            divisibilityMap[asset] = info?.divisible ?? false;
-          } catch {
-            divisibilityMap[asset] = false;
-          }
-        })
-      );
-
-      // Build transactions with normalized quantities
-      const normalizedTransactions = assetDestQuantList.map((item: any[], index: number) => {
-        const [asset, destination, quantity] = item;
-        const isDivisible = divisibilityMap[asset];
-        const memo = result.params.memos?.[index];
-
-        // Normalize: divide by 10^8 for divisible assets
-        const quantityNormalized = isDivisible
-          ? fromSatoshis(quantity.toString())
-          : quantity.toString();
-
-        return {
-          asset,
-          destination,
-          quantity,
-          quantityNormalized,
-          memo
-        };
-      });
-
-      setTransactions(normalizedTransactions);
-      setIsLoading(false);
+  // Render the API's normalized quantities (the signed values) rather than
+  // re-deriving divisibility client-side, which can diverge from what is signed.
+  const transactions = (result.params.asset_dest_quant_list_normalized || []).map(
+    (item: any[], index: number) => {
+      const [asset, destination, quantity] = item;
+      return {
+        asset,
+        destination,
+        quantity,
+        memo: result.params.memos?.[index],
+      };
     }
-
-    normalizeQuantities();
-  }, [assetDestQuantList, result.params.memos]);
+  );
 
   // Build custom fields showing detailed breakdown
   const customFields: Array<{ label: string; value: string | number; rightElement?: React.ReactNode }> = [
@@ -95,15 +39,13 @@ export function ReviewMPMA({
       value: "",
       rightElement: (
         <div className="space-y-2 max-h-48 overflow-y-auto mt-2 w-full">
-          {isLoading ? (
-            <div className="text-xs text-gray-500">Loading...</div>
-          ) : transactions.length === 0 ? (
+          {transactions.length === 0 ? (
             <div className="text-xs text-gray-500">No sends</div>
           ) : (
-            transactions.map((tx, idx) => (
+            transactions.map((tx: { asset: string; destination: string; quantity: string | number; memo?: string }, idx: number) => (
               <div key={idx} className="text-xs border-b pb-1">
                 <div className="font-mono">
-                  Send #{idx + 1}: {tx.quantityNormalized} {tx.asset}
+                  Send #{idx + 1}: {tx.quantity} {tx.asset}
                 </div>
                 <div className="text-gray-600 truncate">
                   to {tx.destination}

--- a/src/pages/requests/message/approve.tsx
+++ b/src/pages/requests/message/approve.tsx
@@ -3,6 +3,8 @@ import { FiGlobe, FiClock } from '@/components/icons';
 import { Button } from '@/components/ui/button';
 import { ErrorAlert } from '@/components/ui/error-alert';
 import { useWallet } from '@/contexts/wallet-context';
+import { getIdentityMismatchError } from '@/utils/provider/requestIdentity';
+import { usePopupLifecycle } from '@/hooks/usePopupLifecycle';
 import { useHeader } from '@/contexts/header-context';
 import { useSignMessageRequest } from '@/hooks/useSignMessageRequest';
 import { signMessage } from '@/utils/blockchain/bitcoin/messageSigner';
@@ -19,6 +21,7 @@ export default function ApproveMessagePage() {
     handleCancel,
     isProviderRequest
   } = useSignMessageRequest();
+  usePopupLifecycle(request?.id, 'sign-message');
 
   const [isSigning, setIsSigning] = useState(false);
   const [error, setError] = useState<string>('');
@@ -46,6 +49,12 @@ export default function ApproveMessagePage() {
 
   const handleSign = async () => {
     if (!request || !activeWallet || !activeAddress) return;
+
+    const identityError = getIdentityMismatchError(request, activeAddress.address, activeWallet.id);
+    if (identityError) {
+      setError(identityError);
+      return;
+    }
 
     setIsSigning(true);
     setError('');

--- a/src/pages/requests/psbt/approve.tsx
+++ b/src/pages/requests/psbt/approve.tsx
@@ -6,6 +6,8 @@ import { VerificationStatus } from '@/components/domain/tx/verification-status';
 import { formatAddress, formatAmount } from '@/utils/format';
 import { fromSatoshis } from '@/utils/numeric';
 import { useWallet } from '@/contexts/wallet-context';
+import { getIdentityMismatchError } from '@/utils/provider/requestIdentity';
+import { usePopupLifecycle } from '@/hooks/usePopupLifecycle';
 import { useSettings } from '@/contexts/settings-context';
 import { useHeader } from '@/contexts/header-context';
 import { useSignPsbtRequest } from '@/hooks/useSignPsbtRequest';
@@ -93,6 +95,7 @@ export default function ApprovePsbtPage() {
     handleCancel,
     isProviderRequest
   } = useSignPsbtRequest(activeAddress?.address);
+  usePopupLifecycle(request?.id, 'sign-psbt');
 
   const [isSigning, setIsSigning] = useState(false);
   const [error, setError] = useState<string>('');
@@ -121,6 +124,12 @@ export default function ApprovePsbtPage() {
 
   const handleSign = async () => {
     if (!request || !decodedInfo) return;
+
+    const identityError = getIdentityMismatchError(request, activeAddress?.address, activeWallet?.id);
+    if (identityError) {
+      setError(identityError);
+      return;
+    }
 
     setIsSigning(true);
     setError('');

--- a/src/pages/requests/transaction/approve.tsx
+++ b/src/pages/requests/transaction/approve.tsx
@@ -6,6 +6,8 @@ import { VerificationStatus } from '@/components/domain/tx/verification-status';
 import { formatAddress, formatAmount, formatPriceRatio } from '@/utils/format';
 import { fromSatoshis } from '@/utils/numeric';
 import { useWallet } from '@/contexts/wallet-context';
+import { getIdentityMismatchError } from '@/utils/provider/requestIdentity';
+import { usePopupLifecycle } from '@/hooks/usePopupLifecycle';
 import { useSettings } from '@/contexts/settings-context';
 import { useHeader } from '@/contexts/header-context';
 import { useSignTransactionRequest } from '@/hooks/useSignTransactionRequest';
@@ -219,6 +221,7 @@ export default function ApproveTransactionPage() {
     handleCancel,
     isProviderRequest
   } = useSignTransactionRequest(activeAddress?.address);
+  usePopupLifecycle(request?.id, 'sign-transaction');
 
   const [isSigning, setIsSigning] = useState(false);
   const [error, setError] = useState<string>('');
@@ -249,6 +252,12 @@ export default function ApproveTransactionPage() {
   const handleSign = async () => {
     if (!request || !decodedInfo || !activeAddress) return;
 
+    const identityError = getIdentityMismatchError(request, activeAddress.address, activeWallet?.id);
+    if (identityError) {
+      setError(identityError);
+      return;
+    }
+
     setIsSigning(true);
     setError('');
 
@@ -256,7 +265,7 @@ export default function ApproveTransactionPage() {
       const walletService = getWalletService();
       const signedTxHex = await walletService.signTransaction(
         request.rawTxHex,
-        activeAddress.address
+        request.address
       );
 
       await handleSuccess(signedTxHex);
@@ -417,11 +426,11 @@ export default function ApproveTransactionPage() {
                 </div>
 
                 {/* Expiration */}
-                {txAction.expiration > 0 && (
-                  <p className="text-xs text-gray-400 text-center mt-2">
-                    Expires in {txAction.expiration.toLocaleString()} blocks
-                  </p>
-                )}
+                <p className="text-xs text-gray-400 text-center mt-2">
+                  {txAction.expiration === 0
+                    ? 'Never expires'
+                    : `Expires in ${txAction.expiration.toLocaleString()} blocks`}
+                </p>
               </div>
             ) : (
               /* Fallback — flat label + description (all other types) */

--- a/src/pages/settings/__tests__/order-settings.test.tsx
+++ b/src/pages/settings/__tests__/order-settings.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, waitFor } from '@testing-library/react';
+import { OrderSettings } from '../order-settings';
+import { LEGACY_MAX_ORDER_EXPIRATION } from '@/utils/settings';
+
+const mockUpdateSettings = vi.fn();
+vi.mock('@/contexts/settings-context', () => ({
+  useSettings: () => ({
+    settings: { defaultOrderExpiration: 0 },
+    updateSettings: mockUpdateSettings,
+  }),
+}));
+
+const mockGetStatus = vi.fn();
+vi.mock('@/utils/blockchain/counterparty/capabilities', () => ({
+  getCounterpartyFeatureStatus: (...args: unknown[]) => mockGetStatus(...args),
+}));
+
+describe('OrderSettings — activation-window gating', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('coerces a "never" (0) default to the legacy max when the node lacks indefinite orders', async () => {
+    mockGetStatus.mockResolvedValue({ supported: false });
+    const onExpirationChange = vi.fn();
+
+    render(<OrderSettings onExpirationChange={onExpirationChange} />);
+
+    // The illegal default (0) must be snapped down and pushed up to the form so
+    // an untouched order form can't submit a value the node rejects.
+    await waitFor(() => {
+      expect(onExpirationChange).toHaveBeenCalledWith(LEGACY_MAX_ORDER_EXPIRATION);
+    });
+
+    // Label must not claim "Never expires" in legacy mode.
+    expect(screen.queryByText(/Never expires/)).not.toBeInTheDocument();
+    expect(screen.getByText(/8,064 blocks/)).toBeInTheDocument();
+
+    // Legacy presets are shown (no "Never"); the legacy-only "1 Hour" is present.
+    expect(screen.getByRole('button', { name: '1 Hour' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Never' })).not.toBeInTheDocument();
+
+    // Coercion is form-local only — it must not overwrite the saved preference.
+    expect(mockUpdateSettings).not.toHaveBeenCalled();
+  });
+
+  it('preserves "never" (0) and offers it as a preset when the node supports indefinite orders', async () => {
+    mockGetStatus.mockResolvedValue({ supported: true });
+    const onExpirationChange = vi.fn();
+
+    render(<OrderSettings onExpirationChange={onExpirationChange} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Never' })).toBeInTheDocument();
+    });
+
+    expect(onExpirationChange).not.toHaveBeenCalledWith(LEGACY_MAX_ORDER_EXPIRATION);
+    expect(screen.getByText(/Never expires/)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '1 Hour' })).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/settings/advanced.tsx
+++ b/src/pages/settings/advanced.tsx
@@ -79,7 +79,7 @@ export default function AdvancedSettingsPage(): ReactElement {
         />
         {shouldShowHelpText && (
           <Description className="mt-2 text-sm text-gray-500">
-            The Counterparty API endpoint URL. Must be a mainnet API server.
+            The Counterparty API endpoint URL. Must be a mainnet API server running Counterparty Core 11.1.0 or newer.
           </Description>
         )}
       </Field>

--- a/src/pages/settings/order-settings.tsx
+++ b/src/pages/settings/order-settings.tsx
@@ -1,5 +1,11 @@
 import { useState, useEffect } from 'react';
 import { useSettings } from '@/contexts/settings-context';
+import {
+  DEFAULT_ORDER_EXPIRATION,
+  LEGACY_MAX_ORDER_EXPIRATION,
+  MAX_ORDER_EXPIRATION,
+} from '@/utils/settings';
+import { getCounterpartyFeatureStatus } from '@/utils/blockchain/counterparty/capabilities';
 import type { ReactElement } from 'react';
 
 interface OrderSettingsProps {
@@ -11,18 +17,23 @@ interface OrderSettingsProps {
   showHelpText?: boolean;
 }
 
-// Common expiration presets (in blocks)
-const EXPIRATION_PRESETS = [
+const LEGACY_EXPIRATION_PRESETS = [
   { label: '1 Hour', blocks: 6 },
   { label: '1 Day', blocks: 144 },
   { label: '1 Week', blocks: 1008 },
   { label: '2 Weeks', blocks: 2016 },
   { label: '1 Month', blocks: 4320 },
-  { label: 'Max', blocks: 8064 },
+  { label: 'Max', blocks: LEGACY_MAX_ORDER_EXPIRATION },
 ];
 
-// Default expiration value (Max preset)
-const DEFAULT_EXPIRATION = 8064;
+const EXPIRATION_PRESETS = [
+  { label: 'Never', blocks: 0 },
+  { label: '1 Day', blocks: 144 },
+  { label: '1 Week', blocks: 1008 },
+  { label: '1 Month', blocks: 4320 },
+  { label: '1 Year', blocks: 52560 },
+  { label: 'Max', blocks: MAX_ORDER_EXPIRATION },
+];
 
 export function OrderSettings({
   customExpiration,
@@ -34,20 +45,56 @@ export function OrderSettings({
 }: OrderSettingsProps): ReactElement {
   const { settings, updateSettings } = useSettings();
 
-  // Calculate initial expiration - always default to Max (8064) if no value set
   const getInitialExpiration = () => {
-    if (customExpiration !== undefined && customExpiration > 0) return customExpiration;
-    if (settings?.defaultOrderExpiration !== undefined && settings.defaultOrderExpiration > 0) return settings.defaultOrderExpiration;
-    return DEFAULT_EXPIRATION;
+    if (customExpiration !== undefined) return customExpiration;
+    if (settings?.defaultOrderExpiration !== undefined) return settings.defaultOrderExpiration;
+    return DEFAULT_ORDER_EXPIRATION;
   };
 
   const [expiration, setExpiration] = useState<number>(getInitialExpiration);
   const [customValue, setCustomValue] = useState<string>('');
   const [feeRequired, setFeeRequired] = useState<number>(customFeeRequired);
+  const [usesLegacyExpirations, setUsesLegacyExpirations] = useState(true);
+  const minCustomExpiration = usesLegacyExpirations ? 1 : 0;
+  const maxCustomExpiration = usesLegacyExpirations ? LEGACY_MAX_ORDER_EXPIRATION : MAX_ORDER_EXPIRATION;
+  const expirationPresets = usesLegacyExpirations ? LEGACY_EXPIRATION_PRESETS : EXPIRATION_PRESETS;
+
+  useEffect(() => {
+    let cancelled = false;
+
+    // Without node support, clamp an illegal value (0, or > legacy max) to the
+    // legacy max and propagate to the form. Not persisted, so the saved
+    // preference returns once the feature is supported.
+    const enforceLegacy = () => {
+      setExpiration((prev) => {
+        if (prev === 0 || prev > LEGACY_MAX_ORDER_EXPIRATION) {
+          onExpirationChange(LEGACY_MAX_ORDER_EXPIRATION);
+          return LEGACY_MAX_ORDER_EXPIRATION;
+        }
+        return prev;
+      });
+    };
+
+    getCounterpartyFeatureStatus('indefiniteOrders')
+      .then((status) => {
+        if (cancelled) return;
+        setUsesLegacyExpirations(!status.supported);
+        if (!status.supported) enforceLegacy();
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setUsesLegacyExpirations(true);
+        enforceLegacy();
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [onExpirationChange]);
 
   // Update local state when settings change
   useEffect(() => {
-    if (!customExpiration && settings?.defaultOrderExpiration) {
+    if (customExpiration === undefined && settings?.defaultOrderExpiration !== undefined) {
       setExpiration(settings.defaultOrderExpiration);
     }
   }, [settings?.defaultOrderExpiration, customExpiration]);
@@ -69,7 +116,7 @@ export function OrderSettings({
   const handleCustomKeyDown = async (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' && customValue) {
       const numValue = parseInt(customValue, 10);
-      if (numValue > 0 && numValue <= 1000000) {
+      if (numValue >= minCustomExpiration && numValue <= maxCustomExpiration) {
         setExpiration(numValue);
         onExpirationChange(numValue);
         await updateSettings({ defaultOrderExpiration: numValue });
@@ -78,11 +125,17 @@ export function OrderSettings({
   };
 
   const calculateDays = (blocks: number) => {
+    if (blocks === 0) return 'never';
     const days = blocks / 144;
     if (days < 1) return `${(days * 24).toFixed(0)}h`;
     if (days < 7) return `${days.toFixed(1)}d`;
+    if (days >= 30) return `${(days / 30).toFixed(1)}mo`;
     return `${(days / 7).toFixed(1)}w`;
   };
+
+  const expirationLabel = (expiration === 0 && !usesLegacyExpirations)
+    ? 'Never expires'
+    : `${expiration.toLocaleString()} blocks (~${calculateDays(expiration)})`;
 
   const handleFeeRequiredChange = (value: string) => {
     // Only allow numbers
@@ -107,13 +160,13 @@ export function OrderSettings({
               Order Expiration
             </label>
             <span className="text-sm text-gray-500 tabular-nums">
-              {expiration} blocks (~{calculateDays(expiration)})
+              {expirationLabel}
             </span>
           </div>
 
           {/* Preset buttons */}
           <div className="grid grid-cols-3 gap-2 mb-3">
-            {EXPIRATION_PRESETS.map((preset) => {
+            {expirationPresets.map((preset) => {
               // Button is selected if expiration matches and no custom value is being entered
               const isSelected = expiration === preset.blocks && customValue === '';
               return (
@@ -141,14 +194,16 @@ export function OrderSettings({
               value={customValue}
               onChange={(e) => handleCustomChange(e.target.value)}
               onKeyDown={handleCustomKeyDown}
-              placeholder="Custom blocks (press Enter)"
+              placeholder={`Custom blocks, ${minCustomExpiration}-${maxCustomExpiration}`}
               inputMode="numeric"
               aria-label="Custom expiration in blocks"
               className="flex-1 px-3 py-2.5 text-sm border border-gray-300 rounded-md outline-none focus:border-blue-500 focus-visible:ring-2 focus-visible:ring-blue-500"
             />
             {showHelpText && (
               <p className="text-xs text-gray-500">
-                Orders cancel after n blocks. Max is recommended.
+                {usesLegacyExpirations
+                  ? `Orders cancel after the selected number of blocks. The current maximum is ${LEGACY_MAX_ORDER_EXPIRATION}.`
+                  : 'Use 0 for orders that never expire. Finite orders cancel after the selected number of blocks.'}
               </p>
             )}
           </div>

--- a/src/pages/transactions/_messages/fairminter.tsx
+++ b/src/pages/transactions/_messages/fairminter.tsx
@@ -88,6 +88,17 @@ export function fairminter(tx: Transaction): Array<{ label: string; value: strin
     });
   }
 
+  if (params.max_mint_per_address_normalized !== undefined && Number(params.max_mint_per_address_normalized) > 0) {
+    fields.push({
+      label: "Max Mint per Address",
+      value: formatAmount({
+        value: Number(params.max_mint_per_address_normalized),
+        minimumFractionDigits: isDivisible ? 8 : 0,
+        maximumFractionDigits: isDivisible ? 8 : 0,
+      }),
+    });
+  }
+
   if (params.soft_cap_normalized !== undefined && Number(params.soft_cap_normalized) > 0) {
     fields.push({
       label: "Soft Cap",

--- a/src/pages/transactions/_messages/order.tsx
+++ b/src/pages/transactions/_messages/order.tsx
@@ -168,7 +168,7 @@ export function order(tx: Transaction): Array<{ label: string; value: string | R
     if (params.expiration === 0) {
       fields.push({
         label: "Expiration",
-        value: "Never",
+        value: "Never expires",
       });
     } else {
       const currentBlock = params.block_index || 0;

--- a/src/services/__tests__/connectionService.test.ts
+++ b/src/services/__tests__/connectionService.test.ts
@@ -38,6 +38,22 @@ vi.mock('@/services/walletService', () => ({
   getWalletService: vi.fn(() => ({
     isKeychainUnlocked: vi.fn().mockResolvedValue(true),
     getActiveAddress: vi.fn().mockResolvedValue({ address: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa' }),
+    // Connected-website access delegates to the walletManager mock so existing
+    // getSettings/updateSettings drivers and assertions keep working.
+    getSettings: () => walletManager.getSettings(),
+    addConnectedWebsite: async (origin: string) => {
+      const s = walletManager.getSettings();
+      if (!s.connectedWebsites.includes(origin)) {
+        await walletManager.updateSettings({ connectedWebsites: [...s.connectedWebsites, origin] });
+      }
+    },
+    removeConnectedWebsite: async (origin: string) => {
+      const s = walletManager.getSettings();
+      await walletManager.updateSettings({ connectedWebsites: s.connectedWebsites.filter((x: string) => x !== origin) });
+    },
+    clearConnectedWebsites: async () => {
+      await walletManager.updateSettings({ connectedWebsites: [] });
+    },
   })),
 }));
 

--- a/src/services/connectionService.ts
+++ b/src/services/connectionService.ts
@@ -10,7 +10,6 @@
  */
 
 import { BaseService } from '@/services/core/BaseService';
-import { walletManager } from '@/utils/wallet/walletManager';
 import { getWalletService } from '@/services/walletService';
 import { getApprovalService, type ApprovalResult } from '@/services/approvalService';
 import { connectionRateLimiter } from '@/utils/provider/rateLimiter';
@@ -18,6 +17,7 @@ import { analyzeCSP } from '@/utils/security/cspValidation';
 import { analytics } from '@/utils/fathom';
 import { eventEmitterService } from '@/services/eventEmitterService';
 import { generateRequestId } from '@/utils/id';
+import { ProviderError, PROVIDER_ERROR_CODES } from '@/utils/errors';
 
 export interface ConnectionStatus {
   origin: string;
@@ -97,7 +97,7 @@ export class ConnectionService extends BaseService {
    * Perform the actual permission lookup from storage
    */
   private async doPermissionLookup(origin: string): Promise<boolean> {
-    const settings = walletManager.getSettings();
+    const settings = await getWalletService().getSettings();
     const isConnected = settings.connectedWebsites.includes(origin);
 
     // Update cache
@@ -236,12 +236,7 @@ export class ConnectionService extends BaseService {
       await analytics.track('connection_established');
 
       // Add to connected websites
-      const settings = walletManager.getSettings();
-      if (!settings.connectedWebsites.includes(origin)) {
-        await walletManager.updateSettings({
-          connectedWebsites: [...settings.connectedWebsites, origin],
-        });
-      }
+      await getWalletService().addConnectedWebsite(origin);
 
       // Update cache
       this.state.connectionCache.set(origin, {
@@ -259,7 +254,7 @@ export class ConnectionService extends BaseService {
       
       return accounts;
     } else {
-      throw new Error('User denied the request');
+      throw new ProviderError(PROVIDER_ERROR_CODES.USER_REJECTED, 'User denied the request');
     }
   }
 
@@ -270,12 +265,7 @@ export class ConnectionService extends BaseService {
     console.debug('[ConnectionService] Disconnecting dApp:', origin);
 
     // Remove from connected websites
-    const settings = walletManager.getSettings();
-    const updatedSites = settings.connectedWebsites.filter(site => site !== origin);
-
-    await walletManager.updateSettings({
-      connectedWebsites: updatedSites,
-    });
+    await getWalletService().removeConnectedWebsite(origin);
 
     // Update cache
     this.state.connectionCache.delete(origin);
@@ -309,7 +299,7 @@ export class ConnectionService extends BaseService {
    * Get all connected websites
    */
   async getConnectedWebsites(): Promise<ConnectionStatus[]> {
-    const settings = walletManager.getSettings();
+    const settings = await getWalletService().getSettings();
     const connections: ConnectionStatus[] = [];
 
     for (const origin of settings.connectedWebsites) {
@@ -331,11 +321,10 @@ export class ConnectionService extends BaseService {
    * Disconnect all websites
    */
   async disconnectAll(): Promise<void> {
-    const settings = walletManager.getSettings();
-    const connectedSites = [...settings.connectedWebsites];
+    const connectedSites = [...(await getWalletService().getSettings()).connectedWebsites];
 
     // Update settings
-    await walletManager.updateSettings({ connectedWebsites: [] });
+    await getWalletService().clearConnectedWebsites();
 
     // Clear cache
     this.state.connectionCache.clear();

--- a/src/services/popupMonitorService.ts
+++ b/src/services/popupMonitorService.ts
@@ -8,10 +8,21 @@
 import { eventEmitterService } from '@/services/eventEmitterService';
 import { signMessageRequestStorage } from '@/utils/storage/signMessageRequestStorage';
 import { signPsbtRequestStorage } from '@/utils/storage/signPsbtRequestStorage';
+import { signTransactionRequestStorage } from '@/utils/storage/signTransactionRequestStorage';
+import { getSignFlow, recordSignOutcome } from '@/utils/provider/signFlow';
+
+type SignRequestKind = 'sign-message' | 'sign-psbt' | 'sign-transaction';
+
+/** Per-kind event prefix (for the cancel event) and request store. */
+const REQUEST_KINDS = {
+  'sign-message': { eventPrefix: 'sign-message', storage: signMessageRequestStorage },
+  'sign-psbt': { eventPrefix: 'sign-psbt', storage: signPsbtRequestStorage },
+  'sign-transaction': { eventPrefix: 'sign-tx', storage: signTransactionRequestStorage },
+} as const;
 
 class PopupMonitorService {
   private popupPort: chrome.runtime.Port | null = null;
-  private activeRequests = new Map<string, { type: 'sign-message' | 'sign-psbt', timestamp: number }>();
+  private activeRequests = new Map<string, { type: SignRequestKind, timestamp: number }>();
   private cleanupTimer: NodeJS.Timeout | null = null;
 
   /**
@@ -91,20 +102,18 @@ class PopupMonitorService {
     }
 
     for (const [requestId, info] of this.activeRequests) {
-      console.log(`[PopupMonitor] Cancelling abandoned request: ${requestId}`);
+      // Only cancel if the user never reached a decision (flow still pending).
+      const flow = await getSignFlow(requestId);
+      if (flow && flow.status !== 'pending') continue;
 
-      // Emit cancellation event
-      if (info.type === 'sign-message') {
-        eventEmitterService.emit(`sign-message-cancel-${requestId}`, {
-          reason: 'Popup closed unexpectedly'
-        });
-        await signMessageRequestStorage.remove(requestId);
-      } else if (info.type === 'sign-psbt') {
-        eventEmitterService.emit(`sign-psbt-cancel-${requestId}`, {
-          reason: 'Popup closed unexpectedly'
-        });
-        await signPsbtRequestStorage.remove(requestId);
-      }
+      console.log(`[PopupMonitor] Cancelling abandoned request: ${requestId}`);
+      const { eventPrefix, storage } = REQUEST_KINDS[info.type];
+      // Persist the cancellation so a rejoin after a worker restart sees it too.
+      await recordSignOutcome(requestId, 'cancelled');
+      eventEmitterService.emit(`${eventPrefix}-cancel-${requestId}`, {
+        reason: 'Popup closed unexpectedly'
+      });
+      await storage.remove(requestId);
     }
 
     // Clear tracked requests
@@ -182,7 +191,7 @@ class PopupMonitorService {
   /**
    * Register a request as active
    */
-  registerActiveRequest(requestId: string, type: 'sign-message' | 'sign-psbt'): void {
+  registerActiveRequest(requestId: string, type: SignRequestKind): void {
     this.activeRequests.set(requestId, {
       type,
       timestamp: Date.now()

--- a/src/services/providerService.ts
+++ b/src/services/providerService.ts
@@ -20,6 +20,13 @@ import { signMessageRequestStorage } from '@/utils/storage/signMessageRequestSto
 import { signPsbtRequestStorage } from '@/utils/storage/signPsbtRequestStorage';
 import { signTransactionRequestStorage } from '@/utils/storage/signTransactionRequestStorage';
 import { getUpdateService } from '@/services/updateService';
+import {
+  computeRequestKey,
+  beginSignFlow,
+  findActiveFlowByKey,
+  getSignFlow,
+  removeSignFlow,
+} from '@/utils/provider/signFlow';
 import { fetchBTCBalance } from '@/utils/blockchain/bitcoin/balance';
 import { fetchTokenBalances } from '@/utils/blockchain/counterparty/api';
 import { checkReplayAttempt, recordTransaction, markTransactionBroadcasted } from '@/utils/security/replayPrevention';
@@ -27,6 +34,7 @@ import { signMessage as signMessageDirect } from '@/utils/blockchain/bitcoin/mes
 import { openExtensionPopup } from '@/utils/popup';
 import { generateRequestId } from '@/utils/id';
 import { keychainExists } from '@/utils/storage/walletStorage';
+import { ProviderError, PROVIDER_ERROR_CODES } from '@/utils/errors';
 
 // In-memory storage for active requests (primary storage, fast access)
 const activeSignRequests = new Map<string, any>();
@@ -113,10 +121,124 @@ export interface ProviderService {
   destroy: () => Promise<void>;
 }
 
+/**
+ * Drives the popup approval lifecycle for a dApp signing request: registers the
+ * critical operation, resolves/rejects on the popup's complete/cancel events,
+ * times out after 10 minutes, and cleans up listeners (and any per-request
+ * state via onCleanup) on every exit path.
+ */
+function awaitSignApproval<T>(opts: {
+  requestId: string;
+  eventPrefix: string;
+  analyticsEvent: string;
+  cancelMessage: string;
+  timeoutMessage: string;
+  mapResult: (result: any) => T;
+  onCleanup?: () => void;
+}): Promise<T> {
+  const updateService = getUpdateService();
+  updateService.registerCriticalOperation(`${opts.eventPrefix}-${opts.requestId}`);
+
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    let timeout: ReturnType<typeof setTimeout>;
+    let poll: ReturnType<typeof setInterval>;
+
+    const cleanup = () => {
+      if (timeout) clearTimeout(timeout);
+      if (poll) clearInterval(poll);
+      updateService.unregisterCriticalOperation(`${opts.eventPrefix}-${opts.requestId}`);
+      eventEmitterService.off(`${opts.eventPrefix}-complete-${opts.requestId}`, handleComplete);
+      eventEmitterService.off(`${opts.eventPrefix}-cancel-${opts.requestId}`, handleCancel);
+      void removeSignFlow(opts.requestId);
+      opts.onCleanup?.();
+    };
+
+    const handleComplete = (result: any) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      analytics.track(opts.analyticsEvent);
+      resolve(opts.mapResult(result));
+    };
+
+    const handleCancel = () => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(new ProviderError(PROVIDER_ERROR_CODES.USER_REJECTED, opts.cancelMessage));
+    };
+
+    timeout = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(new Error(opts.timeoutMessage));
+    }, 10 * 60 * 1000);
+
+    eventEmitterService.on(`${opts.eventPrefix}-complete-${opts.requestId}`, handleComplete);
+    eventEmitterService.on(`${opts.eventPrefix}-cancel-${opts.requestId}`, handleCancel);
+
+    // Recovery path: if this worker is a fresh rejoin after a restart, the popup's
+    // outcome is persisted in signFlow even though the original listener was lost.
+    poll = setInterval(() => {
+      if (settled) return;
+      void getSignFlow(opts.requestId).then((flow) => {
+        if (settled || !flow) return;
+        if (flow.status === 'completed') handleComplete(flow.result);
+        else if (flow.status === 'cancelled') handleCancel();
+      });
+    }, 1500);
+  });
+}
+
+/**
+ * Run a signing request through its durable flow: recover a completed result,
+ * rejoin a pending one (no new popup), or begin a fresh flow. createAndOpen
+ * stores the per-type request and opens the popup for the new-flow case.
+ */
+async function runSignFlow<T>(args: {
+  origin: string;
+  method: string;
+  params: unknown;
+  approval: {
+    eventPrefix: string;
+    analyticsEvent: string;
+    cancelMessage: string;
+    timeoutMessage: string;
+    mapResult: (result: any) => T;
+  };
+  cleanup?: (requestId: string) => void;
+  createAndOpen: (requestId: string) => Promise<void>;
+}): Promise<T> {
+  const requestKey = computeRequestKey(args.origin, args.method, args.params);
+  const existing = await findActiveFlowByKey(requestKey);
+
+  const awaitFor = (requestId: string) =>
+    awaitSignApproval({
+      ...args.approval,
+      requestId,
+      onCleanup: args.cleanup ? () => args.cleanup!(requestId) : undefined,
+    });
+
+  if (existing?.status === 'completed') {
+    await removeSignFlow(existing.id);
+    args.cleanup?.(existing.id);
+    analytics.track(args.approval.analyticsEvent);
+    return args.approval.mapResult(existing.result);
+  }
+  if (existing?.status === 'pending') {
+    // Rejoin the original flow rather than opening a duplicate popup.
+    return awaitFor(existing.id);
+  }
+
+  const requestId = generateRequestId(args.approval.eventPrefix);
+  await beginSignFlow(requestId, args.origin, requestKey);
+  await args.createAndOpen(requestId);
+  return awaitFor(requestId);
+}
+
 export function createProviderService(): ProviderService {
-  /**
-   * Get accounts for connected origin
-   */
   /**
    * Generate a connection proof: auto-sign a deterministic message proving
    * the user controls the address. No user prompt — they already approved connecting.
@@ -187,6 +309,32 @@ export function createProviderService(): ProviderService {
   async function buildConnectResponse(origin: string, accounts: string[]) {
     const proof = accounts.length > 0 ? await generateConnectionProof(origin) : null;
     return { accounts, proof };
+  }
+
+  /**
+   * Resolve a connection request: return existing accounts if already connected,
+   * otherwise connect and build the response. onBeforeConnect runs only for a
+   * new connection (after the already-connected check, before connect).
+   */
+  async function completeConnection(origin: string, onBeforeConnect?: () => Promise<void>) {
+    const walletService = getWalletService();
+    const connectionService = getConnectionService();
+
+    const activeAddress = await walletService.getActiveAddress();
+    const activeWallet = await walletService.getActiveWallet();
+    if (!activeAddress || !activeWallet) {
+      throw new Error('No active wallet or address');
+    }
+
+    if (await connectionService.hasPermission(origin)) {
+      return buildConnectResponse(origin, await getAccounts(origin));
+    }
+
+    await onBeforeConnect?.();
+
+    const accounts = await connectionService.connect(origin, activeAddress.address, activeWallet.id);
+    await analytics.track('connection_established');
+    return buildConnectResponse(origin, accounts);
   }
 
   /**
@@ -278,24 +426,7 @@ export function createProviderService(): ProviderService {
 
                 // Continue with connection flow now that wallet exists
                 try {
-                  const activeAddress = await walletService.getActiveAddress();
-                  const activeWallet = await walletService.getActiveWallet();
-
-                  if (!activeAddress || !activeWallet) {
-                    reject(new Error('No active wallet or address after setup'));
-                    return;
-                  }
-
-                  // Check if already connected (unlikely after fresh setup)
-                  if (await connectionService.hasPermission(origin)) {
-                    resolve(await buildConnectResponse(origin, await getAccounts(origin)));
-                    return;
-                  }
-
-                  // Request connection
-                  const accounts = await connectionService.connect(origin, activeAddress.address, activeWallet.id);
-                  await analytics.track('connection_established');
-                  resolve(await buildConnectResponse(origin, accounts));
+                  resolve(await completeConnection(origin));
                 } catch (error) {
                   reject(error);
                 }
@@ -305,7 +436,7 @@ export function createProviderService(): ProviderService {
                 if (settled) return;
                 settled = true;
                 cleanup();
-                reject(new Error('Wallet setup timeout - please try again'));
+                reject(new ProviderError(PROVIDER_ERROR_CODES.UNAUTHORIZED, 'Wallet setup timeout - please try again'));
               }, 10 * 60 * 1000); // 10 minute timeout for onboarding
 
               eventEmitterService.on('wallet-created', handleWalletCreated);
@@ -349,30 +480,13 @@ export function createProviderService(): ProviderService {
                 // Re-check wallet state after unlock
                 const nowUnlocked = await walletService.isKeychainUnlocked();
                 if (!nowUnlocked) {
-                  reject(new Error('Wallet still locked after unlock attempt'));
+                  reject(new ProviderError(PROVIDER_ERROR_CODES.UNAUTHORIZED, 'Wallet still locked after unlock attempt'));
                   return;
                 }
 
                 // Continue with connection flow
                 try {
-                  const activeAddress = await walletService.getActiveAddress();
-                  const activeWallet = await walletService.getActiveWallet();
-
-                  if (!activeAddress || !activeWallet) {
-                    reject(new Error('No active wallet or address after unlock'));
-                    return;
-                  }
-
-                  // Check if already connected
-                  if (await connectionService.hasPermission(origin)) {
-                    resolve(await buildConnectResponse(origin, await getAccounts(origin)));
-                    return;
-                  }
-
-                  // Request connection
-                  const accounts = await connectionService.connect(origin, activeAddress.address, activeWallet.id);
-                  await analytics.track('connection_established');
-                  resolve(await buildConnectResponse(origin, accounts));
+                  resolve(await completeConnection(origin));
                 } catch (error) {
                   reject(error);
                 }
@@ -389,52 +503,29 @@ export function createProviderService(): ProviderService {
             });
           }
 
-          // Get current wallet and address info
-          const activeAddress = await walletService.getActiveAddress();
-          if (!activeAddress) {
-            throw new Error('No address selected');
-          }
+          // CSP analysis (warning mode only) runs just before a new connection.
+          return completeConnection(origin, async () => {
+            let cspHostname = origin;
+            try { cspHostname = new URL(origin).hostname; } catch { /* use raw origin */ }
 
-          const activeWallet = await walletService.getActiveWallet();
-          if (!activeWallet) {
-            throw new Error('No wallet selected');
-          }
-
-          // Check if already connected
-          if (await connectionService.hasPermission(origin)) {
-            return buildConnectResponse(origin, await getAccounts(origin));
-          }
-          
-          // CSP Security Analysis (warning mode only)
-          // Safely extract hostname for logging
-          let cspHostname = origin;
-          try { cspHostname = new URL(origin).hostname; } catch { /* use raw origin */ }
-
-          try {
-            const cspAnalysis = await analyzeCSP(origin);
-            if (!cspAnalysis.hasCSP || cspAnalysis.warnings.length > 0) {
-              console.warn('[ProviderService] Site has CSP security issues', {
+            try {
+              const cspAnalysis = await analyzeCSP(origin);
+              if (!cspAnalysis.hasCSP || cspAnalysis.warnings.length > 0) {
+                console.warn('[ProviderService] Site has CSP security issues', {
+                  origin: cspHostname,
+                  hasCSP: cspAnalysis.hasCSP,
+                  isSecure: cspAnalysis.isSecure,
+                  warningCount: cspAnalysis.warnings.length,
+                  warnings: cspAnalysis.warnings.slice(0, 3)
+                });
+              }
+            } catch (error) {
+              console.warn('[ProviderService] CSP analysis failed', {
                 origin: cspHostname,
-                hasCSP: cspAnalysis.hasCSP,
-                isSecure: cspAnalysis.isSecure,
-                warningCount: cspAnalysis.warnings.length,
-                warnings: cspAnalysis.warnings.slice(0, 3)
+                error: (error as Error).message
               });
             }
-          } catch (error) {
-            console.warn('[ProviderService] CSP analysis failed', {
-              origin: cspHostname,
-              error: (error as Error).message
-            });
-          }
-          
-          // Request connection through ConnectionService
-          const accounts = await connectionService.connect(origin, activeAddress.address, activeWallet.id);
-
-          // Track successful connection
-          await analytics.track('connection_established');
-
-          return buildConnectResponse(origin, accounts);
+          });
         }
         
         case 'xcp_accounts': {
@@ -475,12 +566,13 @@ export function createProviderService(): ProviderService {
 
           // Check if connected
           if (!await connectionService.hasPermission(origin)) {
-            throw new Error('Unauthorized - not connected to wallet');
+            throw new ProviderError(PROVIDER_ERROR_CODES.UNAUTHORIZED, 'Unauthorized - not connected to wallet');
           }
 
-          // Get active address for the request
+          // Get active address/wallet for the request
           const activeAddress = await walletService.getActiveAddress();
-          if (!activeAddress) {
+          const activeWallet = await walletService.getActiveWallet();
+          if (!activeAddress || !activeWallet) {
             throw new Error('No active address');
           }
 
@@ -489,68 +581,37 @@ export function createProviderService(): ProviderService {
             throw new Error('Specified address does not match active address');
           }
 
-          // Store the sign message request for the popup to retrieve
-          const signMessageRequestId = generateRequestId('sign-message');
-          await signMessageRequestStorage.store({
-            id: signMessageRequestId,
+          return runSignFlow({
             origin,
-            message,
-            timestamp: Date.now()
-          });
-
-          // Send message to popup to navigate to sign message form
-          chrome.runtime.sendMessage({
-            type: 'NAVIGATE_TO_SIGN_MESSAGE',
-            signMessageRequestId
-          }).catch(() => {
-            // Popup might not be open yet
-          });
-
-          // Open popup at the sign message approval page
-          await openExtensionPopup(`#/requests/message/approve?requestId=${signMessageRequestId}`);
-
-          // Track as critical operation to prevent extension updates during sign message
-          const updateService = getUpdateService();
-          updateService.registerCriticalOperation(`sign-message-${signMessageRequestId}`);
-
-          // Return a promise that will resolve when the user completes the sign message flow
-          return new Promise((resolve, reject) => {
-            let settled = false;
-            let timeout: ReturnType<typeof setTimeout>;
-
-            // Centralized cleanup - called on any exit path
-            const cleanup = () => {
-              if (timeout) clearTimeout(timeout);
-              updateService.unregisterCriticalOperation(`sign-message-${signMessageRequestId}`);
-              eventEmitterService.off(`sign-message-complete-${signMessageRequestId}`, handleComplete);
-              eventEmitterService.off(`sign-message-cancel-${signMessageRequestId}`, handleCancel);
-            };
-
-            const handleComplete = (result: any) => {
-              if (settled) return;
-              settled = true;
-              cleanup();
-              analytics.track('message_signed');
-              resolve(result.signature); // Return just the signature for compatibility
-            };
-
-            const handleCancel = () => {
-              if (settled) return;
-              settled = true;
-              cleanup();
-              reject(new Error('User cancelled sign message request'));
-            };
-
-            timeout = setTimeout(() => {
-              if (settled) return;
-              settled = true;
-              cleanup();
-              reject(new Error('Sign message request timeout'));
-            }, 10 * 60 * 1000); // 10 minute timeout
-
-            // Listen for completion events
-            eventEmitterService.on(`sign-message-complete-${signMessageRequestId}`, handleComplete);
-            eventEmitterService.on(`sign-message-cancel-${signMessageRequestId}`, handleCancel);
+            method,
+            params,
+            approval: {
+              eventPrefix: 'sign-message',
+              analyticsEvent: 'message_signed',
+              cancelMessage: 'User cancelled sign message request',
+              timeoutMessage: 'Sign message request timeout',
+              mapResult: (result) => result.signature,
+            },
+            cleanup: (requestId) => {
+              void signMessageRequestStorage.remove(requestId);
+            },
+            createAndOpen: async (requestId) => {
+              // Binds the request to the authorized address/wallet so signing
+              // can't later use a different identity.
+              await signMessageRequestStorage.store({
+                id: requestId,
+                origin,
+                message,
+                address: activeAddress.address,
+                walletId: activeWallet.id,
+                timestamp: Date.now(),
+              });
+              chrome.runtime.sendMessage({
+                type: 'NAVIGATE_TO_SIGN_MESSAGE',
+                signMessageRequestId: requestId,
+              }).catch(() => { /* Popup might not be open yet */ });
+              await openExtensionPopup(`#/requests/message/approve?requestId=${requestId}`);
+            },
           });
         }
         
@@ -566,85 +627,50 @@ export function createProviderService(): ProviderService {
 
           // Check if connected
           if (!await connectionService.hasPermission(origin)) {
-            throw new Error('Unauthorized - not connected to wallet');
+            throw new ProviderError(PROVIDER_ERROR_CODES.UNAUTHORIZED, 'Unauthorized - not connected to wallet');
           }
 
-          // Get active address for the request
+          // Get active address/wallet for the request
           const activeAddress = await walletService.getActiveAddress();
-          if (!activeAddress) {
+          const activeWallet = await walletService.getActiveWallet();
+          if (!activeAddress || !activeWallet) {
             throw new Error('No active address');
           }
 
-          // Store the sign transaction request
-          const signTxRequestId = generateRequestId('sign-tx');
-          const request = {
-            id: signTxRequestId,
+          return runSignFlow({
             origin,
-            rawTxHex,
-            timestamp: Date.now()
-          };
-
-          // Store in memory for fast access
-          activeSignTransactionRequests.set(signTxRequestId, request);
-
-          // Also store in chrome.storage as backup
-          await signTransactionRequestStorage.store(request);
-
-          // Send message to popup to navigate to approve transaction page
-          chrome.runtime.sendMessage({
-            type: 'NAVIGATE_TO_APPROVE_TRANSACTION',
-            signTxRequestId
-          }).catch(() => {
-            // Popup might not be open yet
-          });
-
-          // Open popup at the approve transaction page
-          await openExtensionPopup(`#/requests/transaction/approve?requestId=${signTxRequestId}`);
-
-          // Track as critical operation to prevent extension updates during transaction signing
-          const updateService = getUpdateService();
-          updateService.registerCriticalOperation(`sign-tx-${signTxRequestId}`);
-
-          // Return a promise that will resolve when the user completes the sign transaction flow
-          return new Promise((resolve, reject) => {
-            let settled = false;
-            let timeout: ReturnType<typeof setTimeout>;
-
-            // Centralized cleanup - called on any exit path
-            const cleanup = () => {
-              if (timeout) clearTimeout(timeout);
-              activeSignTransactionRequests.delete(signTxRequestId);
-              signTransactionRequestStorage.remove(signTxRequestId);
-              updateService.unregisterCriticalOperation(`sign-tx-${signTxRequestId}`);
-              eventEmitterService.off(`sign-tx-complete-${signTxRequestId}`, handleComplete);
-              eventEmitterService.off(`sign-tx-cancel-${signTxRequestId}`, handleCancel);
-            };
-
-            const handleComplete = (result: any) => {
-              if (settled) return;
-              settled = true;
-              cleanup();
-              analytics.track('transaction_signed');
-              resolve({ hex: result.signedTxHex }); // Return signed transaction hex
-            };
-
-            const handleCancel = () => {
-              if (settled) return;
-              settled = true;
-              cleanup();
-              reject(new Error('User cancelled transaction signing request'));
-            };
-
-            timeout = setTimeout(() => {
-              if (settled) return;
-              settled = true;
-              cleanup();
-              reject(new Error('Transaction signing request timeout'));
-            }, 10 * 60 * 1000); // 10 minute timeout
-
-            // Listen for completion events
-            eventEmitterService.on(`sign-tx-complete-${signTxRequestId}`, handleComplete);
-            eventEmitterService.on(`sign-tx-cancel-${signTxRequestId}`, handleCancel);
+            method,
+            params,
+            approval: {
+              eventPrefix: 'sign-tx',
+              analyticsEvent: 'transaction_signed',
+              cancelMessage: 'User cancelled transaction signing request',
+              timeoutMessage: 'Transaction signing request timeout',
+              mapResult: (result) => ({ hex: result.signedTxHex }),
+            },
+            cleanup: (requestId) => {
+              activeSignTransactionRequests.delete(requestId);
+              void signTransactionRequestStorage.remove(requestId);
+            },
+            createAndOpen: async (requestId) => {
+              // Binds the request to the authorized address/wallet so signing
+              // can't later use a different identity.
+              const request = {
+                id: requestId,
+                origin,
+                rawTxHex,
+                address: activeAddress.address,
+                walletId: activeWallet.id,
+                timestamp: Date.now(),
+              };
+              activeSignTransactionRequests.set(requestId, request);
+              await signTransactionRequestStorage.store(request);
+              chrome.runtime.sendMessage({
+                type: 'NAVIGATE_TO_APPROVE_TRANSACTION',
+                signTxRequestId: requestId,
+              }).catch(() => { /* Popup might not be open yet */ });
+              await openExtensionPopup(`#/requests/transaction/approve?requestId=${requestId}`);
+            },
           });
         }
 
@@ -667,87 +693,50 @@ export function createProviderService(): ProviderService {
 
           // Check if connected
           if (!await connectionService.hasPermission(origin)) {
-            throw new Error('Unauthorized - not connected to wallet');
+            throw new ProviderError(PROVIDER_ERROR_CODES.UNAUTHORIZED, 'Unauthorized - not connected to wallet');
           }
 
-          // Get active address for the request
+          // Get active address/wallet for the request
           const activeAddress = await walletService.getActiveAddress();
-          if (!activeAddress) {
+          const activeWallet = await walletService.getActiveWallet();
+          if (!activeAddress || !activeWallet) {
             throw new Error('No active address');
           }
 
-          // Store the sign PSBT request
-          const signPsbtRequestId = generateRequestId('sign-psbt');
-          const request = {
-            id: signPsbtRequestId,
+          return runSignFlow({
             origin,
-            psbtHex,
-            signInputs,
-            sighashTypes,
-            timestamp: Date.now()
-          };
-
-          // Store in memory for fast access
-          activeSignPsbtRequests.set(signPsbtRequestId, request);
-
-          // Also store in chrome.storage as backup
-          await signPsbtRequestStorage.store(request);
-
-          // Send message to popup to navigate to approve PSBT page
-          chrome.runtime.sendMessage({
-            type: 'NAVIGATE_TO_APPROVE_PSBT',
-            signPsbtRequestId
-          }).catch(() => {
-            // Popup might not be open yet
-          });
-
-          // Open popup at the approve PSBT page
-          await openExtensionPopup(`#/requests/psbt/approve?requestId=${signPsbtRequestId}`);
-
-          // Track as critical operation to prevent extension updates during PSBT signing
-          const updateService = getUpdateService();
-          updateService.registerCriticalOperation(`sign-psbt-${signPsbtRequestId}`);
-
-          // Return a promise that will resolve when the user completes the sign PSBT flow
-          return new Promise((resolve, reject) => {
-            let settled = false;
-            let timeout: ReturnType<typeof setTimeout>;
-
-            // Centralized cleanup - called on any exit path
-            const cleanup = () => {
-              if (timeout) clearTimeout(timeout);
-              activeSignPsbtRequests.delete(signPsbtRequestId);
-              signPsbtRequestStorage.remove(signPsbtRequestId);
-              updateService.unregisterCriticalOperation(`sign-psbt-${signPsbtRequestId}`);
-              eventEmitterService.off(`sign-psbt-complete-${signPsbtRequestId}`, handleComplete);
-              eventEmitterService.off(`sign-psbt-cancel-${signPsbtRequestId}`, handleCancel);
-            };
-
-            const handleComplete = (result: any) => {
-              if (settled) return;
-              settled = true;
-              cleanup();
-              analytics.track('psbt_signed');
-              resolve({ hex: result.signedPsbtHex }); // Return signed PSBT hex
-            };
-
-            const handleCancel = () => {
-              if (settled) return;
-              settled = true;
-              cleanup();
-              reject(new Error('User cancelled PSBT signing request'));
-            };
-
-            timeout = setTimeout(() => {
-              if (settled) return;
-              settled = true;
-              cleanup();
-              reject(new Error('PSBT signing request timeout'));
-            }, 10 * 60 * 1000); // 10 minute timeout
-
-            // Listen for completion events
-            eventEmitterService.on(`sign-psbt-complete-${signPsbtRequestId}`, handleComplete);
-            eventEmitterService.on(`sign-psbt-cancel-${signPsbtRequestId}`, handleCancel);
+            method,
+            params,
+            approval: {
+              eventPrefix: 'sign-psbt',
+              analyticsEvent: 'psbt_signed',
+              cancelMessage: 'User cancelled PSBT signing request',
+              timeoutMessage: 'PSBT signing request timeout',
+              mapResult: (result) => ({ hex: result.signedPsbtHex }),
+            },
+            cleanup: (requestId) => {
+              activeSignPsbtRequests.delete(requestId);
+              void signPsbtRequestStorage.remove(requestId);
+            },
+            createAndOpen: async (requestId) => {
+              const request = {
+                id: requestId,
+                origin,
+                psbtHex,
+                signInputs,
+                sighashTypes,
+                address: activeAddress.address,
+                walletId: activeWallet.id,
+                timestamp: Date.now(),
+              };
+              activeSignPsbtRequests.set(requestId, request);
+              await signPsbtRequestStorage.store(request);
+              chrome.runtime.sendMessage({
+                type: 'NAVIGATE_TO_APPROVE_PSBT',
+                signPsbtRequestId: requestId,
+              }).catch(() => { /* Popup might not be open yet */ });
+              await openExtensionPopup(`#/requests/psbt/approve?requestId=${requestId}`);
+            },
           });
         }
 
@@ -756,7 +745,7 @@ export function createProviderService(): ProviderService {
         case 'xcp_getBalances': {
           // Check if connected
           if (!await connectionService.hasPermission(origin)) {
-            throw new Error('Unauthorized - not connected to wallet');
+            throw new ProviderError(PROVIDER_ERROR_CODES.UNAUTHORIZED, 'Unauthorized - not connected to wallet');
           }
           
           const activeAddress = await walletService.getActiveAddress();
@@ -797,12 +786,12 @@ export function createProviderService(): ProviderService {
         
         case 'xcp_getAssets': {
           // Not supported - dApps should use Counterparty API directly
-          throw new Error('Method xcp_getAssets is not supported. Please use the Counterparty API directly with the connected address.');
+          throw new ProviderError(PROVIDER_ERROR_CODES.UNSUPPORTED_METHOD, 'Method xcp_getAssets is not supported. Please use the Counterparty API directly with the connected address.');
         }
         
         case 'xcp_getHistory': {
           // For privacy, we don't allow reading transaction history
-          throw new Error('Permission denied - transaction history not available through provider');
+          throw new ProviderError(PROVIDER_ERROR_CODES.UNSUPPORTED_METHOD, 'Permission denied - transaction history not available through provider');
         }
 
         // ==================== Transaction Broadcasting ====================
@@ -810,7 +799,7 @@ export function createProviderService(): ProviderService {
         case 'xcp_broadcastTransaction': {
           // Check if connected
           if (!await connectionService.hasPermission(origin)) {
-            throw new Error('Unauthorized - not connected to wallet');
+            throw new ProviderError(PROVIDER_ERROR_CODES.UNAUTHORIZED, 'Unauthorized - not connected to wallet');
           }
 
           const signedTx = params?.[0];
@@ -857,7 +846,7 @@ export function createProviderService(): ProviderService {
         }
         
         default:
-          throw new Error(`Unsupported method: ${method}`);
+          throw new ProviderError(PROVIDER_ERROR_CODES.UNSUPPORTED_METHOD, `Unsupported method: ${method}`);
       }
       
     } catch (error) {
@@ -929,22 +918,7 @@ export function createProviderService(): ProviderService {
     activeSignPsbtRequests.clear();
     activeSignTransactionRequests.clear();
   }
-  
-  // Register the pending request resolver with event emitter service
-  eventEmitterService.on('resolve-pending-request', ({ requestId, approved, updatedParams }: any) => {
-    const approvalService = getApprovalService();
-    
-    // Track the approval/rejection event
-    const eventName = approved ? 'request_approved' : 'request_rejected';
-    analytics.track(eventName);
-    
-    // Resolve the approval
-    approvalService.resolveApproval(requestId, {
-      approved,
-      updatedParams
-    });
-  });
-  
+
   return {
     handleRequest,
     isConnected,

--- a/src/services/walletService.ts
+++ b/src/services/walletService.ts
@@ -19,6 +19,9 @@ interface WalletService {
   refreshWallets: () => Promise<void>;
   getSettings: () => Promise<import('@/utils/settings').AppSettings>;
   updateSettings: (updates: Partial<import('@/utils/settings').AppSettings>) => Promise<void>;
+  addConnectedWebsite: (origin: string) => Promise<void>;
+  removeConnectedWebsite: (origin: string) => Promise<void>;
+  clearConnectedWebsites: () => Promise<void>;
   getWallets: () => Promise<Wallet[]>;
   getActiveWallet: () => Promise<Wallet | undefined>;
   getActiveAddress: () => Promise<Address | undefined>;
@@ -67,6 +70,22 @@ interface WalletService {
 }
 
 function createWalletService(): WalletService {
+  // Resolve the active address as a string (mirrors getActiveAddress's selection).
+  function resolveActiveAddressString(): string | undefined {
+    const activeWallet = walletManager.getActiveWallet();
+    if (!activeWallet) return undefined;
+    const lastActive = walletManager.getSettings()?.lastActiveAddress;
+    const match = activeWallet.addresses.find((a) => a.address === lastActive);
+    return (match ?? activeWallet.addresses[0])?.address;
+  }
+
+  // Emit accountsChanged to each connected dApp, per-origin (not a global broadcast).
+  function emitAccountsChangedToConnected(addresses: string[]) {
+    for (const origin of walletManager.getSettings().connectedWebsites) {
+      eventEmitterService.emit('emit-provider-event', { origin, event: 'accountsChanged', data: addresses });
+    }
+  }
+
   return {
     refreshWallets: async () => {
       await walletManager.refreshWallets();
@@ -74,6 +93,23 @@ function createWalletService(): WalletService {
     getSettings: async () => walletManager.getSettings(),
     updateSettings: async (updates) => {
       await walletManager.updateSettings(updates);
+    },
+    addConnectedWebsite: async (origin) => {
+      const settings = walletManager.getSettings();
+      if (!settings.connectedWebsites.includes(origin)) {
+        await walletManager.updateSettings({
+          connectedWebsites: [...settings.connectedWebsites, origin],
+        });
+      }
+    },
+    removeConnectedWebsite: async (origin) => {
+      const settings = walletManager.getSettings();
+      await walletManager.updateSettings({
+        connectedWebsites: settings.connectedWebsites.filter((site) => site !== origin),
+      });
+    },
+    clearConnectedWebsites: async () => {
+      await walletManager.updateSettings({ connectedWebsites: [] });
     },
     getWallets: async () => walletManager.getWallets(),
     getActiveWallet: async () => walletManager.getActiveWallet(),
@@ -101,6 +137,9 @@ function createWalletService(): WalletService {
       await walletManager.unlockKeychain(password);
       // Emit wallet-unlocked event for any pending connection requests
       eventEmitterService.emit('wallet-unlocked', {});
+      // Tell connected dApps the accounts are back (they were emptied on lock).
+      const activeAddress = resolveActiveAddressString();
+      if (activeAddress) emitAccountsChangedToConnected([activeAddress]);
     },
     selectWallet: async (walletId) => {
       await walletManager.selectWallet(walletId);
@@ -117,16 +156,9 @@ function createWalletService(): WalletService {
         // Popup might not be open, which is fine
         console.debug('[WalletService] Could not notify popup of keychain lock event:', error);
       }
-      // Emit disconnect event to connected dApps
-      // Broadcast to all tabs (no origin specified)
-      eventEmitterService.emit('emit-provider-event', {
-        event: 'accountsChanged',
-        data: []
-      });
-      eventEmitterService.emit('emit-provider-event', {
-        event: 'disconnect',
-        data: {}
-      });
+      // Tell connected dApps the accounts are gone — per-origin, and without a
+      // terminal disconnect, so unlock can restore them via accountsChanged.
+      emitAccountsChangedToConnected([]);
     },
     createMnemonicWallet: async (mnemonic, password, name, addressFormat) => {
       const wallet = await walletManager.createMnemonicWallet(mnemonic, password, name, addressFormat);

--- a/src/utils/__tests__/errors.test.ts
+++ b/src/utils/__tests__/errors.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ProviderError,
+  classifyProviderError,
+  PROVIDER_ERROR_CODES,
+  JSON_RPC_ERROR_CODES,
+} from '@/utils/errors';
+
+describe('ProviderError', () => {
+  it('carries a code alongside the message', () => {
+    const err = new ProviderError(PROVIDER_ERROR_CODES.USER_REJECTED, 'User cancelled');
+    expect(err).toBeInstanceOf(Error);
+    expect(err.code).toBe(4001);
+    expect(err.message).toBe('User cancelled');
+  });
+});
+
+describe('classifyProviderError', () => {
+  it('prefers a carried code and surfaces its message (no string matching)', () => {
+    // Message that matches no pattern — only the code can classify it.
+    const err = new ProviderError(PROVIDER_ERROR_CODES.UNAUTHORIZED, 'wallet busy zzz');
+    expect(classifyProviderError(err)).toEqual({ code: 4100, message: 'wallet busy zzz' });
+  });
+
+  it('masks a carried INTERNAL_ERROR rather than leaking its message', () => {
+    const err = new ProviderError(JSON_RPC_ERROR_CODES.INTERNAL_ERROR, 'db connection string leaked');
+    expect(classifyProviderError(err)).toEqual({ code: -32603, message: 'Request failed' });
+  });
+
+  it('masks an unrecognized numeric code so accidental .code does not leak the message', () => {
+    // e.g. a network/library error that happens to carry a numeric code.
+    const err = Object.assign(new Error('ECONN secret host:port'), { code: 500 });
+    expect(classifyProviderError(err)).toEqual({ code: -32603, message: 'Request failed' });
+  });
+
+  it('masks un-coded throws regardless of message — dApp errors must be ProviderError', () => {
+    // A plain Error is never trusted to be dApp-safe, even if its text looks user-facing.
+    expect(classifyProviderError(new Error('User cancelled the request')))
+      .toEqual({ code: -32603, message: 'Request failed' });
+    expect(classifyProviderError(new Error('TypeError: undefined is not a function')))
+      .toEqual({ code: -32603, message: 'Request failed' });
+  });
+});

--- a/src/utils/__tests__/proxy.test.ts
+++ b/src/utils/__tests__/proxy.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { defineProxyService, isBackgroundScript, disconnectAllPorts } from '../proxy';
+import { ProviderError } from '../errors';
 
 // ---------------------------------------------------------------------------
 // Mock Chrome API
@@ -97,6 +98,7 @@ describe('defineProxyService', () => {
     setValue: (value: number) => void;
     getAsync: () => Promise<string>;
     throwError: () => void;
+    throwCoded: () => void;
   }
 
   let testServiceInstance: TestService;
@@ -115,6 +117,7 @@ describe('defineProxyService', () => {
       setValue: vi.fn(),
       getAsync: vi.fn(() => Promise.resolve('async-result')),
       throwError: vi.fn(() => { throw new Error('Test error'); }),
+      throwCoded: vi.fn(() => { throw new ProviderError(4001, 'rejected'); }),
     };
 
     [register, getService] = defineProxyService(
@@ -176,7 +179,21 @@ describe('defineProxyService', () => {
       await new Promise(r => setTimeout(r, 0));
 
       expect(port.postMessage).toHaveBeenCalledWith({
-        id: 1, success: false, error: 'Test error',
+        id: 1, success: false, error: { message: 'Test error', code: undefined },
+      });
+    });
+
+    it('serializes the code only for deliberately-coded ProviderErrors', async () => {
+      register();
+
+      const port = createMockPort(`proxy:${currentServiceName}`);
+      onConnectListeners.forEach(fn => fn(port));
+
+      port._fireMessage({ id: 1, methodName: 'throwCoded', args: [] });
+      await new Promise(r => setTimeout(r, 0));
+
+      expect(port.postMessage).toHaveBeenCalledWith({
+        id: 1, success: false, error: { message: 'rejected', code: 4001 },
       });
     });
 
@@ -190,7 +207,7 @@ describe('defineProxyService', () => {
       await new Promise(r => setTimeout(r, 0));
 
       expect(port.postMessage).toHaveBeenCalledWith({
-        id: 1, success: false, error: `Method nonExistent not found on ${currentServiceName}`,
+        id: 1, success: false, error: { message: `Method nonExistent not found on ${currentServiceName}` },
       });
     });
 
@@ -259,11 +276,14 @@ describe('defineProxyService', () => {
 
       clientPort.postMessage.mockImplementation((msg: any) => {
         setTimeout(() => clientPort._fireMessage({
-          id: msg.id, success: false, error: 'Service error',
+          id: msg.id, success: false, error: { message: 'Service error', code: 4001 },
         }), 0);
       });
 
-      await expect(service.getValue()).rejects.toThrow('Service error');
+      const rejection = service.getValue();
+      await expect(rejection).rejects.toThrow('Service error');
+      // The code carried over the port is reconstructed onto the error.
+      await expect(rejection).rejects.toMatchObject({ code: 4001 });
     });
 
     it('should reject pending calls on port disconnect', async () => {
@@ -285,7 +305,34 @@ describe('defineProxyService', () => {
         setTimeout(() => secondPort._fireDisconnect(), 0);
       });
 
-      await expect(service.getValue()).rejects.toThrow('Port disconnected');
+      const rejection = service.getValue();
+      await expect(rejection).rejects.toThrow('Port disconnected');
+      // Coded DISCONNECTED so the boundary surfaces it and the dApp SDK retries.
+      await expect(rejection).rejects.toMatchObject({ code: 4900 });
+    });
+
+    it('does not replay non-idempotent provider methods on disconnect', async () => {
+      const service = getService();
+
+      // A retry (if it happened) would connect a second time.
+      const secondPort = createMockPort(`proxy:${currentServiceName}`);
+      let callCount = 0;
+      mockChrome.runtime.connect.mockImplementation(() => {
+        callCount++;
+        return callCount === 1 ? clientPort : secondPort;
+      });
+      clientPort.postMessage.mockImplementation(() => {
+        setTimeout(() => clientPort._fireDisconnect(), 0);
+      });
+      secondPort.postMessage.mockImplementation(() => {
+        setTimeout(() => secondPort._fireDisconnect(), 0);
+      });
+
+      // A signing request must NOT auto-retry across a disconnect (no duplicate popup).
+      await expect(
+        (service as any).handleRequest('https://dapp.com', 'xcp_signTransaction', [])
+      ).rejects.toThrow('Port disconnected');
+      expect(callCount).toBe(1);
     });
 
     it('should reconnect and retry once after disconnect', async () => {

--- a/src/utils/__tests__/settings.test.ts
+++ b/src/utils/__tests__/settings.test.ts
@@ -8,6 +8,10 @@
 import { describe, it, expect } from 'vitest';
 import {
   DEFAULT_SETTINGS,
+  DEFAULT_ORDER_EXPIRATION,
+  INDEFINITE_ORDER_EXPIRATION,
+  LEGACY_MAX_ORDER_EXPIRATION,
+  MAX_ORDER_EXPIRATION,
   SETTINGS_VERSION,
   AUTO_LOCK_TIMEOUT_MS,
   VALID_AUTO_LOCK_TIMERS,
@@ -18,6 +22,21 @@ import {
 describe('SETTINGS_VERSION', () => {
   it('is 2', () => {
     expect(SETTINGS_VERSION).toBe(2);
+  });
+});
+
+describe('order expiration constants', () => {
+  it('tracks zero as the never-expires value', () => {
+    expect(INDEFINITE_ORDER_EXPIRATION).toBe(0);
+  });
+
+  it('tracks legacy and v11.1 finite limits', () => {
+    expect(LEGACY_MAX_ORDER_EXPIRATION).toBe(8064);
+    expect(MAX_ORDER_EXPIRATION).toBe(65535);
+  });
+
+  it('uses the legacy-safe expiration default until activation is guaranteed', () => {
+    expect(DEFAULT_ORDER_EXPIRATION).toBe(LEGACY_MAX_ORDER_EXPIRATION);
   });
 });
 
@@ -121,7 +140,7 @@ describe('DEFAULT_SETTINGS', () => {
     expect(DEFAULT_SETTINGS.counterpartyApiBase).toBe('https://api.counterparty.io:4000');
   });
 
-  it('has default order expiration of 8064 blocks', () => {
+  it('has default order expiration set to the legacy-safe maximum', () => {
     expect(DEFAULT_SETTINGS.defaultOrderExpiration).toBe(8064);
   });
 

--- a/src/utils/blockchain/bitcoin/__tests__/transactionBroadcaster.test.ts
+++ b/src/utils/blockchain/bitcoin/__tests__/transactionBroadcaster.test.ts
@@ -1,14 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { broadcastTransaction } from '@/utils/blockchain/bitcoin/transactionBroadcaster';
-import { walletManager } from '@/utils/wallet/walletManager';
-import { DEFAULT_SETTINGS } from '@/utils/settings';
+import { DEFAULT_SETTINGS, getActiveSettings } from '@/utils/settings';
 
-vi.mock('@/utils/wallet/walletManager', () => ({
-  walletManager: {
-    getSettings: vi.fn().mockReturnValue({
-      counterpartyApiBase: 'https://api.counterparty.io',
-    }),
-  },
+vi.mock('@/utils/settings', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/utils/settings')>()),
+  getActiveSettings: vi.fn().mockReturnValue({
+    counterpartyApiBase: 'https://api.counterparty.io',
+  }),
 }));
 vi.mock('@/utils/apiClient', () => ({
   apiClient: {
@@ -28,7 +26,7 @@ vi.mock('@/utils/apiClient', () => ({
 // Import the mocked modules
 import { apiClient } from '@/utils/apiClient';
 const mockApiClient = apiClient as any;
-const mockGetSettings = vi.mocked(walletManager.getSettings);
+const mockGetSettings = vi.mocked(getActiveSettings);
 
 describe('Transaction Broadcaster Utilities', () => {
   const mockSignedTxHex = '01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff08044c86041b020602ffffffff0100f2052a010000004341041b0e8c2567c12536aa13357b79a073dc4444acb83c4ec7a0e2f99dd7457516c5817242da796924ca4e99947d087fedf9ce467cb9f7c6287078f801df276fdf84424ac00000000';

--- a/src/utils/blockchain/bitcoin/__tests__/utxo.test.ts
+++ b/src/utils/blockchain/bitcoin/__tests__/utxo.test.ts
@@ -9,7 +9,7 @@ import {
   clearBitcoinCaches
 } from '@/utils/blockchain/bitcoin/utxo';
 import { apiClient } from '@/utils/apiClient';
-import { walletManager } from '@/utils/wallet/walletManager';
+import { getActiveSettings } from '@/utils/settings';
 
 vi.mock('@/utils/apiClient', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/utils/apiClient')>();
@@ -18,16 +18,15 @@ vi.mock('@/utils/apiClient', async (importOriginal) => {
     apiClient: { get: vi.fn(), post: vi.fn() },
   };
 });
-vi.mock('@/utils/wallet/walletManager', () => ({
-  walletManager: {
-    getSettings: vi.fn().mockReturnValue({
-      counterpartyApiBase: 'https://api.counterparty.io',
-    }),
-  },
+vi.mock('@/utils/settings', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/utils/settings')>()),
+  getActiveSettings: vi.fn().mockReturnValue({
+    counterpartyApiBase: 'https://api.counterparty.io',
+  }),
 }));
 
 const mockApiClient = vi.mocked(apiClient, true);
-const mockGetSettings = vi.mocked(walletManager.getSettings);
+const mockGetSettings = vi.mocked(getActiveSettings);
 
 /** Helper to create a mock apiClient response */
 function mockApiResponse<T>(data: T) {

--- a/src/utils/blockchain/bitcoin/bareMultisig.ts
+++ b/src/utils/blockchain/bitcoin/bareMultisig.ts
@@ -2,7 +2,7 @@ import { Transaction } from '@scure/btc-signer';
 import { apiClient } from '@/utils/apiClient';
 import { hexToBytes } from '@noble/hashes/utils.js';
 import { getPublicKey } from '@noble/secp256k1';
-import { walletManager } from '@/utils/wallet/walletManager';
+import { getActiveSettings } from '@/utils/settings';
 import { toSatoshis } from '@/utils/numeric';
 import { 
   analyzeMultisigScript, 
@@ -566,7 +566,7 @@ async function fetchPreviousRawTransaction(txid: string): Promise<string | null>
 
   // Fallback to Counterparty API
   try {
-    const settings = walletManager.getSettings();
+    const settings = getActiveSettings();
     const response = await apiClient.get<{ result: { hex: string } }>(
       `${settings.counterpartyApiBase}/v2/bitcoin/transactions/${txid}`
     );

--- a/src/utils/blockchain/bitcoin/transactionBroadcaster.ts
+++ b/src/utils/blockchain/bitcoin/transactionBroadcaster.ts
@@ -1,7 +1,7 @@
 import { Transaction } from '@scure/btc-signer';
 import { hexToBytes, bytesToHex } from '@noble/hashes/utils.js';
 import { apiClient, withRetry, isApiError, type ApiResponse } from '@/utils/apiClient';
-import { walletManager } from '@/utils/wallet/walletManager';
+import { getActiveSettings } from '@/utils/settings';
 import { clearApiCache } from '@/utils/blockchain/counterparty/api';
 import { clearBitcoinCaches } from '@/utils/blockchain/bitcoin/utxo';
 import { clearBalanceCache } from '@/utils/blockchain/bitcoin/balance';
@@ -26,7 +26,7 @@ const broadcastEndpoints: BroadcastEndpoint[] = [
   {
     name: 'counterparty',
     getUrl: async (signedTxHex: string) => {
-      const settings = walletManager.getSettings();
+      const settings = getActiveSettings();
       const encoded = encodeURIComponent(signedTxHex);
       return `${settings.counterpartyApiBase}/v2/bitcoin/transactions?signedhex=${encoded}`;
     },
@@ -107,7 +107,7 @@ const generateMockTxid = (signedTxHex: string): string => {
 };
 
 export async function broadcastTransaction(signedTxHex: string): Promise<TransactionResponse> {
-  const settings = walletManager.getSettings();
+  const settings = getActiveSettings();
   
   if (settings.transactionDryRun) {
     await new Promise(resolve => setTimeout(resolve, 500));

--- a/src/utils/blockchain/bitcoin/utxo.ts
+++ b/src/utils/blockchain/bitcoin/utxo.ts
@@ -1,5 +1,5 @@
 import { apiClient, isCancel } from '@/utils/apiClient';
-import { walletManager } from '@/utils/wallet/walletManager';
+import { getActiveSettings } from '@/utils/settings';
 import { KeyedTTLCache, CacheTTL, cachedFetch } from '@/utils/cache';
 
 // UTXOs can change with each block but short cache prevents API spam
@@ -206,7 +206,7 @@ export async function fetchPreviousRawTransaction(txid: string): Promise<string 
     async () => {
       // Try Counterparty API first
       try {
-        const settings = walletManager.getSettings();
+        const settings = getActiveSettings();
         const response = await apiClient.get<{ result: BitcoinTransaction }>(
           `${settings.counterpartyApiBase}/v2/bitcoin/transactions/${txid}`
         );
@@ -251,7 +251,7 @@ export async function fetchBitcoinTransaction(txid: string): Promise<BitcoinTran
     txid,
     async () => {
       try {
-        const settings = walletManager.getSettings();
+        const settings = getActiveSettings();
 
         // Fetch from both Counterparty API and mempool.space in parallel
         const [counterpartyResponse, mempoolResponse] = await Promise.all([

--- a/src/utils/blockchain/counterparty/__tests__/api.test.ts
+++ b/src/utils/blockchain/counterparty/__tests__/api.test.ts
@@ -35,7 +35,7 @@ import * as formatUtils from '@/utils/format';
 import * as bitcoinBalance from '@/utils/blockchain/bitcoin/balance';
 import { apiClient } from '@/utils/apiClient';
 import { CounterpartyApiError } from '@/utils/blockchain/errors';
-import { walletManager } from '@/utils/wallet/walletManager';
+import { getActiveSettings } from '@/utils/settings';
 
 // Mock dependencies
 vi.mock('@/utils/apiClient');
@@ -44,18 +44,17 @@ vi.mock('@/utils/blockchain/bitcoin/balance');
 vi.mock('@/utils/blockchain/counterparty/capabilities', () => ({
   requireCounterpartyFeature: vi.fn().mockResolvedValue(undefined),
 }));
-vi.mock('@/utils/wallet/walletManager', () => ({
-  walletManager: {
-    getSettings: vi.fn().mockReturnValue({
-      counterpartyApiBase: 'https://api.counterparty.io',
-    }),
-  },
+vi.mock('@/utils/settings', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/utils/settings')>()),
+  getActiveSettings: vi.fn().mockReturnValue({
+    counterpartyApiBase: 'https://api.counterparty.io',
+  }),
 }));
 
 const mockedApiClient = vi.mocked(apiClient, true);
 const mockedFormatAmount = vi.mocked(formatUtils.formatAmount);
 const mockedFetchBTCBalance = vi.mocked(bitcoinBalance.fetchBTCBalance);
-const mockedGetSettings = vi.mocked(walletManager.getSettings);
+const mockedGetSettings = vi.mocked(getActiveSettings);
 
 // Test data
 const mockAddress = 'bc1qtest123address';

--- a/src/utils/blockchain/counterparty/__tests__/capabilities.test.ts
+++ b/src/utils/blockchain/counterparty/__tests__/capabilities.test.ts
@@ -7,17 +7,16 @@ import {
 } from '../capabilities';
 import { apiClient } from '@/utils/apiClient';
 import { CounterpartyApiError } from '@/utils/blockchain/errors';
-import { walletManager } from '@/utils/wallet/walletManager';
+import { getActiveSettings } from '@/utils/settings';
 
 vi.mock('@/utils/apiClient');
-vi.mock('@/utils/wallet/walletManager', () => ({
-  walletManager: {
-    getSettings: vi.fn(),
-  },
+vi.mock('@/utils/settings', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/utils/settings')>()),
+  getActiveSettings: vi.fn(),
 }));
 
 const mockedApiClient = vi.mocked(apiClient, true);
-const mockedGetSettings = vi.mocked(walletManager.getSettings);
+const mockedGetSettings = vi.mocked(getActiveSettings);
 const mockApiBase = 'https://api.counterparty.io:4000';
 
 function mockServerInfo(overrides: Record<string, unknown> = {}) {
@@ -28,7 +27,7 @@ function mockServerInfo(overrides: Record<string, unknown> = {}) {
         network: 'mainnet',
         version: '11.1.0',
         backend_height: 900000,
-        counterparty_height: 952500,
+        counterparty_height: 952800,
         ...overrides,
       },
     },
@@ -51,6 +50,8 @@ describe('counterparty capabilities', () => {
     expect(isVersionAtLeast('11.1.0-alpha.1', '11.1.0')).toBe(true);
     expect(isVersionAtLeast('11.2.0', '11.1.0')).toBe(true);
     expect(isVersionAtLeast('11.0.9', '11.1.0')).toBe(false);
+    expect(isVersionAtLeast('11.10.0', '11.2.0')).toBe(true);
+    expect(isVersionAtLeast('11.2.0', '11.10.0')).toBe(false);
   });
 
   it('reports AMM pools as supported when version and height are ready', async () => {
@@ -75,7 +76,24 @@ describe('counterparty capabilities', () => {
     const status = await getCounterpartyFeatureStatus('ammPools');
 
     expect(status.supported).toBe(false);
-    expect(status.reason).toContain('activate at block 952500');
+    expect(status.reason).toContain('activate at block 952800');
+  });
+
+  it('reports indefinite orders as supported when version and height are ready', async () => {
+    mockServerInfo();
+
+    const status = await getCounterpartyFeatureStatus('indefiniteOrders');
+
+    expect(status.supported).toBe(true);
+  });
+
+  it('rejects indefinite orders before activation height', async () => {
+    mockServerInfo({ counterparty_height: 952799 });
+
+    const status = await getCounterpartyFeatureStatus('indefiniteOrders');
+
+    expect(status.supported).toBe(false);
+    expect(status.reason).toContain('activate at block 952800');
   });
 
   it('allows AMM pools on regtest once the API version supports them', async () => {

--- a/src/utils/blockchain/counterparty/__tests__/compose.assets.test.ts
+++ b/src/utils/blockchain/counterparty/__tests__/compose.assets.test.ts
@@ -7,7 +7,7 @@ import {
   composeBurn
 } from '../compose';
 import * as apiClientUtils from '@/utils/apiClient';
-import { walletManager } from '@/utils/wallet/walletManager';
+import { getActiveSettings } from '@/utils/settings';
 import {
   mockAddress,
   mockApiBase,
@@ -22,11 +22,10 @@ import {
 
 // Mock dependencies
 vi.mock('@/utils/apiClient');
-vi.mock('@/utils/wallet/walletManager', () => ({
-  walletManager: {
-    getSettings: vi.fn(),
-  },
-}));
+vi.mock('@/utils/settings', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/utils/settings')>();
+  return { ...actual, getActiveSettings: vi.fn().mockReturnValue(actual.DEFAULT_SETTINGS) };
+});
 
 // Mock UTXO selection to prevent real API calls to mempool.space
 vi.mock('@/utils/blockchain/counterparty/utxo-selection', () => ({
@@ -39,7 +38,7 @@ vi.mock('@/utils/blockchain/counterparty/utxo-selection', () => ({
 }));
 
 const mockedApiClient = vi.mocked(apiClientUtils.apiClient, true);
-const mockedGetSettings = vi.mocked(walletManager.getSettings);
+const mockedGetSettings = vi.mocked(getActiveSettings);
 
 describe('Compose Asset Management Operations', () => {
   beforeEach(() => {

--- a/src/utils/blockchain/counterparty/__tests__/compose.send.test.ts
+++ b/src/utils/blockchain/counterparty/__tests__/compose.send.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { composeSend, composeSendOrMPMA, composeMPMA, composeSweep, getSweepEstimateXcpFee, composeMove } from '../compose';
 import * as apiClientUtils from '@/utils/apiClient';
-import { walletManager } from '@/utils/wallet/walletManager';
+import { getActiveSettings } from '@/utils/settings';
 import {
   mockAddress,
   mockDestAddress,
@@ -18,11 +18,10 @@ import {
 
 // Mock dependencies
 vi.mock('@/utils/apiClient');
-vi.mock('@/utils/wallet/walletManager', () => ({
-  walletManager: {
-    getSettings: vi.fn(),
-  },
-}));
+vi.mock('@/utils/settings', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/utils/settings')>();
+  return { ...actual, getActiveSettings: vi.fn().mockReturnValue(actual.DEFAULT_SETTINGS) };
+});
 
 // Mock UTXO selection to prevent real API calls to mempool.space
 vi.mock('@/utils/blockchain/counterparty/utxo-selection', () => ({
@@ -35,7 +34,7 @@ vi.mock('@/utils/blockchain/counterparty/utxo-selection', () => ({
 }));
 
 const mockedApiClient = vi.mocked(apiClientUtils.apiClient, true);
-const mockedGetSettings = vi.mocked(walletManager.getSettings);
+const mockedGetSettings = vi.mocked(getActiveSettings);
 
 describe('Compose Send Operations', () => {
   beforeEach(() => {

--- a/src/utils/blockchain/counterparty/__tests__/compose.specialized.test.ts
+++ b/src/utils/blockchain/counterparty/__tests__/compose.specialized.test.ts
@@ -15,7 +15,7 @@ import {
   composeTransaction
 } from '../compose';
 import * as apiClientUtils from '@/utils/apiClient';
-import { walletManager } from '@/utils/wallet/walletManager';
+import { getActiveSettings } from '@/utils/settings';
 import {
   mockAddress,
   mockApiBase,
@@ -32,11 +32,10 @@ vi.mock('@/utils/apiClient');
 vi.mock('@/utils/blockchain/counterparty/capabilities', () => ({
   requireCounterpartyFeature: vi.fn().mockResolvedValue(undefined),
 }));
-vi.mock('@/utils/wallet/walletManager', () => ({
-  walletManager: {
-    getSettings: vi.fn(),
-  },
-}));
+vi.mock('@/utils/settings', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/utils/settings')>();
+  return { ...actual, getActiveSettings: vi.fn().mockReturnValue(actual.DEFAULT_SETTINGS) };
+});
 
 // Mock UTXO selection to prevent real API calls to mempool.space
 vi.mock('@/utils/blockchain/counterparty/utxo-selection', () => ({
@@ -49,7 +48,7 @@ vi.mock('@/utils/blockchain/counterparty/utxo-selection', () => ({
 }));
 
 const mockedApiClient = vi.mocked(apiClientUtils.apiClient, true);
-const mockedGetSettings = vi.mocked(walletManager.getSettings);
+const mockedGetSettings = vi.mocked(getActiveSettings);
 
 describe('Compose Specialized Operations', () => {
   beforeEach(() => {
@@ -273,6 +272,7 @@ describe('Compose Specialized Operations', () => {
       lot_price: 100000,
       lot_size: 1000,
       max_mint_per_tx: 100,
+      max_mint_per_address: 1000,
       hard_cap: 1000000,
       start_block: 800000,
       end_block: 810000,

--- a/src/utils/blockchain/counterparty/__tests__/compose.trading.test.ts
+++ b/src/utils/blockchain/counterparty/__tests__/compose.trading.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { composeOrder, composeCancel, composeDispenser, composeDispense } from '../compose';
 import * as apiClientUtils from '@/utils/apiClient';
-import { walletManager } from '@/utils/wallet/walletManager';
+import { getActiveSettings } from '@/utils/settings';
+import { requireCounterpartyFeature } from '@/utils/blockchain/counterparty/capabilities';
 import {
   mockAddress,
   mockApiBase,
@@ -16,10 +17,13 @@ import {
 
 // Mock dependencies
 vi.mock('@/utils/apiClient');
-vi.mock('@/utils/wallet/walletManager', () => ({
-  walletManager: {
-    getSettings: vi.fn(),
-  },
+vi.mock('@/utils/settings', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/utils/settings')>();
+  return { ...actual, getActiveSettings: vi.fn().mockReturnValue(actual.DEFAULT_SETTINGS) };
+});
+
+vi.mock('@/utils/blockchain/counterparty/capabilities', () => ({
+  requireCounterpartyFeature: vi.fn().mockResolvedValue(undefined),
 }));
 
 // Mock UTXO selection to prevent real API calls to mempool.space
@@ -33,7 +37,8 @@ vi.mock('@/utils/blockchain/counterparty/utxo-selection', () => ({
 }));
 
 const mockedApiClient = vi.mocked(apiClientUtils.apiClient, true);
-const mockedGetSettings = vi.mocked(walletManager.getSettings);
+const mockedGetSettings = vi.mocked(getActiveSettings);
+const mockedRequireCounterpartyFeature = vi.mocked(requireCounterpartyFeature);
 
 describe('Compose Trading Operations', () => {
   beforeEach(() => {
@@ -137,8 +142,8 @@ describe('Compose Trading Operations', () => {
       assertComposeUrlCalled(mockedApiClient, 'order', assetTradeParams);
     });
 
-    it('should handle zero expiration (fill or kill)', async () => {
-      const fillOrKillParams = {
+    it('should handle zero expiration as an indefinite order', async () => {
+      const indefiniteParams = {
         ...defaultParams,
         expiration: 0,
       };
@@ -146,13 +151,47 @@ describe('Compose Trading Operations', () => {
       await composeOrder({
         sourceAddress: mockAddress,
         sat_per_vbyte: mockSatPerVbyte,
-        ...fillOrKillParams,
+        ...indefiniteParams,
       });
       
       // Check if apiClient.get was called with query parameters
       const actualUrl = mockedApiClient.get.mock.calls[0][0];
       const url = new URL(actualUrl);
       expect(url.searchParams.get('expiration')).toBe('0');
+      expect(mockedRequireCounterpartyFeature).toHaveBeenCalledWith('indefiniteOrders');
+    });
+
+    it('requires indefinite order support for expirations above the legacy max', async () => {
+      await composeOrder({
+        sourceAddress: mockAddress,
+        sat_per_vbyte: mockSatPerVbyte,
+        ...defaultParams,
+        expiration: 65535,
+      });
+
+      expect(mockedRequireCounterpartyFeature).toHaveBeenCalledWith('indefiniteOrders');
+    });
+
+    it('does not require indefinite order support for legacy expirations', async () => {
+      await composeOrder({
+        sourceAddress: mockAddress,
+        sat_per_vbyte: mockSatPerVbyte,
+        ...defaultParams,
+        expiration: 8064,
+      });
+
+      expect(mockedRequireCounterpartyFeature).not.toHaveBeenCalled();
+    });
+
+    it('rejects expirations above the uint16 protocol limit', async () => {
+      await expect(composeOrder({
+        sourceAddress: mockAddress,
+        sat_per_vbyte: mockSatPerVbyte,
+        ...defaultParams,
+        expiration: 65536,
+      })).rejects.toThrow('Order expiration must be between 0 and 65535 blocks.');
+
+      expect(mockedRequireCounterpartyFeature).not.toHaveBeenCalled();
     });
   });
 

--- a/src/utils/blockchain/counterparty/__tests__/pool.fuzz.test.ts
+++ b/src/utils/blockchain/counterparty/__tests__/pool.fuzz.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest';
+import * as fc from 'fast-check';
+import {
+  getCanonicalPoolAssets,
+  getCanonicalPoolPair,
+  applyPoolSlippage,
+  calculateInitialLpEstimate,
+  calculateLimitingLpEstimate,
+} from '../pool';
+import { isValidPositiveNumber, isLessThanOrEqualTo } from '@/utils/numeric';
+
+// 21,000,000 BTC expressed in satoshis — an upper bound on any on-chain quantity.
+const SAT_MAX = 2_100_000_000_000_000n;
+const sat = fc.bigInt({ min: 0n, max: SAT_MAX });
+const satPositive = fc.bigInt({ min: 1n, max: SAT_MAX });
+const assetName = fc.string({ minLength: 1, maxLength: 16 });
+// Slippage percent the UI can produce: 0%..200% with sub-percent precision.
+const slippagePct = fc.double({ min: 0, max: 200, noNaN: true, noDefaultInfinity: true });
+
+// The exact predicate both pool forms gate submission on before slippage can
+// reach compose/signing. applyPoolSlippage must be SAFE for everything it accepts.
+const slippageReachesSigning = (s: string) =>
+  isValidPositiveNumber(s, { allowZero: true, maxDecimals: 2 }) && isLessThanOrEqualTo(s, 50);
+
+describe('Pool Math Fuzz Tests', () => {
+  describe('getCanonicalPoolAssets / Pair', () => {
+    it('returns a sorted pair, independent of argument order', () => {
+      fc.assert(fc.property(assetName, assetName, (a, b) => {
+        const [x, y] = getCanonicalPoolAssets(a, b);
+        expect(x <= y).toBe(true);
+        expect(getCanonicalPoolAssets(a, b)).toEqual(getCanonicalPoolAssets(b, a));
+        expect(getCanonicalPoolPair(a, b)).toBe(getCanonicalPoolPair(b, a));
+      }), { numRuns: 500 });
+    });
+  });
+
+  describe('applyPoolSlippage', () => {
+    it('keeps the result within [0, value] (never worse-than-quoted) for s >= 0', () => {
+      fc.assert(fc.property(sat, slippagePct, (value, s) => {
+        const out = BigInt(applyPoolSlippage(value.toString(), s.toString()));
+        expect(out >= 0n).toBe(true);
+        expect(out <= value).toBe(true);
+      }), { numRuns: 500 });
+    });
+
+    it('is the identity on an already-integer quantity at 0% slippage', () => {
+      fc.assert(fc.property(sat, (value) => {
+        expect(applyPoolSlippage(value.toString(), '0')).toBe(value.toString());
+      }), { numRuns: 300 });
+    });
+
+    it('is monotonic: higher slippage yields a smaller-or-equal result', () => {
+      fc.assert(fc.property(satPositive, slippagePct, slippagePct, (value, s1, s2) => {
+        const lo = Math.min(s1, s2);
+        const hi = Math.max(s1, s2);
+        const outLo = BigInt(applyPoolSlippage(value.toString(), lo.toString()));
+        const outHi = BigInt(applyPoolSlippage(value.toString(), hi.toString()));
+        expect(outHi <= outLo).toBe(true);
+      }), { numRuns: 300 });
+    });
+
+    it('floors the result to zero at >= 100% slippage', () => {
+      fc.assert(fc.property(sat, fc.double({ min: 100, max: 500, noNaN: true, noDefaultInfinity: true }), (value, s) => {
+        expect(applyPoolSlippage(value.toString(), s.toString())).toBe('0');
+      }), { numRuns: 200 });
+    });
+
+    it('degrades null/undefined quote values to "0" rather than throwing', () => {
+      fc.assert(fc.property(fc.constantFrom(null, undefined), fc.constantFrom('0', '1', '50'), (value, s) => {
+        expect(applyPoolSlippage(value, s)).toBe('0');
+      }), { numRuns: 50 });
+    });
+  });
+
+  describe('calculateInitialLpEstimate', () => {
+    it('is the exact integer floor of sqrt(a*b) and is symmetric', () => {
+      fc.assert(fc.property(sat, sat, (a, b) => {
+        const est = calculateInitialLpEstimate(a.toString(), b.toString());
+        const prod = a * b;
+        if (prod <= 0n) {
+          expect(est).toBe('0');
+          return;
+        }
+        const r = BigInt(est);
+        // r == isqrt(prod): r^2 <= prod < (r+1)^2
+        expect(r * r <= prod).toBe(true);
+        expect((r + 1n) * (r + 1n) > prod).toBe(true);
+        expect(calculateInitialLpEstimate(b.toString(), a.toString())).toBe(est);
+      }), { numRuns: 500 });
+    });
+  });
+
+  describe('calculateLimitingLpEstimate', () => {
+    it('scales minted by provided/required (floored) and never exceeds it', () => {
+      fc.assert(fc.property(satPositive, satPositive, satPositive, (minted, required, provided) => {
+        const est = BigInt(
+          calculateLimitingLpEstimate(minted.toString(), required.toString(), provided.toString())
+        );
+        if (provided >= required) {
+          expect(est).toBe(minted);
+        } else {
+          expect(est).toBe((minted * provided) / required); // exact integer floor division
+          expect(est <= minted).toBe(true);
+        }
+        expect(est >= 0n).toBe(true);
+      }), { numRuns: 500 });
+    });
+  });
+
+  describe('Adversarial robustness', () => {
+    // Hostile slippage strings: negatives, scientific notation, whitespace,
+    // percent signs, formula-injection, NaN/Infinity, empty, and junk.
+    const hostileSlippage = fc.oneof(
+      fc.double({ min: -500, max: 5000, noNaN: false }).map(String),
+      fc.constantFrom('-5', '=5', '+5', '@5', '5%', ' 5 ', '1e3', '', 'abc', 'NaN', 'Infinity', '0.001', '50.01'),
+      fc.string()
+    );
+
+    it('applyPoolSlippage never throws and always returns a non-negative integer string', () => {
+      fc.assert(fc.property(sat, hostileSlippage, (value, s) => {
+        const out = applyPoolSlippage(value.toString(), s);
+        expect(/^\d+$/.test(out)).toBe(true);
+        expect(BigInt(out) >= 0n).toBe(true);
+      }), { numRuns: 500 });
+    });
+
+    it('any slippage that can reach signing stays within [0, value] (no inflation)', () => {
+      fc.assert(fc.property(sat, hostileSlippage, (value, s) => {
+        fc.pre(slippageReachesSigning(s));
+        const out = BigInt(applyPoolSlippage(value.toString(), s));
+        expect(out >= 0n && out <= value).toBe(true);
+      }), { numRuns: 500 });
+    });
+  });
+});

--- a/src/utils/blockchain/counterparty/__tests__/transaction.test.ts
+++ b/src/utils/blockchain/counterparty/__tests__/transaction.test.ts
@@ -17,16 +17,15 @@ import {
   type UnpackedCounterpartyData,
 } from '../transaction';
 import { apiClient } from '@/utils/apiClient';
-import { walletManager } from '@/utils/wallet/walletManager';
+import { getActiveSettings } from '@/utils/settings';
 
 // Mock dependencies
 vi.mock('@/utils/apiClient');
-vi.mock('@/utils/wallet/walletManager', () => ({
-  walletManager: {
-    getSettings: vi.fn().mockReturnValue({
-      counterpartyApiBase: 'https://api.counterparty.io',
-    }),
-  },
+vi.mock('@/utils/settings', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/utils/settings')>()),
+  getActiveSettings: vi.fn().mockReturnValue({
+    counterpartyApiBase: 'https://api.counterparty.io',
+  }),
 }));
 vi.mock('../api', () => ({
   fetchAssetDetails: vi.fn().mockImplementation(async (asset: string) => {
@@ -37,7 +36,7 @@ vi.mock('../api', () => ({
 }));
 
 const mockedApiClient = vi.mocked(apiClient, true);
-const mockedGetSettings = vi.mocked(walletManager.getSettings);
+const mockedGetSettings = vi.mocked(getActiveSettings);
 
 const mockApiBase = 'https://api.counterparty.io';
 

--- a/src/utils/blockchain/counterparty/api.ts
+++ b/src/utils/blockchain/counterparty/api.ts
@@ -9,7 +9,7 @@
 
 import { apiClient } from '@/utils/apiClient';
 import { CounterpartyApiError } from '@/utils/blockchain/errors';
-import { walletManager } from '@/utils/wallet/walletManager';
+import { getActiveSettings } from '@/utils/settings';
 
 // =============================================================================
 // CONSTANTS
@@ -433,7 +433,7 @@ export interface ServerInfo {
 // =============================================================================
 
 async function getApiBase(): Promise<string> {
-  const settings = walletManager.getSettings();
+  const settings = getActiveSettings();
   return settings.counterpartyApiBase;
 }
 

--- a/src/utils/blockchain/counterparty/capabilities.ts
+++ b/src/utils/blockchain/counterparty/capabilities.ts
@@ -1,8 +1,8 @@
 import { apiClient } from '@/utils/apiClient';
 import { CounterpartyApiError } from '@/utils/blockchain/errors';
-import { walletManager } from '@/utils/wallet/walletManager';
+import { getActiveSettings } from '@/utils/settings';
 
-export type CounterpartyFeature = 'ammPools';
+export type CounterpartyFeature = 'ammPools' | 'indefiniteOrders';
 
 interface ServerInfo {
   server_ready: boolean;
@@ -24,21 +24,33 @@ const FEATURE_REQUIREMENTS: Record<CounterpartyFeature, FeatureRequirement> = {
   ammPools: {
     minVersion: '11.1.0',
     activationHeights: {
-      mainnet: 952500,
-      testnet: 4961000,
-      testnet3: 4961000,
-      testnet4: 136000,
-      signet: 310000,
+      mainnet: 952800,
+      testnet: 4961300,
+      testnet3: 4961300,
+      testnet4: 136300,
+      signet: 310300,
       regtest: 0,
     },
     label: 'AMM pools',
+  },
+  indefiniteOrders: {
+    minVersion: '11.1.0',
+    activationHeights: {
+      mainnet: 952800,
+      testnet: 4961300,
+      testnet3: 4961300,
+      testnet4: 136300,
+      signet: 310300,
+      regtest: 0,
+    },
+    label: 'Never-expiring orders',
   },
 };
 
 let cachedServerInfo: { apiBase: string; serverInfo: ServerInfo; timestamp: number } | null = null;
 
 function getApiBase(): string {
-  return walletManager.getSettings().counterpartyApiBase;
+  return getActiveSettings().counterpartyApiBase;
 }
 
 function parseVersion(version: string): [number, number, number] {

--- a/src/utils/blockchain/counterparty/compose.ts
+++ b/src/utils/blockchain/counterparty/compose.ts
@@ -1,7 +1,7 @@
 import { apiClient } from '@/utils/apiClient';
-import { walletManager } from '@/utils/wallet/walletManager';
 import { CounterpartyApiError } from '@/utils/blockchain/errors';
 import { requireCounterpartyFeature } from '@/utils/blockchain/counterparty/capabilities';
+import { LEGACY_MAX_ORDER_EXPIRATION, MAX_ORDER_EXPIRATION, getActiveSettings } from '@/utils/settings';
 import { selectUtxosForTransaction } from '@/utils/blockchain/counterparty/utxo-selection';
 
 /**
@@ -217,6 +217,7 @@ export interface FairminterOptions extends BaseComposeOptions {
   lot_price?: number;
   lot_size?: number;
   max_mint_per_tx?: number;
+  max_mint_per_address?: number;
   hard_cap?: number;
   premint_quantity?: number;
   start_block?: number;
@@ -275,7 +276,7 @@ export interface MoveOptions extends BaseComposeOptions {
 }
 
 async function getApiBase() {
-  const settings = walletManager.getSettings();
+  const settings = getActiveSettings();
   return settings.counterpartyApiBase;
 }
 
@@ -442,7 +443,7 @@ export async function composeTransaction<T extends Record<string, unknown>>(
 ): Promise<ApiResponse> {
   const base = await getApiBase();
   const apiUrl = `${base}/v2/addresses/${sourceAddress}/compose/${endpoint}`;
-  const settings = walletManager.getSettings();
+  const settings = getActiveSettings();
 
   const makeRequest = async ({ inputsSet, allowUnconfirmed }: ComposeRequestOptions): Promise<ApiResponse> => {
     const params = new URLSearchParams(toStringParams({
@@ -484,7 +485,7 @@ async function composeTransactionWithArrays<T extends Record<string, unknown>>(
 ): Promise<ApiResponse> {
   const base = await getApiBase();
   const apiUrl = `${base}/v2/addresses/${sourceAddress}/compose/${endpoint}`;
-  const settings = walletManager.getSettings();
+  const settings = getActiveSettings();
 
   const makeRequest = async ({ inputsSet, allowUnconfirmed }: ComposeRequestOptions): Promise<ApiResponse> => {
     const params = new URLSearchParams(toStringParams({
@@ -537,7 +538,7 @@ export async function composeUtxoTransaction<T extends Record<string, unknown>>(
   const apiUrl = `${base}/v2/utxos/${sourceUtxo}/compose/${endpoint}`;
 
   // Get user's unconfirmed transaction preference
-  const settings = walletManager.getSettings();
+  const settings = getActiveSettings();
 
   const params = new URLSearchParams(toStringParams({
     ...paramsObj,
@@ -839,6 +840,15 @@ export async function composeOrder(options: OrderOptions): Promise<ApiResponse> 
     max_fee,
     encoding,
   } = options;
+  if (expiration < 0 || expiration > MAX_ORDER_EXPIRATION) {
+    throw new Error(`Order expiration must be between 0 and ${MAX_ORDER_EXPIRATION} blocks.`);
+  }
+  // The v11.1 indefinite_orders gate covers both never-expiring orders and
+  // finite expirations above the old 8064-block policy cap.
+  if (expiration === 0 || expiration > LEGACY_MAX_ORDER_EXPIRATION) {
+    await requireCounterpartyFeature('indefiniteOrders');
+  }
+
   const paramsObj = {
     give_asset,
     give_quantity: give_quantity.toString(),
@@ -965,6 +975,7 @@ export async function composeFairminter(options: FairminterOptions): Promise<Api
     lot_price = 0,
     lot_size = 1,
     max_mint_per_tx = 0,
+    max_mint_per_address = 0,
     hard_cap = 0,
     premint_quantity = 0,
     start_block = 0,
@@ -990,6 +1001,7 @@ export async function composeFairminter(options: FairminterOptions): Promise<Api
     lot_price: lot_price.toString(),
     lot_size: lot_size.toString(),
     max_mint_per_tx: max_mint_per_tx.toString(),
+    max_mint_per_address: max_mint_per_address.toString(),
     hard_cap: hard_cap.toString(),
     premint_quantity: premint_quantity.toString(),
     start_block: start_block.toString(),

--- a/src/utils/blockchain/counterparty/normalize.ts
+++ b/src/utils/blockchain/counterparty/normalize.ts
@@ -94,11 +94,12 @@ const NORMALIZATION_CONFIG: Record<string, {
     assetFields: { quantity: 'asset' }
   },
   fairminter: {
-    quantityFields: ['premint_quantity', 'lot_size', 'max_mint_per_tx', 'hard_cap', 'soft_cap'],
+    quantityFields: ['premint_quantity', 'lot_size', 'max_mint_per_tx', 'max_mint_per_address', 'hard_cap', 'soft_cap'],
     assetFields: {
       premint_quantity: 'asset',
       lot_size: 'asset',
       max_mint_per_tx: 'asset',
+      max_mint_per_address: 'asset',
       hard_cap: 'asset',
       soft_cap: 'asset'
     },

--- a/src/utils/blockchain/counterparty/transaction.ts
+++ b/src/utils/blockchain/counterparty/transaction.ts
@@ -6,7 +6,7 @@
  */
 
 import { apiClient, API_TIMEOUTS } from '@/utils/apiClient';
-import { walletManager } from '@/utils/wallet/walletManager';
+import { getActiveSettings } from '@/utils/settings';
 import { fromSatoshis } from '@/utils/numeric';
 import { fetchAssetDetails } from './api';
 import { arc4, hexToBytes, bytesToHex } from './unpack/binary';
@@ -66,7 +66,7 @@ export async function decodeRawTransaction(
   rawTxHex: string,
   verbose: boolean = true
 ): Promise<DecodedBitcoinTransaction> {
-  const settings = walletManager.getSettings();
+  const settings = getActiveSettings();
   const apiBase = settings.counterpartyApiBase || 'https://api.counterparty.io';
 
   const url = `${apiBase}/v2/bitcoin/transactions/decode`;
@@ -156,7 +156,7 @@ export async function unpackCounterpartyData(
   dataHex: string,
   verbose: boolean = true
 ): Promise<UnpackedCounterpartyData | null> {
-  const settings = walletManager.getSettings();
+  const settings = getActiveSettings();
   const apiBase = settings.counterpartyApiBase || 'https://api.counterparty.io';
 
   const url = `${apiBase}/v2/transactions/unpack`;

--- a/src/utils/blockchain/counterparty/unpack/__tests__/counterparty-core-compat.test.ts
+++ b/src/utils/blockchain/counterparty/unpack/__tests__/counterparty-core-compat.test.ts
@@ -206,32 +206,56 @@ describe('Counterparty-Core Compatibility', () => {
   describe('Dispenser', () => {
     /**
      * From dispenser.py:
-     * FORMAT = ">QQQB"
-     * - asset (Q): 8 bytes
+     * FORMAT = ">QQQQB", LENGTH = 33  (mainchainrate is BEFORE status, and mandatory)
+     * - asset_id (Q): 8 bytes
      * - give_quantity (Q): 8 bytes
      * - escrow_quantity (Q): 8 bytes
+     * - mainchainrate (Q): 8 bytes
      * - status (B): 1 byte
-     * + optional: mainchainrate (Q): 8 bytes
-     * + optional: open_address bytes
+     * + optional action_address (21 bytes) and oracle_address (21 bytes)
      */
 
-    it('should unpack basic dispenser', () => {
-      // This tests the minimum dispenser format
-      const assetId = '0000000000000001'; // XCP
-      const giveQty = '0000000000000064'; // 100 per dispense
-      const escrowQty = '00000000000003e8'; // 1000 total
-      const status = '00'; // open
-      const mainchainrate = '00000000000f4240'; // 1000000 sats = 0.01 BTC
+    // Core byte order (mainchainrate before status), built via bigintToHex8.
+    const baseHex =
+      bigintToHex8(1n) + // asset_id = XCP
+      bigintToHex8(100n) + // give_quantity
+      bigintToHex8(1000n) + // escrow_quantity
+      bigintToHex8(1000000n); // mainchainrate = 1,000,000 sats = 0.01 BTC
 
-      const payload = hexToBytes(assetId + giveQty + escrowQty + status + mainchainrate);
-
-      const result = unpackDispenser(payload);
+    it('should unpack a basic (33-byte) dispenser', () => {
+      const result = unpackDispenser(hexToBytes(baseHex + '00')); // status = OPEN
 
       expect(result.asset).toBe('XCP');
       expect(result.giveQuantity).toBe(100n);
       expect(result.escrowQuantity).toBe(1000n);
-      expect(result.status).toBe(0);
       expect(result.mainchainrate).toBe(1000000n);
+      expect(result.status).toBe(0);
+      expect(result.statusName).toBe('open');
+      expect(result.openAddress).toBeUndefined();
+      expect(result.oracleAddress).toBeUndefined();
+    });
+
+    it('should read action_address for OPEN_EMPTY_ADDRESS (status 1)', () => {
+      const payload = baseHex + '01' + '6f' + TEST_ADDRESSES.addr1_hash; // 33 + 21 bytes
+      const result = unpackDispenser(hexToBytes(payload));
+
+      expect(result.status).toBe(1);
+      expect(result.statusName).toBe('open_empty_address');
+      expect(result.openAddress).toBe(TEST_ADDRESSES.addr1);
+      expect(result.oracleAddress).toBeUndefined();
+    });
+
+    it('should read oracle_address for an OPEN oracle dispenser', () => {
+      const payload = baseHex + '00' + '6f' + TEST_ADDRESSES.addr0_hash; // 33 + 21, status OPEN
+      const result = unpackDispenser(hexToBytes(payload));
+
+      expect(result.status).toBe(0);
+      expect(result.openAddress).toBeUndefined(); // not read for OPEN
+      expect(result.oracleAddress).toBe(TEST_ADDRESSES.addr0);
+    });
+
+    it('should reject a payload shorter than the 33-byte struct (matches core)', () => {
+      expect(() => unpackDispenser(hexToBytes(baseHex))).toThrow(); // 32 bytes, no status
     });
   });
 
@@ -434,6 +458,7 @@ import { unpackDividend } from '../messages/dividend';
 import { unpackFairmint } from '../messages/fairmint';
 import { unpackFairminter } from '../messages/fairminter';
 import { unpackAttach } from '../messages/attach';
+import { unpackPoolDeposit, unpackPoolWithdraw } from '../messages/pool';
 
 describe('BTCPay', () => {
   /**
@@ -629,5 +654,91 @@ describe('Attach', () => {
     expect(result.asset).toBe('PEPECASH');
     expect(result.quantity).toBe(50000000n);
     expect(result.destinationVout).toBe(2);
+  });
+});
+
+describe('Pool Deposit', () => {
+  /**
+   * From pooldeposit.py:
+   * FORMAT = ">QQQQQQ", LENGTH = 48
+   * - asset_a_id (Q): 8 bytes
+   * - asset_b_id (Q): 8 bytes
+   * - quantity_a (Q): 8 bytes
+   * - quantity_b (Q): 8 bytes
+   * - min_lp_quantity (Q): 8 bytes
+   * - lp_asset_id (Q): 8 bytes
+   * Core rejects any message whose length != 48 (UnpackError).
+   */
+
+  const lpAssetId = 26n ** 12n + 2000n; // numeric LP asset
+  const assetBId = 26n ** 12n + 1000n; // numeric paired asset
+  // Build every 8-byte field via bigintToHex8 so hex can't drift from the asserts.
+  const depositHex =
+    bigintToHex8(1n) + // asset_a_id = XCP
+    bigintToHex8(assetBId) + // asset_b_id (numeric)
+    bigintToHex8(100000000n) + // quantity_a
+    bigintToHex8(200000000n) + // quantity_b
+    bigintToHex8(141421264n) + // min_lp_quantity
+    bigintToHex8(lpAssetId); // lp_asset_id (numeric)
+
+  it('should unpack a pool deposit (48 bytes)', () => {
+    const result = unpackPoolDeposit(hexToBytes(depositHex));
+
+    expect(result.assetA).toBe('XCP');
+    expect(result.assetBId).toBe(assetBId);
+    expect(result.assetB).toBe(`A${assetBId.toString()}`);
+    expect(result.quantityA).toBe(100000000n);
+    expect(result.quantityB).toBe(200000000n);
+    expect(result.minLpQuantity).toBe(141421264n);
+    expect(result.lpAssetId).toBe(lpAssetId);
+    expect(result.lpAsset).toBe(`A${lpAssetId.toString()}`);
+  });
+
+  it('should reject a deposit payload with trailing bytes (matches core length check)', () => {
+    expect(() => unpackPoolDeposit(hexToBytes(depositHex + '00'))).toThrow();
+  });
+
+  it('should reject a truncated deposit payload', () => {
+    expect(() => unpackPoolDeposit(hexToBytes(depositHex.slice(0, -2)))).toThrow();
+  });
+});
+
+describe('Pool Withdraw', () => {
+  /**
+   * From poolwithdraw.py:
+   * FORMAT = ">QQQQQ", LENGTH = 40
+   * - asset_a_id (Q): 8 bytes
+   * - asset_b_id (Q): 8 bytes
+   * - quantity (Q): 8 bytes
+   * - min_quantity_a (Q): 8 bytes
+   * - min_quantity_b (Q): 8 bytes
+   * Core rejects any message whose length != 40 (UnpackError).
+   */
+
+  const assetBId = 26n ** 12n + 1000n;
+  const withdrawHex =
+    bigintToHex8(1n) + // asset_a_id = XCP
+    bigintToHex8(assetBId) + // asset_b_id (numeric)
+    bigintToHex8(70710528n) + // quantity (LP burned)
+    bigintToHex8(99000000n) + // min_quantity_a
+    bigintToHex8(198000000n); // min_quantity_b
+
+  it('should unpack a pool withdraw (40 bytes)', () => {
+    const result = unpackPoolWithdraw(hexToBytes(withdrawHex));
+
+    expect(result.assetA).toBe('XCP');
+    expect(result.assetBId).toBe(assetBId);
+    expect(result.assetB).toBe(`A${assetBId.toString()}`);
+    expect(result.quantity).toBe(70710528n);
+    expect(result.minQuantityA).toBe(99000000n);
+    expect(result.minQuantityB).toBe(198000000n);
+  });
+
+  it('should reject a withdraw payload with trailing bytes (matches core length check)', () => {
+    expect(() => unpackPoolWithdraw(hexToBytes(withdrawHex + '00'))).toThrow();
+  });
+
+  it('should reject a truncated withdraw payload', () => {
+    expect(() => unpackPoolWithdraw(hexToBytes(withdrawHex.slice(0, -2)))).toThrow();
   });
 });

--- a/src/utils/blockchain/counterparty/unpack/__tests__/providerVerify.test.ts
+++ b/src/utils/blockchain/counterparty/unpack/__tests__/providerVerify.test.ts
@@ -495,7 +495,7 @@ describe('verifyProviderTransaction', () => {
   });
 
   describe('dispenser verification', () => {
-    // Dispenser binary: asset_id(8) + give_quantity(8) + escrow_quantity(8) + status(1) + [mainchainrate(8)]
+    // Dispenser binary (core ">QQQQB"): asset_id(8) + give_quantity(8) + escrow_quantity(8) + mainchainrate(8) + status(1)
     function makeDispenser(
       assetId: bigint, giveQty: bigint, escrowQty: bigint, rate: bigint
     ): string {
@@ -503,7 +503,7 @@ describe('verifyProviderTransaction', () => {
       return buildMessage(
         MessageTypeId.DISPENSER,
         bigintHex(assetId) + bigintHex(giveQty) + bigintHex(escrowQty) +
-        status + bigintHex(rate)
+        bigintHex(rate) + status
       );
     }
 

--- a/src/utils/blockchain/counterparty/unpack/messages/dispenser.ts
+++ b/src/utils/blockchain/counterparty/unpack/messages/dispenser.ts
@@ -2,16 +2,16 @@
  * Dispenser Message Unpacker
  *
  * Message ID: 12
- * Format: ">QQQB" (25 bytes minimum) + optional fields
+ * Format: ">QQQQB" (33 bytes fixed, matching counterparty-core dispenser.py) + optional fields
  *   - asset_id (Q): 8 bytes - Asset to dispense
  *   - give_quantity (Q): 8 bytes - Units given per dispense
  *   - escrow_quantity (Q): 8 bytes - Total quantity in escrow
+ *   - mainchainrate (Q): 8 bytes - Satoshis required per give_quantity (BEFORE status)
  *   - status (B): 1 byte - Status code
  *
- * Optional fields (appended):
- *   - mainchainrate (Q): 8 bytes - Satoshis required per give_quantity
- *   - action_address: 21 bytes (if status = 1 or closing with different source)
- *   - oracle_address: 21 bytes (if oracle dispenser)
+ * Optional fields (appended, 21 bytes each):
+ *   - action_address: present for OPEN_EMPTY_ADDRESS, or CLOSED when extra bytes exist
+ *   - oracle_address: present for oracle dispensers
  *
  * Status values:
  *   0 = OPEN
@@ -25,8 +25,8 @@ import { assetIdToName } from '../assetId';
 import { unpackAddress, PACKED_ADDRESS_LENGTH } from '../address';
 import { DispenserStatus } from '../messageTypes';
 
-/** Base length of dispenser message (without optional fields) */
-const DISPENSER_BASE_LENGTH = 25; // 3 x Q (8 bytes) + 1 x B (1 byte)
+/** Fixed length of the dispenser struct (">QQQQB"), matching core's LENGTH=33. */
+const DISPENSER_LENGTH = 33; // 4 x Q (8 bytes) + 1 x B (1 byte)
 
 /**
  * Unpacked dispenser data
@@ -78,15 +78,17 @@ function getStatusName(status: number): string {
  * @throws Error if payload is invalid
  */
 export function unpackDispenser(payload: Uint8Array): DispenserData {
-  if (payload.length < DISPENSER_BASE_LENGTH) {
-    throw new Error(`Invalid dispenser payload length: ${payload.length} (minimum ${DISPENSER_BASE_LENGTH})`);
+  if (payload.length < DISPENSER_LENGTH) {
+    throw new Error(`Invalid dispenser payload length: ${payload.length} (minimum ${DISPENSER_LENGTH})`);
   }
 
   const reader = new BinaryReader(payload);
 
+  // Fixed-layout ">QQQQB": mainchainrate precedes status and is mandatory.
   const assetId = reader.readUint64BE();
   const giveQuantity = reader.readUint64BE();
   const escrowQuantity = reader.readUint64BE();
+  const mainchainrate = reader.readUint64BE();
   const status = reader.readUint8();
 
   // Convert asset ID to name
@@ -97,31 +99,24 @@ export function unpackDispenser(payload: Uint8Array): DispenserData {
     assetId,
     giveQuantity,
     escrowQuantity,
-    mainchainrate: 0n, // Default, may be updated below
+    mainchainrate,
     status,
     statusName: getStatusName(status),
   };
 
-  // Read optional mainchainrate (8 bytes)
-  if (reader.remaining >= 8) {
-    result.mainchainrate = reader.readUint64BE();
+  // Optional action_address (21 bytes): read for OPEN_EMPTY_ADDRESS, or CLOSED
+  // when a full address follows. Never for OPEN/CLOSING. (Core additionally gates
+  // the CLOSED case on a protocol fork, which needs a block height unavailable here.)
+  if (
+    reader.remaining >= PACKED_ADDRESS_LENGTH &&
+    (status === DispenserStatus.OPEN_EMPTY_ADDRESS || status === DispenserStatus.CLOSED)
+  ) {
+    result.openAddress = unpackAddress(reader.readBytes(PACKED_ADDRESS_LENGTH));
   }
 
-  // Check for optional action address
-  // Present if status = OPEN_EMPTY_ADDRESS or (CLOSING with remaining bytes)
+  // Optional oracle_address (21 bytes) — any remaining full address.
   if (reader.remaining >= PACKED_ADDRESS_LENGTH) {
-    if (status === DispenserStatus.OPEN_EMPTY_ADDRESS ||
-        status === DispenserStatus.CLOSED ||
-        status === DispenserStatus.CLOSING) {
-      const packedAddress = reader.readBytes(PACKED_ADDRESS_LENGTH);
-      result.openAddress = unpackAddress(packedAddress);
-    }
-  }
-
-  // Check for optional oracle address
-  if (reader.remaining >= PACKED_ADDRESS_LENGTH) {
-    const packedOracle = reader.readBytes(PACKED_ADDRESS_LENGTH);
-    result.oracleAddress = unpackAddress(packedOracle);
+    result.oracleAddress = unpackAddress(reader.readBytes(PACKED_ADDRESS_LENGTH));
   }
 
   return result;

--- a/src/utils/blockchain/counterparty/unpack/messages/enhancedSend.ts
+++ b/src/utils/blockchain/counterparty/unpack/messages/enhancedSend.ts
@@ -98,6 +98,11 @@ function unpackLegacy(payload: Uint8Array): EnhancedSendData {
     }
   }
 
+  // Core rejects asset_id 0 (BTC) for enhanced sends; reject it here too.
+  if (assetId === 0n) {
+    throw new Error('Invalid enhanced send: BTC (asset_id 0) is not allowed');
+  }
+
   // Convert asset ID to name
   const asset = assetIdToName(assetId);
 

--- a/src/utils/blockchain/counterparty/unpack/messages/order.ts
+++ b/src/utils/blockchain/counterparty/unpack/messages/order.ts
@@ -2,7 +2,7 @@
  * Order Message Unpacker
  *
  * Message ID: 10
- * Format: ">QQQQHQ" (34 bytes)
+ * Format: ">QQQQHQ" (42 bytes)
  *   - give_id (Q): 8 bytes - Asset ID to give
  *   - give_quantity (Q): 8 bytes - Quantity to give
  *   - get_id (Q): 8 bytes - Asset ID to get

--- a/src/utils/blockchain/counterparty/unpack/messages/pool.ts
+++ b/src/utils/blockchain/counterparty/unpack/messages/pool.ts
@@ -1,6 +1,11 @@
 import { BinaryReader } from '../binary';
 import { assetIdToName } from '../assetId';
 
+// Exact payload lengths, matching counterparty-core (pooldeposit.py ">QQQQQQ",
+// poolwithdraw.py ">QQQQQ"). Core rejects any other length, so the verifier must too.
+const POOL_DEPOSIT_LENGTH = 48;
+const POOL_WITHDRAW_LENGTH = 40;
+
 export interface PoolDepositData {
   assetA: string;
   assetAId: bigint;
@@ -24,6 +29,10 @@ export interface PoolWithdrawData {
 }
 
 export function unpackPoolDeposit(payload: Uint8Array): PoolDepositData {
+  if (payload.length !== POOL_DEPOSIT_LENGTH) {
+    throw new Error(`Invalid pool deposit payload length: ${payload.length} (expected ${POOL_DEPOSIT_LENGTH})`);
+  }
+
   const reader = new BinaryReader(payload);
 
   const assetAId = reader.readUint64BE();
@@ -47,6 +56,10 @@ export function unpackPoolDeposit(payload: Uint8Array): PoolDepositData {
 }
 
 export function unpackPoolWithdraw(payload: Uint8Array): PoolWithdrawData {
+  if (payload.length !== POOL_WITHDRAW_LENGTH) {
+    throw new Error(`Invalid pool withdraw payload length: ${payload.length} (expected ${POOL_WITHDRAW_LENGTH})`);
+  }
+
   const reader = new BinaryReader(payload);
 
   const assetAId = reader.readUint64BE();

--- a/src/utils/blockchain/counterparty/unpack/messages/sweep.ts
+++ b/src/utils/blockchain/counterparty/unpack/messages/sweep.ts
@@ -96,13 +96,9 @@ export function unpackSweep(payload: Uint8Array): SweepData {
       // Binary memo - store as hex
       result.memo = Array.from(result.memoBytes).map(b => b.toString(16).padStart(2, '0')).join('');
     } else {
-      // Try to decode as UTF-8 text
-      try {
-        result.memo = new TextDecoder('utf-8', { fatal: true }).decode(result.memoBytes);
-      } catch {
-        // Not valid UTF-8, store as hex
-        result.memo = Array.from(result.memoBytes).map(b => b.toString(16).padStart(2, '0')).join('');
-      }
+      // Non-binary memo: core decodes strict UTF-8 and aborts on invalid bytes;
+      // let it throw rather than masking with a hex fallback.
+      result.memo = new TextDecoder('utf-8', { fatal: true }).decode(result.memoBytes);
     }
   }
 

--- a/src/utils/blockchain/counterparty/unpack/paramSchema.ts
+++ b/src/utils/blockchain/counterparty/unpack/paramSchema.ts
@@ -122,7 +122,7 @@ export const MESSAGE_SCHEMAS: Record<string, MessageSchema> = {
       },
       expiration: {
         criticality: 'dangerous',
-        riskDescription: 'Too short = expires before fill, too long = funds locked longer',
+        riskDescription: 'Wrong expiration = expires too soon or stays locked until cancelled',
       },
       fee_required: {
         criticality: 'dangerous',
@@ -296,6 +296,10 @@ export const MESSAGE_SCHEMAS: Record<string, MessageSchema> = {
       max_mint_per_tx: {
         criticality: 'dangerous',
         riskDescription: 'Max per transaction - rate limiting',
+      },
+      max_mint_per_address: {
+        criticality: 'dangerous',
+        riskDescription: 'Max per address - rate limiting',
       },
       divisible: {
         criticality: 'dangerous',

--- a/src/utils/blockchain/counterparty/unpack/providerVerify.ts
+++ b/src/utils/blockchain/counterparty/unpack/providerVerify.ts
@@ -441,6 +441,11 @@ function verifyFairminter(
     mismatches.push(`Hard cap: local=${local.hardCap}, API=${apiHardCap}`);
   }
 
+  const apiMaxMintPerAddress = getApiValue(api, 'max_mint_per_address', 'maxMintPerAddress');
+  if (apiMaxMintPerAddress !== undefined && !quantitiesEqual(local.maxMintPerAddress, apiMaxMintPerAddress)) {
+    mismatches.push(`Max mint per address: local=${local.maxMintPerAddress}, API=${apiMaxMintPerAddress}`);
+  }
+
   if (api.divisible !== undefined && local.divisible !== api.divisible) {
     mismatches.push(`Divisible: local=${local.divisible}, API=${api.divisible}`);
   }

--- a/src/utils/encryption/encryption.ts
+++ b/src/utils/encryption/encryption.ts
@@ -1,17 +1,17 @@
 /**
  * Key-Based Encryption - Shared AES-GCM encryption utilities
  *
- * Provides key-based encryption/decryption for both settings and wallet vault.
+ * Provides key-based encryption/decryption for the keychain and wallet secrets.
  * Keys are derived once from password via PBKDF2, then stored in session.
  *
  * Used by:
- * - settings.ts: encrypts/decrypts application settings
- * - walletManager.ts: encrypts/decrypts wallet vault and secrets
+ * - walletManager.ts: encrypts/decrypts the keychain (incl. settings) and wallet secrets
+ * - sessionManager.ts: manages the cached master key
  */
 
 import { bufferToBase64, base64ToBuffer, generateRandomBytes, combineBuffers } from './buffer';
 
-// Crypto constants (shared with settings.ts)
+// Crypto constants
 const IV_BYTES = 12;
 const KEY_BITS = 256;
 const GCM_TAG_BYTES = 16;

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -141,6 +141,54 @@ export const PROVIDER_ERROR_CODES = {
 // } as const;
 
 /**
+ * Error carrying a JSON-RPC / EIP-1193 code. Throwing this at a provider boundary
+ * is the author's signal that the message is dApp-safe and should be surfaced with
+ * the given code — no string matching required downstream.
+ */
+export class ProviderError extends Error {
+  readonly code: number;
+  constructor(code: number, message: string) {
+    super(message);
+    this.name = 'ProviderError';
+    this.code = code;
+  }
+}
+
+/**
+ * Map a thrown provider error to the code and message a dApp should receive.
+ * User-facing states (rejection, not-connected/locked/setup) are surfaced with a
+ * structured code so dApps can branch; everything else is masked to a generic
+ * message so internals don't leak. Used at every dApp-facing boundary so the
+ * classification can't drift out of sync with the messages the wallet throws.
+ */
+/**
+ * Codes whose accompanying message is safe to surface to a dApp. A carried code
+ * outside this set (an internal error, or an accidental numeric `.code` on an
+ * unexpected throw) is masked so internals never leak.
+ */
+const SURFACEABLE_CODES: ReadonlySet<number> = new Set([
+  PROVIDER_ERROR_CODES.USER_REJECTED,
+  PROVIDER_ERROR_CODES.UNAUTHORIZED,
+  PROVIDER_ERROR_CODES.UNSUPPORTED_METHOD,
+  PROVIDER_ERROR_CODES.DISCONNECTED,
+  PROVIDER_ERROR_CODES.CHAIN_DISCONNECTED,
+  PROVIDER_ERROR_CODES.CHAINS_NOT_ADDED,
+  JSON_RPC_ERROR_CODES.METHOD_NOT_FOUND,
+  JSON_RPC_ERROR_CODES.INVALID_PARAMS,
+]);
+
+export function classifyProviderError(error: unknown): { code: number; message: string } {
+  // A recognized code carried from the throw site (a ProviderError) means the
+  // message is intentional and dApp-safe — surface both. Anything else is masked
+  // so internals never leak. dApp-facing errors must be thrown as ProviderError.
+  const carried = (error as { code?: unknown })?.code;
+  if (typeof carried === 'number' && SURFACEABLE_CODES.has(carried)) {
+    return { code: carried, message: error instanceof Error ? error.message : String(error) };
+  }
+  return { code: JSON_RPC_ERROR_CODES.INTERNAL_ERROR, message: 'Request failed' };
+}
+
+/**
  * Helper function to create a JSON-RPC error object
  */
 export function createJsonRpcError(

--- a/src/utils/fathom.ts
+++ b/src/utils/fathom.ts
@@ -28,7 +28,7 @@
  * - Aligns with cryptocurrency ecosystem privacy values
  */
 
-import { walletManager } from '@/utils/wallet/walletManager';
+import { getActiveSettings } from '@/utils/settings';
 
 // Fathom configuration constants
 export const FATHOM_SITE_ID = 'PEMZGNDB';
@@ -230,7 +230,7 @@ async function isAnalyticsEnabled(): Promise<boolean> {
     }
 
     // Fall back to our settings (Chrome and older Firefox)
-    const settings = walletManager.getSettings();
+    const settings = getActiveSettings();
     return settings.analyticsAllowed;
   } catch (error) {
     // If we can't get settings, don't track

--- a/src/utils/hardware/trezorAdapter.ts
+++ b/src/utils/hardware/trezorAdapter.ts
@@ -80,7 +80,7 @@ import {
   OutputScriptType,
 } from './types';
 import { extractPsbtDetails } from '@/utils/blockchain/bitcoin/psbt';
-import { walletManager } from '@/utils/wallet/walletManager';
+import { getActiveSettings } from '@/utils/settings';
 
 // ============================================================================
 // Internal Types for Trezor SDK Compatibility
@@ -330,7 +330,7 @@ export class TrezorAdapter implements IHardwareWalletAdapter {
         // Note: This is intentionally separate from transactionDryRun to prevent
         // accidental security weakening when users just want to preview transactions
         try {
-          const settings = walletManager.getSettings();
+          const settings = getActiveSettings();
           isTestMode = settings.trezorEmulatorMode === true;
         } catch {
           // Settings not available (keychain locked), use production mode

--- a/src/utils/provider/__tests__/requestIdentity.test.ts
+++ b/src/utils/provider/__tests__/requestIdentity.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { getIdentityMismatchError } from '../requestIdentity';
+import type { AuthorizedRequest } from '@/utils/storage/requestStorage';
+
+const req = (over?: Partial<AuthorizedRequest>): AuthorizedRequest => ({
+  id: 'r1',
+  origin: 'https://example.com',
+  timestamp: 0,
+  address: 'bc1qauthorized',
+  walletId: 'wallet-1',
+  ...over,
+});
+
+describe('getIdentityMismatchError', () => {
+  it('returns null when address and wallet match', () => {
+    expect(getIdentityMismatchError(req(), 'bc1qauthorized', 'wallet-1')).toBeNull();
+  });
+
+  it('flags a changed active address', () => {
+    expect(getIdentityMismatchError(req(), 'bc1qother', 'wallet-1')).toMatch(/active address changed/);
+  });
+
+  it('flags a changed active wallet', () => {
+    expect(getIdentityMismatchError(req(), 'bc1qauthorized', 'wallet-2')).toMatch(/active address changed/);
+  });
+
+  it('flags a missing active identity', () => {
+    expect(getIdentityMismatchError(req(), undefined, undefined)).not.toBeNull();
+  });
+
+  it('ignores walletId when the request has none (back-compat)', () => {
+    expect(getIdentityMismatchError(req({ walletId: '' }), 'bc1qauthorized', 'any-wallet')).toBeNull();
+  });
+});

--- a/src/utils/provider/__tests__/signFlow.test.ts
+++ b/src/utils/provider/__tests__/signFlow.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { fakeBrowser } from 'wxt/testing';
+import {
+  computeRequestKey,
+  beginSignFlow,
+  recordSignOutcome,
+  findActiveFlowByKey,
+  getSignFlow,
+  removeSignFlow,
+} from '../signFlow';
+
+describe('signFlow', () => {
+  beforeEach(() => {
+    fakeBrowser.reset();
+  });
+
+  describe('computeRequestKey', () => {
+    it('is deterministic for identical inputs', () => {
+      const a = computeRequestKey('https://x.com', 'xcp_signTransaction', [{ hex: '00' }]);
+      const b = computeRequestKey('https://x.com', 'xcp_signTransaction', [{ hex: '00' }]);
+      expect(a).toBe(b);
+    });
+
+    it('differs by origin, method, or params', () => {
+      const base = computeRequestKey('https://x.com', 'xcp_signTransaction', ['00']);
+      expect(computeRequestKey('https://y.com', 'xcp_signTransaction', ['00'])).not.toBe(base);
+      expect(computeRequestKey('https://x.com', 'xcp_signPsbt', ['00'])).not.toBe(base);
+      expect(computeRequestKey('https://x.com', 'xcp_signTransaction', ['01'])).not.toBe(base);
+    });
+  });
+
+  describe('lifecycle', () => {
+    it('records pending, then outcome, recoverable by id and key', async () => {
+      const key = computeRequestKey('https://x.com', 'xcp_signTransaction', ['00']);
+      await beginSignFlow('id-1', 'https://x.com', key);
+
+      let flow = await findActiveFlowByKey(key);
+      expect(flow?.id).toBe('id-1');
+      expect(flow?.status).toBe('pending');
+
+      await recordSignOutcome('id-1', 'completed', { signedTxHex: 'deadbeef' });
+      flow = await getSignFlow('id-1');
+      expect(flow?.status).toBe('completed');
+      expect(flow?.result).toEqual({ signedTxHex: 'deadbeef' });
+
+      await removeSignFlow('id-1');
+      expect(await getSignFlow('id-1')).toBeNull();
+      expect(await findActiveFlowByKey(key)).toBeNull();
+    });
+
+    it('recordSignOutcome is a no-op for an unknown id', async () => {
+      await expect(recordSignOutcome('nope', 'completed', {})).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/utils/provider/requestIdentity.ts
+++ b/src/utils/provider/requestIdentity.ts
@@ -1,0 +1,19 @@
+import type { AuthorizedRequest } from '@/utils/storage/requestStorage';
+
+/**
+ * Returns an error message if the active signing identity no longer matches the
+ * one authorized when the request was created, or null if it still matches.
+ * Used by the approve screens to refuse signing after a wallet/address switch.
+ */
+export function getIdentityMismatchError(
+  request: AuthorizedRequest,
+  activeAddress: string | undefined,
+  activeWalletId: string | undefined,
+): string | null {
+  const addressChanged = request.address !== activeAddress;
+  const walletChanged = Boolean(request.walletId) && request.walletId !== activeWalletId;
+  if (addressChanged || walletChanged) {
+    return 'The active address changed after this request was made. Switch back to the authorized address, or reconnect the site.';
+  }
+  return null;
+}

--- a/src/utils/provider/signFlow.ts
+++ b/src/utils/provider/signFlow.ts
@@ -1,0 +1,64 @@
+/**
+ * Persistent lifecycle for dApp signing requests so they survive a service-worker
+ * restart. The awaited Promise + event listeners live only in worker memory; this
+ * store persists the request's status/result keyed by requestId, and a deterministic
+ * requestKey lets a dApp re-request rejoin (or recover the result of) the original
+ * flow instead of opening a duplicate popup.
+ */
+
+import { RequestStorage, BaseRequest } from '@/utils/storage/requestStorage';
+
+export type SignFlowStatus = 'pending' | 'completed' | 'cancelled';
+
+export interface SignFlowEntry extends BaseRequest {
+  /** Deterministic key over (origin, method, params); identical re-requests share it. */
+  requestKey: string;
+  status: SignFlowStatus;
+  /** The completion payload (e.g. { signedTxHex }) once status === 'completed'. */
+  result?: unknown;
+}
+
+/** Active flows older than this are treated as stale and ignored for rejoin/recovery. */
+export const SIGN_FLOW_TTL_MS = 10 * 60 * 1000; // matches the in-memory approval timeout
+
+export const signFlowStorage = new RequestStorage<SignFlowEntry>({
+  storageKey: 'pending_sign_flow',
+  requestName: 'sign flow',
+});
+
+/** Deterministic key for a provider request so a retry maps to the same flow. */
+export function computeRequestKey(origin: string, method: string, params: unknown): string {
+  const json = JSON.stringify({ origin, method, params });
+  // djb2 — collision risk is negligible for this short-lived, per-origin keyspace.
+  let hash = 5381;
+  for (let i = 0; i < json.length; i++) {
+    hash = ((hash << 5) + hash + json.charCodeAt(i)) >>> 0;
+  }
+  return `${method}:${hash.toString(16)}`;
+}
+
+/** Record a new pending flow for a request. */
+export async function beginSignFlow(id: string, origin: string, requestKey: string): Promise<void> {
+  await signFlowStorage.store({ id, origin, requestKey, status: 'pending', timestamp: Date.now() });
+}
+
+/** Update a flow's outcome (called when the popup signals completion/cancellation). */
+export async function recordSignOutcome(id: string, status: SignFlowStatus, result?: unknown): Promise<void> {
+  const entry = await signFlowStorage.get(id);
+  if (!entry) return;
+  // store() appends rather than upserts, so replace the existing entry.
+  await signFlowStorage.remove(id);
+  await signFlowStorage.store({ ...entry, status, result });
+}
+
+/** Find a non-stale flow for a request key (for dedup/rejoin/recovery). */
+export async function findActiveFlowByKey(requestKey: string): Promise<SignFlowEntry | null> {
+  const now = Date.now();
+  const all = await signFlowStorage.getAll();
+  return (
+    all.find((e) => e.requestKey === requestKey && now - e.timestamp < SIGN_FLOW_TTL_MS) ?? null
+  );
+}
+
+export const getSignFlow = (id: string) => signFlowStorage.get(id);
+export const removeSignFlow = (id: string) => signFlowStorage.remove(id);

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -8,6 +8,8 @@
  * API is unchanged: defineProxyService(name, factory) => [register, getService]
  */
 
+import { ProviderError, PROVIDER_ERROR_CODES } from '@/utils/errors';
+
 type ServiceFactory<T> = () => T;
 
 interface PortRequest {
@@ -20,7 +22,7 @@ interface PortResponse {
   id: number;
   success: boolean;
   result?: any;
-  error?: string;
+  error?: { message: string; code?: number };
 }
 
 // Prevent duplicate onConnect listeners after service worker restarts
@@ -30,6 +32,23 @@ const registeredServices = new Set<string>();
 const activePorts = new Map<string, chrome.runtime.Port>();
 
 const PORT_PREFIX = 'proxy:';
+
+/**
+ * Provider methods whose effects must NOT be silently replayed across a service
+ * worker restart — they open a popup and/or sign. On a mid-call port disconnect
+ * these reject (the dApp can re-request) instead of spawning a duplicate popup.
+ */
+const NON_REPLAYABLE_PROVIDER_METHODS = new Set([
+  'xcp_requestAccounts',
+  'xcp_signMessage',
+  'xcp_signTransaction',
+  'xcp_signPsbt',
+]);
+
+/** A call is replay-safe unless it is a provider request for a non-idempotent method. */
+function isReplaySafe(methodName: string, args: any[]): boolean {
+  return !(methodName === 'handleRequest' && NON_REPLAYABLE_PROVIDER_METHODS.has(args?.[1]));
+}
 
 /**
  * Disconnect all cached proxy ports. Call this before BFCache freeze
@@ -83,7 +102,7 @@ export function defineProxyService<T extends Record<string, any>>(
 
         if (!serviceInstance || !(methodName in serviceInstance) || typeof serviceInstance[methodName] !== 'function') {
           try {
-            port.postMessage({ id, success: false, error: `Method ${methodName} not found on ${serviceName}` } as PortResponse);
+            port.postMessage({ id, success: false, error: { message: `Method ${methodName} not found on ${serviceName}` } } as PortResponse);
           } catch {}
           return;
         }
@@ -96,7 +115,11 @@ export function defineProxyService<T extends Record<string, any>>(
             port.postMessage({
               id,
               success: false,
-              error: error instanceof Error ? error.message : String(error),
+              error: {
+                message: error instanceof Error ? error.message : String(error),
+                // Only deliberately-coded errors carry a code across the wire.
+                code: error instanceof ProviderError ? error.code : undefined,
+              },
             } as PortResponse);
           } catch {}
         }
@@ -130,7 +153,12 @@ export function defineProxyService<T extends Record<string, any>>(
       if (msg.success) {
         pending.resolve(msg.result);
       } else {
-        pending.reject(new Error(msg.error || `${serviceName} call failed`));
+        const message = msg.error?.message || `${serviceName} call failed`;
+        pending.reject(
+          typeof msg.error?.code === 'number'
+            ? new ProviderError(msg.error.code, message)
+            : new Error(message),
+        );
       }
     });
 
@@ -138,9 +166,10 @@ export function defineProxyService<T extends Record<string, any>>(
       if (chrome.runtime?.lastError) { /* consumed */ }
       port = null;
       activePorts.delete(serviceName);
-      // Reject all in-flight calls — callers can retry
+      // Reject all in-flight calls — callers can retry. Coded DISCONNECTED so the
+      // boundary surfaces it (not masked) and the dApp SDK recognizes it as transient.
       for (const [, pending] of pendingCalls) {
-        pending.reject(new Error('Port disconnected'));
+        pending.reject(new ProviderError(PROVIDER_ERROR_CODES.DISCONNECTED, 'Port disconnected'));
       }
       pendingCalls.clear();
     });
@@ -177,8 +206,8 @@ export function defineProxyService<T extends Record<string, any>>(
                 msg.includes('Attempting to use a disconnected port') ||
                 msg.includes('Extension context invalidated');
 
-              if (isDisconnect && attempt === 0) {
-                // Port died — null it out and retry once
+              if (isDisconnect && attempt === 0 && isReplaySafe(prop, args)) {
+                // Port died — null it out and retry once (idempotent calls only)
                 port = null;
                 activePorts.delete(serviceName);
                 await new Promise(r => setTimeout(r, 200));

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -45,6 +45,11 @@ export function getAutoLockTimeoutMs(timer: AutoLockTimer): number {
  */
 export const SETTINGS_VERSION = 2;
 
+export const INDEFINITE_ORDER_EXPIRATION = 0;
+export const LEGACY_MAX_ORDER_EXPIRATION = 8064;
+export const MAX_ORDER_EXPIRATION = 2 ** 16 - 1;
+export const DEFAULT_ORDER_EXPIRATION = LEGACY_MAX_ORDER_EXPIRATION;
+
 /**
  * Application settings - stored encrypted inside the keychain.
  */
@@ -122,9 +127,28 @@ export const DEFAULT_SETTINGS: AppSettings = {
   enableAdvancedBroadcasts: false,
   transactionDryRun: false,
   counterpartyApiBase: 'https://api.counterparty.io:4000',
-  defaultOrderExpiration: 8064,
+  defaultOrderExpiration: DEFAULT_ORDER_EXPIRATION,
   strictTransactionVerification: true,
   connectedWebsites: [],
   pinnedAssets: ['XCP', 'PEPECASH', 'BITCRYSTALS', 'BITCORN', 'CROPS', 'MINTS'],
   hasVisitedRecoverBitcoin: false,
 };
+
+/**
+ * Live read-only settings access for modules that need config (e.g. the API
+ * base) without importing the wallet singleton. walletManager registers the
+ * provider on init; until then (or when locked) DEFAULT_SETTINGS is returned.
+ */
+let settingsProvider: (() => AppSettings) | null = null;
+
+export function setSettingsProvider(provider: () => AppSettings): void {
+  settingsProvider = provider;
+}
+
+export function getActiveSettings(): AppSettings {
+  return settingsProvider ? settingsProvider() : DEFAULT_SETTINGS;
+}
+
+export function getCounterpartyApiBase(): string {
+  return getActiveSettings().counterpartyApiBase;
+}

--- a/src/utils/storage/__tests__/keyStorage.test.ts
+++ b/src/utils/storage/__tests__/keyStorage.test.ts
@@ -1,10 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { fakeBrowser } from 'wxt/testing';
 import {
-  getCachedSettingsMasterKey,
-  setCachedSettingsMasterKey,
-  clearCachedSettingsMasterKey,
-  hasSettingsMasterKey,
   getCachedKeychainMasterKey,
   setCachedKeychainMasterKey,
   clearCachedKeychainMasterKey,
@@ -13,59 +9,6 @@ import {
 describe('keyStorage.ts', () => {
   beforeEach(() => {
     fakeBrowser.reset();
-  });
-
-  describe('Cached Settings Master Key (session storage)', () => {
-    it('should return null when no key is cached', async () => {
-      const result = await getCachedSettingsMasterKey();
-      expect(result).toBeNull();
-    });
-
-    it('should store and retrieve cached key', async () => {
-      const key = 'dGVzdEtleQ=='; // "testKey" in base64
-
-      await setCachedSettingsMasterKey(key);
-      const result = await getCachedSettingsMasterKey();
-
-      expect(result).toBe(key);
-    });
-
-    it('should clear cached key', async () => {
-      await setCachedSettingsMasterKey('keyToRemove');
-      expect(await getCachedSettingsMasterKey()).toBe('keyToRemove');
-
-      await clearCachedSettingsMasterKey();
-
-      expect(await getCachedSettingsMasterKey()).toBeNull();
-    });
-
-    it('should handle clearing non-existent key', async () => {
-      // Should not throw
-      await expect(clearCachedSettingsMasterKey()).resolves.not.toThrow();
-    });
-  });
-
-  describe('hasSettingsMasterKey', () => {
-    it('should return false when no key is cached', async () => {
-      const result = await hasSettingsMasterKey();
-      expect(result).toBe(false);
-    });
-
-    it('should return true when key is cached', async () => {
-      await setCachedSettingsMasterKey('someKey');
-
-      const result = await hasSettingsMasterKey();
-      expect(result).toBe(true);
-    });
-
-    it('should return false after key is cleared', async () => {
-      await setCachedSettingsMasterKey('keyToRemove');
-      expect(await hasSettingsMasterKey()).toBe(true);
-
-      await clearCachedSettingsMasterKey();
-
-      expect(await hasSettingsMasterKey()).toBe(false);
-    });
   });
 
   describe('Cached Keychain Master Key (session storage)', () => {
@@ -91,35 +34,9 @@ describe('keyStorage.ts', () => {
 
       expect(await getCachedKeychainMasterKey()).toBeNull();
     });
-  });
 
-  describe('Settings and Keychain key independence', () => {
-    it('should store settings and keychain keys independently', async () => {
-      await setCachedSettingsMasterKey('settingsKey');
-      await setCachedKeychainMasterKey('keychainKey');
-
-      expect(await getCachedSettingsMasterKey()).toBe('settingsKey');
-      expect(await getCachedKeychainMasterKey()).toBe('keychainKey');
-    });
-
-    it('should clear settings key without affecting keychain key', async () => {
-      await setCachedSettingsMasterKey('settingsKey');
-      await setCachedKeychainMasterKey('keychainKey');
-
-      await clearCachedSettingsMasterKey();
-
-      expect(await getCachedSettingsMasterKey()).toBeNull();
-      expect(await getCachedKeychainMasterKey()).toBe('keychainKey');
-    });
-
-    it('should clear keychain key without affecting settings key', async () => {
-      await setCachedSettingsMasterKey('settingsKey');
-      await setCachedKeychainMasterKey('keychainKey');
-
-      await clearCachedKeychainMasterKey();
-
-      expect(await getCachedSettingsMasterKey()).toBe('settingsKey');
-      expect(await getCachedKeychainMasterKey()).toBeNull();
+    it('should handle clearing a non-existent keychain key', async () => {
+      await expect(clearCachedKeychainMasterKey()).resolves.not.toThrow();
     });
   });
 });

--- a/src/utils/storage/__tests__/signMessageRequestStorage.test.ts
+++ b/src/utils/storage/__tests__/signMessageRequestStorage.test.ts
@@ -27,6 +27,8 @@ describe('signMessageRequestStorage', () => {
     id: 'test-id-' + Math.random().toString(36).slice(2),
     origin: 'https://example.com',
     message: 'Sign this message',
+    address: 'bc1qauthorized',
+    walletId: 'wallet-1',
     timestamp: Date.now(),
     ...overrides,
   });

--- a/src/utils/storage/keyStorage.ts
+++ b/src/utils/storage/keyStorage.ts
@@ -1,23 +1,12 @@
 /**
- * Storage for master keys (session storage).
+ * Storage for the keychain master key (session storage).
  *
- * Master keys are derived from password via PBKDF2 and cached in session
- * storage to survive service worker restarts. Both settings and wallet
- * use the same pattern: derive once on unlock, cache until lock/browser close.
- *
- * Salt is stored inside each encrypted record (SettingsRecord, WalletVaultRecord),
- * not separately, for atomic storage operations.
+ * Derived from the password via PBKDF2 and cached in session storage to survive
+ * service worker restarts: derived once on unlock, cleared on lock/browser
+ * close. Salt is stored inside the encrypted keychain record, not separately.
  */
 
 import { storage } from '#imports';
-
-/**
- * Settings master key - cached in session storage.
- * Cleared when browser closes or keychain locks.
- */
-const settingsMasterKeyItem = storage.defineItem<string | null>('session:settingsMasterKey', {
-  fallback: null,
-});
 
 /**
  * Keychain master key - cached in session storage.
@@ -27,57 +16,6 @@ const settingsMasterKeyItem = storage.defineItem<string | null>('session:setting
 const keychainMasterKeyItem = storage.defineItem<string | null>('session:keychainMasterKey', {
   fallback: null,
 });
-
-// ============================================================================
-// Settings Master Key
-// ============================================================================
-
-/**
- * Gets the cached settings master key from session storage.
- * Returns null if no key is cached (keychain locked).
- */
-export async function getCachedSettingsMasterKey(): Promise<string | null> {
-  try {
-    return await settingsMasterKeyItem.getValue();
-  } catch (err) {
-    console.error('Failed to get cached settings master key:', err);
-    return null;
-  }
-}
-
-/**
- * Stores the settings master key in session storage.
- * Key is automatically cleared when browser closes.
- */
-export async function setCachedSettingsMasterKey(keyBase64: string): Promise<void> {
-  try {
-    await settingsMasterKeyItem.setValue(keyBase64);
-  } catch (err) {
-    console.error('Failed to cache settings master key:', err);
-    throw new Error('Failed to cache settings master key');
-  }
-}
-
-/**
- * Clears the cached settings master key from session storage.
- * Call this during keychain lock.
- */
-export async function clearCachedSettingsMasterKey(): Promise<void> {
-  try {
-    await settingsMasterKeyItem.removeValue();
-  } catch (err) {
-    console.error('Failed to clear cached settings master key:', err);
-    throw new Error('Failed to clear cached settings master key');
-  }
-}
-
-/**
- * Checks if a settings master key is currently cached.
- */
-export async function hasSettingsMasterKey(): Promise<boolean> {
-  const key = await getCachedSettingsMasterKey();
-  return key !== null;
-}
 
 // ============================================================================
 // Keychain Master Key Storage

--- a/src/utils/storage/requestStorage.ts
+++ b/src/utils/storage/requestStorage.ts
@@ -40,6 +40,15 @@ export interface BaseRequest {
 }
 
 /**
+ * A request authorized for a specific signing identity. Signing is bound to the
+ * address/wallet captured here when the request was created.
+ */
+export interface AuthorizedRequest extends BaseRequest {
+  address: string;
+  walletId: string;
+}
+
+/**
  * Validates that a value has the minimum BaseRequest shape.
  */
 function isValidBaseRequest(value: unknown): value is BaseRequest {

--- a/src/utils/storage/signMessageRequestStorage.ts
+++ b/src/utils/storage/signMessageRequestStorage.ts
@@ -5,12 +5,12 @@
  * here so the popup can retrieve them and pre-populate the sign message form.
  */
 
-import { RequestStorage, BaseRequest } from './requestStorage';
+import { RequestStorage, AuthorizedRequest } from './requestStorage';
 
 /**
  * Sign message request from a dApp.
  */
-export interface SignMessageRequest extends BaseRequest {
+export interface SignMessageRequest extends AuthorizedRequest {
   message: string;
 }
 

--- a/src/utils/storage/signPsbtRequestStorage.ts
+++ b/src/utils/storage/signPsbtRequestStorage.ts
@@ -5,12 +5,12 @@
  * here so the popup can retrieve them and show the approval UI.
  */
 
-import { RequestStorage, BaseRequest } from './requestStorage';
+import { RequestStorage, AuthorizedRequest } from './requestStorage';
 
 /**
  * Sign PSBT request from a dApp.
  */
-export interface SignPsbtRequest extends BaseRequest {
+export interface SignPsbtRequest extends AuthorizedRequest {
   psbtHex: string;
   signInputs?: Record<string, number[]>;
   sighashTypes?: number[];

--- a/src/utils/storage/signTransactionRequestStorage.ts
+++ b/src/utils/storage/signTransactionRequestStorage.ts
@@ -5,12 +5,12 @@
  * here so the popup can retrieve them and show the approval UI.
  */
 
-import { RequestStorage, BaseRequest } from './requestStorage';
+import { RequestStorage, AuthorizedRequest } from './requestStorage';
 
 /**
  * Sign transaction request from a dApp.
  */
-export interface SignTransactionRequest extends BaseRequest {
+export interface SignTransactionRequest extends AuthorizedRequest {
   rawTxHex: string;
 }
 

--- a/src/utils/validation/__tests__/api.test.ts
+++ b/src/utils/validation/__tests__/api.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { validateCounterpartyApi } from '../api';
+
+const originalFetch = global.fetch;
+
+function mockFetchResult(result: Record<string, unknown>, ok = true, status = 200) {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok,
+    status,
+    json: vi.fn().mockResolvedValue({ result }),
+  } as unknown as Response);
+}
+
+function validApiResult(overrides: Record<string, unknown> = {}) {
+  return {
+    server_ready: true,
+    network: 'mainnet',
+    version: '11.1.0',
+    backend_height: 952800,
+    counterparty_height: 952800,
+    ...overrides,
+  };
+}
+
+describe('validateCounterpartyApi', () => {
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('accepts a mainnet 11.1.0 API', async () => {
+    mockFetchResult(validApiResult());
+
+    const result = await validateCounterpartyApi('https://api.example.com');
+
+    expect(result.isValid).toBe(true);
+    expect(result.apiInfo?.version).toBe('11.1.0');
+  });
+
+  it('accepts newer patch and minor versions', async () => {
+    mockFetchResult(validApiResult({ version: '11.2.0' }));
+
+    const result = await validateCounterpartyApi('https://api.example.com');
+
+    expect(result.isValid).toBe(true);
+  });
+
+  it('compares API versions numerically instead of lexicographically', async () => {
+    mockFetchResult(validApiResult({ version: '11.10.0' }));
+
+    const result = await validateCounterpartyApi('https://api.example.com');
+
+    expect(result.isValid).toBe(true);
+  });
+
+  it('rejects APIs older than 11.1.0', async () => {
+    mockFetchResult(validApiResult({ version: '11.0.0' }));
+
+    const result = await validateCounterpartyApi('https://api.example.com');
+
+    expect(result.isValid).toBe(false);
+    expect(result.error).toBe('API must be Counterparty Core 11.1.0 or newer');
+  });
+
+  it('rejects missing or unparsable API versions', async () => {
+    mockFetchResult(validApiResult({ version: undefined }));
+
+    const result = await validateCounterpartyApi('https://api.example.com');
+
+    expect(result.isValid).toBe(false);
+    expect(result.error).toBe('API must be Counterparty Core 11.1.0 or newer');
+  });
+
+  it('rejects non-mainnet APIs before version acceptance', async () => {
+    mockFetchResult(validApiResult({ network: 'testnet4', version: '11.1.0' }));
+
+    const result = await validateCounterpartyApi('https://api.example.com');
+
+    expect(result.isValid).toBe(false);
+    expect(result.error).toBe('API must be connected to mainnet');
+  });
+});

--- a/src/utils/validation/api.ts
+++ b/src/utils/validation/api.ts
@@ -1,3 +1,5 @@
+import { isVersionAtLeast } from '@/utils/blockchain/counterparty/capabilities';
+
 /**
  * Interface for Counterparty API validation result
  */
@@ -11,6 +13,8 @@ export interface ApiValidationResult {
     counterpartyHeight: number;
   };
 }
+
+const MIN_COUNTERPARTY_API_VERSION = '11.1.0';
 
 /**
  * Validates a Counterparty API endpoint
@@ -60,6 +64,14 @@ export async function validateCounterpartyApi(url: string): Promise<ApiValidatio
 
     if (data.result.network !== "mainnet") {
       return { isValid: false, error: "API must be connected to mainnet" };
+    }
+
+    const version = String(data.result.version ?? '');
+    if (!isVersionAtLeast(version, MIN_COUNTERPARTY_API_VERSION)) {
+      return {
+        isValid: false,
+        error: `API must be Counterparty Core ${MIN_COUNTERPARTY_API_VERSION} or newer`,
+      };
     }
 
     // Success

--- a/src/utils/wallet/__tests__/addressDeriver.test.ts
+++ b/src/utils/wallet/__tests__/addressDeriver.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest';
+import {
+  generateWalletId,
+  generateWalletIdFromPrivateKey,
+  deriveMnemonicAddress,
+  deriveAddressFromPrivateKey,
+  deriveAddressesFromSecret,
+} from '../addressDeriver';
+import {
+  getAddressFromMnemonic,
+  getDerivationPathForAddressFormat,
+  AddressFormat,
+} from '@/utils/blockchain/bitcoin/address';
+import { getAddressFromPrivateKey } from '@/utils/blockchain/bitcoin/privateKey';
+import type { WalletRecord } from '@/types/wallet';
+
+// Standard BIP39 test vector mnemonic.
+const MNEMONIC =
+  'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+// Private key = 1 (valid secp256k1 scalar).
+const PRIV_HEX = '0000000000000000000000000000000000000000000000000000000000000001';
+
+describe('addressDeriver', () => {
+  describe('deriveMnemonicAddress', () => {
+    it('derives the same address as getAddressFromMnemonic at the indexed path', () => {
+      for (const format of [AddressFormat.P2WPKH, AddressFormat.P2PKH, AddressFormat.P2TR]) {
+        for (const index of [0, 1, 5]) {
+          const expectedPath = `${getDerivationPathForAddressFormat(format)}/${index}`;
+          const result = deriveMnemonicAddress(MNEMONIC, format, index);
+
+          expect(result.address).toBe(getAddressFromMnemonic(MNEMONIC, expectedPath, format));
+          expect(result.path).toBe(expectedPath);
+          expect(result.name).toBe(`Address ${index + 1}`);
+          expect(result.pubKey).toMatch(/^[0-9a-f]+$/);
+        }
+      }
+    });
+
+    it('is deterministic', () => {
+      const a = deriveMnemonicAddress(MNEMONIC, AddressFormat.P2WPKH, 0);
+      const b = deriveMnemonicAddress(MNEMONIC, AddressFormat.P2WPKH, 0);
+      expect(a).toEqual(b);
+    });
+  });
+
+  describe('generateWalletId', () => {
+    it('is deterministic for the same mnemonic + format', async () => {
+      const a = await generateWalletId(MNEMONIC, AddressFormat.P2WPKH);
+      const b = await generateWalletId(MNEMONIC, AddressFormat.P2WPKH);
+      expect(a).toBe(b);
+      expect(a).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it('differs by address format (format is part of the id)', async () => {
+      const p2wpkh = await generateWalletId(MNEMONIC, AddressFormat.P2WPKH);
+      const p2pkh = await generateWalletId(MNEMONIC, AddressFormat.P2PKH);
+      expect(p2wpkh).not.toBe(p2pkh);
+    });
+  });
+
+  describe('generateWalletIdFromPrivateKey', () => {
+    it('is deterministic and format-sensitive', async () => {
+      const a = await generateWalletIdFromPrivateKey(PRIV_HEX, AddressFormat.P2WPKH);
+      const b = await generateWalletIdFromPrivateKey(PRIV_HEX, AddressFormat.P2WPKH);
+      const other = await generateWalletIdFromPrivateKey(PRIV_HEX, AddressFormat.P2PKH);
+      expect(a).toBe(b);
+      expect(a).toMatch(/^[0-9a-f]{64}$/);
+      expect(a).not.toBe(other);
+    });
+  });
+
+  describe('deriveAddressFromPrivateKey', () => {
+    it('matches getAddressFromPrivateKey and labels Address 1', () => {
+      const result = deriveAddressFromPrivateKey(
+        JSON.stringify({ hex: PRIV_HEX, compressed: true }),
+        AddressFormat.P2WPKH
+      );
+      expect(result.address).toBe(getAddressFromPrivateKey(PRIV_HEX, AddressFormat.P2WPKH, true));
+      expect(result.name).toBe('Address 1');
+      expect(result.path).toBe('');
+    });
+  });
+
+  describe('deriveAddressesFromSecret', () => {
+    it('derives addressCount addresses for a mnemonic wallet', () => {
+      const record = {
+        type: 'mnemonic',
+        addressFormat: AddressFormat.P2WPKH,
+        addressCount: 3,
+      } as unknown as WalletRecord;
+
+      const addresses = deriveAddressesFromSecret(MNEMONIC, record);
+      expect(addresses).toHaveLength(3);
+      addresses.forEach((addr, i) => {
+        expect(addr.address).toBe(deriveMnemonicAddress(MNEMONIC, AddressFormat.P2WPKH, i).address);
+      });
+    });
+
+    it('uses the record previewAddress for a hardware wallet', () => {
+      const record = {
+        type: 'hardware',
+        previewAddress: 'bc1qhardwarepreview',
+      } as unknown as WalletRecord;
+      const secret = JSON.stringify({ derivationPath: "m/84'/0'/0'/0/0", publicKey: 'deadbeef' });
+
+      const addresses = deriveAddressesFromSecret(secret, record);
+      expect(addresses).toEqual([
+        { name: 'Address 1', path: "m/84'/0'/0'/0/0", address: 'bc1qhardwarepreview', pubKey: 'deadbeef' },
+      ]);
+    });
+
+    it('returns the embedded address for a test-only wallet', () => {
+      const record = { type: 'privateKey', isTestOnly: true } as unknown as WalletRecord;
+      const secret = JSON.stringify({ isTestWallet: true, address: 'test-address' });
+
+      const addresses = deriveAddressesFromSecret(secret, record);
+      expect(addresses).toEqual([
+        { name: 'Test Address', path: 'm/test', address: 'test-address', pubKey: '' },
+      ]);
+    });
+
+    it('derives from a private key for a private-key wallet', () => {
+      const record = { type: 'privateKey', addressFormat: AddressFormat.P2WPKH } as unknown as WalletRecord;
+      const secret = JSON.stringify({ hex: PRIV_HEX, compressed: true });
+
+      const addresses = deriveAddressesFromSecret(secret, record);
+      expect(addresses).toHaveLength(1);
+      expect(addresses[0].address).toBe(getAddressFromPrivateKey(PRIV_HEX, AddressFormat.P2WPKH, true));
+    });
+
+    it('returns [] for malformed hardware secret', () => {
+      const record = { type: 'hardware', previewAddress: 'x' } as unknown as WalletRecord;
+      expect(deriveAddressesFromSecret('not-json', record)).toEqual([]);
+    });
+  });
+});

--- a/src/utils/wallet/__tests__/helpers/testHelpers.ts
+++ b/src/utils/wallet/__tests__/helpers/testHelpers.ts
@@ -49,7 +49,6 @@ export const defaultMocks = {
       autoLockTimer: '5m',
     }),
     updateSettings: vi.fn().mockResolvedValue(undefined),
-    initializeSettingsMasterKey: vi.fn().mockResolvedValue(undefined),
     invalidateSettingsCache: vi.fn(),
   },
   walletStorage: {

--- a/src/utils/wallet/__tests__/keychainCrypto.test.ts
+++ b/src/utils/wallet/__tests__/keychainCrypto.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { encryptKeychainRecord, decryptKeychain, KEYCHAIN_VERSION } from '../keychainCrypto';
+import { deriveKey } from '@/utils/encryption/encryption';
+import { generateRandomBytes, bufferToBase64 } from '@/utils/encryption/buffer';
+import { DEFAULT_SETTINGS } from '@/utils/settings';
+import type { Keychain } from '@/types/wallet';
+
+const ITERATIONS = 500000; // deriveKey enforces a 500k minimum (ADR-014)
+
+const sampleKeychain = (): Keychain => ({
+  version: KEYCHAIN_VERSION,
+  wallets: [],
+  settings: { ...DEFAULT_SETTINGS },
+});
+
+describe('keychainCrypto', () => {
+  it('round-trips a keychain through encrypt/decrypt with the same key', async () => {
+    const salt = generateRandomBytes(16);
+    const key = await deriveKey('correct-horse-battery', salt, ITERATIONS);
+    const keychain = sampleKeychain();
+
+    const record = await encryptKeychainRecord(keychain, key, bufferToBase64(salt), ITERATIONS);
+
+    expect(record.version).toBe(KEYCHAIN_VERSION);
+    expect(record.kdf.iterations).toBe(ITERATIONS);
+    expect(record.salt).toBe(bufferToBase64(salt));
+    expect(typeof record.encryptedKeychain).toBe('string');
+
+    const decrypted = await decryptKeychain(record, key);
+    expect(decrypted).toEqual(keychain);
+  });
+
+  it('fails to decrypt with the wrong key', async () => {
+    const salt = generateRandomBytes(16);
+    const key = await deriveKey('right-password', salt, ITERATIONS);
+    const wrongKey = await deriveKey('wrong-password', salt, ITERATIONS);
+
+    const record = await encryptKeychainRecord(sampleKeychain(), key, bufferToBase64(salt), ITERATIONS);
+
+    await expect(decryptKeychain(record, wrongKey)).rejects.toThrow();
+  });
+});

--- a/src/utils/wallet/addressDeriver.ts
+++ b/src/utils/wallet/addressDeriver.ts
@@ -1,0 +1,111 @@
+/**
+ * Pure address and wallet-id derivation — derives only from arguments, no
+ * wallet state.
+ */
+
+import { sha256 } from '@noble/hashes/sha2.js';
+import { utf8ToBytes, bytesToHex } from '@noble/hashes/utils.js';
+import { HDKey } from '@scure/bip32';
+import {
+  getAddressFromMnemonic,
+  getDerivationPathForAddressFormat,
+  getSeedFromMnemonic,
+  type AddressFormat,
+} from '@/utils/blockchain/bitcoin/address';
+import { getAddressFromPrivateKey, getPublicKeyFromPrivateKey } from '@/utils/blockchain/bitcoin/privateKey';
+import type { Address, WalletRecord, HardwareWalletSecret } from '@/types/wallet';
+
+export async function generateWalletId(mnemonic: string, addressFormat: AddressFormat): Promise<string> {
+  const seed = getSeedFromMnemonic(mnemonic, addressFormat);
+  const derivationPath = getDerivationPathForAddressFormat(addressFormat);
+  const pathParts = derivationPath.split('/').slice(0, -1).join('/');
+  const root = HDKey.fromMasterSeed(seed);
+  const accountNode = root.derive(pathParts);
+  if (!accountNode.publicKey) {
+    throw new Error('Unable to derive public key for ID creation.');
+  }
+  const xpub = accountNode.publicExtendedKey;
+  const xpubHash = sha256(utf8ToBytes(xpub));
+  const typeHash = sha256(utf8ToBytes(addressFormat));
+  const combined = new Uint8Array([...xpubHash, ...typeHash]);
+  const finalHash = sha256(combined);
+  return bytesToHex(finalHash);
+}
+
+export async function generateWalletIdFromPrivateKey(privateKeyHex: string, addressFormat: AddressFormat): Promise<string> {
+  const pubkeyCompressed = getPublicKeyFromPrivateKey(privateKeyHex, true);
+  const combined = utf8ToBytes(pubkeyCompressed + addressFormat);
+  const hash = sha256(combined);
+  return bytesToHex(hash);
+}
+
+export function deriveMnemonicAddress(mnemonic: string, addressFormat: AddressFormat, index: number): Address {
+  const path = `${getDerivationPathForAddressFormat(addressFormat)}/${index}`;
+  const address = getAddressFromMnemonic(mnemonic, path, addressFormat);
+  const seed = getSeedFromMnemonic(mnemonic, addressFormat);
+  const root = HDKey.fromMasterSeed(seed);
+  const child = root.derive(path);
+  if (!child.publicKey) {
+    throw new Error('Unable to derive public key');
+  }
+  const pubKeyHex = bytesToHex(child.publicKey);
+  return {
+    name: `Address ${index + 1}`,
+    path,
+    address,
+    pubKey: pubKeyHex,
+  };
+}
+
+export function deriveAddressFromPrivateKey(privKeyData: string, addressFormat: AddressFormat): Address {
+  const parsed = JSON.parse(privKeyData);
+  const address = getAddressFromPrivateKey(parsed.hex, addressFormat, parsed.compressed);
+  const pubKey = getPublicKeyFromPrivateKey(parsed.hex, parsed.compressed);
+  return {
+    name: 'Address 1',
+    path: '',
+    address,
+    pubKey,
+  };
+}
+
+/** Derives addresses from a decrypted secret based on wallet type */
+export function deriveAddressesFromSecret(secret: string, record: WalletRecord): Address[] {
+  if (record.type === 'mnemonic') {
+    const count = record.addressCount || 1;
+    return Array.from({ length: count }, (_, i) =>
+      deriveMnemonicAddress(secret, record.addressFormat, i)
+    );
+  }
+
+  if (record.type === 'hardware') {
+    // Hardware wallet secret contains metadata, not private keys
+    // The address is stored in the secret, no derivation needed
+    try {
+      const hardwareData: HardwareWalletSecret = JSON.parse(secret);
+      // We need the address from the record's previewAddress since
+      // hardware secrets don't store the address directly
+      return [{
+        name: 'Address 1',
+        path: hardwareData.derivationPath,
+        address: record.previewAddress,
+        pubKey: hardwareData.publicKey,
+      }];
+    } catch {
+      return [];
+    }
+  }
+
+  if (record.isTestOnly) {
+    try {
+      const testData = JSON.parse(secret);
+      if (testData.isTestWallet && testData.address) {
+        return [{ name: "Test Address", path: "m/test", address: testData.address, pubKey: '' }];
+      }
+    } catch {
+      return [];
+    }
+  }
+
+  return [deriveAddressFromPrivateKey(secret, record.addressFormat)];
+}

--- a/src/utils/wallet/keychainCrypto.ts
+++ b/src/utils/wallet/keychainCrypto.ts
@@ -1,0 +1,31 @@
+/**
+ * Keychain encrypt/decrypt for an already-derived master key. KDF derivation
+ * stays with the caller so the unlock path can use the off-thread worker.
+ */
+
+import { encryptJsonWithKey, decryptJsonWithKey } from '@/utils/encryption/encryption';
+import type { Keychain, KeychainRecord } from '@/types/wallet';
+
+/** Keychain blob schema version. */
+export const KEYCHAIN_VERSION = 1;
+
+/** Encrypt a keychain into a storable record. */
+export async function encryptKeychainRecord(
+  keychain: Keychain,
+  masterKey: CryptoKey,
+  salt: string,
+  iterations: number,
+): Promise<KeychainRecord> {
+  const encryptedKeychain = await encryptJsonWithKey(keychain, masterKey);
+  return {
+    version: KEYCHAIN_VERSION,
+    kdf: { iterations },
+    salt,
+    encryptedKeychain,
+  };
+}
+
+/** Decrypt a keychain record. */
+export async function decryptKeychain(record: KeychainRecord, masterKey: CryptoKey): Promise<Keychain> {
+  return decryptJsonWithKey<Keychain>(record.encryptedKeychain, masterKey);
+}

--- a/src/utils/wallet/walletManager.ts
+++ b/src/utils/wallet/walletManager.ts
@@ -1,6 +1,5 @@
 import { sha256 } from '@noble/hashes/sha2.js';
 import { utf8ToBytes, bytesToHex } from '@noble/hashes/utils.js';
-import { HDKey } from '@scure/bip32';
 import { validateMnemonic } from '@scure/bip39';
 import { wordlist } from '@scure/bip39/wordlists/english.js';
 import * as sessionManager from '@/utils/auth/sessionManager';
@@ -14,16 +13,22 @@ import {
   deriveKeyAsync,
   encryptWithKey,
   decryptWithKey,
-  encryptJsonWithKey,
-  decryptJsonWithKey,
   DEFAULT_PBKDF2_ITERATIONS,
 } from '@/utils/encryption/encryption';
 import { base64ToBuffer, generateRandomBytes, bufferToBase64 } from '@/utils/encryption/buffer';
-import { getAddressFromMnemonic, getDerivationPathForAddressFormat, AddressFormat, isCounterwalletFormat, getSeedFromMnemonic } from '@/utils/blockchain/bitcoin/address';
+import { getAddressFromMnemonic, getDerivationPathForAddressFormat, AddressFormat, isCounterwalletFormat } from '@/utils/blockchain/bitcoin/address';
 import { getPrivateKeyFromMnemonic, getAddressFromPrivateKey, getPublicKeyFromPrivateKey, decodeWIF, isWIF, encodeWIF } from '@/utils/blockchain/bitcoin/privateKey';
 import { signMessage } from '@/utils/blockchain/bitcoin/messageSigner';
 import { isValidCounterwalletMnemonic } from '@/utils/blockchain/counterwallet';
-import { DEFAULT_SETTINGS, getAutoLockTimeoutMs, type AppSettings } from '@/utils/settings';
+import {
+  generateWalletId,
+  generateWalletIdFromPrivateKey,
+  deriveMnemonicAddress,
+  deriveAddressFromPrivateKey,
+  deriveAddressesFromSecret,
+} from '@/utils/wallet/addressDeriver';
+import { KEYCHAIN_VERSION, encryptKeychainRecord, decryptKeychain } from '@/utils/wallet/keychainCrypto';
+import { DEFAULT_SETTINGS, getAutoLockTimeoutMs, setSettingsProvider, type AppSettings } from '@/utils/settings';
 import { signTransaction as btcSignTransaction } from '@/utils/blockchain/bitcoin/transactionSigner';
 import { broadcastTransaction as btcBroadcastTransaction } from '@/utils/blockchain/bitcoin/transactionBroadcaster';
 import { signPSBT as btcSignPSBT, extractPsbtDetails, completePsbtWithInputValues } from '@/utils/blockchain/bitcoin/psbt';
@@ -41,9 +46,6 @@ import { MAX_WALLETS, MAX_ADDRESSES_PER_WALLET } from './constants';
 
 // Re-export from constants to maintain backwards compatibility
 export { MAX_WALLETS, MAX_ADDRESSES_PER_WALLET };
-
-/** Current keychain schema version */
-const KEYCHAIN_VERSION = 1;
 
 /**
  * WalletManager - Core wallet state management (ADR-015)
@@ -109,7 +111,7 @@ export class WalletManager {
     if (!keychainRecord) return;
 
     try {
-      const decryptedKeychain = await decryptJsonWithKey<Keychain>(keychainRecord.encryptedKeychain, masterKey);
+      const decryptedKeychain = await decryptKeychain(keychainRecord, masterKey);
       this.keychain = decryptedKeychain;
       this.wallets = decryptedKeychain.wallets.map((r) => this.walletFromRecord(r));
       await this.refreshWalletAddresses();
@@ -157,49 +159,8 @@ export class WalletManager {
       const record = this.keychain.wallets.find(r => r.id === wallet.id);
       if (!record) continue;
 
-      wallet.addresses = this.deriveAddressesFromSecret(secret, record);
+      wallet.addresses = deriveAddressesFromSecret(secret, record);
     }
-  }
-
-  /** Derives addresses from a decrypted secret based on wallet type */
-  private deriveAddressesFromSecret(secret: string, record: WalletRecord): Address[] {
-    if (record.type === 'mnemonic') {
-      const count = record.addressCount || 1;
-      return Array.from({ length: count }, (_, i) =>
-        this.deriveMnemonicAddress(secret, record.addressFormat, i)
-      );
-    }
-
-    if (record.type === 'hardware') {
-      // Hardware wallet secret contains metadata, not private keys
-      // The address is stored in the secret, no derivation needed
-      try {
-        const hardwareData: HardwareWalletSecret = JSON.parse(secret);
-        // We need the address from the record's previewAddress since
-        // hardware secrets don't store the address directly
-        return [{
-          name: 'Address 1',
-          path: hardwareData.derivationPath,
-          address: record.previewAddress,
-          pubKey: hardwareData.publicKey,
-        }];
-      } catch {
-        return [];
-      }
-    }
-
-    if (record.isTestOnly) {
-      try {
-        const testData = JSON.parse(secret);
-        if (testData.isTestWallet && testData.address) {
-          return [{ name: "Test Address", path: "m/test", address: testData.address, pubKey: '' }];
-        }
-      } catch {
-        return [];
-      }
-    }
-
-    return [this.deriveAddressFromPrivateKey(secret, record.addressFormat)];
   }
 
   public getWallets(): Wallet[] {
@@ -249,7 +210,7 @@ export class WalletManager {
 
       try {
         const secret = await decryptWithKey(record.encryptedSecret, masterKey);
-        const addresses = this.deriveAddressesFromSecret(secret, record);
+        const addresses = deriveAddressesFromSecret(secret, record);
         if (addresses.some((addr) => addr.address.toLowerCase() === normalizedAddress)) {
           return true;
         }
@@ -287,7 +248,7 @@ export class WalletManager {
     }
 
     const walletName = name || `Wallet ${this.wallets.length + 1}`;
-    const id = await this.generateWalletId(mnemonic, addressFormat);
+    const id = await generateWalletId(mnemonic, addressFormat);
 
     if (this.wallets.some((w) => w.id === id)) {
       throw new Error('A wallet with this mnemonic+addressType combination already exists.');
@@ -370,7 +331,7 @@ export class WalletManager {
       compressed
     });
 
-    const id = await this.generateWalletIdFromPrivateKey(privateKeyHex, addressFormat);
+    const id = await generateWalletIdFromPrivateKey(privateKeyHex, addressFormat);
     if (this.wallets.some((w) => w.id === id)) {
       throw new Error('A wallet with this private key already exists.');
     }
@@ -708,7 +669,7 @@ export class WalletManager {
     // Decrypt keychain
     let decryptedKeychain: Keychain;
     try {
-      decryptedKeychain = await decryptJsonWithKey<Keychain>(keychainRecord.encryptedKeychain, masterKey);
+      decryptedKeychain = await decryptKeychain(keychainRecord, masterKey);
     } catch {
       throw new Error('Invalid password');
     }
@@ -788,7 +749,7 @@ export class WalletManager {
     // Decrypt and derive addresses
     const secret = await decryptWithKey(record.encryptedSecret, masterKey);
     sessionManager.storeUnlockedSecret(walletId, secret);
-    wallet.addresses = this.deriveAddressesFromSecret(secret, record);
+    wallet.addresses = deriveAddressesFromSecret(secret, record);
     wallet.addressCount = wallet.addresses.length;
     this.activeWalletId = walletId;
 
@@ -818,8 +779,10 @@ export class WalletManager {
     if (!this.keychain) {
       return { ...DEFAULT_SETTINGS };
     }
-    // Return a copy to prevent direct mutation
+    // DEFAULT_SETTINGS first backfills fields missing from keychains created
+    // under an older schema; stored values override. Copy to prevent mutation.
     return {
+      ...DEFAULT_SETTINGS,
       ...this.keychain.settings,
       connectedWebsites: [...(this.keychain.settings.connectedWebsites || [])],
       pinnedAssets: [...(this.keychain.settings.pinnedAssets || [])],
@@ -870,15 +833,12 @@ export class WalletManager {
       throw new Error('Cannot persist keychain: no existing record');
     }
 
-    // Re-encrypt keychain with master key
-    const encryptedKeychain = await encryptJsonWithKey(this.keychain, masterKey);
-
-    const updatedRecord: KeychainRecord = {
-      version: KEYCHAIN_VERSION,
-      kdf: existingRecord.kdf,
-      salt: existingRecord.salt,
-      encryptedKeychain,
-    };
+    const updatedRecord = await encryptKeychainRecord(
+      this.keychain,
+      masterKey,
+      existingRecord.salt,
+      existingRecord.kdf.iterations,
+    );
 
     await saveKeychainRecord(updatedRecord);
   }
@@ -897,13 +857,12 @@ export class WalletManager {
       settings: { ...DEFAULT_SETTINGS },
     };
 
-    const encryptedKeychain = await encryptJsonWithKey(newKeychain, masterKey);
-    const keychainRecord: KeychainRecord = {
-      version: KEYCHAIN_VERSION,
-      kdf: { iterations: DEFAULT_PBKDF2_ITERATIONS },
-      salt: bufferToBase64(salt),
-      encryptedKeychain,
-    };
+    const keychainRecord = await encryptKeychainRecord(
+      newKeychain,
+      masterKey,
+      bufferToBase64(salt),
+      DEFAULT_PBKDF2_ITERATIONS,
+    );
 
     await saveKeychainRecord(keychainRecord);
     await sessionManager.storeKeychainMasterKey(masterKey);
@@ -969,7 +928,7 @@ export class WalletManager {
     }
 
     const index = wallet.addressCount;
-    const newAddr = this.deriveMnemonicAddress(mnemonic, wallet.addressFormat, index);
+    const newAddr = deriveMnemonicAddress(mnemonic, wallet.addressFormat, index);
     wallet.addresses.push(newAddr);
     wallet.addressCount++;
 
@@ -1029,7 +988,7 @@ export class WalletManager {
     try {
       const salt = base64ToBuffer(keychainRecord.salt);
       const masterKey = await deriveKey(password, salt, keychainRecord.kdf.iterations);
-      await decryptJsonWithKey<Keychain>(keychainRecord.encryptedKeychain, masterKey);
+      await decryptKeychain(keychainRecord, masterKey);
       return true;
     } catch {
       return false;
@@ -1058,7 +1017,7 @@ export class WalletManager {
     // Decrypt keychain with current password
     const currentSalt = base64ToBuffer(keychainRecord.salt);
     const currentKey = await deriveKey(currentPassword, currentSalt, keychainRecord.kdf.iterations);
-    const decryptedKeychain = await decryptJsonWithKey<Keychain>(keychainRecord.encryptedKeychain, currentKey);
+    const decryptedKeychain = await decryptKeychain(keychainRecord, currentKey);
 
     // Re-encrypt each wallet's secret with new key
     const newSalt = generateRandomBytes(16);
@@ -1070,16 +1029,14 @@ export class WalletManager {
       walletRecord.encryptedSecret = await encryptWithKey(secret, newKey);
     }
 
-    // Re-encrypt keychain with new key
-    const encryptedKeychain = await encryptJsonWithKey(decryptedKeychain, newKey);
-
-    // Save updated keychain (settings are inside, so they're re-encrypted automatically)
-    const newKeychainRecord: KeychainRecord = {
-      version: KEYCHAIN_VERSION,
-      kdf: { iterations: DEFAULT_PBKDF2_ITERATIONS },
-      salt: bufferToBase64(newSalt),
-      encryptedKeychain,
-    };
+    // Re-encrypt the keychain with the new key (settings are inside, so they
+    // are re-encrypted automatically).
+    const newKeychainRecord = await encryptKeychainRecord(
+      decryptedKeychain,
+      newKey,
+      bufferToBase64(newSalt),
+      DEFAULT_PBKDF2_ITERATIONS,
+    );
     await saveKeychainRecord(newKeychainRecord);
 
     await this.lockKeychain();
@@ -1098,7 +1055,7 @@ export class WalletManager {
 
     wallet.addressFormat = newType;
     wallet.addressCount = 1;
-    wallet.addresses = [this.deriveMnemonicAddress(mnemonic, newType, 0)];
+    wallet.addresses = [deriveMnemonicAddress(mnemonic, newType, 0)];
     // Update preview address to match new format
     const derivationPath = `${getDerivationPathForAddressFormat(newType)}/0`;
     wallet.previewAddress = getAddressFromMnemonic(mnemonic, derivationPath, newType);
@@ -1436,59 +1393,9 @@ export class WalletManager {
     }
   }
 
-  private async generateWalletId(mnemonic: string, addressFormat: AddressFormat): Promise<string> {
-    const seed = getSeedFromMnemonic(mnemonic, addressFormat);
-    const derivationPath = getDerivationPathForAddressFormat(addressFormat);
-    const pathParts = derivationPath.split('/').slice(0, -1).join('/');
-    const root = HDKey.fromMasterSeed(seed);
-    const accountNode = root.derive(pathParts);
-    if (!accountNode.publicKey) {
-      throw new Error('Unable to derive public key for ID creation.');
-    }
-    const xpub = accountNode.publicExtendedKey;
-    const xpubHash = sha256(utf8ToBytes(xpub));
-    const typeHash = sha256(utf8ToBytes(addressFormat));
-    const combined = new Uint8Array([...xpubHash, ...typeHash]);
-    const finalHash = sha256(combined);
-    return bytesToHex(finalHash);
-  }
-
-  private async generateWalletIdFromPrivateKey(privateKeyHex: string, addressFormat: AddressFormat): Promise<string> {
-    const pubkeyCompressed = getPublicKeyFromPrivateKey(privateKeyHex, true);
-    const combined = utf8ToBytes(pubkeyCompressed + addressFormat);
-    const hash = sha256(combined);
-    return bytesToHex(hash);
-  }
-
-  private deriveMnemonicAddress(mnemonic: string, addressFormat: AddressFormat, index: number): Address {
-    const path = `${getDerivationPathForAddressFormat(addressFormat)}/${index}`;
-    const address = getAddressFromMnemonic(mnemonic, path, addressFormat);
-    const seed = getSeedFromMnemonic(mnemonic, addressFormat);
-    const root = HDKey.fromMasterSeed(seed);
-    const child = root.derive(path);
-    if (!child.publicKey) {
-      throw new Error('Unable to derive public key');
-    }
-    const pubKeyHex = bytesToHex(child.publicKey);
-    return {
-      name: `Address ${index + 1}`,
-      path,
-      address,
-      pubKey: pubKeyHex,
-    };
-  }
-
-  private deriveAddressFromPrivateKey(privKeyData: string, addressFormat: AddressFormat): Address {
-    const parsed = JSON.parse(privKeyData);
-    const address = getAddressFromPrivateKey(parsed.hex, addressFormat, parsed.compressed);
-    const pubKey = getPublicKeyFromPrivateKey(parsed.hex, parsed.compressed);
-    return {
-      name: 'Address 1',
-      path: '',
-      address,
-      pubKey,
-    };
-  }
 }
 
 export const walletManager = new WalletManager();
+
+// Expose read-only settings to modules that must not import the wallet singleton.
+setSettingsProvider(() => walletManager.getSettings());

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -16,7 +16,9 @@ export default defineConfig({
       web_accessible_resources: [
         {
           resources: ['injected.js'],
-          matches: ['<all_urls>'],
+          // Mirror the content-script matches so injected.js isn't probeable on
+          // pages where the provider is never injected (fingerprinting surface).
+          matches: ['https://*/*', 'http://localhost/*', 'http://127.0.0.1/*'],
         },
       ],
       permissions: [


### PR DESCRIPTION
Cuts **0.4.0** ahead of the pools + order-expiration go-live. Manifest bumped to 0.4.0.

## What's in it (5 commits, grouped for review)
1. **Provider hardening** — durable sign-flow that survives MV3 service-worker restarts (a dApp re-request rejoins a pending prompt or recovers an approved result, instead of duplicate popups / double-signs); structured `ProviderError` codes carried to dApps (`4001/4100/4200/4900`) with internals masked; per-origin `accountsChanged` on lock/unlock (no terminal disconnect); popup-close → prompt cancel. Contract documented in `PROVIDER.md`.
2. **Counterparty parsing/unpack + compose** — decoders (dispenser, order, pool, sweep, enhanced send) and paramSchema/providerVerify aligned to counterparty-core; compose/api/capabilities/normalize/transaction updates; pool fuzz test.
3. **Compose & settings UI** — order expiration, fairminter, dispenser, sweep, MPMA; order-settings + advanced pages.
4. **Bitcoin utils** — UTXO selection, broadcaster, bare multisig.
5. **Wallet/keychain crypto + infra** — keychainCrypto / addressDeriver modules, settings, validation, build config; version bump to 0.4.0.

## Verification
- `wxt build` clean · **3632 unit tests green** · `tsc --noEmit` clean
- Dependencies exact-pinned + lockfile; the one `npm audit` advisory (`ws`) is a non-bundled transitive (not reachable in the shipped artifact)
- Store package produced: `xcp-wallet-0.4.0-chrome.zip` (715 KB)

E2E (Playwright) runs in CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)