### PR TITLE
Disable hardware wallet selection in popup

### DIFF
--- a/src/components/ui/cards/wallet-card.test.tsx
+++ b/src/components/ui/cards/wallet-card.test.tsx
@@ -68,6 +68,20 @@ describe('WalletCard', () => {
     addresses: []
   };
 
+  const mockHardwareWallet: Wallet = {
+    id: 'wallet-4',
+    name: 'Trezor Safe 7',
+    type: 'hardware',
+    addressFormat: 'p2wpkh',
+    addressCount: 1,
+    addresses: [{
+      name: 'Trezor Address',
+      address: 'bc1qhardwarewalletaddress000000000000000000000',
+      path: "m/84'/0'/0'/0/0",
+      pubKey: 'mockhardwarepublickey'
+    }]
+  };
+
   const mockOnSelect = vi.fn();
 
   beforeEach(() => {
@@ -229,6 +243,28 @@ describe('WalletCard', () => {
     const walletName = screen.getByText('Main Wallet');
     fireEvent.click(walletName);
     expect(mockOnSelect).toHaveBeenCalledWith(mockMnemonicWallet);
+  });
+
+  it('shows disabled message and does not select disabled hardware wallet', () => {
+    render(
+      <TestWrapper value={mockMnemonicWallet} onChange={mockOnSelect}>
+        <WalletCard
+          wallet={mockHardwareWallet}
+          selected={false}
+          onSelect={mockOnSelect}
+          isOnlyWallet={false}
+          disabled
+          disabledMessage="Open in sidepanel"
+        />
+      </TestWrapper>
+    );
+
+    expect(screen.getByText('Trezor Safe 7')).toBeInTheDocument();
+    expect(screen.getByText('Open in sidepanel')).toBeInTheDocument();
+    expect(screen.getByText('Hardware')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Trezor Safe 7'));
+    expect(mockOnSelect).not.toHaveBeenCalled();
   });
 
   it('does not call onSelect when menu is clicked', () => {

--- a/src/components/ui/cards/wallet-card.tsx
+++ b/src/components/ui/cards/wallet-card.tsx
@@ -11,6 +11,8 @@ interface WalletCardProps {
   onSelect: (wallet: Wallet) => void;
   isOnlyWallet: boolean;
   displayAddress?: Address | null;
+  disabled?: boolean;
+  disabledMessage?: string;
 }
 
 /**
@@ -19,15 +21,27 @@ interface WalletCardProps {
  * @param props - The component props
  * @returns A ReactElement representing the wallet card
  */
-export function WalletCard({ wallet, selected, onSelect, isOnlyWallet, displayAddress }: WalletCardProps): ReactElement {
+export function WalletCard({
+  wallet,
+  selected,
+  onSelect,
+  isOnlyWallet,
+  displayAddress,
+  disabled = false,
+  disabledMessage,
+}: WalletCardProps): ReactElement {
   // Use the active address for the selected wallet, otherwise fall back to address 0.
   const primaryAddress =
-    displayAddress?.address ||
-    (wallet.addresses.length > 0
-      ? wallet.addresses[0].address
-      : wallet.previewAddress || 'No address');
+    disabled && disabledMessage
+      ? disabledMessage
+      : displayAddress?.address ||
+        (wallet.addresses.length > 0
+          ? wallet.addresses[0].address
+          : wallet.previewAddress || 'No address');
 
   const handleClick = (e: React.MouseEvent) => {
+    if (disabled) return;
+
     // Only select the wallet if the menu wasn't clicked
     if (!(e.target as HTMLElement).closest('.wallet-menu')) {
       onSelect(wallet);
@@ -37,13 +51,16 @@ export function WalletCard({ wallet, selected, onSelect, isOnlyWallet, displayAd
   return (
     <RadioGroup.Option
       value={wallet}
+      disabled={disabled}
       className={({ checked }) => `
-        relative w-full rounded transition duration-300 p-4 cursor-pointer
-        ${checked ? 'bg-blue-600 text-white shadow-md' : 'bg-blue-100 hover:bg-blue-200 text-gray-800'}
+        relative w-full rounded transition duration-300 p-4
+        ${disabled ? 'cursor-not-allowed bg-gray-100 text-gray-500' : 'cursor-pointer'}
+        ${!disabled && checked ? 'bg-blue-600 text-white shadow-md' : ''}
+        ${!disabled && !checked ? 'bg-blue-100 hover:bg-blue-200 text-gray-800' : ''}
       `}
     >
       {({ checked }) => (
-        <div onClick={handleClick} className="flex flex-col">
+        <div onClick={handleClick} className="flex flex-col" aria-disabled={disabled}>
           <div className="flex justify-between items-center">
             <div className="text-sm font-medium">{wallet.name}</div>
             <div className="absolute top-2 right-2 wallet-menu">
@@ -51,7 +68,9 @@ export function WalletCard({ wallet, selected, onSelect, isOnlyWallet, displayAd
             </div>
           </div>
           <div className="flex justify-between items-center mt-1">
-            <span className="font-mono text-sm">{formatAddress(primaryAddress)}</span>
+            <span className={disabled && disabledMessage ? 'text-sm font-medium' : 'font-mono text-sm'}>
+              {disabled && disabledMessage ? primaryAddress : formatAddress(primaryAddress)}
+            </span>
             <span className="text-xs capitalize flex items-center gap-1">
               {wallet.type === 'hardware' && (
                 <FiShield className="w-3 h-3" aria-hidden="true" />

--- a/src/components/ui/lists/wallet-list.test.tsx
+++ b/src/components/ui/lists/wallet-list.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { WalletList } from './wallet-list';
 import type { Wallet } from '@/types/wallet';
@@ -6,15 +6,18 @@ import { AddressFormat } from '@/utils/blockchain/bitcoin/address';
 
 // Mock WalletCard component
 vi.mock('@/components/ui/cards/wallet-card', () => ({
-  WalletCard: ({ wallet, selected, displayAddress, onSelect, isOnlyWallet }: any) => (
+  WalletCard: ({ wallet, selected, displayAddress, onSelect, isOnlyWallet, disabled, disabledMessage }: any) => (
     <div
       data-testid={`wallet-card-${wallet.id}`}
       data-selected={selected}
       data-display-address={displayAddress?.address || ''}
       data-only={isOnlyWallet}
-      onClick={() => onSelect(wallet)}
+      data-disabled={disabled}
+      data-disabled-message={disabledMessage || ''}
+      onClick={() => !disabled && onSelect(wallet)}
       role="radio"
       aria-checked={selected}
+      aria-disabled={disabled}
     >
       {wallet.name}
     </div>
@@ -46,10 +49,22 @@ describe('WalletList', () => {
       addressFormat: AddressFormat.P2WPKH,
       addressCount: 1,
       addresses: []
+    },
+    {
+      id: 'wallet-4',
+      name: 'Trezor Wallet',
+      type: 'hardware' as const,
+      addressFormat: AddressFormat.P2WPKH,
+      addressCount: 1,
+      addresses: []
     }
   ];
 
   const mockOnSelectWallet = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
 
   it('should render all wallets', () => {
     render(
@@ -63,6 +78,7 @@ describe('WalletList', () => {
     expect(screen.getByTestId('wallet-card-wallet-1')).toBeInTheDocument();
     expect(screen.getByTestId('wallet-card-wallet-2')).toBeInTheDocument();
     expect(screen.getByTestId('wallet-card-wallet-3')).toBeInTheDocument();
+    expect(screen.getByTestId('wallet-card-wallet-4')).toBeInTheDocument();
   });
 
   it('should show selected wallet', () => {
@@ -99,6 +115,7 @@ describe('WalletList', () => {
     expect(screen.getByTestId('wallet-card-wallet-1')).toHaveAttribute('data-display-address', '');
     expect(screen.getByTestId('wallet-card-wallet-2')).toHaveAttribute('data-display-address', 'bc1qselectedaddress7');
     expect(screen.getByTestId('wallet-card-wallet-3')).toHaveAttribute('data-display-address', '');
+    expect(screen.getByTestId('wallet-card-wallet-4')).toHaveAttribute('data-display-address', '');
   });
 
   it('should call onSelectWallet when wallet is clicked', () => {
@@ -173,5 +190,24 @@ describe('WalletList', () => {
     fireEvent.click(walletCard3);
 
     expect(mockOnSelectWallet).toHaveBeenCalledWith(mockWallets[2]);
+  });
+
+  it('should disable hardware wallet selection when requested', () => {
+    render(
+      <WalletList
+        wallets={mockWallets}
+        selectedWallet={mockWallets[0]}
+        onSelectWallet={mockOnSelectWallet}
+        disableHardwareWallets
+        hardwareWalletDisabledMessage="Open in sidepanel"
+      />
+    );
+
+    const hardwareCard = screen.getByTestId('wallet-card-wallet-4');
+    expect(hardwareCard).toHaveAttribute('data-disabled', 'true');
+    expect(hardwareCard).toHaveAttribute('data-disabled-message', 'Open in sidepanel');
+
+    fireEvent.click(hardwareCard);
+    expect(mockOnSelectWallet).not.toHaveBeenCalled();
   });
 });

--- a/src/components/ui/lists/wallet-list.tsx
+++ b/src/components/ui/lists/wallet-list.tsx
@@ -8,6 +8,8 @@ interface WalletListProps {
   selectedWallet: Wallet | null;
   selectedAddress?: Address | null;
   onSelectWallet: (wallet: Wallet) => void;
+  disableHardwareWallets?: boolean;
+  hardwareWalletDisabledMessage?: string;
 }
 
 /**
@@ -16,9 +18,16 @@ interface WalletListProps {
  * @param props - The component props
  * @returns A ReactElement representing the wallet list
  */
-export function WalletList({ wallets, selectedWallet, selectedAddress, onSelectWallet }: WalletListProps): ReactElement {
+export function WalletList({
+  wallets,
+  selectedWallet,
+  selectedAddress,
+  onSelectWallet,
+  disableHardwareWallets = false,
+  hardwareWalletDisabledMessage = 'Open in sidepanel',
+}: WalletListProps): ReactElement {
   const handleWalletChange = (wallet: Wallet | null) => {
-    if (wallet) {
+    if (wallet && !(disableHardwareWallets && wallet.type === 'hardware')) {
       onSelectWallet(wallet);
     }
   };
@@ -29,16 +38,22 @@ export function WalletList({ wallets, selectedWallet, selectedAddress, onSelectW
       onChange={handleWalletChange}
       className="space-y-2"
     >
-      {wallets.map((wallet) => (
-        <WalletCard
-          key={wallet.id}
-          wallet={wallet}
-          selected={selectedWallet?.id === wallet.id}
-          displayAddress={selectedWallet?.id === wallet.id ? selectedAddress : null}
-          onSelect={onSelectWallet}
-          isOnlyWallet={wallets.length === 1}
-        />
-      ))}
+      {wallets.map((wallet) => {
+        const isHardwareDisabled = disableHardwareWallets && wallet.type === 'hardware';
+
+        return (
+          <WalletCard
+            key={wallet.id}
+            wallet={wallet}
+            selected={selectedWallet?.id === wallet.id}
+            displayAddress={selectedWallet?.id === wallet.id ? selectedAddress : null}
+            onSelect={isHardwareDisabled ? () => undefined : onSelectWallet}
+            isOnlyWallet={wallets.length === 1}
+            disabled={isHardwareDisabled}
+            disabledMessage={isHardwareDisabled ? hardwareWalletDisabledMessage : undefined}
+          />
+        );
+      })}
     </RadioGroup>
   );
 }

--- a/src/pages/keychain/wallets/index.tsx
+++ b/src/pages/keychain/wallets/index.tsx
@@ -9,6 +9,9 @@ import { ErrorAlert } from '@/components/ui/error-alert';
 import { MAX_WALLETS } from '@/utils/wallet/constants';
 import type { Wallet } from '@/types/wallet';
 
+/** Check if we're running in the sidepanel (vs popup) */
+const isSidepanel = () => document.body.dataset.context === 'sidepanel';
+
 /**
  * SelectWallet component allows users to choose an active wallet or add a new one.
  *
@@ -22,6 +25,7 @@ function WalletsPage() {
   const { setHeaderProps } = useHeader();
   const { wallets, activeWallet, activeAddress, selectWallet } = useWallet();
   const [error, setError] = useState<string | null>(null);
+  const canUseHardwareWallet = isSidepanel();
 
   // Constants for paths
   const PATHS = {
@@ -52,6 +56,10 @@ function WalletsPage() {
   }, [setHeaderProps, navigate, handleAddWallet]);
 
   const handleSelectWalletInternal = async (wallet: Wallet) => {
+    if (wallet.type === 'hardware' && !canUseHardwareWallet) {
+      return;
+    }
+
     try {
       // Load wallet (decrypts secret and derives addresses)
       await selectWallet(wallet.id);
@@ -78,6 +86,8 @@ function WalletsPage() {
           selectedWallet={activeWallet}
           selectedAddress={activeAddress}
           onSelectWallet={handleSelectWalletInternal}
+          disableHardwareWallets={!canUseHardwareWallet}
+          hardwareWalletDisabledMessage="Open in sidepanel"
         />
       </div>
       <div className="p-4">


### PR DESCRIPTION
## Summary
- Keep hardware wallets visible in the popup wallet list but disable selection there
- Replace the hardware wallet address line with Open in sidepanel when shown in popup
- Preserve hardware wallet selection in sidepanel context
- Add wallet card/list regression tests

## Why
Trezor hardware-wallet flows require sidepanel context. Selecting a hardware wallet from the popup could leave the app with an active hardware wallet but no active address, causing downstream screens to report no active wallet/address.

## Tests
- npx.cmd vitest src/components/ui/cards/wallet-card.test.tsx src/components/ui/lists/wallet-list.test.tsx --run
- npm.cmd run build