### PR TITLE
Add permissioned Legacy and SegWit PSBT signing

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -277,17 +277,37 @@ jobs:
           # protobufjs crypto dep. @trezor/connect-webextension loads that SDK remotely from
           # connect.trezor.io — none of it is bundled into the shipped extension (verified by
           # unpacking the published artifact), and the advisories have no fix available.
-          # Anything OUTSIDE this accepted set must still be clean at high/critical.
+          # React Router 7.18.1 is also affected by GHSA-qwww-vcr4-c8h2 only in
+          # RSC server-action mode. This extension is client-only (HashRouter)
+          # and has no RSC/server runtime. Keep this exception advisory-specific
+          # so any other React Router high/critical finding still blocks CI.
+          # Anything OUTSIDE these accepted cases must still be clean at high/critical.
           ACCEPTED='^@trezor/|^protobufjs$'
           audit_output=$(npm audit --omit=dev --json 2>/dev/null || true)
           real=$(echo "$audit_output" | jq --arg re "$ACCEPTED" '
+            def accepted:
+              (.key | test($re)) or
+              (.key == "react-router" and
+                ([.value.via[] | select(type == "object") | .url] ==
+                  ["https://github.com/advisories/GHSA-qwww-vcr4-c8h2"])) or
+              (.key == "react-router-dom" and .value.via == ["react-router"]);
             [.vulnerabilities | to_entries[]
              | select(.value.severity == "high" or .value.severity == "critical")
-             | select(.key | test($re) | not)] | length')
+             | select(accepted | not)] | length')
 
           if [ "$real" -gt 0 ]; then
-            echo "Found $real high/critical vulnerabilities outside the accepted Trezor SDK subtree:"
-            echo "$audit_output" | jq -r --arg re "$ACCEPTED" '.vulnerabilities | to_entries[] | select(.value.severity == "high" or .value.severity == "critical") | select(.key | test($re) | not) | "\(.key): \(.value.severity)"'
+            echo "Found $real unaccepted high/critical vulnerabilities:"
+            echo "$audit_output" | jq -r --arg re "$ACCEPTED" '
+              def accepted:
+                (.key | test($re)) or
+                (.key == "react-router" and
+                  ([.value.via[] | select(type == "object") | .url] ==
+                    ["https://github.com/advisories/GHSA-qwww-vcr4-c8h2"])) or
+                (.key == "react-router-dom" and .value.via == ["react-router"]);
+              .vulnerabilities | to_entries[]
+              | select(.value.severity == "high" or .value.severity == "critical")
+              | select(accepted | not)
+              | "\(.key): \(.value.severity)"'
             exit 1
           fi
-          echo "No high/critical vulnerabilities outside the accepted (non-bundled) Trezor SDK subtree."
+          echo "No unaccepted high/critical vulnerabilities."

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -160,6 +160,9 @@ Invalid inputs are rejected with exceptions (fail-closed), not silently accepted
 | ✅ | Rate limiting per origin | Tiered: 5 connections, 10 transactions, 100 API calls/min |
 | ✅ | Global rate limit | 500 requests/min backstop |
 | ✅ | Queue size limits | Max 100 pending requests, 10 per origin |
+| ✅ | Explicit capability consent | Paired-address access is opt-in and unchecked by default |
+| ✅ | Capability identity binding | Grants are scoped to origin, wallet ID, and active address |
+| ✅ | Multi-address signing constraints | Only the active address and its same-index Legacy/SegWit sibling pair are accepted; indices are unique and bounded |
 
 ## Transaction Security
 
@@ -308,6 +311,7 @@ This is not true constant-time code. For higher-security applications, constant-
 | ADR-015 | Unified keychain architecture | [walletManager.ts](src/utils/wallet/walletManager.ts) |
 | ADR-016 | Privacy-focused analytics with Fathom | [fathom.ts](src/utils/fathom.ts) |
 | ADR-017 | Hardware wallet integration architecture | [trezorAdapter.ts](src/utils/hardware/trezorAdapter.ts) |
+| ADR-018 | Explicit, identity-bound paired-address provider capability | [providerService.ts](src/services/providerService.ts) |
 
 ---
 
@@ -319,7 +323,7 @@ This is not true constant-time code. For higher-security applications, constant-
 | Session | 6 | 0 | 0 | 2 |
 | Password | 3 | 2 | 1 | 0 |
 | Extension | 10 | 1 | 0 | 2 |
-| Provider API | 8 | 0 | 0 | 0 |
+| Provider API | 11 | 0 | 0 | 0 |
 | Transaction | 5 | 0 | 0 | 0 |
 | Input Validation | 5 | 0 | 0 | 0 |
 | UI/UX | 3 | 0 | 1 | 2 |
@@ -327,6 +331,6 @@ This is not true constant-time code. For higher-security applications, constant-
 | Privacy & Analytics | 9 | 0 | 0 | 1 |
 | Supply Chain | 4 | 0 | 0 | 1 |
 | Hardware Wallet | 12 | 1 | 0 | 1 |
-| **Total** | **79** | **5** | **2** | **11** |
+| **Total** | **82** | **5** | **2** | **11** |
 
 **Gaps (❌):** Password strength meter, screenshot prevention (browser limitation)

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -161,7 +161,7 @@ Invalid inputs are rejected with exceptions (fail-closed), not silently accepted
 | ✅ | Global rate limit | 500 requests/min backstop |
 | ✅ | Queue size limits | Max 100 pending requests, 10 per origin |
 | ✅ | Explicit capability consent | Paired-address access is opt-in and unchecked by default |
-| ✅ | Capability identity binding | Grants are scoped to origin, wallet ID, and active address |
+| ✅ | Capability identity binding | Grants are scoped to origin, wallet ID, and active address, then rechecked immediately before signing |
 | ✅ | Multi-address signing constraints | Only the active address and its same-index Legacy/SegWit sibling pair are accepted; indices are unique and bounded, and each claimed signer must match the embedded prevout |
 
 ## Transaction Security

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -162,7 +162,7 @@ Invalid inputs are rejected with exceptions (fail-closed), not silently accepted
 | ✅ | Queue size limits | Max 100 pending requests, 10 per origin |
 | ✅ | Explicit capability consent | Paired-address access is opt-in and unchecked by default |
 | ✅ | Capability identity binding | Grants are scoped to origin, wallet ID, and active address |
-| ✅ | Multi-address signing constraints | Only the active address and its same-index Legacy/SegWit sibling pair are accepted; indices are unique and bounded |
+| ✅ | Multi-address signing constraints | Only the active address and its same-index Legacy/SegWit sibling pair are accepted; indices are unique and bounded, and each claimed signer must match the embedded prevout |
 
 ## Transaction Security
 

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -163,6 +163,7 @@ Invalid inputs are rejected with exceptions (fail-closed), not silently accepted
 | ✅ | Explicit capability consent | Paired-address access is opt-in and unchecked by default |
 | ✅ | Capability identity binding | Grants are scoped to origin, wallet ID, and active address, then rechecked immediately before signing |
 | ✅ | Multi-address signing constraints | Only the active address and its same-index Legacy/SegWit sibling pair are accepted; indices are unique and bounded, and each claimed signer must match the embedded prevout |
+| ✅ | Effective sighash disclosure | Override arrays use absolute PSBT input indices and require coverage; approval warnings use the effective override, embedded value, or SIGHASH_ALL default |
 
 ## Transaction Security
 

