### PR TITLE
Pool deposit/withdraw: rationalized slippage behind a gear, clearer labels

### DIFF
--- a/src/pages/compose/pool/__tests__/pool-slippage-settings.test.tsx
+++ b/src/pages/compose/pool/__tests__/pool-slippage-settings.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { PoolSlippageSettings } from "../pool-slippage-settings";
+
+const mockUpdateSettings = vi.fn();
+vi.mock("@/contexts/settings-context", () => ({
+  useSettings: () => ({ settings: {}, updateSettings: mockUpdateSettings }),
+}));
+
+beforeEach(() => vi.clearAllMocks());
+afterEach(() => cleanup());
+
+describe("PoolSlippageSettings", () => {
+  it("updates the per-transaction value and persists it as the default", () => {
+    const onChange = vi.fn();
+    render(<PoolSlippageSettings value="1" onChange={onChange} onBack={() => {}} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "3%" }));
+
+    expect(onChange).toHaveBeenCalledWith("3");
+    expect(mockUpdateSettings).toHaveBeenCalledWith({ defaultPoolSlippage: "3" });
+  });
+
+  it("persists a custom value as the default", () => {
+    const onChange = vi.fn();
+    render(<PoolSlippageSettings value="1" onChange={onChange} onBack={() => {}} />);
+
+    fireEvent.change(screen.getByLabelText("Custom slippage percent"), {
+      target: { value: "0.8" },
+    });
+
+    expect(onChange).toHaveBeenCalledWith("0.8");
+    expect(mockUpdateSettings).toHaveBeenCalledWith({ defaultPoolSlippage: "0.8" });
+  });
+
+  it("calls onBack when Done is pressed", () => {
+    const onBack = vi.fn();
+    render(<PoolSlippageSettings value="1" onChange={() => {}} onBack={onBack} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Done" }));
+
+    expect(onBack).toHaveBeenCalled();
+  });
+});

