### PR TITLE
Sweep: align the +BTC toggle with the destination label

### DIFF
--- a/src/components/ui/inputs/destination-input.tsx
+++ b/src/components/ui/inputs/destination-input.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useEffect, ChangeEvent, useCallback } from "react";
+import { forwardRef, useEffect, ChangeEvent, useCallback, ReactNode } from "react";
 import { Field, Label, Description, Input } from "@headlessui/react";
 import { isValidBitcoinAddress } from "@/utils/validation/bitcoin";
 import { shouldTriggerAssetLookup } from "@/utils/validation/assetOwner";
@@ -16,6 +16,7 @@ interface DestinationInputProps {
   name?: string;
   label?: string;
   helpText?: string;
+  labelRight?: ReactNode; // Optional content aligned right of the label
 }
 
 export const DestinationInput = forwardRef<HTMLInputElement, DestinationInputProps>(
@@ -32,6 +33,7 @@ export const DestinationInput = forwardRef<HTMLInputElement, DestinationInputPro
       name = "destination",
       label = "Destination",
       helpText = "Enter recipient's address.",
+      labelRight,
     },
     ref
   ) => {
@@ -87,8 +89,9 @@ export const DestinationInput = forwardRef<HTMLInputElement, DestinationInputPro
 
     return (
       <Field>
-        <Label className="text-sm font-medium text-gray-700">
-          {label} {required && <span className="text-red-500">*</span>}
+        <Label className={`text-sm font-medium text-gray-700 ${labelRight ? "flex justify-between items-center" : ""}`}>
+          <span>{label} {required && <span className="text-red-500">*</span>}</span>
+          {labelRight}
         </Label>
         <div className="relative">
           <Input

--- a/src/pages/compose/sweep/form.tsx
+++ b/src/pages/compose/sweep/form.tsx
@@ -144,11 +144,8 @@ export function SweepForm({
         showHelpText={showHelpText}
         name="destination_display"
         helpText="Enter the address to sweep all assets to."
-      />
-
-      {enableMoreOutputs && (
-        <>
-          <div className="flex justify-end">
+        labelRight={
+          enableMoreOutputs ? (
             <button
               type="button"
               onClick={() => {
@@ -158,31 +155,31 @@ export function SweepForm({
               className="text-xs font-normal text-blue-600 hover:text-blue-700 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
               disabled={pending}
             >
-              {showBtcOutput ? "- BTC" : "+ BTC"}
+              {showBtcOutput ? "− BTC" : "+ BTC"}
             </button>
-          </div>
+          ) : undefined
+        }
+      />
 
-          {showBtcOutput && (
-            <AmountWithMaxInput
-              asset="BTC"
-              availableBalance={btcBalance}
-              value={btcAmount}
-              onChange={setBtcAmount}
-              feeRate={feeRate}
-              setError={() => {}}
-              sourceAddress={activeAddress}
-              maxAmount={btcBalance}
-              showHelpText={showHelpText}
-              label="Add BTC"
-              placeholder="0.00000000 BTC"
-              name="btc_output_display"
-              description="BTC to send alongside the sweep to the same destination."
-              disabled={pending}
-              isDivisible={true}
-              extraOutputCount={1}
-            />
-          )}
-        </>
+      {enableMoreOutputs && showBtcOutput && (
+        <AmountWithMaxInput
+          asset="BTC"
+          availableBalance={btcBalance}
+          value={btcAmount}
+          onChange={setBtcAmount}
+          feeRate={feeRate}
+          setError={() => {}}
+          sourceAddress={activeAddress}
+          maxAmount={btcBalance}
+          showHelpText={showHelpText}
+          label="Add BTC"
+          placeholder="0.00000000 BTC"
+          name="btc_output_display"
+          description="BTC to send alongside the sweep to the same destination."
+          disabled={pending}
+          isDivisible={true}
+          extraOutputCount={1}
+        />
       )}
 
       <input type="hidden" name="memo" value={memo} />


### PR DESCRIPTION
Moves the sweep form's +/- BTC toggle **inline with the Destination label** (right-aligned), matching how the send form places its +BTC toggle beside the Amount label. Previously the toggle floated on its own line above the attached-BTC input, disconnected from any label.

- Adds a `labelRight` prop to `DestinationInput` (same pattern `AmountWithMaxInput` already uses).
- Removes the orphaned toggle row; the attached-BTC input still appears below when toggled on.

tsc clean · destination-input + sweep tests pass (29).