--- a/PROVIDER.md
+++ b/PROVIDER.md
@@ -149,6 +149,11 @@ const result = await xcpwallet.request({
 // { hex: '<signed PSBT hex>' }
 ```
 
+When `signInputs` is supplied, it must contain at least one input. Every index must be
+unique, in range, and assigned to the address found in that input's embedded prevout.
+The provider rejects mismatches before opening the approval popup. Omitting `signInputs`
+preserves the legacy best-effort behavior for the active address only.
+
 ### Broadcasting
 
 #### `xcp_broadcastTransaction`

--- a/PROVIDER.md
+++ b/PROVIDER.md
@@ -79,6 +79,11 @@ address index until disconnect. It only permits address disclosure and signing r
 every transaction still requires approval. Connection and paired-address grants are rechecked
 immediately before signing, so disconnecting the site invalidates an open request.
 
+This capability has a privacy cost: the site can associate the Legacy and SegWit addresses as
+belonging to the same wallet. It can request signatures for explicitly identified inputs from
+either address, but cannot access other derivation indices. The approval screen shows the value
+attributed to each signer, external outputs, the network fee, and any flexible sighash rules.
+
 #### `xcp_accounts`
 
 Get currently connected accounts. No popup — returns empty array if not connected or wallet is locked.

--- a/PROVIDER.md
+++ b/PROVIDER.md
@@ -144,7 +144,7 @@ const result = await xcpwallet.request({
   params: [{
     hex: '<PSBT hex>',
     signInputs: { 'bc1q...': [0, 1] },  // optional: which inputs to sign
-    sighashTypes: [0x01]                  // optional: sighash types
+    sighashTypes: [0x01, 0x01]            // optional: one entry per signed PSBT input index
   }]
 });
 // { hex: '<signed PSBT hex>' }
@@ -154,6 +154,11 @@ When `signInputs` is supplied, it must contain at least one input. Every index m
 unique, in range, and assigned to the address found in that input's embedded prevout.
 The provider rejects mismatches before opening the approval popup. Omitting `signInputs`
 preserves the legacy best-effort behavior for the active address only.
+
+`sighashTypes` is indexed by absolute PSBT input index, not by `signInputs` entry
+or subset order. When supplied, it must cover every input the wallet is asked to
+sign; missing entries are rejected rather than silently defaulted. Prefer setting
+the standard `sighashType` field on each PSBT input and omitting this override.
 
 ### Broadcasting
 

--- a/PROVIDER.md
+++ b/PROVIDER.md
@@ -76,7 +76,8 @@ await xcpwallet.request({
 
 The additional checkbox is opt-in and remains scoped to the connected site, wallet, and
 address index until disconnect. It only permits address disclosure and signing requests;
-every transaction still requires approval.
+every transaction still requires approval. Connection and paired-address grants are rechecked
+immediately before signing, so disconnecting the site invalidates an open request.
 
 #### `xcp_accounts`
 

--- a/PROVIDER.md
+++ b/PROVIDER.md
@@ -65,6 +65,19 @@ const result = await xcpwallet.request({ method: 'xcp_requestAccounts' });
 
 The proof is auto-signed during connection — no additional user prompt beyond the connect approval.
 
+Sites may optionally request access to the paired Legacy and native SegWit addresses:
+
+```js
+await xcpwallet.request({
+  method: 'xcp_requestAccounts',
+  params: [{ capabilities: { pairedAddresses: true } }]
+});
+```
+
+The additional checkbox is opt-in and remains scoped to the connected site, wallet, and
+address index until disconnect. It only permits address disclosure and signing requests;
+every transaction still requires approval.
+
 #### `xcp_accounts`
 
 Get currently connected accounts. No popup — returns empty array if not connected or wallet is locked.
@@ -159,6 +172,16 @@ Get BTC and token balances for the connected address.
 ```js
 const result = await xcpwallet.request({ method: 'xcp_getBalances' });
 // { address: 'bc1q...', btc: { ... }, xcp: { ... }, tokens: [...] }
+```
+
+#### `xcp_getAddresses`
+
+Returns the active address for ordinary connections. When paired-address access was granted,
+it returns the corresponding P2PKH and P2WPKH addresses and public keys.
+
+```js
+const addresses = await xcpwallet.request({ method: 'xcp_getAddresses' });
+// { active: 'segwit', legacy: {...}, segwit: {...} }
 ```
 
 #### `xcp_chainId`

--- a/PROVIDER.md
+++ b/PROVIDER.md
@@ -181,7 +181,7 @@ it returns the corresponding P2PKH and P2WPKH addresses and public keys.
 
 ```js
 const addresses = await xcpwallet.request({ method: 'xcp_getAddresses' });
-// { active: 'segwit', legacy: {...}, segwit: {...} }
+// { active: {...}, legacy: {...}, segwit: {...} }
 ```
 
 #### `xcp_chainId`

--- a/src/hooks/useSignPsbtRequest.ts
+++ b/src/hooks/useSignPsbtRequest.ts
@@ -178,7 +178,7 @@ export function useSignPsbtRequest(signerAddress?: string) {
     };
 
     loadRequest();
-  }, [requestId, decodePsbt]);
+  }, [requestId, decodePsbt, signerAddress]);
 
   // Listen for navigation messages from background
   useEffect(() => {
@@ -205,7 +205,7 @@ export function useSignPsbtRequest(signerAddress?: string) {
     return () => {
       chrome.runtime.onMessage.removeListener(handleMessage);
     };
-  }, [decodePsbt]);
+  }, [decodePsbt, signerAddress]);
 
   // Handle completion - called when user approves and signs
   const handleSuccess = useCallback(async (signedPsbtHex: string) => {

--- a/src/hooks/useSignPsbtRequest.ts
+++ b/src/hooks/useSignPsbtRequest.ts
@@ -69,7 +69,10 @@ export function useSignPsbtRequest(signerAddress?: string) {
   const requestId = searchParams.get('requestId');
 
   // Decode PSBT and enrich with API data
-  const decodePsbt = useCallback(async (psbtHex: string, signerAddress?: string): Promise<DecodedPsbtInfo> => {
+  const decodePsbt = useCallback(async (
+    psbtHex: string,
+    signerAddresses?: string[]
+  ): Promise<DecodedPsbtInfo> => {
     // First, extract pure Bitcoin details (no API calls)
     const psbtDetails = extractPsbtDetails(psbtHex);
 
@@ -126,7 +129,7 @@ export function useSignPsbtRequest(signerAddress?: string) {
     // Analyze for security risks (dangerous types, suspicious outputs)
     const messageType = counterpartyMessage?.messageType
       ?? verification.localUnpack?.messageType;
-    const safety = analyzeTransactionSafety(messageType, psbtDetails.outputs, signerAddress || '');
+    const safety = analyzeTransactionSafety(messageType, psbtDetails.outputs, signerAddresses ?? []);
 
     return {
       psbtDetails,
@@ -160,7 +163,11 @@ export function useSignPsbtRequest(signerAddress?: string) {
         setRequest(req);
 
         // Decode the PSBT
-        const decoded = await decodePsbt(req.psbtHex, signerAddress);
+        const requestedSigners = Object.keys(req.signInputs ?? {});
+        const decoded = await decodePsbt(
+          req.psbtHex,
+          requestedSigners.length > 0 ? requestedSigners : signerAddress ? [signerAddress] : []
+        );
         setDecodedInfo(decoded);
       } catch (err) {
         console.error('Failed to load PSBT request:', err);
@@ -182,7 +189,11 @@ export function useSignPsbtRequest(signerAddress?: string) {
           const req = await signPsbtRequestStorage.get(message.signPsbtRequestId);
           if (req) {
             setRequest(req);
-            const decoded = await decodePsbt(req.psbtHex, signerAddress);
+            const requestedSigners = Object.keys(req.signInputs ?? {});
+            const decoded = await decodePsbt(
+              req.psbtHex,
+              requestedSigners.length > 0 ? requestedSigners : signerAddress ? [signerAddress] : []
+            );
             setDecodedInfo(decoded);
           }
         };

--- a/src/pages/requests/connect/__tests__/approve.test.tsx
+++ b/src/pages/requests/connect/__tests__/approve.test.tsx
@@ -7,9 +7,14 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import '@testing-library/jest-dom/vitest';
+
+const approvalMocks = vi.hoisted(() => ({
+  getCurrentApproval: vi.fn(),
+  getPairedAddresses: vi.fn(),
+}));
 
 // Mock webext-bridge before any imports that might use it
 vi.mock('webext-bridge/popup', () => ({
@@ -29,12 +34,19 @@ vi.mock('@/contexts/header-context', () => ({
   }),
 }));
 
+// Mock wallet service imported by the optional paired-address consent path.
+vi.mock('@/services/walletService', () => ({
+  getWalletService: () => ({
+    getPairedAddresses: approvalMocks.getPairedAddresses,
+  }),
+}));
+
 // Mock the approval service
 vi.mock('@/services/approvalService', () => ({
   getApprovalService: () => ({
     resolveApproval: vi.fn(),
     rejectApproval: vi.fn(),
-    getCurrentApproval: vi.fn().mockReturnValue(null),
+    getCurrentApproval: approvalMocks.getCurrentApproval,
   }),
 }));
 
@@ -66,6 +78,8 @@ describe('ApproveConnection', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    approvalMocks.getCurrentApproval.mockReturnValue(null);
+    approvalMocks.getPairedAddresses.mockResolvedValue(null);
   });
 
   afterEach(() => {
@@ -186,6 +200,34 @@ describe('ApproveConnection', () => {
       // Should show approval UI elements
       expect(screen.getByRole('button', { name: /connect/i })).toBeInTheDocument();
       expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
+    });
+
+    it('shows requested paired addresses behind an unchecked opt-in', async () => {
+      setupWalletContext({
+        activeWallet: {
+          id: 'test-wallet',
+          type: 'mnemonic',
+          addressFormat: 'p2wpkh',
+        } as any,
+        activeAddress: { address: 'bc1qtest123' },
+        isLoading: false,
+      });
+      approvalMocks.getCurrentApproval.mockReturnValue({
+        params: [{ capabilities: { pairedAddresses: true } }],
+      });
+      approvalMocks.getPairedAddresses.mockResolvedValue({
+        legacy: { address: '1legacy', pubKey: '02aa', path: "m/44'/0'/0'/0/0", name: 'Legacy', format: 'p2pkh', type: 'p2pkh' },
+        segwit: { address: 'bc1qsegwit', pubKey: '02bb', path: "m/84'/0'/0'/0/0", name: 'SegWit', format: 'p2wpkh', type: 'p2wpkh' },
+      });
+
+      renderWithRouter();
+
+      const checkbox = await screen.findByRole('checkbox');
+      expect(checkbox).not.toBeChecked();
+      await waitFor(() => {
+        expect(screen.getByText(/Legacy: 1legacy/)).toBeInTheDocument();
+        expect(screen.getByText(/SegWit: bc1qsegwit/)).toBeInTheDocument();
+      });
     });
 
     it('should display the origin domain in approval UI', () => {

--- a/src/pages/requests/connect/__tests__/approve.test.tsx
+++ b/src/pages/requests/connect/__tests__/approve.test.tsx
@@ -213,7 +213,12 @@ describe('ApproveConnection', () => {
         isLoading: false,
       });
       approvalMocks.getCurrentApproval.mockReturnValue({
-        params: [{ capabilities: { pairedAddresses: true } }],
+        id: 'test-123',
+        params: [{
+          capabilities: { pairedAddresses: true },
+          address: 'bc1qtest123',
+          walletId: 'test-wallet',
+        }],
       });
       approvalMocks.getPairedAddresses.mockResolvedValue({
         legacy: { address: '1legacy', pubKey: '02aa', path: "m/44'/0'/0'/0/0", name: 'Legacy', format: 'p2pkh', type: 'p2pkh' },
@@ -227,9 +232,31 @@ describe('ApproveConnection', () => {
       await waitFor(() => {
         expect(screen.getByText(/Legacy: 1legacy/)).toBeInTheDocument();
         expect(screen.getByText(/SegWit: bc1qsegwit/)).toBeInTheDocument();
+        expect(checkbox).toBeEnabled();
       });
     });
 
+    it('blocks approval if the active wallet identity changed', async () => {
+      setupWalletContext({
+        activeWallet: { id: 'different-wallet' },
+        activeAddress: { address: 'bc1qdifferent' },
+        isLoading: false,
+      });
+      approvalMocks.getCurrentApproval.mockReturnValue({
+        id: 'test-123',
+        params: [{
+          capabilities: { pairedAddresses: true },
+          address: 'bc1qtest123',
+          walletId: 'test-wallet',
+        }],
+      });
+
+      renderWithRouter();
+
+      expect(await screen.findByText(/active address changed/i)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /connect/i })).toBeDisabled();
+      expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+    });
     it('should display the origin domain in approval UI', () => {
       setupWalletContext({
         activeWallet: { id: 'test-wallet' },

--- a/src/pages/requests/connect/__tests__/approve.test.tsx
+++ b/src/pages/requests/connect/__tests__/approve.test.tsx
@@ -34,6 +34,7 @@ vi.mock('@/services/approvalService', () => ({
   getApprovalService: () => ({
     resolveApproval: vi.fn(),
     rejectApproval: vi.fn(),
+    getCurrentApproval: vi.fn().mockReturnValue(null),
   }),
 }));
 

--- a/src/pages/requests/connect/approve.tsx
+++ b/src/pages/requests/connect/approve.tsx
@@ -2,14 +2,29 @@ import { useEffect, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { FiGlobe, FaCheck } from "@/components/icons";
 import { Button } from "@/components/ui/button";
+import { ErrorAlert } from "@/components/ui/error-alert";
 import { useWallet } from "@/contexts/wallet-context";
 import { useHeader } from "@/contexts/header-context";
 import { getApprovalService } from "@/services/approvalService";
 import { getWalletService } from "@/services/walletService";
 import { getPairedAddressFormats } from "@/utils/wallet/addressDeriver";
 import type { PairedAddresses } from "@/types/wallet";
+import type { ApprovalRequest } from "@/types/provider";
 import type { ReactElement } from "react";
 
+function getApprovalIdentityError(
+  approval: ApprovalRequest | null,
+  requestId: string,
+  activeAddress: string | undefined,
+  activeWalletId: string | undefined
+): string | null {
+  if (!approval || approval.id !== requestId) return 'This connection request is no longer available.';
+  const request = approval.params?.[0];
+  if (request?.address !== activeAddress || request?.walletId !== activeWalletId) {
+    return 'The active address changed after this request was made. Switch back to the requested address and try again.';
+  }
+  return null;
+}
 /**
  * Connection approval page for dApp requests
  * Shows when a website requests access to the wallet
@@ -24,6 +39,8 @@ export default function ApproveConnectionPage(): ReactElement {
   const [pairedAddressesRequested, setPairedAddressesRequested] = useState(false);
   const [grantPairedAddresses, setGrantPairedAddresses] = useState(false);
   const [pairedAddresses, setPairedAddresses] = useState<PairedAddresses | null>(null);
+  const [approvalError, setApprovalError] = useState<string | null>(null);
+  const [pairedAddressError, setPairedAddressError] = useState(false);
 
   const origin = searchParams.get("origin") || "";
   const requestId = searchParams.get("requestId") || "";
@@ -42,13 +59,24 @@ export default function ApproveConnectionPage(): ReactElement {
   const faviconUrl = `https://www.google.com/s2/favicons?domain=${domain}&sz=64`;
 
   useEffect(() => {
-    if (!requestId) return;
+    if (!requestId || !activeAddress || !activeWallet) return;
     const approvalService = getApprovalService();
     Promise.resolve(approvalService.getCurrentApproval()).then((approval) => {
-      const requested = approval?.params?.[0]?.capabilities?.pairedAddresses === true;
-      setPairedAddressesRequested(requested);
-    }).catch(() => setPairedAddressesRequested(false));
-  }, [requestId]);
+      const identityError = getApprovalIdentityError(
+        approval,
+        requestId,
+        activeAddress.address,
+        activeWallet.id
+      );
+      setApprovalError(identityError);
+      setPairedAddressesRequested(
+        !identityError && approval?.params?.[0]?.capabilities?.pairedAddresses === true
+      );
+    }).catch(() => {
+      setApprovalError('Unable to load this connection request.');
+      setPairedAddressesRequested(false);
+    });
+  }, [requestId, activeAddress, activeWallet]);
 
   useEffect(() => {
     if (
@@ -57,11 +85,16 @@ export default function ApproveConnectionPage(): ReactElement {
       !getPairedAddressFormats(activeWallet.addressFormat)
     ) {
       setPairedAddresses(null);
+      setPairedAddressError(false);
       return;
     }
+    setPairedAddressError(false);
     getWalletService().getPairedAddresses()
       .then(setPairedAddresses)
-      .catch(() => setPairedAddresses(null));
+      .catch(() => {
+        setPairedAddresses(null);
+        setPairedAddressError(true);
+      });
   }, [pairedAddressesRequested, activeWallet]);
 
   // Configure header
@@ -86,9 +119,23 @@ export default function ApproveConnectionPage(): ReactElement {
     try {
       // Resolve approval via ApprovalService proxy
       const approvalService = getApprovalService();
+      const approval = await Promise.resolve(approvalService.getCurrentApproval());
+      const identityError = getApprovalIdentityError(
+        approval,
+        requestId,
+        activeAddress?.address,
+        activeWallet?.id
+      );
+      if (identityError) {
+        setApprovalError(identityError);
+        setIsProcessing(false);
+        return;
+      }
       await approvalService.resolveApproval(requestId, {
         approved: true,
-        updatedParams: { pairedAddresses: pairedAddressesRequested && grantPairedAddresses },
+        updatedParams: {
+          pairedAddresses: pairedAddressesRequested && grantPairedAddresses && Boolean(pairedAddresses),
+        },
       });
       // Close the popup
       window.close();
@@ -196,12 +243,15 @@ export default function ApproveConnectionPage(): ReactElement {
             </ul>
           </div>
 
+          {approvalError && <ErrorAlert message={approvalError} />}
+
           {pairedAddressesRequested && activeWallet.type === 'mnemonic' &&
             getPairedAddressFormats(activeWallet.addressFormat) && (
             <label className="mt-4 flex items-start gap-3 rounded-xl border border-blue-200 bg-blue-50 p-4 cursor-pointer">
               <input
                 type="checkbox"
                 checked={grantPairedAddresses}
+                disabled={!pairedAddresses || Boolean(approvalError)}
                 onChange={(event) => setGrantPairedAddresses(event.target.checked)}
                 className="mt-1 size-4"
               />
@@ -213,6 +263,14 @@ export default function ApproveConnectionPage(): ReactElement {
                   This lets the site associate both addresses and request transactions using them.
                   Every transaction still requires approval. Access lasts until you disconnect the site.
                 </span>
+                {pairedAddressError && (
+                  <span className="mt-2 block text-xs font-medium text-red-700">
+                    Paired addresses are unavailable. This additional permission cannot be granted.
+                  </span>
+                )}
+                {!pairedAddresses && !pairedAddressError && (
+                  <span className="mt-2 block text-xs text-blue-700">Loading paired addresses…</span>
+                )}
                 {pairedAddresses && (
                   <span className="mt-2 block space-y-1 text-xs text-blue-900">
                     <span className="block break-all font-mono">Legacy: {pairedAddresses.legacy.address}</span>
@@ -239,7 +297,7 @@ export default function ApproveConnectionPage(): ReactElement {
           <Button
             color="blue"
             onClick={handleApprove}
-            disabled={isProcessing}
+            disabled={isProcessing || Boolean(approvalError)}
             fullWidth
           >
             {isProcessing ? "Processing…" : "Connect"}

--- a/src/pages/requests/connect/approve.tsx
+++ b/src/pages/requests/connect/approve.tsx
@@ -5,6 +5,9 @@ import { Button } from "@/components/ui/button";
 import { useWallet } from "@/contexts/wallet-context";
 import { useHeader } from "@/contexts/header-context";
 import { getApprovalService } from "@/services/approvalService";
+import { getWalletService } from "@/services/walletService";
+import { getPairedAddressFormats } from "@/utils/wallet/addressDeriver";
+import type { PairedAddresses } from "@/types/wallet";
 import type { ReactElement } from "react";
 
 /**
@@ -20,6 +23,7 @@ export default function ApproveConnectionPage(): ReactElement {
   const [faviconError, setFaviconError] = useState(false);
   const [pairedAddressesRequested, setPairedAddressesRequested] = useState(false);
   const [grantPairedAddresses, setGrantPairedAddresses] = useState(false);
+  const [pairedAddresses, setPairedAddresses] = useState<PairedAddresses | null>(null);
 
   const origin = searchParams.get("origin") || "";
   const requestId = searchParams.get("requestId") || "";
@@ -45,6 +49,20 @@ export default function ApproveConnectionPage(): ReactElement {
       setPairedAddressesRequested(requested);
     }).catch(() => setPairedAddressesRequested(false));
   }, [requestId]);
+
+  useEffect(() => {
+    if (
+      !pairedAddressesRequested ||
+      activeWallet?.type !== 'mnemonic' ||
+      !getPairedAddressFormats(activeWallet.addressFormat)
+    ) {
+      setPairedAddresses(null);
+      return;
+    }
+    getWalletService().getPairedAddresses()
+      .then(setPairedAddresses)
+      .catch(() => setPairedAddresses(null));
+  }, [pairedAddressesRequested, activeWallet]);
 
   // Configure header
   useEffect(() => {
@@ -178,14 +196,8 @@ export default function ApproveConnectionPage(): ReactElement {
             </ul>
           </div>
 
-          {pairedAddressesRequested && activeWallet.type === 'mnemonic' && [
-            'counterwallet',
-            'counterwallet-segwit',
-            'freewallet-bip39',
-            'freewallet-bip39-segwit',
-            'p2pkh',
-            'p2wpkh',
-          ].includes(activeWallet.addressFormat) && (
+          {pairedAddressesRequested && activeWallet.type === 'mnemonic' &&
+            getPairedAddressFormats(activeWallet.addressFormat) && (
             <label className="mt-4 flex items-start gap-3 rounded-xl border border-blue-200 bg-blue-50 p-4 cursor-pointer">
               <input
                 type="checkbox"
@@ -201,6 +213,12 @@ export default function ApproveConnectionPage(): ReactElement {
                   This lets the site associate both addresses and request transactions using them.
                   Every transaction still requires approval. Access lasts until you disconnect the site.
                 </span>
+                {pairedAddresses && (
+                  <span className="mt-2 block space-y-1 text-xs text-blue-900">
+                    <span className="block break-all font-mono">Legacy: {pairedAddresses.legacy.address}</span>
+                    <span className="block break-all font-mono">SegWit: {pairedAddresses.segwit.address}</span>
+                  </span>
+                )}
               </span>
             </label>
           )}

--- a/src/pages/requests/connect/approve.tsx
+++ b/src/pages/requests/connect/approve.tsx
@@ -260,8 +260,9 @@ export default function ApproveConnectionPage(): ReactElement {
                   Share paired Legacy and SegWit addresses
                 </span>
                 <span className="mt-1 block text-xs text-blue-800">
-                  This lets the site associate both addresses and request transactions using them.
-                  Every transaction still requires approval. Access lasts until you disconnect the site.
+                  This lets the site associate both addresses and request signatures that spend
+                  inputs belonging to either address. Each request still shows the inputs, outputs,
+                  fees, and signature rules for your approval. Access lasts until you disconnect the site.
                 </span>
                 {pairedAddressError && (
                   <span className="mt-2 block text-xs font-medium text-red-700">

--- a/src/pages/requests/connect/approve.tsx
+++ b/src/pages/requests/connect/approve.tsx
@@ -18,6 +18,8 @@ export default function ApproveConnectionPage(): ReactElement {
   const { setHeaderProps } = useHeader();
   const [isProcessing, setIsProcessing] = useState(false);
   const [faviconError, setFaviconError] = useState(false);
+  const [pairedAddressesRequested, setPairedAddressesRequested] = useState(false);
+  const [grantPairedAddresses, setGrantPairedAddresses] = useState(false);
 
   const origin = searchParams.get("origin") || "";
   const requestId = searchParams.get("requestId") || "";
@@ -34,6 +36,15 @@ export default function ApproveConnectionPage(): ReactElement {
 
   const domain = getDomain(origin);
   const faviconUrl = `https://www.google.com/s2/favicons?domain=${domain}&sz=64`;
+
+  useEffect(() => {
+    if (!requestId) return;
+    const approvalService = getApprovalService();
+    Promise.resolve(approvalService.getCurrentApproval()).then((approval) => {
+      const requested = approval?.params?.[0]?.capabilities?.pairedAddresses === true;
+      setPairedAddressesRequested(requested);
+    }).catch(() => setPairedAddressesRequested(false));
+  }, [requestId]);
 
   // Configure header
   useEffect(() => {
@@ -57,7 +68,10 @@ export default function ApproveConnectionPage(): ReactElement {
     try {
       // Resolve approval via ApprovalService proxy
       const approvalService = getApprovalService();
-      await approvalService.resolveApproval(requestId, { approved: true });
+      await approvalService.resolveApproval(requestId, {
+        approved: true,
+        updatedParams: { pairedAddresses: pairedAddressesRequested && grantPairedAddresses },
+      });
       // Close the popup
       window.close();
     } catch (error) {
@@ -163,6 +177,33 @@ export default function ApproveConnectionPage(): ReactElement {
               </li>
             </ul>
           </div>
+
+          {pairedAddressesRequested && activeWallet.type === 'mnemonic' && [
+            'counterwallet',
+            'counterwallet-segwit',
+            'freewallet-bip39',
+            'freewallet-bip39-segwit',
+            'p2pkh',
+            'p2wpkh',
+          ].includes(activeWallet.addressFormat) && (
+            <label className="mt-4 flex items-start gap-3 rounded-xl border border-blue-200 bg-blue-50 p-4 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={grantPairedAddresses}
+                onChange={(event) => setGrantPairedAddresses(event.target.checked)}
+                className="mt-1 size-4"
+              />
+              <span>
+                <span className="block text-sm font-medium text-blue-900">
+                  Share paired Legacy and SegWit addresses
+                </span>
+                <span className="mt-1 block text-xs text-blue-800">
+                  This lets the site associate both addresses and request transactions using them.
+                  Every transaction still requires approval. Access lasts until you disconnect the site.
+                </span>
+              </span>
+            </label>
+          )}
         </div>
       </div>
 

--- a/src/pages/requests/psbt/approve.tsx
+++ b/src/pages/requests/psbt/approve.tsx
@@ -6,12 +6,13 @@ import { VerificationStatus } from '@/components/domain/tx/verification-status';
 import { formatAddress, formatAmount } from '@/utils/format';
 import { fromSatoshis } from '@/utils/numeric';
 import { useWallet } from '@/contexts/wallet-context';
-import { getIdentityMismatchError } from '@/utils/provider/requestIdentity';
+import { getIdentityMismatchError, getPsbtPermissionError } from '@/utils/provider/requestIdentity';
 import { usePopupLifecycle } from '@/hooks/usePopupLifecycle';
 import { useSettings } from '@/contexts/settings-context';
 import { useHeader } from '@/contexts/header-context';
 import { useSignPsbtRequest } from '@/hooks/useSignPsbtRequest';
 import { getWalletService } from '@/services/walletService';
+import { getConnectionService } from '@/services/connectionService';
 import type { DecodedPsbtInfo } from '@/hooks/useSignPsbtRequest';
 import { normalizeAddressForComparison } from '@/utils/blockchain/bitcoin/address';
 
@@ -136,6 +137,13 @@ export default function ApprovePsbtPage() {
     setError('');
 
     try {
+      const permissionError = await getPsbtPermissionError(
+        request,
+        activeAddress!.address,
+        getConnectionService()
+      );
+      if (permissionError) throw new Error(permissionError);
+
       const walletService = getWalletService();
       const signedPsbtHex = await walletService.signPsbt(
         request.psbtHex,

--- a/src/pages/requests/psbt/approve.tsx
+++ b/src/pages/requests/psbt/approve.tsx
@@ -15,10 +15,20 @@ import { getWalletService } from '@/services/walletService';
 import { getConnectionService } from '@/services/connectionService';
 import type { DecodedPsbtInfo } from '@/hooks/useSignPsbtRequest';
 import { normalizeAddressForComparison } from '@/utils/blockchain/bitcoin/address';
+import { resolvePsbtSighashType } from '@/utils/blockchain/bitcoin/psbt';
 
 function normalizeLpQuantity(quantity: unknown): string {
   if (quantity == null) return '?';
   return fromSatoshis(String(quantity), { removeTrailingZeros: true });
+}
+
+function formatSighashType(sighashType: number): string {
+  switch (sighashType) {
+    case 0x01: return 'ALL';
+    case 0x81: return 'ALL | ANYONECANPAY';
+    case 0x83: return 'SINGLE | ANYONECANPAY';
+    default: return `0x${sighashType.toString(16)}`;
+  }
 }
 
 /**
@@ -220,7 +230,7 @@ export default function ApprovePsbtPage() {
   // - Seller: the REQUEST asks the user to sign with ANYONECANPAY (0x80 bit set)
   // - Buyer: the PSBT contains an ANYONECANPAY input (seller's signature) but
   //   the user is signing with SIGHASH_ALL — they are completing the swap
-  const userSignsWithAnyoneCanPay = request.sighashTypes?.some(t => (t & 0x80) !== 0) ?? false;
+
 
   const verificationPassed = verification?.passed;
   const verificationWarning = verification?.warning;
@@ -239,6 +249,21 @@ export default function ApprovePsbtPage() {
       ),
     })
   );
+  const requestedInputIndices = request.signInputs
+    ? Object.values(request.signInputs).flat()
+    : psbtDetails.inputs
+        .filter(input => input.address && normalizeAddressForComparison(input.address)
+          === normalizeAddressForComparison(activeAddress.address))
+        .map(input => input.index);
+  const effectiveSighashes = requestedInputIndices.map(index => ({
+    index,
+    type: resolvePsbtSighashType(
+      request.sighashTypes?.[index],
+      psbtDetails.inputs[index]?.sighashType
+    ),
+  }));
+  const anyoneCanPaySighashes = effectiveSighashes.filter(({ type }) => (type & 0x80) !== 0);
+  const userSignsWithAnyoneCanPay = anyoneCanPaySighashes.length > 0;
   const usesPairedAddress = requestedAddressSpends.some(
     ({ address }) => normalizeAddressForComparison(address)
       !== normalizeAddressForComparison(activeAddress.address)
@@ -586,14 +611,23 @@ export default function ApprovePsbtPage() {
             </div>
           )}
 
-          {/* ANYONECANPAY Info (PSBT-specific) */}
+          {/* ANYONECANPAY warning (PSBT-specific) */}
           {userSignsWithAnyoneCanPay && (
-            <div className="bg-green-50 border border-green-200 rounded-lg p-4">
+            <div className="bg-orange-50 border border-orange-200 rounded-lg p-4">
               <div className="flex items-start">
-                <FaCheckCircle className="size-5 text-green-600 mt-0.5 mr-2 flex-shrink-0" aria-hidden="true" />
-                <div className="text-sm text-green-800">
-                  <p className="font-medium">Atomic Swap</p>
-                  <p className="text-xs mt-1">Your signature only authorizes this specific UTXO and payment amount. The buyer will add their inputs to complete the trade.</p>
+                <FiAlertTriangle className="size-5 text-orange-600 mt-0.5 mr-2 flex-shrink-0" aria-hidden="true" />
+                <div className="text-sm text-orange-800">
+                  <p className="font-medium">Flexible signature rules</p>
+                  <p className="text-xs mt-1">
+                    ANYONECANPAY allows other inputs to be added or removed after you sign.
+                    SINGLE commits only to the output at the same input index. Review the paired
+                    inputs and outputs carefully.
+                  </p>
+                  <ul className="mt-2 space-y-1 text-xs font-medium">
+                    {anyoneCanPaySighashes.map(({ index, type }) => (
+                      <li key={index}>Input #{index}: {formatSighashType(type)}</li>
+                    ))}
+                  </ul>
                 </div>
               </div>
             </div>

--- a/src/pages/requests/psbt/approve.tsx
+++ b/src/pages/requests/psbt/approve.tsx
@@ -220,6 +220,19 @@ export default function ApprovePsbtPage() {
   const safetyBlocked = safety?.blocked ?? false;
   const safetyWarnings = safety?.warnings ?? [];
   const shouldBlockSigning = safetyBlocked || (isStrictMode && verificationFailed);
+  const requestedAddressSpends = Object.entries(request.signInputs ?? {}).map(
+    ([address, indices]) => ({
+      address,
+      indices,
+      value: indices.reduce(
+        (sum, index) => sum + (psbtDetails.inputs[index]?.value ?? 0),
+        0
+      ),
+    })
+  );
+  const usesPairedAddress = requestedAddressSpends.some(
+    ({ address }) => address !== activeAddress.address
+  );
 
   // Detect swap buy PSBT fee breakdown (buyer completing a swap):
   // The PSBT has the seller's ANYONECANPAY input, but the USER is not signing
@@ -272,6 +285,29 @@ export default function ApprovePsbtPage() {
               <div className="size-2.5 bg-green-500 rounded-full"></div>
             </div>
           </div>
+
+          {usesPairedAddress && (
+            <div className="rounded-lg border border-blue-200 bg-blue-50 p-4">
+              <p className="text-sm font-medium text-blue-900">Uses a paired wallet address</p>
+              <p className="mt-1 text-xs text-blue-800">
+                This request signs explicitly selected inputs from your paired Legacy and SegWit addresses.
+              </p>
+              <div className="mt-3 space-y-2">
+                {requestedAddressSpends.map(({ address, indices, value }) => (
+                  <div key={address} className="flex items-start justify-between gap-3 text-xs">
+                    <div>
+                      <p className="font-mono text-blue-900">{formatAddress(address, true)}</p>
+                      <p className="text-blue-700">Inputs {indices.map(index => `#${index}`).join(', ')}</p>
+                    </div>
+                    <p className="font-medium text-blue-900">{value.toLocaleString()} sats</p>
+                  </div>
+                ))}
+              </div>
+              <p className="mt-3 text-xs font-medium text-blue-900">
+                Network fee: {psbtDetails.fee.toLocaleString()} sats
+              </p>
+            </div>
+          )}
 
           {/* Site info - slim bar since user is already connected */}
           <div className="bg-white rounded-lg shadow-sm px-4 py-3 flex items-center gap-3">

--- a/src/pages/requests/psbt/approve.tsx
+++ b/src/pages/requests/psbt/approve.tsx
@@ -13,6 +13,7 @@ import { useHeader } from '@/contexts/header-context';
 import { useSignPsbtRequest } from '@/hooks/useSignPsbtRequest';
 import { getWalletService } from '@/services/walletService';
 import type { DecodedPsbtInfo } from '@/hooks/useSignPsbtRequest';
+import { normalizeAddressForComparison } from '@/utils/blockchain/bitcoin/address';
 
 function normalizeLpQuantity(quantity: unknown): string {
   if (quantity == null) return '?';
@@ -231,8 +232,21 @@ export default function ApprovePsbtPage() {
     })
   );
   const usesPairedAddress = requestedAddressSpends.some(
-    ({ address }) => address !== activeAddress.address
+    ({ address }) => normalizeAddressForComparison(address)
+      !== normalizeAddressForComparison(activeAddress.address)
   );
+  const requestedSignerSet = new Set(
+    requestedAddressSpends.map(({ address }) => normalizeAddressForComparison(address))
+  );
+  const spendableOutputs = psbtDetails.outputs.filter(output => output.type !== 'op_return');
+  const externalOutputValue = spendableOutputs.every(output => Boolean(output.address))
+    ? spendableOutputs.reduce(
+        (sum, output) => requestedSignerSet.has(normalizeAddressForComparison(output.address!))
+          ? sum
+          : sum + output.value,
+        0
+      )
+    : null;
 
   // Detect swap buy PSBT fee breakdown (buyer completing a swap):
   // The PSBT has the seller's ANYONECANPAY input, but the USER is not signing
@@ -303,9 +317,14 @@ export default function ApprovePsbtPage() {
                   </div>
                 ))}
               </div>
-              <p className="mt-3 text-xs font-medium text-blue-900">
-                Network fee: {psbtDetails.fee.toLocaleString()} sats
-              </p>
+              <div className="mt-3 flex justify-between text-xs font-medium text-blue-900">
+                <span>Network fee: {psbtDetails.fee.toLocaleString()} sats</span>
+                <span>
+                  External BTC: {externalOutputValue === null
+                    ? 'unknown'
+                    : `${externalOutputValue.toLocaleString()} sats`}
+                </span>
+              </div>
             </div>
           )}
 

--- a/src/services/__tests__/connectionService.test.ts
+++ b/src/services/__tests__/connectionService.test.ts
@@ -41,6 +41,7 @@ vi.mock('@/services/walletService', () => ({
     // Connected-website access delegates to the walletManager mock so existing
     // getSettings/updateSettings drivers and assertions keep working.
     getSettings: () => walletManager.getSettings(),
+    updateSettings: (updates: any) => walletManager.updateSettings(updates),
     addConnectedWebsite: async (origin: string) => {
       const s = walletManager.getSettings();
       if (!s.connectedWebsites.includes(origin)) {
@@ -284,6 +285,35 @@ describe('ConnectionService', () => {
       // Should save to storage
       expect(mockUpdateSettings).toHaveBeenCalledWith({
         connectedWebsites: ['https://newsite.com'],
+      });
+    });
+
+    it('stores paired access only when explicitly requested and approved', async () => {
+      mockApprovalService.requestApproval.mockResolvedValueOnce({
+        approved: true,
+        updatedParams: { pairedAddresses: true },
+      });
+
+      await connectionService.connect(
+        'https://paired.com',
+        'bc1qactive',
+        'wallet-123',
+        true
+      );
+
+      expect(mockApprovalService.requestApproval).toHaveBeenCalledWith(
+        expect.objectContaining({
+          params: [{ capabilities: { pairedAddresses: true } }],
+        })
+      );
+      expect(mockUpdateSettings).toHaveBeenCalledWith({
+        providerCapabilities: {
+          'https://paired.com': {
+            pairedAddresses: true,
+            walletId: 'wallet-123',
+            address: 'bc1qactive',
+          },
+        },
       });
     });
 

--- a/src/services/__tests__/connectionService.test.ts
+++ b/src/services/__tests__/connectionService.test.ts
@@ -321,6 +321,27 @@ describe('ConnectionService', () => {
       });
     });
 
+    it('clears an orphaned paired grant during an ordinary reconnect', async () => {
+      mockGetSettings.mockReturnValue({
+        connectedWebsites: [],
+        providerCapabilities: {
+          'https://reconnect.com': {
+            pairedAddresses: true,
+            walletId: 'wallet-123',
+            address: 'bc1qactive',
+          },
+        },
+      });
+
+      await connectionService.connect(
+        'https://reconnect.com',
+        'bc1qactive',
+        'wallet-123'
+      );
+
+      expect(mockUpdateSettings).toHaveBeenCalledWith({ providerCapabilities: {} });
+    });
+
     it('should return existing connection if already connected', async () => {
       // Setup existing connection
       mockGetSettings.mockReturnValue({
@@ -379,6 +400,50 @@ describe('ConnectionService', () => {
       // Connection should succeed since there's no address validation
       expect(result).toEqual(['1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa']);
     }, 10000); // Increase timeout
+  });
+
+  describe('requestPairedAddressPermission', () => {
+    it('does not persist elevation if the base connection was revoked during approval', async () => {
+      mockGetSettings.mockReturnValue({ connectedWebsites: ['https://paired.com'] });
+      mockApprovalService.requestApproval.mockResolvedValueOnce({
+        approved: true,
+        updatedParams: { pairedAddresses: true },
+      });
+      vi.spyOn(connectionService, 'hasPermission').mockResolvedValue(false);
+
+      await expect(connectionService.requestPairedAddressPermission(
+        'https://paired.com',
+        'bc1qactive',
+        'wallet-123'
+      )).rejects.toThrow('Site disconnected before paired address access was granted');
+
+      expect(mockUpdateSettings).not.toHaveBeenCalledWith(
+        expect.objectContaining({ providerCapabilities: expect.anything() })
+      );
+    });
+
+    it('removes elevation if the base connection is revoked immediately after persistence', async () => {
+      let settings: any = { connectedWebsites: ['https://paired.com'] };
+      mockGetSettings.mockImplementation(() => settings);
+      mockUpdateSettings.mockImplementation(async (updates) => {
+        settings = { ...settings, ...updates };
+      });
+      mockApprovalService.requestApproval.mockResolvedValueOnce({
+        approved: true,
+        updatedParams: { pairedAddresses: true },
+      });
+      vi.spyOn(connectionService, 'hasPermission')
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(false);
+
+      await expect(connectionService.requestPairedAddressPermission(
+        'https://paired.com',
+        'bc1qactive',
+        'wallet-123'
+      )).rejects.toThrow('Site disconnected before paired address access was granted');
+
+      expect(settings.providerCapabilities).toEqual({});
+    });
   });
 
   describe('disconnect', () => {

--- a/src/services/__tests__/connectionService.test.ts
+++ b/src/services/__tests__/connectionService.test.ts
@@ -303,7 +303,11 @@ describe('ConnectionService', () => {
 
       expect(mockApprovalService.requestApproval).toHaveBeenCalledWith(
         expect.objectContaining({
-          params: [{ capabilities: { pairedAddresses: true } }],
+          params: [{
+            capabilities: { pairedAddresses: true },
+            address: 'bc1qactive',
+            walletId: 'wallet-123',
+          }],
         })
       );
       expect(mockUpdateSettings).toHaveBeenCalledWith({

--- a/src/services/__tests__/providerService.test.ts
+++ b/src/services/__tests__/providerService.test.ts
@@ -803,6 +803,18 @@ describe('ProviderService', () => {
 
         expect(signPsbtRequestStorage.signPsbtRequestStorage.store).not.toHaveBeenCalled();
       });
+      it('rejects a short sighash override instead of silently falling back', async () => {
+        const connection = vi.mocked(connectionService.getConnectionService)();
+        connection.hasPermission = vi.fn().mockResolvedValue(true);
+
+        await expect(providerService.handleRequest(
+          'https://test.com',
+          'xcp_signPsbt',
+          [{ hex: VALID_PSBT_HEX, sighashTypes: [0x01] }]
+        )).rejects.toThrow('indexed by absolute PSBT input index and is missing entries for inputs: 1');
+
+        expect(signPsbtRequestStorage.signPsbtRequestStorage.store).not.toHaveBeenCalled();
+      });
       it('should handle xcp_signPsbt with proper storage', async () => {
         // Mock connection service to return true
         const mockConnectionService = vi.mocked(connectionService.getConnectionService)();

--- a/src/services/__tests__/providerService.test.ts
+++ b/src/services/__tests__/providerService.test.ts
@@ -200,7 +200,7 @@ describe('ProviderService', () => {
       removeWallet: vi.fn(),
       getPreviewAddressForFormat: vi.fn(),
       getPairedAddresses: vi.fn().mockResolvedValue({
-        legacy: { address: '1legacy', pubKey: '02bb', path: "m/44'/0'/0'/0/0", name: 'Legacy', format: 'p2pkh', type: 'p2pkh' },
+        legacy: { address: '1FvyAqqELFiQyaEWdhFbWF8MZapKPZS8J7', pubKey: '02bb', path: "m/44'/0'/0'/0/0", name: 'Legacy', format: 'p2pkh', type: 'p2pkh' },
         segwit: { address: 'bc1qtest123', pubKey: '02aa', path: "m/84'/0'/0'/0/0", name: 'SegWit', format: 'p2wpkh', type: 'p2wpkh' },
       }),
       signTransaction: vi.fn(),
@@ -439,7 +439,7 @@ describe('ProviderService', () => {
         ) as any;
 
         expect(result.active.address).toBe('bc1qtest123');
-        expect(result.legacy.address).toBe('1legacy');
+        expect(result.legacy.address).toBe('1FvyAqqELFiQyaEWdhFbWF8MZapKPZS8J7');
         expect(result.segwit.address).toBe('bc1qtest123');
         expect(connection.hasPairedAddressPermission).toHaveBeenCalledWith(
           'https://connected.com',
@@ -717,6 +717,18 @@ describe('ProviderService', () => {
     });
 
     describe('Sign PSBT Request', () => {
+      it('rejects an explicitly empty signer map before opening approval', async () => {
+        const connection = vi.mocked(connectionService.getConnectionService)();
+        connection.hasPermission = vi.fn().mockResolvedValue(true);
+
+        await expect(providerService.handleRequest(
+          'https://test.com',
+          'xcp_signPsbt',
+          [{ hex: VALID_PSBT_HEX, signInputs: {} }]
+        )).rejects.toThrow('at least one input');
+
+        expect(signPsbtRequestStorage.signPsbtRequestStorage.store).not.toHaveBeenCalled();
+      });
       it('rejects unknown signer addresses before opening approval', async () => {
         const connection = vi.mocked(connectionService.getConnectionService)();
         connection.hasPermission = vi.fn().mockResolvedValue(true);
@@ -761,7 +773,7 @@ describe('ProviderService', () => {
         await expect(providerService.handleRequest(
           'https://test.com',
           'xcp_signPsbt',
-          [{ hex: VALID_PSBT_HEX, signInputs: { '1legacy': [0] } }]
+          [{ hex: VALID_PSBT_HEX, signInputs: { '1FvyAqqELFiQyaEWdhFbWF8MZapKPZS8J7': [0] } }]
         )).rejects.toThrow('Paired Legacy/SegWit address access has not been granted');
 
         expect(signPsbtRequestStorage.signPsbtRequestStorage.store).not.toHaveBeenCalled();

--- a/src/services/__tests__/providerService.test.ts
+++ b/src/services/__tests__/providerService.test.ts
@@ -41,6 +41,8 @@ import * as signPsbtRequestStorage from '@/utils/storage/signPsbtRequestStorage'
 import * as updateService from '@/services/updateService';
 import { eventEmitterService } from '@/services/eventEmitterService';
 
+const VALID_PSBT_HEX = '70736274ff01009a0200000002dcdd8cd287d40de3d260ccfc5fa3008f14ff8f13fc840164715cbb2b925874190000000000ffffffff98f9e476f918cc143cf8a6bd09042d1f2ee7c46bfd29c906166613b2d9c516c90000000000ffffffff022202000000000000160014670caa79e51d78ed0c583b89ff39d9c49b7199e75c12000000000000160014670caa79e51d78ed0c583b89ff39d9c49b7199e70000000000010055020000000101010101010101010101010101010101010101010101010101010101010101010000000000ffffffff0122020000000000001976a914a3c6b1ee4a49d9f2af3b3802974744fba924164a88ac000000000001011f8813000000000000160014670caa79e51d78ed0c583b89ff39d9c49b7199e7000000';
+
 // Mock the imports
 vi.mock('../walletService');
 vi.mock('../connectionService');
@@ -173,14 +175,14 @@ describe('ProviderService', () => {
         name: 'Test Wallet',
         type: 'mnemonic',
         addressFormat: 'p2wpkh',
-        addresses: []
+        addresses: [{ address: 'bc1qtest123', path: "m/84'/0'/0'/0/0", pubKey: '02aa', name: 'Address 1' }]
       }]),
       getActiveWallet: vi.fn().mockResolvedValue({
         id: 'wallet1',
         name: 'Test Wallet',
         type: 'mnemonic',
         addressFormat: 'p2wpkh',
-        addresses: []
+        addresses: [{ address: 'bc1qtest123', path: "m/84'/0'/0'/0/0", pubKey: '02aa', name: 'Address 1' }]
       }),
       setActiveWallet: vi.fn().mockResolvedValue(undefined),
       unlockKeychain: vi.fn().mockResolvedValue(undefined),
@@ -197,6 +199,10 @@ describe('ProviderService', () => {
       getPrivateKey: vi.fn().mockResolvedValue({ hex: 'deadbeef'.repeat(8), wif: 'test-wif', compressed: true }),
       removeWallet: vi.fn(),
       getPreviewAddressForFormat: vi.fn(),
+      getPairedAddresses: vi.fn().mockResolvedValue({
+        legacy: { address: '1legacy', pubKey: '02bb', path: "m/44'/0'/0'/0/0", name: 'Legacy', format: 'p2pkh', type: 'p2pkh' },
+        segwit: { address: 'bc1qtest123', pubKey: '02aa', path: "m/84'/0'/0'/0/0", name: 'SegWit', format: 'p2wpkh', type: 'p2wpkh' },
+      }),
       signTransaction: vi.fn(),
       broadcastTransaction: vi.fn(),
       getLastActiveAddress: vi.fn().mockResolvedValue('bc1qtest123'),
@@ -211,7 +217,8 @@ describe('ProviderService', () => {
         label: 'Test Address',
         walletId: 'wallet1',
         walletName: 'Test Wallet',
-        index: 0
+        index: 0,
+        pubKey: '02aa'
       })
     };
     
@@ -220,6 +227,8 @@ describe('ProviderService', () => {
     // Mock connection service
     const mockConnectionService = {
       hasPermission: vi.fn().mockResolvedValue(false),
+      hasPairedAddressPermission: vi.fn().mockResolvedValue(false),
+      requestPairedAddressPermission: vi.fn().mockResolvedValue(undefined),
       requestPermission: vi.fn().mockResolvedValue(true),
       revokePermission: vi.fn().mockResolvedValue(undefined),
       disconnect: vi.fn().mockResolvedValue(undefined),
@@ -396,6 +405,50 @@ describe('ProviderService', () => {
       });
     });
     
+    describe('xcp_getAddresses', () => {
+      it('returns a stable active-only shape without paired permission', async () => {
+        const connection = vi.mocked(connectionService.getConnectionService)();
+        connection.hasPermission = vi.fn().mockResolvedValue(true);
+        connection.hasPairedAddressPermission = vi.fn().mockResolvedValue(false);
+
+        const result = await providerService.handleRequest(
+          'https://connected.com',
+          'xcp_getAddresses',
+          []
+        ) as any;
+
+        expect(result).toEqual({
+          active: {
+            address: 'bc1qtest123',
+            publicKey: '02aa',
+            type: 'p2wpkh',
+          },
+        });
+        expect(vi.mocked(walletService.getWalletService)().getPairedAddresses).not.toHaveBeenCalled();
+      });
+
+      it('returns both formats only with identity-bound paired permission', async () => {
+        const connection = vi.mocked(connectionService.getConnectionService)();
+        connection.hasPermission = vi.fn().mockResolvedValue(true);
+        connection.hasPairedAddressPermission = vi.fn().mockResolvedValue(true);
+
+        const result = await providerService.handleRequest(
+          'https://connected.com',
+          'xcp_getAddresses',
+          []
+        ) as any;
+
+        expect(result.active.address).toBe('bc1qtest123');
+        expect(result.legacy.address).toBe('1legacy');
+        expect(result.segwit.address).toBe('bc1qtest123');
+        expect(connection.hasPairedAddressPermission).toHaveBeenCalledWith(
+          'https://connected.com',
+          'wallet1',
+          'bc1qtest123'
+        );
+      });
+    });
+
     describe('xcp_chainId', () => {
       it('should return 0x0 for Bitcoin mainnet', async () => {
         const result = await providerService.handleRequest(
@@ -444,7 +497,7 @@ describe('ProviderService', () => {
           providerService.handleRequest(
             'https://notconnected.com',
             'xcp_signPsbt',
-            [{ hex: '70736274ff0100' }]
+            [{ hex: VALID_PSBT_HEX }]
           )
         ).rejects.toThrow('Unauthorized - not connected to wallet');
       });
@@ -490,7 +543,7 @@ describe('ProviderService', () => {
           providerService.handleRequest(
             'https://notconnected.com',
             'xcp_signPsbt',
-            [{ hex: '70736274ff0100' }]
+            [{ hex: VALID_PSBT_HEX }]
           )
         ).rejects.toThrow('Unauthorized - not connected to wallet');
       });
@@ -664,6 +717,68 @@ describe('ProviderService', () => {
     });
 
     describe('Sign PSBT Request', () => {
+      it('rejects unknown signer addresses before opening approval', async () => {
+        const connection = vi.mocked(connectionService.getConnectionService)();
+        connection.hasPermission = vi.fn().mockResolvedValue(true);
+
+        await expect(providerService.handleRequest(
+          'https://test.com',
+          'xcp_signPsbt',
+          [{ hex: VALID_PSBT_HEX, signInputs: { '1attacker': [0] } }]
+        )).rejects.toThrow('not in this wallet');
+
+        expect(signPsbtRequestStorage.signPsbtRequestStorage.store).not.toHaveBeenCalled();
+      });
+
+      it('rejects a different HD derivation index even when it belongs to the wallet', async () => {
+        const connection = vi.mocked(connectionService.getConnectionService)();
+        connection.hasPermission = vi.fn().mockResolvedValue(true);
+        const wallet = vi.mocked(walletService.getWalletService)();
+        wallet.getActiveWallet = vi.fn().mockResolvedValue({
+          id: 'wallet1',
+          name: 'Test Wallet',
+          type: 'mnemonic',
+          addressFormat: 'p2wpkh',
+          addresses: [
+            { address: 'bc1qtest123', path: "m/84'/0'/0'/0/0", pubKey: '02aa', name: 'Address 1' },
+            { address: 'bc1qotherindex', path: "m/84'/0'/0'/0/1", pubKey: '02cc', name: 'Address 2' },
+          ],
+        });
+
+        await expect(providerService.handleRequest(
+          'https://test.com',
+          'xcp_signPsbt',
+          [{ hex: VALID_PSBT_HEX, signInputs: { bc1qotherindex: [0] } }]
+        )).rejects.toThrow('not in this wallet');
+
+        expect(signPsbtRequestStorage.signPsbtRequestStorage.store).not.toHaveBeenCalled();
+      });
+      it('requires paired permission before accepting a sibling-format signer', async () => {
+        const connection = vi.mocked(connectionService.getConnectionService)();
+        connection.hasPermission = vi.fn().mockResolvedValue(true);
+        connection.hasPairedAddressPermission = vi.fn().mockResolvedValue(false);
+
+        await expect(providerService.handleRequest(
+          'https://test.com',
+          'xcp_signPsbt',
+          [{ hex: VALID_PSBT_HEX, signInputs: { '1legacy': [0] } }]
+        )).rejects.toThrow('Paired Legacy/SegWit address access has not been granted');
+
+        expect(signPsbtRequestStorage.signPsbtRequestStorage.store).not.toHaveBeenCalled();
+      });
+
+      it('rejects sighash entries beyond the PSBT input count', async () => {
+        const connection = vi.mocked(connectionService.getConnectionService)();
+        connection.hasPermission = vi.fn().mockResolvedValue(true);
+
+        await expect(providerService.handleRequest(
+          'https://test.com',
+          'xcp_signPsbt',
+          [{ hex: VALID_PSBT_HEX, sighashTypes: [0x01, 0x01, 0x01] }]
+        )).rejects.toThrow('more entries than the PSBT has inputs');
+
+        expect(signPsbtRequestStorage.signPsbtRequestStorage.store).not.toHaveBeenCalled();
+      });
       it('should handle xcp_signPsbt with proper storage', async () => {
         // Mock connection service to return true
         const mockConnectionService = vi.mocked(connectionService.getConnectionService)();
@@ -672,7 +787,7 @@ describe('ProviderService', () => {
         // Mock storage
         const mockStorage = vi.mocked(signPsbtRequestStorage).signPsbtRequestStorage;
 
-        const psbtHex = '70736274ff0100';
+        const psbtHex = VALID_PSBT_HEX;
 
         // Start the request - it will return a promise that waits for events
         providerService.handleRequest(
@@ -704,7 +819,7 @@ describe('ProviderService', () => {
         providerService.handleRequest(
           'https://test.com',
           'xcp_signPsbt',
-          [{ hex: '70736274ff0100' }]
+          [{ hex: VALID_PSBT_HEX }]
         ).catch(() => {});
 
         // Wait for async operations
@@ -755,7 +870,7 @@ describe('ProviderService', () => {
           providerService.handleRequest(
             'https://test.com',
             'xcp_signPsbt',
-            [{ hex: '70736274ff0100' }]
+            [{ hex: VALID_PSBT_HEX }]
           )
         ).rejects.toThrow('No active address');
       });

--- a/src/services/__tests__/providerService.test.ts
+++ b/src/services/__tests__/providerService.test.ts
@@ -336,7 +336,8 @@ describe('ProviderService', () => {
         expect(mockConnectionService.connect).toHaveBeenCalledWith(
           'https://newsite.com',
           'bc1qtest123',  // activeAddress from mock
-          'wallet1'       // activeWallet.id from mock (no hyphen)
+          'wallet1',      // activeWallet.id from mock (no hyphen)
+          false            // paired addresses are opt-in
         );
 
         // Should return accounts with proof

--- a/src/services/__tests__/providerService.test.ts
+++ b/src/services/__tests__/providerService.test.ts
@@ -729,6 +729,18 @@ describe('ProviderService', () => {
 
         expect(signPsbtRequestStorage.signPsbtRequestStorage.store).not.toHaveBeenCalled();
       });
+      it.each([null, []])('rejects a malformed signer map (%j) before opening approval', async (signInputs) => {
+        const connection = vi.mocked(connectionService.getConnectionService)();
+        connection.hasPermission = vi.fn().mockResolvedValue(true);
+
+        await expect(providerService.handleRequest(
+          'https://test.com',
+          'xcp_signPsbt',
+          [{ hex: VALID_PSBT_HEX, signInputs }]
+        )).rejects.toThrow('signInputs must be an address-to-input-indices object');
+
+        expect(signPsbtRequestStorage.signPsbtRequestStorage.store).not.toHaveBeenCalled();
+      });
       it('rejects unknown signer addresses before opening approval', async () => {
         const connection = vi.mocked(connectionService.getConnectionService)();
         connection.hasPermission = vi.fn().mockResolvedValue(true);

--- a/src/services/connectionService.ts
+++ b/src/services/connectionService.ts
@@ -116,8 +116,9 @@ export class ConnectionService extends BaseService {
   async requestPermission(
     origin: string,
     address: string,
-    walletId: string
-  ): Promise<boolean> {
+    walletId: string,
+    pairedAddresses = false
+  ): Promise<ApprovalResult> {
     // Prevent duplicate requests for the same origin
     const dedupeKey = `${origin}-pending`;
     if (this.state.pendingPermissionRequests.has(dedupeKey)) {
@@ -154,7 +155,7 @@ export class ConnectionService extends BaseService {
         id: requestId,
         origin,
         method: 'xcp_requestAccounts',
-        params: [],
+        params: [{ capabilities: { pairedAddresses } }],
         type: 'connection',
         metadata: {
           domain,
@@ -165,12 +166,49 @@ export class ConnectionService extends BaseService {
 
       this.state.pendingPermissionRequests.delete(dedupeKey);
       this.state.pendingPermissionRequests.delete(requestId);
-      return result.approved;
+      return result;
     } catch (error) {
       this.state.pendingPermissionRequests.delete(dedupeKey);
       this.state.pendingPermissionRequests.delete(requestId);
       throw error;
     }
+  }
+
+  async hasPairedAddressPermission(origin: string, walletId: string, address: string): Promise<boolean> {
+    const capability = (await getWalletService().getSettings()).providerCapabilities?.[origin];
+    return capability?.pairedAddresses === true
+      && capability.walletId === walletId
+      && capability.address === address;
+  }
+
+  private async storePairedAddressPermission(
+    origin: string,
+    walletId: string,
+    address: string,
+    granted: boolean
+  ): Promise<void> {
+    const walletService = getWalletService();
+    const settings = await walletService.getSettings();
+    const capabilities = { ...(settings.providerCapabilities ?? {}) };
+    if (granted) {
+      capabilities[origin] = { pairedAddresses: true, walletId, address };
+    } else {
+      delete capabilities[origin];
+    }
+    await walletService.updateSettings({ providerCapabilities: capabilities });
+  }
+
+  async requestPairedAddressPermission(
+    origin: string,
+    address: string,
+    walletId: string
+  ): Promise<void> {
+    if (await this.hasPairedAddressPermission(origin, walletId, address)) return;
+    const result = await this.requestPermission(origin, address, walletId, true);
+    if (!result.approved || result.updatedParams?.pairedAddresses !== true) {
+      throw new ProviderError(PROVIDER_ERROR_CODES.USER_REJECTED, 'Paired address access was not granted');
+    }
+    await this.storePairedAddressPermission(origin, walletId, address, true);
   }
 
   /**
@@ -212,7 +250,8 @@ export class ConnectionService extends BaseService {
   async connect(
     origin: string,
     address: string,
-    walletId: string
+    walletId: string,
+    pairedAddresses = false
   ): Promise<string[]> {
     console.debug('[ConnectionService] Connecting dApp:', { origin, address, walletId });
 
@@ -229,14 +268,17 @@ export class ConnectionService extends BaseService {
     }
 
     // Request user permission
-    const approved = await this.requestPermission(origin, address, walletId);
+    const approval = await this.requestPermission(origin, address, walletId, pairedAddresses);
 
-    if (approved) {
+    if (approval.approved) {
       // Track successful connection
       await analytics.track('connection_established');
 
       // Add to connected websites
       await getWalletService().addConnectedWebsite(origin);
+      if (pairedAddresses && approval.updatedParams?.pairedAddresses === true) {
+        await this.storePairedAddressPermission(origin, walletId, address, true);
+      }
 
       // Update cache
       this.state.connectionCache.set(origin, {
@@ -264,8 +306,9 @@ export class ConnectionService extends BaseService {
   async disconnect(origin: string): Promise<void> {
     console.debug('[ConnectionService] Disconnecting dApp:', origin);
 
-    // Remove from connected websites
-    await getWalletService().removeConnectedWebsite(origin);
+    // Remove from connected websites and all associated capabilities.
+    const walletService = getWalletService();
+    await walletService.removeConnectedWebsite(origin);
 
     // Update cache
     this.state.connectionCache.delete(origin);

--- a/src/services/connectionService.ts
+++ b/src/services/connectionService.ts
@@ -193,6 +193,15 @@ export class ConnectionService extends BaseService {
     await walletService.updateSettings({ providerCapabilities: capabilities });
   }
 
+  private async clearPairedAddressPermission(origin: string): Promise<void> {
+    const walletService = getWalletService();
+    const settings = await walletService.getSettings();
+    if (!settings.providerCapabilities?.[origin]) return;
+    const capabilities = { ...settings.providerCapabilities };
+    delete capabilities[origin];
+    await walletService.updateSettings({ providerCapabilities: capabilities });
+  }
+
   async requestPairedAddressPermission(
     origin: string,
     address: string,
@@ -203,7 +212,14 @@ export class ConnectionService extends BaseService {
     if (!result.approved || result.updatedParams?.pairedAddresses !== true) {
       throw new ProviderError(PROVIDER_ERROR_CODES.USER_REJECTED, 'Paired address access was not granted');
     }
+    if (!await this.hasPermission(origin)) {
+      throw new ProviderError(PROVIDER_ERROR_CODES.UNAUTHORIZED, 'Site disconnected before paired address access was granted');
+    }
     await this.storePairedAddressPermission(origin, walletId, address);
+    if (!await this.hasPermission(origin)) {
+      await this.clearPairedAddressPermission(origin);
+      throw new ProviderError(PROVIDER_ERROR_CODES.UNAUTHORIZED, 'Site disconnected before paired address access was granted');
+    }
   }
 
   /**
@@ -273,6 +289,8 @@ export class ConnectionService extends BaseService {
       await getWalletService().addConnectedWebsite(origin);
       if (pairedAddresses && approval.updatedParams?.pairedAddresses === true) {
         await this.storePairedAddressPermission(origin, walletId, address);
+      } else {
+        await this.clearPairedAddressPermission(origin);
       }
 
       // Update cache

--- a/src/services/connectionService.ts
+++ b/src/services/connectionService.ts
@@ -155,7 +155,7 @@ export class ConnectionService extends BaseService {
         id: requestId,
         origin,
         method: 'xcp_requestAccounts',
-        params: [{ capabilities: { pairedAddresses } }],
+        params: [{ capabilities: { pairedAddresses }, address, walletId }],
         type: 'connection',
         metadata: {
           domain,
@@ -184,17 +184,12 @@ export class ConnectionService extends BaseService {
   private async storePairedAddressPermission(
     origin: string,
     walletId: string,
-    address: string,
-    granted: boolean
+    address: string
   ): Promise<void> {
     const walletService = getWalletService();
     const settings = await walletService.getSettings();
     const capabilities = { ...(settings.providerCapabilities ?? {}) };
-    if (granted) {
-      capabilities[origin] = { pairedAddresses: true, walletId, address };
-    } else {
-      delete capabilities[origin];
-    }
+    capabilities[origin] = { pairedAddresses: true, walletId, address };
     await walletService.updateSettings({ providerCapabilities: capabilities });
   }
 
@@ -208,7 +203,7 @@ export class ConnectionService extends BaseService {
     if (!result.approved || result.updatedParams?.pairedAddresses !== true) {
       throw new ProviderError(PROVIDER_ERROR_CODES.USER_REJECTED, 'Paired address access was not granted');
     }
-    await this.storePairedAddressPermission(origin, walletId, address, true);
+    await this.storePairedAddressPermission(origin, walletId, address);
   }
 
   /**
@@ -277,7 +272,7 @@ export class ConnectionService extends BaseService {
       // Add to connected websites
       await getWalletService().addConnectedWebsite(origin);
       if (pairedAddresses && approval.updatedParams?.pairedAddresses === true) {
-        await this.storePairedAddressPermission(origin, walletId, address, true);
+        await this.storePairedAddressPermission(origin, walletId, address);
       }
 
       // Update cache

--- a/src/services/providerService.ts
+++ b/src/services/providerService.ts
@@ -761,6 +761,11 @@ export function createProviderService(): ProviderService {
           if (typeof psbtHex !== 'string') {
             throw new Error('PSBT hex must be a string');
           }
+          if (signInputs !== undefined && (
+            signInputs === null || typeof signInputs !== 'object' || Array.isArray(signInputs)
+          )) {
+            throw new Error('signInputs must be an address-to-input-indices object');
+          }
           if (sighashTypes !== undefined) {
             if (!Array.isArray(sighashTypes) || sighashTypes.some(
               value => ![0x01, 0x81, 0x83].includes(value)
@@ -791,7 +796,7 @@ export function createProviderService(): ProviderService {
             throw new Error('SIGHASH_SINGLE requires an output at the same index');
           }
 
-          if (signInputs) {
+          if (signInputs !== undefined) {
             const supportsPairedAddresses = Boolean(
               getPairedAddressFormats(activeWallet.addressFormat)
             );

--- a/src/services/providerService.ts
+++ b/src/services/providerService.ts
@@ -324,7 +324,8 @@ export function createProviderService(): ProviderService {
    *
    * Signing fails closed before approval storage: requested signer addresses
    * must be the active address or its exact sibling pair, input indices must be
-   * unique and in range, and paired signing requires the bound capability.
+   * unique and in range, each input prevout must match its claimed signer,
+   * and paired signing requires the bound capability.
    * This deliberately does not authorize other HD derivation indices.
    *
    * Resolve a connection request: return existing accounts if already connected,
@@ -804,7 +805,8 @@ export function createProviderService(): ProviderService {
             const validation = validateSignInputs(
               signInputs,
               allowedAddresses,
-              psbtDetails.inputs.length
+              psbtDetails.inputs.length,
+              psbtDetails.inputs.map(input => input.address)
             );
             if (!validation.valid) throw new Error(validation.error);
 

--- a/src/services/providerService.ts
+++ b/src/services/providerService.ts
@@ -837,6 +837,19 @@ export function createProviderService(): ProviderService {
               );
             }
           }
+          if (sighashTypes !== undefined) {
+            const requestedInputIndices = signInputs === undefined
+              ? Array.from({ length: psbtDetails.inputs.length }, (_, index) => index)
+              : Object.values(signInputs).flat();
+            const missingInputIndices = requestedInputIndices.filter(
+              index => sighashTypes[index] === undefined
+            );
+            if (missingInputIndices.length > 0) {
+              throw new Error(
+                `sighashTypes is indexed by absolute PSBT input index and is missing entries for inputs: ${missingInputIndices.join(', ')}`
+              );
+            }
+          }
           return runSignFlow({
             origin,
             method,

--- a/src/services/providerService.ts
+++ b/src/services/providerService.ts
@@ -316,7 +316,11 @@ export function createProviderService(): ProviderService {
    * otherwise connect and build the response. onBeforeConnect runs only for a
    * new connection (after the already-connected check, before connect).
    */
-  async function completeConnection(origin: string, onBeforeConnect?: () => Promise<void>) {
+  async function completeConnection(
+    origin: string,
+    pairedAddresses = false,
+    onBeforeConnect?: () => Promise<void>
+  ) {
     const walletService = getWalletService();
     const connectionService = getConnectionService();
 
@@ -327,12 +331,24 @@ export function createProviderService(): ProviderService {
     }
 
     if (await connectionService.hasPermission(origin)) {
+      if (pairedAddresses) {
+        await connectionService.requestPairedAddressPermission(
+          origin,
+          activeAddress.address,
+          activeWallet.id
+        );
+      }
       return buildConnectResponse(origin, await getAccounts(origin));
     }
 
     await onBeforeConnect?.();
 
-    const accounts = await connectionService.connect(origin, activeAddress.address, activeWallet.id);
+    const accounts = await connectionService.connect(
+      origin,
+      activeAddress.address,
+      activeWallet.id,
+      pairedAddresses
+    );
     await analytics.track('connection_established');
     return buildConnectResponse(origin, accounts);
   }
@@ -403,6 +419,11 @@ export function createProviderService(): ProviderService {
         // ==================== Connection Methods ====================
         
         case 'xcp_requestAccounts': {
+          const accountOptions = params?.[0] as {
+            capabilities?: { pairedAddresses?: boolean }
+          } | undefined;
+          const pairedAddresses = accountOptions?.capabilities?.pairedAddresses === true;
+
           // Check if keychain exists in storage (works even when locked)
           if (!await keychainExists()) {
             // Open popup for wallet setup and wait for onboarding to complete
@@ -426,7 +447,7 @@ export function createProviderService(): ProviderService {
 
                 // Continue with connection flow now that wallet exists
                 try {
-                  resolve(await completeConnection(origin));
+                  resolve(await completeConnection(origin, pairedAddresses));
                 } catch (error) {
                   reject(error);
                 }
@@ -486,7 +507,7 @@ export function createProviderService(): ProviderService {
 
                 // Continue with connection flow
                 try {
-                  resolve(await completeConnection(origin));
+                  resolve(await completeConnection(origin, pairedAddresses));
                 } catch (error) {
                   reject(error);
                 }
@@ -504,7 +525,7 @@ export function createProviderService(): ProviderService {
           }
 
           // CSP analysis (warning mode only) runs just before a new connection.
-          return completeConnection(origin, async () => {
+          return completeConnection(origin, pairedAddresses, async () => {
             let cspHostname = origin;
             try { cspHostname = new URL(origin).hostname; } catch { /* use raw origin */ }
 
@@ -532,6 +553,43 @@ export function createProviderService(): ProviderService {
           return getAccounts(origin);
         }
         
+        case 'xcp_getAddresses': {
+          if (!await connectionService.hasPermission(origin)) {
+            throw new ProviderError(PROVIDER_ERROR_CODES.UNAUTHORIZED, 'Unauthorized - not connected to wallet');
+          }
+          const activeAddress = await walletService.getActiveAddress();
+          const activeWallet = await walletService.getActiveWallet();
+          if (!activeAddress || !activeWallet) throw new Error('No active address');
+          const paired = await connectionService.hasPairedAddressPermission(
+            origin,
+            activeWallet.id,
+            activeAddress.address
+          );
+          if (!paired) {
+            return {
+              active: {
+                address: activeAddress.address,
+                publicKey: activeAddress.pubKey,
+                type: activeWallet.addressFormat,
+              },
+            };
+          }
+          const addresses = await walletService.getPairedAddresses();
+          return {
+            active: activeAddress.address === addresses.legacy.address ? 'legacy' : 'segwit',
+            legacy: {
+              address: addresses.legacy.address,
+              publicKey: addresses.legacy.pubKey,
+              type: addresses.legacy.type,
+            },
+            segwit: {
+              address: addresses.segwit.address,
+              publicKey: addresses.segwit.pubKey,
+              type: addresses.segwit.type,
+            },
+          };
+        }
+
         case 'xcp_chainId': {
           return '0x0'; // Bitcoin mainnet
         }
@@ -690,6 +748,13 @@ export function createProviderService(): ProviderService {
           if (typeof psbtHex !== 'string') {
             throw new Error('PSBT hex must be a string');
           }
+          if (sighashTypes !== undefined) {
+            if (!Array.isArray(sighashTypes) || sighashTypes.some(
+              value => ![0x01, 0x81, 0x83].includes(value)
+            )) {
+              throw new Error('Only SIGHASH_ALL, ALL|ANYONECANPAY, and SINGLE|ANYONECANPAY are supported');
+            }
+          }
 
           // Check if connected
           if (!await connectionService.hasPermission(origin)) {
@@ -701,6 +766,46 @@ export function createProviderService(): ProviderService {
           const activeWallet = await walletService.getActiveWallet();
           if (!activeAddress || !activeWallet) {
             throw new Error('No active address');
+          }
+
+          if (signInputs) {
+            const seenInputs = new Set<number>();
+            for (const indices of Object.values(signInputs)) {
+              if (!Array.isArray(indices) || indices.length === 0) {
+                throw new Error('Each signInputs entry must contain input indices');
+              }
+              for (const index of indices) {
+                if (!Number.isSafeInteger(index) || index < 0 || seenInputs.has(index)) {
+                  throw new Error('signInputs contains an invalid or duplicate input index');
+                }
+                seenInputs.add(index);
+              }
+            }
+            const supportsPairedAddresses = [
+              'counterwallet',
+              'counterwallet-segwit',
+              'freewallet-bip39',
+              'freewallet-bip39-segwit',
+              'p2pkh',
+              'p2wpkh',
+            ].includes(activeWallet.addressFormat);
+            if (activeWallet.type === 'mnemonic' && supportsPairedAddresses) {
+              const paired = await walletService.getPairedAddresses();
+              const pairedAddresses = new Set([paired.legacy.address, paired.segwit.address]);
+              const usesPairedAddress = Object.keys(signInputs).some(
+                address => address !== activeAddress.address && pairedAddresses.has(address)
+              );
+              if (usesPairedAddress && !await connectionService.hasPairedAddressPermission(
+                origin,
+                activeWallet.id,
+                activeAddress.address
+              )) {
+                throw new ProviderError(
+                  PROVIDER_ERROR_CODES.UNAUTHORIZED,
+                  'Paired Legacy/SegWit address access has not been granted'
+                );
+              }
+            }
           }
 
           return runSignFlow({

--- a/src/services/providerService.ts
+++ b/src/services/providerService.ts
@@ -28,6 +28,7 @@ import {
   removeSignFlow,
 } from '@/utils/provider/signFlow';
 import { fetchBTCBalance } from '@/utils/blockchain/bitcoin/balance';
+import { extractPsbtDetails, validateSignInputs } from '@/utils/blockchain/bitcoin/psbt';
 import { fetchTokenBalances } from '@/utils/blockchain/counterparty/api';
 import { checkReplayAttempt, recordTransaction, markTransactionBroadcasted } from '@/utils/security/replayPrevention';
 import { signMessage as signMessageDirect } from '@/utils/blockchain/bitcoin/messageSigner';
@@ -35,6 +36,8 @@ import { openExtensionPopup } from '@/utils/popup';
 import { generateRequestId } from '@/utils/id';
 import { keychainExists } from '@/utils/storage/walletStorage';
 import { ProviderError, PROVIDER_ERROR_CODES } from '@/utils/errors';
+import { getPairedAddressFormats } from '@/utils/wallet/addressDeriver';
+import { normalizeAddressForComparison } from '@/utils/blockchain/bitcoin/address';
 
 // In-memory storage for active requests (primary storage, fast access)
 const activeSignRequests = new Map<string, any>();
@@ -312,6 +315,18 @@ export function createProviderService(): ProviderService {
   }
 
   /**
+   * ADR-018: Paired-address provider capability
+   *
+   * A connection authorizes only its active address. A dApp may opt in to the
+   * active derivation index's Legacy/SegWit sibling pair through explicit,
+   * unchecked-by-default consent. The grant is bound to origin, wallet ID, and
+   * active address, and is removed on disconnect.
+   *
+   * Signing fails closed before approval storage: requested signer addresses
+   * must be the active address or its exact sibling pair, input indices must be
+   * unique and in range, and paired signing requires the bound capability.
+   * This deliberately does not authorize other HD derivation indices.
+   *
    * Resolve a connection request: return existing accounts if already connected,
    * otherwise connect and build the response. onBeforeConnect runs only for a
    * new connection (after the already-connected check, before connect).
@@ -565,18 +580,15 @@ export function createProviderService(): ProviderService {
             activeWallet.id,
             activeAddress.address
           );
-          if (!paired) {
-            return {
-              active: {
-                address: activeAddress.address,
-                publicKey: activeAddress.pubKey,
-                type: activeWallet.addressFormat,
-              },
-            };
-          }
+          const active = {
+            address: activeAddress.address,
+            publicKey: activeAddress.pubKey,
+            type: activeWallet.addressFormat,
+          };
+          if (!paired) return { active };
           const addresses = await walletService.getPairedAddresses();
           return {
-            active: activeAddress.address === addresses.legacy.address ? 'legacy' : 'segwit',
+            active,
             legacy: {
               address: addresses.legacy.address,
               publicKey: addresses.legacy.pubKey,
@@ -768,46 +780,56 @@ export function createProviderService(): ProviderService {
             throw new Error('No active address');
           }
 
-          if (signInputs) {
-            const seenInputs = new Set<number>();
-            for (const indices of Object.values(signInputs)) {
-              if (!Array.isArray(indices) || indices.length === 0) {
-                throw new Error('Each signInputs entry must contain input indices');
-              }
-              for (const index of indices) {
-                if (!Number.isSafeInteger(index) || index < 0 || seenInputs.has(index)) {
-                  throw new Error('signInputs contains an invalid or duplicate input index');
-                }
-                seenInputs.add(index);
-              }
-            }
-            const supportsPairedAddresses = [
-              'counterwallet',
-              'counterwallet-segwit',
-              'freewallet-bip39',
-              'freewallet-bip39-segwit',
-              'p2pkh',
-              'p2wpkh',
-            ].includes(activeWallet.addressFormat);
-            if (activeWallet.type === 'mnemonic' && supportsPairedAddresses) {
-              const paired = await walletService.getPairedAddresses();
-              const pairedAddresses = new Set([paired.legacy.address, paired.segwit.address]);
-              const usesPairedAddress = Object.keys(signInputs).some(
-                address => address !== activeAddress.address && pairedAddresses.has(address)
-              );
-              if (usesPairedAddress && !await connectionService.hasPairedAddressPermission(
-                origin,
-                activeWallet.id,
-                activeAddress.address
-              )) {
-                throw new ProviderError(
-                  PROVIDER_ERROR_CODES.UNAUTHORIZED,
-                  'Paired Legacy/SegWit address access has not been granted'
-                );
-              }
-            }
+          const psbtDetails = extractPsbtDetails(psbtHex);
+          if (sighashTypes && sighashTypes.length > psbtDetails.inputs.length) {
+            throw new Error('sighashTypes contains more entries than the PSBT has inputs');
+          }
+          if (sighashTypes?.some(
+            (value, index) => value === 0x83 && index >= psbtDetails.outputs.length
+          )) {
+            throw new Error('SIGHASH_SINGLE requires an output at the same index');
           }
 
+          if (signInputs) {
+            const supportsPairedAddresses = Boolean(
+              getPairedAddressFormats(activeWallet.addressFormat)
+            );
+            const paired = activeWallet.type === 'mnemonic' && supportsPairedAddresses
+              ? await walletService.getPairedAddresses()
+              : null;
+            const allowedAddresses = [
+              activeAddress.address,
+              ...(paired ? [paired.legacy.address, paired.segwit.address] : []),
+            ];
+            const validation = validateSignInputs(
+              signInputs,
+              allowedAddresses,
+              psbtDetails.inputs.length
+            );
+            if (!validation.valid) throw new Error(validation.error);
+
+            const pairedAddressSet = new Set(
+              paired
+                ? [paired.legacy.address, paired.segwit.address].map(normalizeAddressForComparison)
+                : []
+            );
+            const normalizedActiveAddress = normalizeAddressForComparison(activeAddress.address);
+            const usesPairedAddress = Object.keys(signInputs).some(address => {
+              const normalizedAddress = normalizeAddressForComparison(address);
+              return normalizedAddress !== normalizedActiveAddress
+                && pairedAddressSet.has(normalizedAddress);
+            });
+            if (usesPairedAddress && !await connectionService.hasPairedAddressPermission(
+              origin,
+              activeWallet.id,
+              activeAddress.address
+            )) {
+              throw new ProviderError(
+                PROVIDER_ERROR_CODES.UNAUTHORIZED,
+                'Paired Legacy/SegWit address access has not been granted'
+              );
+            }
+          }
           return runSignFlow({
             origin,
             method,

--- a/src/services/walletService.ts
+++ b/src/services/walletService.ts
@@ -13,7 +13,7 @@ import { MessageBus } from '@/services/core/MessageBus';
 import { eventEmitterService } from '@/services/eventEmitterService';
 import { AddressFormat } from '@/utils/blockchain/bitcoin/address';
 import { walletManager } from '@/utils/wallet/walletManager';
-import type { Wallet, Address, SignTransactionOptions } from '@/types/wallet';
+import type { Wallet, Address, PairedAddresses, SignTransactionOptions } from '@/types/wallet';
 
 interface WalletService {
   refreshWallets: () => Promise<void>;
@@ -59,6 +59,7 @@ interface WalletService {
   getPrivateKey: (walletId: string, derivationPath?: string) => Promise<{ wif: string; hex: string; compressed: boolean }>;
   removeWallet: (walletId: string) => Promise<void>;
   getPreviewAddressForFormat: (walletId: string, addressFormat: AddressFormat) => Promise<string>;
+  getPairedAddresses: () => Promise<PairedAddresses>;
   isAddressInAnyWallet: (address: string) => Promise<boolean>;
   signTransaction: (rawTxHex: string, sourceAddress: string, options?: SignTransactionOptions) => Promise<string>;
   broadcastTransaction: (signedTxHex: string) => Promise<{ txid: string; fees?: number }>;
@@ -104,12 +105,15 @@ function createWalletService(): WalletService {
     },
     removeConnectedWebsite: async (origin) => {
       const settings = walletManager.getSettings();
+      const providerCapabilities = { ...(settings.providerCapabilities ?? {}) };
+      delete providerCapabilities[origin];
       await walletManager.updateSettings({
         connectedWebsites: settings.connectedWebsites.filter((site) => site !== origin),
+        providerCapabilities,
       });
     },
     clearConnectedWebsites: async () => {
-      await walletManager.updateSettings({ connectedWebsites: [] });
+      await walletManager.updateSettings({ connectedWebsites: [], providerCapabilities: {} });
     },
     getWallets: async () => walletManager.getWallets(),
     getActiveWallet: async () => walletManager.getActiveWallet(),
@@ -208,6 +212,7 @@ function createWalletService(): WalletService {
     getPreviewAddressForFormat: async (walletId, addressFormat) => {
       return await walletManager.getPreviewAddressForFormat(walletId, addressFormat);
     },
+    getPairedAddresses: async () => walletManager.getPairedAddresses(),
     isAddressInAnyWallet: async (address) => {
       return walletManager.isAddressInAnyWallet(address);
     },

--- a/src/types/wallet.ts
+++ b/src/types/wallet.ts
@@ -23,6 +23,16 @@ export interface Address {
   pubKey: string;
 }
 
+export interface PairedAddress extends Address {
+  format: AddressFormat;
+  type: 'p2pkh' | 'p2wpkh';
+}
+
+export interface PairedAddresses {
+  legacy: PairedAddress;
+  segwit: PairedAddress;
+}
+
 /**
  * Represents a wallet containing one or more addresses.
  * This is the runtime representation with derived addresses.

--- a/src/utils/__tests__/settings.test.ts
+++ b/src/utils/__tests__/settings.test.ts
@@ -172,6 +172,7 @@ describe('DEFAULT_SETTINGS', () => {
       'lastActiveWalletId',
       'pinnedAssets',
       'priceUnit',
+      'providerCapabilities',
       'showHelpText',
       'strictTransactionVerification',
       'transactionDryRun',

--- a/src/utils/blockchain/bitcoin/__tests__/psbt.test.ts
+++ b/src/utils/blockchain/bitcoin/__tests__/psbt.test.ts
@@ -261,6 +261,14 @@ describe('validateSignInputs', () => {
     expect(result.valid).toBe(true);
   });
 
+  it('keeps Base58 address comparison case-sensitive', () => {
+    const result = validateSignInputs(
+      { '1legacycase': [0] },
+      ['1LegacyCase']
+    );
+    expect(result.valid).toBe(false);
+  });
+
   it('should reject unknown addresses', () => {
     const signInputs = {
       'bc1qunknownaddress': [0],
@@ -278,7 +286,7 @@ describe('validateSignInputs', () => {
 
     const result = validateSignInputs(signInputs, walletAddresses);
     expect(result.valid).toBe(false);
-    expect(result.error).toContain('Invalid input indices');
+    expect(result.error).toContain('Invalid input index');
   });
 
   it('should reject non-integer indices', () => {
@@ -297,6 +305,29 @@ describe('validateSignInputs', () => {
 
     const result = validateSignInputs(signInputs, walletAddresses);
     expect(result.valid).toBe(false);
+  });
+
+  it('should reject empty index arrays', () => {
+    const result = validateSignInputs({
+      'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4': [],
+    }, walletAddresses, 1);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('No input indices');
+  });
+
+  it('should reject out-of-range and duplicate indices', () => {
+    const outOfRange = validateSignInputs({
+      'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4': [2],
+    }, walletAddresses, 2);
+    expect(outOfRange.valid).toBe(false);
+    expect(outOfRange.error).toContain('Invalid input index');
+
+    const duplicate = validateSignInputs({
+      'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4': [0],
+      'bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3': [0],
+    }, walletAddresses, 1);
+    expect(duplicate.valid).toBe(false);
+    expect(duplicate.error).toContain('more than once');
   });
 
   it('should handle empty signInputs', () => {

--- a/src/utils/blockchain/bitcoin/__tests__/psbt.test.ts
+++ b/src/utils/blockchain/bitcoin/__tests__/psbt.test.ts
@@ -330,11 +330,22 @@ describe('validateSignInputs', () => {
     expect(duplicate.error).toContain('more than once');
   });
 
-  it('should handle empty signInputs', () => {
+  it('should reject an explicitly empty signInputs map', () => {
     const result = validateSignInputs({}, walletAddresses);
-    expect(result.valid).toBe(true);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('at least one input');
   });
 
+  it('should reject an input assigned to the wrong signer address', () => {
+    const result = validateSignInputs(
+      { 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4': [0] },
+      walletAddresses,
+      1,
+      ['bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3']
+    );
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('does not belong');
+  });
   it('should handle multiple addresses', () => {
     const signInputs = {
       'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4': [0],
@@ -386,6 +397,14 @@ describe('signPSBT', () => {
     const fixture = '70736274ff01009a0200000002dcdd8cd287d40de3d260ccfc5fa3008f14ff8f13fc840164715cbb2b925874190000000000ffffffff98f9e476f918cc143cf8a6bd09042d1f2ee7c46bfd29c906166613b2d9c516c90000000000ffffffff022202000000000000160014670caa79e51d78ed0c583b89ff39d9c49b7199e75c12000000000000160014670caa79e51d78ed0c583b89ff39d9c49b7199e70000000000010055020000000101010101010101010101010101010101010101010101010101010101010101010000000000ffffffff0122020000000000001976a914a3c6b1ee4a49d9f2af3b3802974744fba924164a88ac000000000001011f8813000000000000160014670caa79e51d78ed0c583b89ff39d9c49b7199e7000000';
     const legacyKey = '07'.repeat(32);
     const segwitKey = '09'.repeat(32);
+
+    const details = extractPsbtDetails(fixture);
+    expect(details.inputs.map(input => input.value)).toEqual([546, 5000]);
+    expect(details.inputs.map(input => input.address)).toEqual([
+      '1FvyAqqELFiQyaEWdhFbWF8MZapKPZS8J7',
+      'bc1qvux25709r4uw6rzc8wyl7wwecjdhrx085hm5ty',
+    ]);
+    expect(details.fee).toBe(300);
 
     const legacySigned = signPSBT(fixture, legacyKey, [0], AddressFormat.P2PKH);
     const fullySigned = signPSBT(legacySigned, segwitKey, [1], AddressFormat.P2WPKH);

--- a/src/utils/blockchain/bitcoin/__tests__/psbt.test.ts
+++ b/src/utils/blockchain/bitcoin/__tests__/psbt.test.ts
@@ -351,6 +351,40 @@ describe('signPSBT', () => {
     expect(input.partialSig).toBeDefined();
   });
 
+  it('signs the real cross-format move fixture with both owned keys', () => {
+    const fixture = '70736274ff01009a0200000002dcdd8cd287d40de3d260ccfc5fa3008f14ff8f13fc840164715cbb2b925874190000000000ffffffff98f9e476f918cc143cf8a6bd09042d1f2ee7c46bfd29c906166613b2d9c516c90000000000ffffffff022202000000000000160014670caa79e51d78ed0c583b89ff39d9c49b7199e75c12000000000000160014670caa79e51d78ed0c583b89ff39d9c49b7199e70000000000010055020000000101010101010101010101010101010101010101010101010101010101010101010000000000ffffffff0122020000000000001976a914a3c6b1ee4a49d9f2af3b3802974744fba924164a88ac000000000001011f8813000000000000160014670caa79e51d78ed0c583b89ff39d9c49b7199e7000000';
+    const legacyKey = '07'.repeat(32);
+    const segwitKey = '09'.repeat(32);
+
+    const legacySigned = signPSBT(fixture, legacyKey, [0], AddressFormat.P2PKH);
+    const fullySigned = signPSBT(legacySigned, segwitKey, [1], AddressFormat.P2WPKH);
+    const tx = parsePSBT(fullySigned);
+
+    expect(tx.getInput(0).partialSig).toHaveLength(1);
+    expect(tx.getInput(1).partialSig).toHaveLength(1);
+  });
+
+  it('signs one legacy and two SegWit inputs in the widest move fixture', () => {
+    const fixture = '70736274ff0100c30200000003c3b06ae77edf2257a11304daa647b7ce6b90067ab7f826b56b4bdefbee80efd70000000000ffffffff617293be2b6167deb093829b9baac25555216b354542cc09e8b6898102bc49480000000000ffffffff7da32ac879b629c42dd63c60d330b4aa464ed7c0e1b59219dd38d3afe0a00b500000000000ffffffff022202000000000000160014670caa79e51d78ed0c583b89ff39d9c49b7199e76009000000000000160014670caa79e51d78ed0c583b89ff39d9c49b7199e70000000000010055020000000104040404040404040404040404040404040404040404040404040404040404040000000000ffffffff0122020000000000001976a914a3c6b1ee4a49d9f2af3b3802974744fba924164a88ac000000000001011fb004000000000000160014670caa79e51d78ed0c583b89ff39d9c49b7199e70001011fdc05000000000000160014670caa79e51d78ed0c583b89ff39d9c49b7199e7000000';
+    const legacySigned = signPSBT(fixture, '07'.repeat(32), [0], AddressFormat.P2PKH);
+    const fullySigned = signPSBT(legacySigned, '09'.repeat(32), [1, 2], AddressFormat.P2WPKH);
+    const tx = parsePSBT(fullySigned);
+
+    expect(tx.getInput(0).partialSig).toHaveLength(1);
+    expect(tx.getInput(1).partialSig).toHaveLength(1);
+    expect(tx.getInput(2).partialSig).toHaveLength(1);
+  });
+
+  it('sets SIGHASH_SINGLE|ANYONECANPAY on the listing fixture', () => {
+    const fixture = '70736274ff010055020000000186eeddc08bc258a9dd8bdce62058d76b0355c2173ba744ce5c971d94ed1c43af0000000000ffffffff0190d00300000000001976a914a3c6b1ee4a49d9f2af3b3802974744fba924164a88ac0000000000010055020000000103030303030303030303030303030303030303030303030303030303030303030000000000ffffffff0122020000000000001976a914a3c6b1ee4a49d9f2af3b3802974744fba924164a88ac000000000000';
+    const signed = signPSBT(fixture, '07'.repeat(32), [0], AddressFormat.P2PKH, [0x83]);
+    const input = parsePSBT(signed).getInput(0);
+
+    expect(input.sighashType).toBe(0x83);
+    expect(input.partialSig).toHaveLength(1);
+    expect(input.partialSig?.[0][1].at(-1)).toBe(0x83);
+  });
+
   it('should throw on invalid private key', () => {
     const psbtHex = createTestPsbt();
 

--- a/src/utils/blockchain/bitcoin/__tests__/psbt.test.ts
+++ b/src/utils/blockchain/bitcoin/__tests__/psbt.test.ts
@@ -11,6 +11,7 @@ import {
   extractPsbtDetails,
   validateSignInputs,
   signPSBT,
+  resolvePsbtSighashType,
   finalizePSBT,
   completePsbtWithInputValues,
 } from '../psbt';
@@ -358,6 +359,11 @@ describe('validateSignInputs', () => {
 });
 
 describe('signPSBT', () => {
+  it('resolves explicit, embedded, and default sighash values in signer order', () => {
+    expect(resolvePsbtSighashType(0x81, 0x83)).toBe(0x81);
+    expect(resolvePsbtSighashType(undefined, 0x83)).toBe(0x83);
+    expect(resolvePsbtSighashType()).toBe(0x01);
+  });
   it('should sign a PSBT input', () => {
     const psbtHex = createTestPsbt();
 

--- a/src/utils/blockchain/bitcoin/address.ts
+++ b/src/utils/blockchain/bitcoin/address.ts
@@ -38,6 +38,11 @@ export const AddressFormat = {
  */
 export type AddressFormat = typeof AddressFormat[keyof typeof AddressFormat];
 
+/** Normalize only Bech32 addresses; Base58 addresses remain case-sensitive. */
+export function normalizeAddressForComparison(address: string): string {
+  return address.toLowerCase().startsWith('bc1') ? address.toLowerCase() : address;
+}
+
 /**
  * Check if an address format is a SegWit format (P2WPKH, P2SH-P2WPKH, CounterwalletSegwit, or P2TR).
  */

--- a/src/utils/blockchain/bitcoin/psbt.ts
+++ b/src/utils/blockchain/bitcoin/psbt.ts
@@ -8,7 +8,7 @@
 import { Transaction, p2wpkh, SigHash } from '@scure/btc-signer';
 import { hexToBytes, bytesToHex } from '@noble/hashes/utils.js';
 import { getPublicKey } from '@noble/secp256k1';
-import { AddressFormat } from '@/utils/blockchain/bitcoin/address';
+import { AddressFormat, normalizeAddressForComparison } from '@/utils/blockchain/bitcoin/address';
 import { SigningError, ValidationError } from '@/utils/blockchain/errors';
 
 /**
@@ -496,12 +496,14 @@ export function completePsbtWithInputValues(
  */
 export function validateSignInputs(
   signInputs: Record<string, number[]>,
-  walletAddresses: string[]
+  walletAddresses: string[],
+  inputCount?: number
 ): { valid: boolean; error?: string } {
-  const walletAddressSet = new Set(walletAddresses.map(a => a.toLowerCase()));
+  const walletAddressSet = new Set(walletAddresses.map(normalizeAddressForComparison));
+  const seenIndices = new Set<number>();
 
   for (const address of Object.keys(signInputs)) {
-    if (!walletAddressSet.has(address.toLowerCase())) {
+    if (!walletAddressSet.has(normalizeAddressForComparison(address))) {
       return {
         valid: false,
         error: `Address ${address} is not in this wallet`,
@@ -509,11 +511,17 @@ export function validateSignInputs(
     }
 
     const indices = signInputs[address];
-    if (!Array.isArray(indices) || indices.some(i => !Number.isInteger(i) || i < 0)) {
-      return {
-        valid: false,
-        error: `Invalid input indices for address ${address}`,
-      };
+    if (!Array.isArray(indices) || indices.length === 0) {
+      return { valid: false, error: `No input indices provided for address ${address}` };
+    }
+    for (const index of indices) {
+      if (!Number.isSafeInteger(index) || index < 0 || (inputCount !== undefined && index >= inputCount)) {
+        return { valid: false, error: `Invalid input index ${index} for address ${address}` };
+      }
+      if (seenIndices.has(index)) {
+        return { valid: false, error: `Input index ${index} was requested more than once` };
+      }
+      seenIndices.add(index);
     }
   }
 

--- a/src/utils/blockchain/bitcoin/psbt.ts
+++ b/src/utils/blockchain/bitcoin/psbt.ts
@@ -11,6 +11,14 @@ import { getPublicKey } from '@noble/secp256k1';
 import { AddressFormat, decodeAddressFromScript, normalizeAddressForComparison } from '@/utils/blockchain/bitcoin/address';
 import { SigningError, ValidationError } from '@/utils/blockchain/errors';
 
+/** Resolve the exact sighash the signer will use for one PSBT input. */
+export function resolvePsbtSighashType(
+  explicitSighashType?: number,
+  embeddedSighashType?: number
+): number {
+  return explicitSighashType ?? embeddedSighashType ?? SigHash.ALL;
+}
+
 /**
  * Normalize PSBT string to hex format.
  *
@@ -384,9 +392,7 @@ export function signPSBT(
       // then fall back to the sighash embedded in the PSBT input, then default to ALL
       const input = tx.getInput(inputIdx);
       const requestedSighashType = sighashTypes?.[inputIdx];
-      const sighashType = requestedSighashType
-        ?? input.sighashType
-        ?? SigHash.ALL;
+      const sighashType = resolvePsbtSighashType(requestedSighashType, input.sighashType);
       if (requestedSighashType !== undefined) {
         tx.updateInput(inputIdx, { sighashType: requestedSighashType });
       }

--- a/src/utils/blockchain/bitcoin/psbt.ts
+++ b/src/utils/blockchain/bitcoin/psbt.ts
@@ -377,9 +377,13 @@ export function signPSBT(
       // Determine sighash: use the explicit sighashTypes param if provided,
       // then fall back to the sighash embedded in the PSBT input, then default to ALL
       const input = tx.getInput(inputIdx);
-      const sighashType = sighashTypes?.[inputIdx]
+      const requestedSighashType = sighashTypes?.[inputIdx];
+      const sighashType = requestedSighashType
         ?? input.sighashType
         ?? SigHash.ALL;
+      if (requestedSighashType !== undefined) {
+        tx.updateInput(inputIdx, { sighashType: requestedSighashType });
+      }
 
       try {
         tx.signIdx(privateKeyBytes, inputIdx, [sighashType]);

--- a/src/utils/blockchain/bitcoin/psbt.ts
+++ b/src/utils/blockchain/bitcoin/psbt.ts
@@ -8,7 +8,7 @@
 import { Transaction, p2wpkh, SigHash } from '@scure/btc-signer';
 import { hexToBytes, bytesToHex } from '@noble/hashes/utils.js';
 import { getPublicKey } from '@noble/secp256k1';
-import { AddressFormat, normalizeAddressForComparison } from '@/utils/blockchain/bitcoin/address';
+import { AddressFormat, decodeAddressFromScript, normalizeAddressForComparison } from '@/utils/blockchain/bitcoin/address';
 import { SigningError, ValidationError } from '@/utils/blockchain/errors';
 
 /**
@@ -111,7 +111,7 @@ export interface PsbtDetails {
   rawTxHex: string;
   inputs: DecodedInput[];
   outputs: DecodedOutput[];
-  /** Total input value (from witnessUtxo data in PSBT) */
+  /** Total input value from embedded witness or non-witness prevout data */
   totalInputValue: number;
   /** Total output value */
   totalOutputValue: number;
@@ -254,7 +254,12 @@ export function extractPsbtDetails(psbtHex: string): PsbtDetails {
     const input = tx.getInput(i);
     if (input?.txid) {
       const txidHex = bytesToHex(input.txid);
-      const value = input.witnessUtxo?.amount ? Number(input.witnessUtxo.amount) : undefined;
+      const prevout = input.witnessUtxo
+        ?? (input.index !== undefined ? input.nonWitnessUtxo?.outputs[input.index] : undefined);
+      const value = prevout?.amount !== undefined ? Number(prevout.amount) : undefined;
+      const address = prevout?.script
+        ? decodeAddressFromScript(bytesToHex(prevout.script)) ?? undefined
+        : undefined;
 
       if (value !== undefined) {
         totalInputValue += value;
@@ -264,6 +269,7 @@ export function extractPsbtDetails(psbtHex: string): PsbtDetails {
         index: i,
         txid: txidHex,
         vout: input.index ?? 0,
+        address,
         value,
         sighashType: input.sighashType,
       });
@@ -492,13 +498,18 @@ export function completePsbtWithInputValues(
 }
 
 /**
- * Validate signInputs parameter - ensure addresses belong to wallet
+ * Validate signInputs and bind each requested index to its actual prevout address
  */
 export function validateSignInputs(
   signInputs: Record<string, number[]>,
   walletAddresses: string[],
-  inputCount?: number
+  inputCount?: number,
+  inputAddresses?: Array<string | undefined>
 ): { valid: boolean; error?: string } {
+  if (Object.keys(signInputs).length === 0) {
+    return { valid: false, error: 'signInputs must identify at least one input' };
+  }
+
   const walletAddressSet = new Set(walletAddresses.map(normalizeAddressForComparison));
   const seenIndices = new Set<number>();
 
@@ -520,6 +531,12 @@ export function validateSignInputs(
       }
       if (seenIndices.has(index)) {
         return { valid: false, error: `Input index ${index} was requested more than once` };
+      }
+      if (inputAddresses) {
+        const inputAddress = inputAddresses[index];
+        if (!inputAddress || normalizeAddressForComparison(inputAddress) !== normalizeAddressForComparison(address)) {
+          return { valid: false, error: `Input index ${index} does not belong to address ${address}` };
+        }
       }
       seenIndices.add(index);
     }

--- a/src/utils/blockchain/counterparty/__tests__/transactionSafety.test.ts
+++ b/src/utils/blockchain/counterparty/__tests__/transactionSafety.test.ts
@@ -202,13 +202,24 @@ describe('suspicious output detection', () => {
     expect(result.warnings[0].message).toContain('2 addresses');
   });
 
-  it('should be case-insensitive when comparing signer address', () => {
+  it('should be case-insensitive when comparing Bech32 signer addresses', () => {
+    const signer = 'bc1qvux25709r4uw6rzc8wyl7wwecjdhrx085hm5ty';
+    const outputs = makeOutputs(
+      { value: 0, type: 'op_return' },
+      { value: 50000, address: signer.toUpperCase() },
+    );
+    const result = analyzeTransactionSafety('enhanced_send', outputs, signer);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('should preserve Base58 case sensitivity when comparing signer addresses', () => {
     const outputs = makeOutputs(
       { value: 0, type: 'op_return' },
       { value: 50000, address: SIGNER.toUpperCase() },
     );
-    const result = analyzeTransactionSafety('enhanced_send', outputs, SIGNER.toLowerCase());
-    expect(result.warnings).toHaveLength(0);
+    const result = analyzeTransactionSafety('enhanced_send', outputs, SIGNER);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].title).toContain('External Address');
   });
 
   it('should combine message type and output warnings', () => {

--- a/src/utils/blockchain/counterparty/transactionSafety.ts
+++ b/src/utils/blockchain/counterparty/transactionSafety.ts
@@ -91,7 +91,7 @@ const DUST_THRESHOLD = 546;
 export function analyzeTransactionSafety(
   messageType: string | undefined,
   outputs: AnalyzableOutput[],
-  signerAddress: string
+  signerAddress: string | string[]
 ): SafetyAnalysis {
   const warnings: SecurityWarning[] = [];
   let blocked = false;
@@ -127,7 +127,10 @@ export function analyzeTransactionSafety(
 
   // ── Check for suspicious outputs ──
 
-  const normalizedSigner = signerAddress.toLowerCase();
+  const normalizedSigners = new Set(
+    (Array.isArray(signerAddress) ? signerAddress : [signerAddress])
+      .map(address => address.toLowerCase())
+  );
   const suspiciousOutputs: Array<{ address: string; value: number }> = [];
 
   for (const output of outputs) {
@@ -135,7 +138,7 @@ export function analyzeTransactionSafety(
     if (output.type === 'op_return') continue;
 
     // Skip outputs back to the signer (change)
-    if (output.address && output.address.toLowerCase() === normalizedSigner) continue;
+    if (output.address && normalizedSigners.has(output.address.toLowerCase())) continue;
 
     // Skip dust outputs — normal for Counterparty (multisig encoding, dispenser triggers)
     if (output.value <= DUST_THRESHOLD) continue;

--- a/src/utils/blockchain/counterparty/transactionSafety.ts
+++ b/src/utils/blockchain/counterparty/transactionSafety.ts
@@ -6,6 +6,8 @@
  * that could indicate a malicious site trying to drain the wallet.
  */
 
+import { normalizeAddressForComparison } from '@/utils/blockchain/bitcoin/address';
+
 /** Severity of a security warning */
 export type WarningSeverity = 'block' | 'danger' | 'warning' | 'info';
 
@@ -129,7 +131,7 @@ export function analyzeTransactionSafety(
 
   const normalizedSigners = new Set(
     (Array.isArray(signerAddress) ? signerAddress : [signerAddress])
-      .map(address => address.toLowerCase())
+      .map(normalizeAddressForComparison)
   );
   const suspiciousOutputs: Array<{ address: string; value: number }> = [];
 
@@ -138,7 +140,7 @@ export function analyzeTransactionSafety(
     if (output.type === 'op_return') continue;
 
     // Skip outputs back to the signer (change)
-    if (output.address && normalizedSigners.has(output.address.toLowerCase())) continue;
+    if (output.address && normalizedSigners.has(normalizeAddressForComparison(output.address))) continue;
 
     // Skip dust outputs — normal for Counterparty (multisig encoding, dispenser triggers)
     if (output.value <= DUST_THRESHOLD) continue;

--- a/src/utils/provider/__tests__/requestIdentity.test.ts
+++ b/src/utils/provider/__tests__/requestIdentity.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getIdentityMismatchError } from '../requestIdentity';
+import { getIdentityMismatchError, getPsbtPermissionError } from '../requestIdentity';
 import type { AuthorizedRequest } from '@/utils/storage/requestStorage';
 
 const req = (over?: Partial<AuthorizedRequest>): AuthorizedRequest => ({
@@ -30,5 +30,43 @@ describe('getIdentityMismatchError', () => {
 
   it('ignores walletId when the request has none (back-compat)', () => {
     expect(getIdentityMismatchError(req({ walletId: '' }), 'bc1qauthorized', 'any-wallet')).toBeNull();
+  });
+});
+describe('getPsbtPermissionError', () => {
+  const permissions = (connected: boolean, paired: boolean) => ({
+    hasPermission: async () => connected,
+    hasPairedAddressPermission: async () => paired,
+  });
+
+  it('rejects a request after the site disconnects', async () => {
+    await expect(getPsbtPermissionError(
+      req(),
+      'bc1qauthorized',
+      permissions(false, true)
+    )).resolves.toMatch(/no longer connected/);
+  });
+
+  it('allows an active-address-only request without the paired grant', async () => {
+    await expect(getPsbtPermissionError(
+      { ...req(), signInputs: { bc1qauthorized: [0] } },
+      'bc1qauthorized',
+      permissions(true, false)
+    )).resolves.toBeNull();
+  });
+
+  it('rejects a paired request after its additional grant is revoked', async () => {
+    await expect(getPsbtPermissionError(
+      { ...req(), signInputs: { bc1qauthorized: [0], '1paired': [1] } },
+      'bc1qauthorized',
+      permissions(true, false)
+    )).resolves.toMatch(/Paired address access was revoked/);
+  });
+
+  it('allows a paired request while both grants remain active', async () => {
+    await expect(getPsbtPermissionError(
+      { ...req(), signInputs: { bc1qauthorized: [0], '1paired': [1] } },
+      'bc1qauthorized',
+      permissions(true, true)
+    )).resolves.toBeNull();
   });
 });

--- a/src/utils/provider/requestIdentity.ts
+++ b/src/utils/provider/requestIdentity.ts
@@ -1,3 +1,4 @@
+import { normalizeAddressForComparison } from '@/utils/blockchain/bitcoin/address';
 import type { AuthorizedRequest } from '@/utils/storage/requestStorage';
 
 /**
@@ -15,5 +16,37 @@ export function getIdentityMismatchError(
   if (addressChanged || walletChanged) {
     return 'The active address changed after this request was made. Switch back to the authorized address, or reconnect the site.';
   }
+  return null;
+}
+interface PsbtAuthorizationRequest extends AuthorizedRequest {
+  signInputs?: Record<string, number[]>;
+}
+
+interface ProviderPermissionReader {
+  hasPermission(origin: string): Promise<boolean>;
+  hasPairedAddressPermission(origin: string, walletId: string, address: string): Promise<boolean>;
+}
+
+/** Revalidate provider grants immediately before a stored PSBT request is signed. */
+export async function getPsbtPermissionError(
+  request: PsbtAuthorizationRequest,
+  activeAddress: string,
+  permissions: ProviderPermissionReader
+): Promise<string | null> {
+  if (!await permissions.hasPermission(request.origin)) {
+    return 'This site is no longer connected. Reconnect it before signing.';
+  }
+
+  const normalizedActiveAddress = normalizeAddressForComparison(activeAddress);
+  const usesPairedAddress = Object.keys(request.signInputs ?? {}).some(
+    address => normalizeAddressForComparison(address) !== normalizedActiveAddress
+  );
+  if (usesPairedAddress && (
+    !request.walletId ||
+    !await permissions.hasPairedAddressPermission(request.origin, request.walletId, request.address)
+  )) {
+    return 'Paired address access was revoked. Reconnect the site before signing.';
+  }
+
   return null;
 }

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -84,6 +84,13 @@ export interface AppSettings {
   /** Connected dApp websites */
   connectedWebsites: string[];
 
+  /** Optional provider capabilities, scoped to the connected wallet identity. */
+  providerCapabilities?: Record<string, {
+    pairedAddresses?: boolean;
+    walletId?: string;
+    address?: string;
+  }>;
+
   /** Allow unconfirmed transaction inputs */
   allowUnconfirmedTxs: boolean;
   /** Enable multi-peer multi-asset sends */
@@ -137,6 +144,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   defaultPoolSlippage: DEFAULT_POOL_SLIPPAGE,
   strictTransactionVerification: true,
   connectedWebsites: [],
+  providerCapabilities: {},
   pinnedAssets: ['XCP', 'PEPECASH', 'BITCRYSTALS', 'BITCORN', 'CROPS', 'MINTS'],
   hasVisitedRecoverBitcoin: false,
 };

--- a/src/utils/wallet/__tests__/addressDeriver.test.ts
+++ b/src/utils/wallet/__tests__/addressDeriver.test.ts
@@ -5,6 +5,7 @@ import {
   deriveMnemonicAddress,
   deriveAddressFromPrivateKey,
   deriveAddressesFromSecret,
+  getPairedAddressFormats,
 } from '../addressDeriver';
 import {
   getAddressFromMnemonic,
@@ -21,6 +22,21 @@ const MNEMONIC =
 const PRIV_HEX = '0000000000000000000000000000000000000000000000000000000000000001';
 
 describe('addressDeriver', () => {
+  describe('getPairedAddressFormats', () => {
+    it('pairs only supported Legacy and native SegWit formats', () => {
+      expect(getPairedAddressFormats(AddressFormat.Counterwallet)).toEqual({
+        legacy: AddressFormat.Counterwallet,
+        segwit: AddressFormat.CounterwalletSegwit,
+      });
+      expect(getPairedAddressFormats(AddressFormat.P2WPKH)).toEqual({
+        legacy: AddressFormat.P2PKH,
+        segwit: AddressFormat.P2WPKH,
+      });
+      expect(getPairedAddressFormats(AddressFormat.P2TR)).toBeNull();
+      expect(getPairedAddressFormats(AddressFormat.P2SH_P2WPKH)).toBeNull();
+    });
+  });
+
   describe('deriveMnemonicAddress', () => {
     it('derives the same address as getAddressFromMnemonic at the indexed path', () => {
       for (const format of [AddressFormat.P2WPKH, AddressFormat.P2PKH, AddressFormat.P2TR]) {

--- a/src/utils/wallet/__tests__/addressDeriver.test.ts
+++ b/src/utils/wallet/__tests__/addressDeriver.test.ts
@@ -24,14 +24,16 @@ const PRIV_HEX = '00000000000000000000000000000000000000000000000000000000000000
 describe('addressDeriver', () => {
   describe('getPairedAddressFormats', () => {
     it('pairs only supported Legacy and native SegWit formats', () => {
-      expect(getPairedAddressFormats(AddressFormat.Counterwallet)).toEqual({
-        legacy: AddressFormat.Counterwallet,
-        segwit: AddressFormat.CounterwalletSegwit,
-      });
-      expect(getPairedAddressFormats(AddressFormat.P2WPKH)).toEqual({
-        legacy: AddressFormat.P2PKH,
-        segwit: AddressFormat.P2WPKH,
-      });
+      const supportedPairs = [
+        [AddressFormat.Counterwallet, AddressFormat.CounterwalletSegwit],
+        [AddressFormat.FreewalletBIP39, AddressFormat.FreewalletBIP39Segwit],
+        [AddressFormat.P2PKH, AddressFormat.P2WPKH],
+      ] as const;
+
+      for (const [legacy, segwit] of supportedPairs) {
+        expect(getPairedAddressFormats(legacy)).toEqual({ legacy, segwit });
+        expect(getPairedAddressFormats(segwit)).toEqual({ legacy, segwit });
+      }
       expect(getPairedAddressFormats(AddressFormat.P2TR)).toBeNull();
       expect(getPairedAddressFormats(AddressFormat.P2SH_P2WPKH)).toBeNull();
     });

--- a/src/utils/wallet/__tests__/walletManager.test.ts
+++ b/src/utils/wallet/__tests__/walletManager.test.ts
@@ -32,6 +32,11 @@ vi.mock('@/utils/blockchain/bitcoin/privateKey');
 vi.mock('@/utils/blockchain/bitcoin/messageSigner');
 vi.mock('@/utils/blockchain/bitcoin/transactionSigner');
 vi.mock('@/utils/blockchain/bitcoin/transactionBroadcaster');
+vi.mock('@/utils/blockchain/bitcoin/psbt', () => ({
+  signPSBT: vi.fn().mockReturnValue('signed-psbt'),
+  extractPsbtDetails: vi.fn(),
+  completePsbtWithInputValues: vi.fn(),
+}));
 vi.mock('@/utils/blockchain/counterwallet');
 vi.mock('@noble/hashes/sha2.js');
 vi.mock('@noble/hashes/utils.js');
@@ -47,6 +52,7 @@ import { base64ToBuffer } from '@/utils/encryption/buffer';
 import { HDKey } from '@scure/bip32';
 import { mnemonicToSeedSync } from '@scure/bip39';
 import { bytesToHex } from '@noble/hashes/utils.js';
+import { signPSBT } from '@/utils/blockchain/bitcoin/psbt';
 
 describe('WalletManager', () => {
   let walletManager: WalletManager;
@@ -357,6 +363,36 @@ describe('WalletManager', () => {
     });
   });
 
+  describe('PSBT Signing', () => {
+    it('uses the active address for fallback signing when signInputs is omitted', async () => {
+      const wallet = createTestWallet({
+        addresses: [
+          { name: 'Address 1', address: 'bc1qfirst', path: "m/84'/0'/0'/0/0", pubKey: '02aa' },
+          { name: 'Address 2', address: 'bc1qactive', path: "m/84'/0'/0'/0/1", pubKey: '02bb' },
+        ],
+      });
+      walletManager['wallets'] = [wallet];
+      walletManager['activeWalletId'] = wallet.id;
+      vi.spyOn(walletManager, 'getSettings').mockReturnValue({ lastActiveAddress: 'bc1qactive' } as any);
+      const privateKeySpy = vi.spyOn(walletManager, 'getPrivateKey').mockResolvedValue({
+        hex: '11'.repeat(32),
+        wif: 'test-wif',
+        compressed: true,
+      });
+
+      const result = await walletManager.signPsbt('test-psbt');
+
+      expect(result).toBe('signed-psbt');
+      expect(privateKeySpy).toHaveBeenCalledWith(wallet.id, "m/84'/0'/0'/0/1");
+      expect(signPSBT).toHaveBeenCalledWith(
+        'test-psbt',
+        '11'.repeat(32),
+        [],
+        AddressFormat.P2WPKH,
+        undefined
+      );
+    });
+  });
   describe('Mnemonic Access', () => {
     it('should get unencrypted mnemonic for unlocked wallet', async () => {
       const wallet = createTestWallet({ type: 'mnemonic' });

--- a/src/utils/wallet/addressDeriver.ts
+++ b/src/utils/wallet/addressDeriver.ts
@@ -15,6 +15,25 @@ import {
 import { getAddressFromPrivateKey, getPublicKeyFromPrivateKey } from '@/utils/blockchain/bitcoin/privateKey';
 import type { Address, WalletRecord, HardwareWalletSecret } from '@/types/wallet';
 
+export function getPairedAddressFormats(addressFormat: AddressFormat): {
+  legacy: AddressFormat;
+  segwit: AddressFormat;
+} | null {
+  switch (addressFormat) {
+    case 'counterwallet':
+    case 'counterwallet-segwit':
+      return { legacy: 'counterwallet', segwit: 'counterwallet-segwit' };
+    case 'freewallet-bip39':
+    case 'freewallet-bip39-segwit':
+      return { legacy: 'freewallet-bip39', segwit: 'freewallet-bip39-segwit' };
+    case 'p2pkh':
+    case 'p2wpkh':
+      return { legacy: 'p2pkh', segwit: 'p2wpkh' };
+    default:
+      return null;
+  }
+}
+
 export async function generateWalletId(mnemonic: string, addressFormat: AddressFormat): Promise<string> {
   const seed = getSeedFromMnemonic(mnemonic, addressFormat);
   const derivationPath = getDerivationPathForAddressFormat(addressFormat);

--- a/src/utils/wallet/walletManager.ts
+++ b/src/utils/wallet/walletManager.ts
@@ -26,6 +26,7 @@ import {
   deriveMnemonicAddress,
   deriveAddressFromPrivateKey,
   deriveAddressesFromSecret,
+  getPairedAddressFormats,
 } from '@/utils/wallet/addressDeriver';
 import { KEYCHAIN_VERSION, encryptKeychainRecord, decryptKeychain } from '@/utils/wallet/keychainCrypto';
 import { DEFAULT_SETTINGS, getAutoLockTimeoutMs, setSettingsProvider, type AppSettings } from '@/utils/settings';
@@ -36,7 +37,7 @@ import { signPSBT as btcSignPSBT, extractPsbtDetails, completePsbtWithInputValue
 // loading @trezor/connect-webextension at extension startup (it auto-initializes)
 
 // Import types from centralized types module
-import type { Address, Wallet, Keychain, KeychainRecord, WalletRecord, HardwareWalletSecret, SignTransactionOptions } from '@/types/wallet';
+import type { Address, PairedAddresses, Wallet, Keychain, KeychainRecord, WalletRecord, HardwareWalletSecret, SignTransactionOptions } from '@/types/wallet';
 
 // Re-export types for backwards compatibility
 export type { Address, Wallet };
@@ -1139,6 +1140,28 @@ export class WalletManager {
     }
   }
 
+  public async getPairedAddresses(): Promise<PairedAddresses> {
+    if (!this.activeWalletId) throw new Error('No active wallet set');
+    const wallet = this.getWalletById(this.activeWalletId);
+    if (!wallet || wallet.type !== 'mnemonic') {
+      throw new Error('Paired addresses are available only for mnemonic wallets');
+    }
+    const formats = getPairedAddressFormats(wallet.addressFormat);
+    if (!formats) throw new Error('The active address format has no paired Legacy/SegWit format');
+    const activeAddress = wallet.addresses.find(
+      address => address.address === this.getSettings().lastActiveAddress
+    ) ?? wallet.addresses[0];
+    if (!activeAddress) throw new Error('No active address');
+    const index = Number(activeAddress.path.split('/').at(-1));
+    if (!Number.isSafeInteger(index) || index < 0) throw new Error('Invalid active derivation index');
+    const secret = await sessionManager.getUnlockedSecret(wallet.id);
+    if (!secret) throw new Error('Wallet is locked');
+    return {
+      legacy: { ...deriveMnemonicAddress(secret, formats.legacy, index), format: formats.legacy, type: 'p2pkh' },
+      segwit: { ...deriveMnemonicAddress(secret, formats.segwit, index), format: formats.segwit, type: 'p2wpkh' },
+    };
+  }
+
   /**
    * Get an initialized Trezor adapter for a hardware wallet.
    *
@@ -1357,18 +1380,29 @@ export class WalletManager {
     if (signInputs && Object.keys(signInputs).length > 0) {
       let signedPsbtHex = psbtHex;
 
+      const paired = wallet.type === 'mnemonic' && getPairedAddressFormats(wallet.addressFormat)
+        ? await this.getPairedAddresses()
+        : null;
       for (const [address, inputIndices] of Object.entries(signInputs)) {
-        const targetAddress = wallet.addresses.find(addr => addr.address === address);
+        const pairedTarget = paired
+          ? [paired.legacy, paired.segwit].find(addr => addr.address === address)
+          : undefined;
+        const targetAddress = wallet.addresses.find(addr => addr.address === address) ?? pairedTarget;
         if (!targetAddress) {
           throw new Error(`Address ${address} not found in wallet`);
         }
 
-        const privateKeyResult = await this.getPrivateKey(wallet.id, targetAddress.path);
+        const targetFormat = pairedTarget?.format ?? wallet.addressFormat;
+        const secret = await sessionManager.getUnlockedSecret(wallet.id);
+        if (!secret) throw new Error('Wallet is locked');
+        const privateKeyHex = targetFormat === wallet.addressFormat
+          ? (await this.getPrivateKey(wallet.id, targetAddress.path)).hex
+          : getPrivateKeyFromMnemonic(secret, targetAddress.path, targetFormat);
         signedPsbtHex = btcSignPSBT(
           signedPsbtHex,
-          privateKeyResult.hex,
+          privateKeyHex,
           inputIndices,
-          wallet.addressFormat,
+          targetFormat,
           sighashTypes
         );
       }

--- a/src/utils/wallet/walletManager.ts
+++ b/src/utils/wallet/walletManager.ts
@@ -778,7 +778,10 @@ export class WalletManager {
    */
   public getSettings(): AppSettings {
     if (!this.keychain) {
-      return { ...DEFAULT_SETTINGS };
+      return {
+        ...DEFAULT_SETTINGS,
+        providerCapabilities: { ...(DEFAULT_SETTINGS.providerCapabilities ?? {}) },
+      };
     }
     // DEFAULT_SETTINGS first backfills fields missing from keychains created
     // under an older schema; stored values override. Copy to prevent mutation.
@@ -786,6 +789,11 @@ export class WalletManager {
       ...DEFAULT_SETTINGS,
       ...this.keychain.settings,
       connectedWebsites: [...(this.keychain.settings.connectedWebsites || [])],
+      providerCapabilities: Object.fromEntries(
+        Object.entries(this.keychain.settings.providerCapabilities ?? {}).map(
+          ([origin, capability]) => [origin, { ...capability }]
+        )
+      ),
       pinnedAssets: [...(this.keychain.settings.pinnedAssets || [])],
     };
   }

--- a/src/utils/wallet/walletManager.ts
+++ b/src/utils/wallet/walletManager.ts
@@ -16,7 +16,7 @@ import {
   DEFAULT_PBKDF2_ITERATIONS,
 } from '@/utils/encryption/encryption';
 import { base64ToBuffer, generateRandomBytes, bufferToBase64 } from '@/utils/encryption/buffer';
-import { getAddressFromMnemonic, getDerivationPathForAddressFormat, AddressFormat, isCounterwalletFormat } from '@/utils/blockchain/bitcoin/address';
+import { getAddressFromMnemonic, getDerivationPathForAddressFormat, AddressFormat, isCounterwalletFormat, normalizeAddressForComparison } from '@/utils/blockchain/bitcoin/address';
 import { getPrivateKeyFromMnemonic, getAddressFromPrivateKey, getPublicKeyFromPrivateKey, decodeWIF, isWIF, encodeWIF } from '@/utils/blockchain/bitcoin/privateKey';
 import { signMessage } from '@/utils/blockchain/bitcoin/messageSigner';
 import { isValidCounterwalletMnemonic } from '@/utils/blockchain/counterwallet';
@@ -1384,10 +1384,15 @@ export class WalletManager {
         ? await this.getPairedAddresses()
         : null;
       for (const [address, inputIndices] of Object.entries(signInputs)) {
+        const normalizedAddress = normalizeAddressForComparison(address);
         const pairedTarget = paired
-          ? [paired.legacy, paired.segwit].find(addr => addr.address === address)
+          ? [paired.legacy, paired.segwit].find(
+              addr => normalizeAddressForComparison(addr.address) === normalizedAddress
+            )
           : undefined;
-        const targetAddress = wallet.addresses.find(addr => addr.address === address) ?? pairedTarget;
+        const targetAddress = wallet.addresses.find(
+          addr => normalizeAddressForComparison(addr.address) === normalizedAddress
+        ) ?? pairedTarget;
         if (!targetAddress) {
           throw new Error(`Address ${address} not found in wallet`);
         }

--- a/src/utils/wallet/walletManager.ts
+++ b/src/utils/wallet/walletManager.ts
@@ -1422,14 +1422,15 @@ export class WalletManager {
 
       return signedPsbtHex;
     } else {
-      // Sign all inputs using the first address in the wallet
-      // When no signInputs specified, try to sign all inputs with available keys
-      const firstAddress = wallet.addresses[0];
-      if (!firstAddress) {
+      // Preserve legacy best-effort signing, but only with the connected active address.
+      const activeAddress = wallet.addresses.find(
+        address => address.address === this.getSettings().lastActiveAddress
+      ) ?? wallet.addresses[0];
+      if (!activeAddress) {
         throw new Error("No addresses in wallet");
       }
 
-      const privateKeyResult = await this.getPrivateKey(wallet.id, firstAddress.path);
+      const privateKeyResult = await this.getPrivateKey(wallet.id, activeAddress.path);
       return btcSignPSBT(
         psbtHex,
         privateKeyResult.hex,


### PR DESCRIPTION
Closes #210.

## Summary
- add an explicit, unchecked-by-default `pairedAddresses` connection capability, bound to origin, wallet, and active address
- expose `xcp_getAddresses` with a stable active-only response and disclose the same-index Legacy/SegWit pair only after consent
- sign mixed P2PKH/P2WPKH PSBT inputs, including the requested `SIGHASH_SINGLE | ANYONECANPAY` flow
- show the exact paired addresses at consent time and signer/input/external-BTC details at signing time
- document the provider API and ADR-018 security boundary in `AUDIT.md`

## Security properties
- unrelated HD derivation indices are never authorized
- signer addresses and input indices are validated before approval storage
- duplicate/out-of-range inputs, unsupported sighashes, excess sighash entries, and invalid `SIGHASH_SINGLE` layouts fail closed
- Base58 comparisons remain case-sensitive; Bech32 comparisons are normalized
- disconnect removes the paired-address grant; connected-sites settings remain intentionally simple

## Verification
- real issue fixtures: Legacy+SegWit fee flow, marketplace ANYONECANPAY flow, and one Legacy+two SegWit flow
- focused provider, connection, consent UI, PSBT, transaction-safety, address derivation, wallet manager, settings, and provider-security tests
- `npm run compile`
- `npm run build`