--- a/src/pages/compose/pool/__tests__/slippage-input.test.tsx
+++ b/src/pages/compose/pool/__tests__/slippage-input.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { SlippageInput } from "../slippage-input";
+
+afterEach(() => cleanup());
+
+function setup(value = "1") {
+  const onChange = vi.fn();
+  render(<SlippageInput value={value} onChange={onChange} showHelpText />);
+  return { onChange };
+}
+
+describe("SlippageInput", () => {
+  it("renders the rationalized presets and a custom field", () => {
+    setup();
+    expect(screen.getByRole("button", { name: "0.5%" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "1%" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "3%" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Custom slippage percent")).toBeInTheDocument();
+  });
+
+  it("emits the preset value when a chip is clicked", () => {
+    const { onChange } = setup("1");
+    fireEvent.click(screen.getByRole("button", { name: "3%" }));
+    expect(onChange).toHaveBeenCalledWith("3");
+  });
+
+  it("holds the value in the custom field only when it is not a preset", () => {
+    setup("2");
+    expect(screen.getByLabelText("Custom slippage percent")).toHaveValue("2");
+  });
+
+  it("emits typed custom values and rejects non-numeric input", () => {
+    const { onChange } = setup("1");
+    const custom = screen.getByLabelText("Custom slippage percent");
+
+    fireEvent.change(custom, { target: { value: "0.3" } });
+    expect(onChange).toHaveBeenCalledWith("0.3");
+
+    onChange.mockClear();
+    fireEvent.change(custom, { target: { value: "abc" } });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("warns on a very low tolerance (below the tightest preset)", () => {
+    setup("0.1");
+    expect(screen.getByText(/Very low/i)).toBeInTheDocument();
+  });
+
+  it("warns on a very high tolerance", () => {
+    setup("10");
+    expect(screen.getByText(/Very high/i)).toBeInTheDocument();
+  });
+
+  it("shows no warning for an in-band value", () => {
+    setup("1");
+    expect(screen.queryByText(/Very low|Very high/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/compose/pool/deposit/form.tsx
+++ b/src/pages/compose/pool/deposit/form.tsx
@@ -27,9 +27,11 @@ import {
   roundDown,
   toSatoshis,
 } from "@/utils/numeric";
+import { FaCog } from "@/components/icons";
 import type { PoolDepositOptions } from "@/utils/blockchain/counterparty/compose";
 import type { TokenBalance } from "@/utils/blockchain/counterparty/api";
-import { DEFAULT_POOL_SLIPPAGE, SlippageInput } from "../slippage-input";
+import { DEFAULT_POOL_SLIPPAGE } from "@/utils/settings";
+import { PoolSlippageSettings } from "../pool-slippage-settings";
 
 interface PoolDepositFormProps {
   formAction: (formData: FormData) => void;
@@ -44,7 +46,7 @@ export function PoolDepositForm({
   initialAssetA,
   initialAssetB,
 }: PoolDepositFormProps): ReactElement {
-  const { activeAddress, showHelpText, feeRate } = useComposer<PoolDepositOptions>();
+  const { activeAddress, showHelpText, feeRate, settings } = useComposer<PoolDepositOptions>();
   const { pending } = useFormStatus();
   const [assetA, setAssetA] = useState(initialFormData?.asset_a || initialAssetA || "XCP");
   const [assetB, setAssetB] = useState(initialFormData?.asset_b || initialAssetB || "");
@@ -52,17 +54,21 @@ export function PoolDepositForm({
   const [quantityB, setQuantityB] = useState(initialFormData?.quantity_b?.toString() || "");
   const [lpAsset, setLpAsset] = useState(initialFormData?.lp_asset || "");
   const [isLpAssetValid, setIsLpAssetValid] = useState(false);
-  const [slippage, setSlippage] = useState((initialFormData as PoolDepositOptions & { slippage?: string })?.slippage || DEFAULT_POOL_SLIPPAGE);
+  const [slippage, setSlippage] = useState((initialFormData as PoolDepositOptions & { slippage?: string })?.slippage || settings?.defaultPoolSlippage || DEFAULT_POOL_SLIPPAGE);
+  const [showSettings, setShowSettings] = useState(false);
   const [localError, setLocalError] = useState<string | null>(null);
 
   const { data: assetADetails } = useAssetDetails(assetA);
   const { data: assetBDetails } = useAssetDetails(assetB);
-  const { data: pool } = usePool(assetA, assetB);
+  const { data: pool, isLoading: isPoolLoading } = usePool(assetA, assetB);
 
   const assetADetailsReady = assetADetails?.assetInfo?.asset === assetA;
   const assetBDetailsReady = assetB ? assetBDetails?.assetInfo?.asset === assetB : false;
   const isAssetADivisible = assetADetailsReady ? assetADetails.isDivisible : true;
   const isAssetBDivisible = assetBDetailsReady && assetBDetails ? assetBDetails.isDivisible : true;
+  const bothAssetsSelected = Boolean(assetA && assetB && assetA !== assetB);
+  // The pool doesn't exist yet — known as soon as both assets resolve, before any quote.
+  const isNewPool = bothAssetsSelected && !isPoolLoading && pool === null;
   const canQuote = assetA && assetB && assetA !== assetB && assetADetailsReady && isGreaterThan(quantityA || 0, 0);
   const needsQuote = canQuote && isGreaterThan(quantityB || 0, 0);
   const { data: quote, isLoading: isLoadingQuote, error: quoteError } = usePoolDepositQuote({
@@ -147,15 +153,38 @@ export function PoolDepositForm({
     formAction(formData);
   };
 
+  if (showSettings) {
+    return (
+      <PoolSlippageSettings
+        value={slippage}
+        onChange={setSlippage}
+        onBack={() => setShowSettings(false)}
+        showHelpText={showHelpText}
+      />
+    );
+  }
+
   return (
     <ComposerForm
       formAction={handleFormAction}
       header={
-        pool ? (
-          <PoolHeader pool={pool} className="mt-1 mb-5" />
-        ) : assetABalanceHeader ? (
-          <BalanceHeader balance={assetABalanceHeader} className="mt-1 mb-5" />
-        ) : null
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0 flex-1">
+            {pool ? (
+              <PoolHeader pool={pool} className="mt-1 mb-5" />
+            ) : assetABalanceHeader ? (
+              <BalanceHeader balance={assetABalanceHeader} className="mt-1 mb-5" />
+            ) : null}
+          </div>
+          <button
+            type="button"
+            onClick={() => setShowSettings(true)}
+            aria-label="Pool settings"
+            className="mt-1 shrink-0 p-2 rounded-full hover:bg-gray-100 transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+          >
+            <FaCog className="size-4 text-gray-600" aria-hidden="true" />
+          </button>
+        </div>
       }
       submitText="Review Deposit"
       submitDisabled={pending || submitDisabled}
@@ -165,7 +194,7 @@ export function PoolDepositForm({
       <AssetSelectInput
         selectedAsset={assetA}
         onChange={setAssetA}
-        label="First Asset"
+        label="Asset A"
         required
         showHelpText={showHelpText}
       />
@@ -180,7 +209,7 @@ export function PoolDepositForm({
         showHelpText={showHelpText}
         sourceAddress={activeAddress}
         maxAmount={assetADetails?.availableBalance || "0"}
-        label={`${assetA || "Asset"} Amount`}
+        label="Amount"
         name="quantity_a_display"
         disabled={pending || !assetA}
         isDivisible={isAssetADivisible}
@@ -189,7 +218,7 @@ export function PoolDepositForm({
       <AssetSelectInput
         selectedAsset={assetB}
         onChange={setAssetB}
-        label="Second Asset"
+        label="Asset B"
         required
         showHelpText={showHelpText}
       />
@@ -204,7 +233,7 @@ export function PoolDepositForm({
         showHelpText={showHelpText}
         sourceAddress={activeAddress}
         maxAmount={assetBDetails?.availableBalance || "0"}
-        label={`${assetB || "Asset"} Amount`}
+        label="Amount"
         name="quantity_b_display"
         disabled={pending || !assetB}
         isDivisible={isAssetBDivisible}
@@ -257,27 +286,17 @@ export function PoolDepositForm({
         </div>
       )}
 
-      {(isFirstDeposit || isZeroSupplyRestart || (quote?.quantity_minted_estimate !== undefined && quote.quantity_minted_estimate !== null)) && (
-        <>
-          <SlippageInput
-            value={slippage}
-            onChange={setSlippage}
-            showHelpText={showHelpText}
-          />
-
-          {hasLpMinimum && (
-            <div className="rounded border border-gray-200 bg-gray-50 p-3 text-sm text-gray-600">
-              Minimum LP tokens:{" "}
-              <span className="font-medium text-gray-900">
-                {fromSatoshis(minLpQuantity, { removeTrailingZeros: true })}
-              </span>{" "}
-              after {slippage || "0"}% slippage.
-            </div>
-          )}
-        </>
+      {hasLpMinimum && (
+        <div className="rounded border border-gray-200 bg-gray-50 p-3 text-sm text-gray-600">
+          Minimum LP tokens:{" "}
+          <span className="font-medium text-gray-900">
+            {fromSatoshis(minLpQuantity, { removeTrailingZeros: true })}
+          </span>{" "}
+          after {slippage || "0"}% slippage.
+        </div>
       )}
 
-      {isFirstDeposit && (
+      {isNewPool && (
         <Field>
           <AssetNameInput
             value={lpAsset}

--- a/src/pages/compose/pool/pool-slippage-settings.tsx
+++ b/src/pages/compose/pool/pool-slippage-settings.tsx
@@ -1,0 +1,45 @@
+import { useSettings } from "@/contexts/settings-context";
+import { SlippageInput } from "./slippage-input";
+import type { ReactElement } from "react";
+
+interface PoolSlippageSettingsProps {
+  value: string;
+  onChange: (value: string) => void;
+  onBack: () => void;
+  showHelpText?: boolean;
+}
+
+/**
+ * Gear-panel for pool slippage, shown in place of the deposit/withdraw form.
+ * Edits the per-transaction value and persists it as the user's default so it
+ * sticks across transactions.
+ */
+export function PoolSlippageSettings({
+  value,
+  onChange,
+  onBack,
+  showHelpText = false,
+}: PoolSlippageSettingsProps): ReactElement {
+  const { updateSettings } = useSettings();
+
+  const handleChange = (next: string) => {
+    onChange(next);
+    void updateSettings({ defaultPoolSlippage: next });
+  };
+
+  return (
+    <div className="bg-white rounded-lg shadow-lg p-3 sm:p-4 space-y-4">
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-semibold text-gray-900">Pool Settings</span>
+        <button
+          type="button"
+          onClick={onBack}
+          className="text-sm text-blue-600 hover:text-blue-800 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
+        >
+          Done
+        </button>
+      </div>
+      <SlippageInput value={value} onChange={handleChange} showHelpText={showHelpText} />
+    </div>
+  );
+}

--- a/src/pages/compose/pool/slippage-input.tsx
+++ b/src/pages/compose/pool/slippage-input.tsx
@@ -1,35 +1,15 @@
-import { useEffect, useState } from "react";
-import {
-  Field,
-  Label,
-  Description,
-  Input,
-  Listbox,
-  ListboxButton,
-  ListboxOption,
-  ListboxOptions,
-} from "@headlessui/react";
-import { Button } from "@/components/ui/button";
-import {
-  isFiniteNumber,
-  isGreaterThanOrEqualTo,
-  isLessThan,
-} from "@/utils/numeric";
+import { Field, Label, Description, Input } from "@headlessui/react";
+import { isFiniteNumber, isGreaterThan, isLessThan } from "@/utils/numeric";
 import type { ReactElement } from "react";
 
-export const DEFAULT_POOL_SLIPPAGE = "2.5";
+export { DEFAULT_POOL_SLIPPAGE } from "@/utils/settings";
 
-const PRESET_OPTIONS = [
-  { id: "tight", name: "Tight", value: "0.5" },
-  { id: "standard", name: "Standard", value: DEFAULT_POOL_SLIPPAGE },
-  { id: "loose", name: "Loose", value: "5" },
-] as const;
-
-type PresetId = typeof PRESET_OPTIONS[number]["id"];
-type OptionId = PresetId | "custom";
-
-const LOW_SLIPPAGE_THRESHOLD = "0.05";
-const HIGH_SLIPPAGE_THRESHOLD = "20";
+// Presets skew slightly above fast-chain DEXs: Counterparty's ~10-min blocks leave
+// more time for someone else to move the pool before a deposit/withdraw confirms.
+// 0% / very-high values are intentionally Custom-only.
+const PRESETS = ["0.5", "1", "3"] as const;
+const LOW_SLIPPAGE_THRESHOLD = "0.5";
+const HIGH_SLIPPAGE_THRESHOLD = "5";
 
 interface SlippageInputProps {
   value: string;
@@ -42,138 +22,76 @@ export function SlippageInput({
   onChange,
   showHelpText = false,
 }: SlippageInputProps): ReactElement {
-  const [selectedOption, setSelectedOption] = useState<OptionId>("standard");
-  const [customInput, setCustomInput] = useState(value);
+  const isPreset = (PRESETS as readonly string[]).includes(value);
 
-  useEffect(() => {
-    const matchingPreset = PRESET_OPTIONS.find((option) => option.value === value);
-    if (matchingPreset) {
-      setSelectedOption(matchingPreset.id);
-      setCustomInput(value);
-    } else {
-      setSelectedOption("custom");
-      setCustomInput(value);
-    }
-  }, [value]);
+  const showWarning = value.trim() !== "" && isFiniteNumber(value);
+  const isLow = showWarning && isLessThan(value, LOW_SLIPPAGE_THRESHOLD);
+  const isHigh = showWarning && isGreaterThan(value, HIGH_SLIPPAGE_THRESHOLD);
 
-  const options = [
-    ...PRESET_OPTIONS,
-    { id: "custom" as const, name: "Custom", value: customInput || DEFAULT_POOL_SLIPPAGE },
-  ];
-
-  const showSlippageWarning = value.trim() !== "" && isFiniteNumber(value);
-  const isLowSlippage = showSlippageWarning
-    && isGreaterThanOrEqualTo(value, 0)
-    && isLessThan(value, LOW_SLIPPAGE_THRESHOLD);
-  const isHighSlippage = showSlippageWarning
-    && isGreaterThanOrEqualTo(value, HIGH_SLIPPAGE_THRESHOLD);
-
-  const handleOptionSelect = (option: typeof options[number] | null) => {
-    if (!option) return;
-
-    setSelectedOption(option.id);
-    if (option.id !== "custom") {
-      setCustomInput(option.value);
-      onChange(option.value);
-    }
-  };
-
-  const handleCustomInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const nextValue = event.target.value.trim();
-    const parts = nextValue.split(".");
-    if (parts.length > 2) return;
-    if (nextValue !== "" && !isFiniteNumber(nextValue)) return;
-
-    setCustomInput(nextValue);
-    onChange(nextValue);
-  };
-
-  const handleCustomInputBlur = () => {
-    if (!customInput || isLessThan(customInput, 0)) {
-      setCustomInput(DEFAULT_POOL_SLIPPAGE);
-      onChange(DEFAULT_POOL_SLIPPAGE);
-    }
-  };
-
-  const handleEscClick = () => {
-    const standard = PRESET_OPTIONS.find((option) => option.id === "standard") ?? PRESET_OPTIONS[0];
-    setSelectedOption(standard.id);
-    setCustomInput(standard.value);
-    onChange(standard.value);
+  const handleCustomChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const next = event.target.value.trim();
+    // Accept only a decimal number (or empty); rejects letters and extra dots.
+    if (next !== "" && !/^\d*\.?\d*$/.test(next)) return;
+    onChange(next);
   };
 
   return (
     <Field>
-      <Label className="block text-sm font-medium text-gray-700">
-        Slippage Tolerance <span className="text-red-500">*</span>
-      </Label>
-      <div className="mt-1">
-        {selectedOption === "custom" ? (
-          <div className="relative">
-            <Input
-              type="text"
-              inputMode="decimal"
-              value={customInput}
-              onChange={handleCustomInputChange}
-              onBlur={handleCustomInputBlur}
-              placeholder="Custom %"
-              className="block w-full p-2.5 rounded-md border border-gray-200 bg-gray-50 pr-16 outline-none focus:border-blue-500 focus-visible:ring-2 focus-visible:ring-blue-500"
-            />
-            <Button type="button" variant="input" onClick={handleEscClick} aria-label="Reset to standard slippage">
-              Esc
-            </Button>
-          </div>
-        ) : (
-          <div className="relative">
-            <Listbox
-              value={options.find((option) => option.id === selectedOption) || options[1]}
-              onChange={handleOptionSelect}
-            >
-              <ListboxButton className="w-full p-2.5 text-left rounded-md border border-gray-200 bg-gray-50 outline-none focus:border-blue-500 focus-visible:ring-2 focus-visible:ring-blue-500 cursor-pointer">
-                {({ value }) => (
-                  <div className="flex justify-between">
-                    <span>{value?.name}</span>
-                    {value?.id !== "custom" && <span className="text-gray-500">{value?.value}%</span>}
-                  </div>
-                )}
-              </ListboxButton>
-              <ListboxOptions className="absolute z-10 w-full mt-1 bg-white border border-gray-200 rounded-md shadow-lg max-h-60 overflow-auto">
-                {options.map((option) => (
-                  <ListboxOption
-                    key={option.id}
-                    value={option}
-                    className={({ focus }) =>
-                      `p-2.5 cursor-pointer select-none ${focus ? "bg-blue-500 text-white" : "text-gray-900"}`
-                    }
-                  >
-                    {({ selected, focus }) => (
-                      <div className="flex justify-between">
-                        <span className={selected ? "font-medium" : ""}>{option.name}</span>
-                        {option.id !== "custom" && (
-                          <span className={focus ? "text-blue-100" : "text-gray-500"}>{option.value}%</span>
-                        )}
-                      </div>
-                    )}
-                  </ListboxOption>
-                ))}
-              </ListboxOptions>
-            </Listbox>
-          </div>
-        )}
+      <div className="flex justify-between items-center mb-1">
+        <Label className="text-sm font-medium text-gray-700">
+          Slippage Tolerance <span className="text-red-500">*</span>
+        </Label>
+        <span className="text-sm text-gray-500 tabular-nums">{value || "0"}%</span>
       </div>
+
+      {/* Preset buttons */}
+      <div className="grid grid-cols-3 gap-2 mb-3">
+        {PRESETS.map((preset) => (
+          <button
+            key={preset}
+            type="button"
+            onClick={() => onChange(preset)}
+            className={`px-3 py-2 text-sm rounded-md transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
+              value === preset
+                ? "bg-blue-500 text-white"
+                : "bg-gray-100 hover:bg-gray-200 text-gray-700"
+            }`}
+          >
+            {preset}%
+          </button>
+        ))}
+      </div>
+
+      {/* Custom input */}
+      <div className="relative">
+        <Input
+          type="text"
+          inputMode="decimal"
+          value={isPreset ? "" : value}
+          onChange={handleCustomChange}
+          placeholder="Custom %"
+          aria-label="Custom slippage percent"
+          className={`w-full px-3 py-2.5 pr-8 text-sm border rounded-md outline-none focus:border-blue-500 focus-visible:ring-2 focus-visible:ring-blue-500 ${
+            isPreset ? "border-gray-300" : "border-blue-500"
+          }`}
+        />
+        <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-sm text-gray-500">%</span>
+      </div>
+
       {showHelpText && (
         <Description className="mt-2 text-sm text-gray-500">
-          Sets how far the pool quote may move before the transaction fails.
+          How far the pool ratio may move before the transaction fails. A higher
+          tolerance avoids failures if someone else trades the pool in the same block.
         </Description>
       )}
-      {isLowSlippage && (
+      {isLow && (
         <div className="mt-2 rounded border border-yellow-200 bg-yellow-50 p-2 text-sm text-yellow-800">
-          Low slippage may fail if the pool changes before confirmation.
+          Very low — likely to fail if the pool changes before your transaction confirms.
         </div>
       )}
-      {isHighSlippage && (
+      {isHigh && (
         <div className="mt-2 rounded border border-yellow-200 bg-yellow-50 p-2 text-sm text-yellow-800">
-          High slippage allows a worse result before failing.
+          Very high — you may receive noticeably less than quoted.
         </div>
       )}
     </Field>

--- a/src/pages/compose/pool/withdraw/form.tsx
+++ b/src/pages/compose/pool/withdraw/form.tsx
@@ -11,8 +11,10 @@ import { useLpAssetPool } from "@/hooks/useLpAssetPool";
 import { usePoolWithdrawQuote } from "@/hooks/usePoolQuotes";
 import { applyPoolSlippage } from "@/utils/blockchain/counterparty/pool";
 import { fromSatoshis, isGreaterThan, isLessThanOrEqualTo, isValidPositiveNumber } from "@/utils/numeric";
+import { FaCog } from "@/components/icons";
 import type { PoolWithdrawOptions } from "@/utils/blockchain/counterparty/compose";
-import { DEFAULT_POOL_SLIPPAGE, SlippageInput } from "../slippage-input";
+import { DEFAULT_POOL_SLIPPAGE } from "@/utils/settings";
+import { PoolSlippageSettings } from "../pool-slippage-settings";
 
 interface PoolWithdrawFormProps {
   formAction: (formData: FormData) => void;
@@ -25,13 +27,14 @@ export function PoolWithdrawForm({
   initialFormData,
   lpAsset,
 }: PoolWithdrawFormProps): ReactElement {
-  const { activeAddress, showHelpText, feeRate } = useComposer<PoolWithdrawOptions>();
+  const { activeAddress, showHelpText, feeRate, settings } = useComposer<PoolWithdrawOptions>();
   const { pending } = useFormStatus();
   const { data: pool, isLoading, error: poolError } = useLpAssetPool(lpAsset);
   const { data: assetADetails } = useAssetDetails(pool?.asset_a || "");
   const { data: assetBDetails } = useAssetDetails(pool?.asset_b || "");
   const [quantity, setQuantity] = useState(initialFormData?.quantity?.toString() || "");
-  const [slippage, setSlippage] = useState((initialFormData as PoolWithdrawOptions & { slippage?: string })?.slippage || DEFAULT_POOL_SLIPPAGE);
+  const [slippage, setSlippage] = useState((initialFormData as PoolWithdrawOptions & { slippage?: string })?.slippage || settings?.defaultPoolSlippage || DEFAULT_POOL_SLIPPAGE);
+  const [showSettings, setShowSettings] = useState(false);
   const [localError, setLocalError] = useState<string | null>(null);
 
   const canQuote = !!pool && isGreaterThan(quantity || 0, 0);
@@ -90,10 +93,35 @@ export function PoolWithdrawForm({
     return <div className="p-4 text-center text-gray-600">Pool position not found</div>;
   }
 
+  if (showSettings) {
+    return (
+      <PoolSlippageSettings
+        value={slippage}
+        onChange={setSlippage}
+        onBack={() => setShowSettings(false)}
+        showHelpText={showHelpText}
+      />
+    );
+  }
+
   return (
     <ComposerForm
       formAction={handleFormAction}
-      header={<PoolHeader pool={pool} className="mt-1 mb-5" />}
+      header={
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0 flex-1">
+            <PoolHeader pool={pool} className="mt-1 mb-5" />
+          </div>
+          <button
+            type="button"
+            onClick={() => setShowSettings(true)}
+            aria-label="Pool settings"
+            className="mt-1 shrink-0 p-2 rounded-full hover:bg-gray-100 transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+          >
+            <FaCog className="size-4 text-gray-600" aria-hidden="true" />
+          </button>
+        </div>
+      }
       submitText="Review Withdrawal"
       submitDisabled={pending || submitDisabled}
     >
@@ -135,26 +163,16 @@ export function PoolWithdrawForm({
         </div>
       )}
 
-      {quote?.pool_exists && (
-        <>
-          <SlippageInput
-            value={slippage}
-            onChange={setSlippage}
-            showHelpText={showHelpText}
-          />
-
-          {hasMinimums && (
-            <div className="rounded border border-gray-200 bg-gray-50 p-3 text-sm text-gray-600">
-              Minimum received after {slippage || "0"}% slippage:
-              <div className="mt-1 font-medium text-gray-900">
-                {formatReceived(minQuantityA, isAssetADivisible)} {pool.asset_a}
-              </div>
-              <div className="font-medium text-gray-900">
-                {formatReceived(minQuantityB, isAssetBDivisible)} {pool.asset_b}
-              </div>
-            </div>
-          )}
-        </>
+      {quote?.pool_exists && hasMinimums && (
+        <div className="rounded border border-gray-200 bg-gray-50 p-3 text-sm text-gray-600">
+          Minimum received after {slippage || "0"}% slippage:
+          <div className="mt-1 font-medium text-gray-900">
+            {formatReceived(minQuantityA, isAssetADivisible)} {pool.asset_a}
+          </div>
+          <div className="font-medium text-gray-900">
+            {formatReceived(minQuantityB, isAssetBDivisible)} {pool.asset_b}
+          </div>
+        </div>
       )}
 
       {quote?.message && (

--- a/src/utils/__tests__/settings.test.ts
+++ b/src/utils/__tests__/settings.test.ts
@@ -162,6 +162,7 @@ describe('DEFAULT_SETTINGS', () => {
       'connectedWebsites',
       'counterpartyApiBase',
       'defaultOrderExpiration',
+      'defaultPoolSlippage',
       'enableAdvancedBroadcasts',
       'enableMPMA',
       'enableMoreOutputs',

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -50,6 +50,10 @@ export const LEGACY_MAX_ORDER_EXPIRATION = 8064;
 export const MAX_ORDER_EXPIRATION = 2 ** 16 - 1;
 export const DEFAULT_ORDER_EXPIRATION = LEGACY_MAX_ORDER_EXPIRATION;
 
+/** Default pool slippage tolerance, as a percent string. 1% sits one notch above
+ *  fast-chain DEX defaults to absorb pool drift over Counterparty's ~10-min blocks. */
+export const DEFAULT_POOL_SLIPPAGE = '1';
+
 /**
  * Application settings - stored encrypted inside the keychain.
  */
@@ -94,6 +98,8 @@ export interface AppSettings {
   counterpartyApiBase: string;
   /** Default order expiration in blocks */
   defaultOrderExpiration: number;
+  /** Default pool slippage tolerance, percent (e.g. "2.5"); falls back to DEFAULT_POOL_SLIPPAGE */
+  defaultPoolSlippage?: string;
   /** Block signing if local verification fails */
   strictTransactionVerification: boolean;
 
@@ -128,6 +134,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   transactionDryRun: false,
   counterpartyApiBase: 'https://api.counterparty.io:4000',
   defaultOrderExpiration: DEFAULT_ORDER_EXPIRATION,
+  defaultPoolSlippage: DEFAULT_POOL_SLIPPAGE,
   strictTransactionVerification: true,
   connectedWebsites: [],
   pinnedAssets: ['XCP', 'PEPECASH', 'BITCRYSTALS', 'BITCORN', 'CROPS', 'MINTS'],


### PR DESCRIPTION
Improves the pool deposit/withdraw compose UX.

## Labels
- "First Asset" / "Second Asset" → **"Asset A" / "Asset B"**.
- Amount labels are now a static **"Amount"** (no longer reactive to the selected asset).

## Slippage — behind a gear, rationalized
- Moved the slippage control into a **gear panel** (the same pattern as order expiration), shared by deposit and withdraw. Previously it only appeared once a full quote loaded, so it was easy to miss.
- New **`defaultPoolSlippage`** setting (optional, no migration) — the panel persists changes so a user's tolerance sticks across transactions.
- **Uniswap-style chips** (3-column presets + custom field below), rationalized to **0.5% / 1% / 3%, default 1%**:
  - Counterparty pools are constant-product (Uniswap V2) with no stablecoins, so ultra-tight presets are pointless.
  - Slippage on LP add/remove only matters if someone else moves the pool between quote and execution — and ~10-min blocks give more drift exposure than fast chains, so presets skew slightly **above** Uniswap/Pancake.
  - `0%` (fails on any drift) and extreme values are Custom-only, not one-tap chips.
- Retuned warnings to the preset band: `< 0.5%` "very low", `> 5%" "very high"; cap stays 50%.

## Visibility + validation
- Surface the optional **numeric LP-asset field** (with the `#…#` random-numeric button) as soon as both assets are chosen and the pool doesn't exist yet, instead of waiting for a quote.
- **Fixed** the custom-slippage input to actually reject non-numeric text — `toBigNumber` coerces junk to `0`, so the old `isFiniteNumber` guard never rejected it (submit validation caught it, but the field accepted it).

## Tests
- `slippage-input.test.tsx` — chip selection, custom entry + non-numeric rejection, low/high warnings.
- `pool-slippage-settings.test.tsx` — persists `defaultPoolSlippage` on change; "Done" calls back.
- `applyPoolSlippage` (the %→literal conversion) already covered by `pool.test.ts` / `pool.fuzz.test.ts`.

tsc clean · new unit tests pass · build green.