### PR TITLE
Release 0.6.1: decode taproot-era Counterparty messages, fail closed on unknowns

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Dan Anderson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/e2e/pages/assets/[asset]/balance.spec.ts
+++ b/e2e/pages/assets/[asset]/balance.spec.ts
@@ -51,10 +51,10 @@ walletTest.describe('View Balance Page (/assets/:asset/balance)', () => {
     await expect(page.locator('text="Attach"').first()).not.toBeVisible();
   });
 
-  walletTest('does not show Destroy action for XCP', async ({ page }) => {
+  walletTest('shows Destroy action for XCP', async ({ page }) => {
     await navigateToBalance(page, 'XCP');
 
-    await expect(page.locator('text="Destroy"').first()).not.toBeVisible();
+    await expect(page.locator('text="Destroy"').first()).toBeVisible();
   });
 
   walletTest('shows Send action for BTC', async ({ page }) => {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "Counterparty Web3 Wallet",
   "private": true,
   "version": "0.6.1",
+  "license": "MIT",
   "type": "module",
   "engines": {
     "node": ">=24 <25",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "xcp-wallet",
   "description": "Counterparty Web3 Wallet",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "engines": {
     "node": ">=24 <25",

--- a/src/components/composer/composer.test.tsx
+++ b/src/components/composer/composer.test.tsx
@@ -303,15 +303,11 @@ describe('Composer', () => {
     );
 
     /**
-     * A raw transaction carrying an enhanced send whose memo is not the one requested. The payload
-     * is plaintext, which extraction accepts, so the test needs no ARC4 key.
+     * A raw transaction carrying the given Counterparty message (type id + body) in a plaintext
+     * OP_RETURN, which extraction accepts, so the tests need no ARC4 key.
      */
-    function composedSendWithMemo(memo: string): string {
-      const payload = new Uint8Array([
-        ...hexToBytes(COUNTERPARTY_PREFIX_HEX),
-        0x02,
-        ...encodeEnhancedSendCbor(1n, 100_000_000n, packAddress(DESTINATION), memo),
-      ]);
+    function rawTxCarrying(message: number[]): string {
+      const payload = new Uint8Array([...hexToBytes(COUNTERPARTY_PREFIX_HEX), ...message]);
 
       const tx = new Transaction({ allowUnknownOutputs: true, allowLegacyWitnessUtxo: true });
       tx.addInput({
@@ -322,6 +318,14 @@ describe('Composer', () => {
       tx.addOutput({ script: new Uint8Array([0x6a, payload.length, ...payload]), amount: 0n });
       tx.addOutputAddress('bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4', 98_000n);
       return bytesToHex(tx.unsignedTx);
+    }
+
+    /** A raw transaction carrying an enhanced send with the given memo. */
+    function composedSendWithMemo(memo: string): string {
+      return rawTxCarrying([
+        0x02,
+        ...encodeEnhancedSendCbor(1n, 100_000_000n, packAddress(DESTINATION), memo),
+      ]);
     }
 
     it('shows an informational difference on the review screen', async () => {
@@ -357,6 +361,31 @@ describe('Composer', () => {
       });
 
       renderWithProvider({ FormComponent: SendForm });
+      fireEvent.submit(screen.getByTestId('form-component'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('review-component')).toBeInTheDocument();
+      });
+      expect(
+        screen.queryByText(/Composed transaction differs from your request/i)
+      ).not.toBeInTheDocument();
+    });
+
+    it('claims no difference when the compose type has no field-level verifier', async () => {
+      // A broadcast has no field verifier: only its message type is confirmed. That absence of
+      // checking must not be announced as a detected difference — the banner is only credible on
+      // types with field verification if it stays silent here.
+      mockComposeApi.mockResolvedValue({
+        result: {
+          // Type id 30 (broadcast), CBOR [timestamp 0, value 1, fee_fraction 0, mime "", text ""]
+          rawtransaction: rawTxCarrying([0x1e, 0x85, 0x00, 0x01, 0x00, 0x60, 0x40]),
+          inputs_values: [100_000],
+          tx_hash: 'hash123',
+        },
+        error: null, id: 1, jsonrpc: '2.0',
+      });
+
+      renderWithProvider({ composeType: 'broadcast' });
       fireEvent.submit(screen.getByTestId('form-component'));
 
       await waitFor(() => {

--- a/src/components/composer/composer.test.tsx
+++ b/src/components/composer/composer.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import { MemoryRouter } from 'react-router';
 import type { ReactElement } from 'react';
+import { AddressFormat } from '@/utils/blockchain/bitcoin/address';
 
 // Mock webext-bridge before any imports that might use it
 vi.mock('webext-bridge/background', () => ({
@@ -33,7 +34,7 @@ vi.mock('@/utils/blockchain/bitcoin/feeRate', () => ({
   })
 }));
 
-const mockActiveWallet = { id: 'wallet1', name: 'Test Wallet' };
+const mockActiveWallet = { id: 'wallet1', name: 'Test Wallet', addressFormat: AddressFormat.P2WPKH };
 const mockActiveAddress = { address: 'bc1qtest123', name: 'Test Address' };
 const mockSignTransaction = vi.fn();
 const mockBroadcastTransaction = vi.fn();
@@ -108,6 +109,9 @@ describe('Composer', () => {
     result: {
       // A real, parseable BTC-only transaction so fee verification can decode it.
       rawtransaction: '020000000133997605bfe854fd8bdd784b47bd3b423488e64cc5fb5820e0f8d134670b0b670100000000ffffffff01b8730100000000001976a9145c333992ab554e7573df3d2a412df750a60d1f5b88ac00000000',
+      // Its single output is 95160 sats; fee verification needs the input value to
+      // compute the fee rather than resolve it over the network.
+      inputs_values: [96000],
       tx_hash: 'hash123',
       data: 'data123'
     },

--- a/src/components/composer/composer.test.tsx
+++ b/src/components/composer/composer.test.tsx
@@ -4,6 +4,38 @@ import '@testing-library/jest-dom/vitest';
 import { MemoryRouter } from 'react-router';
 import type { ReactElement } from 'react';
 import { AddressFormat } from '@/utils/blockchain/bitcoin/address';
+import { Transaction, p2wpkh } from '@scure/btc-signer';
+import { getPublicKey } from '@noble/secp256k1';
+import { hexToBytes, bytesToHex } from '@noble/hashes/utils.js';
+import { COUNTERPARTY_PREFIX_HEX } from '@/utils/blockchain/counterparty/unpack/messageTypes';
+import { packAddress } from '@/utils/blockchain/counterparty/unpack/address';
+
+/** Encode an enhanced send as counterparty-core does: CBOR [asset_id, quantity, address, memo]. */
+function encodeEnhancedSendCbor(
+  assetId: bigint,
+  quantity: bigint,
+  address: Uint8Array,
+  memo: string
+): number[] {
+  const uint = (major: number, value: bigint): number[] => {
+    const base = major << 5;
+    if (value < 24n) return [base | Number(value)];
+    if (value < 256n) return [base | 24, Number(value)];
+    if (value < 65536n) return [base | 25, Number(value >> 8n), Number(value & 0xffn)];
+    if (value < 4294967296n) {
+      return [base | 26, ...[24n, 16n, 8n, 0n].map((s) => Number((value >> s) & 0xffn))];
+    }
+    return [base | 27, ...[56n, 48n, 40n, 32n, 24n, 16n, 8n, 0n].map((s) => Number((value >> s) & 0xffn))];
+  };
+  const memoBytes = new TextEncoder().encode(memo);
+  return [
+    0x84,
+    ...uint(0, assetId),
+    ...uint(0, quantity),
+    ...uint(2, BigInt(address.length)), ...address,
+    ...uint(2, BigInt(memoBytes.length)), ...memoBytes,
+  ];
+}
 
 // Mock webext-bridge before any imports that might use it
 vi.mock('webext-bridge/background', () => ({
@@ -247,9 +279,92 @@ describe('Composer', () => {
     
     const signButton = screen.getByText('Sign');
     fireEvent.click(signButton);
-    
+
     await waitFor(() => {
       expect(mockSignTransaction).toHaveBeenCalled();
+    });
+  });
+
+  describe('differences between the request and the composed transaction', () => {
+    const DESTINATION = '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa';
+
+    /** A form submitting the fields a send is verified against. */
+    const SendForm = ({ formAction }: any): ReactElement => (
+      <form data-testid="form-component" onSubmit={(e) => {
+        e.preventDefault();
+        formAction(new FormData(e.currentTarget));
+      }}>
+        <input name="destination" defaultValue={DESTINATION} />
+        <input name="asset" defaultValue="XCP" />
+        <input name="quantity" defaultValue="1" />
+        <input name="memo" defaultValue="requested memo" />
+        <button type="submit">Compose</button>
+      </form>
+    );
+
+    /**
+     * A raw transaction carrying an enhanced send whose memo is not the one requested. The payload
+     * is plaintext, which extraction accepts, so the test needs no ARC4 key.
+     */
+    function composedSendWithMemo(memo: string): string {
+      const payload = new Uint8Array([
+        ...hexToBytes(COUNTERPARTY_PREFIX_HEX),
+        0x02,
+        ...encodeEnhancedSendCbor(1n, 100_000_000n, packAddress(DESTINATION), memo),
+      ]);
+
+      const tx = new Transaction({ allowUnknownOutputs: true, allowLegacyWitnessUtxo: true });
+      tx.addInput({
+        txid: hexToBytes('33'.repeat(32)),
+        index: 0,
+        witnessUtxo: { script: p2wpkh(getPublicKey(hexToBytes('11'.repeat(32)), true)).script, amount: 100_000n },
+      });
+      tx.addOutput({ script: new Uint8Array([0x6a, payload.length, ...payload]), amount: 0n });
+      tx.addOutputAddress('bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4', 98_000n);
+      return bytesToHex(tx.unsignedTx);
+    }
+
+    it('shows an informational difference on the review screen', async () => {
+      // A memo mismatch is informational: it does not block, and before this it went only to a
+      // console.warn that production builds strip.
+      mockComposeApi.mockResolvedValue({
+        result: {
+          rawtransaction: composedSendWithMemo('composed memo'),
+          inputs_values: [100_000],
+          tx_hash: 'hash123',
+        },
+        error: null, id: 1, jsonrpc: '2.0',
+      });
+
+      renderWithProvider({ FormComponent: SendForm });
+      fireEvent.submit(screen.getByTestId('form-component'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('review-component')).toBeInTheDocument();
+      });
+      expect(screen.getByText(/Composed transaction differs from your request/i)).toBeInTheDocument();
+      expect(screen.getByText(/memo/i)).toBeInTheDocument();
+    });
+
+    it('shows nothing when the composed transaction matches', async () => {
+      mockComposeApi.mockResolvedValue({
+        result: {
+          rawtransaction: composedSendWithMemo('requested memo'),
+          inputs_values: [100_000],
+          tx_hash: 'hash123',
+        },
+        error: null, id: 1, jsonrpc: '2.0',
+      });
+
+      renderWithProvider({ FormComponent: SendForm });
+      fireEvent.submit(screen.getByTestId('form-component'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('review-component')).toBeInTheDocument();
+      });
+      expect(
+        screen.queryByText(/Composed transaction differs from your request/i)
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/src/components/composer/composer.tsx
+++ b/src/components/composer/composer.tsx
@@ -202,8 +202,8 @@ function ComposerInner<T>({
                 description="These differences are not dangerous on their own, but review them before signing."
               >
                 <ul className="mt-1 list-disc pl-4 space-y-0.5">
-                  {state.verificationWarnings.map((warning) => (
-                    <li key={warning}>{warning}</li>
+                  {state.verificationWarnings.map((warning, index) => (
+                    <li key={`${index}-${warning}`}>{warning}</li>
                   ))}
                 </ul>
               </Banner>

--- a/src/components/composer/composer.tsx
+++ b/src/components/composer/composer.tsx
@@ -3,6 +3,7 @@ import { FiHelpCircle, FiX, FiRefreshCw } from "@/components/icons";
 import { useNavigate } from "react-router";
 import { SuccessScreen } from "@/components/screens/success-screen";
 import { Spinner } from "@/components/ui/spinner";
+import { Banner } from "@/components/ui/banner";
 import { ComposerProvider, useComposer } from "@/contexts/composer-context";
 import { useHeader } from "@/contexts/header-context";
 import type { ApiResponse } from "@/utils/blockchain/counterparty/compose";
@@ -192,13 +193,30 @@ function ComposerInner<T>({
       )}
 
       {state.step === "review" && state.apiResponse && (
-        <ReviewComponent
-          apiResponse={state.apiResponse}
-          onSign={signAndBroadcast}
-          onBack={goBack}
-          error={state.error}
-          isSigning={state.isSigning}
-        />
+        <>
+          {state.verificationWarnings.length > 0 && (
+            <div className="px-4 pt-4">
+              <Banner
+                severity="warning"
+                title="Composed transaction differs from your request"
+                description="These differences are not dangerous on their own, but review them before signing."
+              >
+                <ul className="mt-1 list-disc pl-4 space-y-0.5">
+                  {state.verificationWarnings.map((warning) => (
+                    <li key={warning}>{warning}</li>
+                  ))}
+                </ul>
+              </Banner>
+            </div>
+          )}
+          <ReviewComponent
+            apiResponse={state.apiResponse}
+            onSign={signAndBroadcast}
+            onBack={goBack}
+            error={state.error}
+            isSigning={state.isSigning}
+          />
+        </>
       )}
 
       {state.step === "success" && state.apiResponse && (

--- a/src/components/domain/approval/mixed-sighash.test.ts
+++ b/src/components/domain/approval/mixed-sighash.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Approval-screen accounting under mixed sighash arrays.
+ *
+ * `sighashTypes` is validated element-by-element, so a request may legally mix
+ * values. An input signed SIGHASH_ALL constrains only transactions that still
+ * contain it; whoever holds the PSBT can drop that input, discard its signature
+ * with it, and rebuild around a SINGLE|ANYONECANPAY input. Outputs the surviving
+ * signature does not cover are therefore redirectable and must be priced as at
+ * risk, not as change.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { committedOutputIndices } from '@/utils/blockchain/bitcoin/psbt';
+import { computeMoneyMovement } from './money-movement';
+
+const ALL = 0x01;
+const ALL_ACP = 0x81;
+const SINGLE_ACP = 0x83;
+
+const MINE = 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4';
+
+/**
+ * A marketplace-shaped request: a small input signed ALL, a large input signed
+ * SINGLE|ANYONECANPAY, and a large final output presented as change.
+ */
+function movementFor(sighashTypes: number[]) {
+  const committedOutputs = committedOutputIndices(
+    sighashTypes.map((type, index) => ({ index, sighashType: type })),
+    3
+  );
+
+  return {
+    committedOutputs,
+    movement: computeMoneyMovement({
+      inputs: [
+        { address: MINE, value: 1_000_000 },
+        { address: MINE, value: 100_000_000 },
+      ],
+      outputs: [
+        { address: MINE, value: 990_000 },
+        { address: MINE, value: 546 },
+        { address: MINE, value: 99_999_454 },
+      ],
+      myAddresses: [MINE],
+      fee: 10_000,
+      committedOutputs,
+    }),
+  };
+}
+
+describe('at-risk accounting with a mixed sighash array', () => {
+  it('prices outputs the surviving signature leaves free as at risk', () => {
+    const { committedOutputs, movement } = movementFor([ALL, SINGLE_ACP]);
+
+    // Only the output sharing the SINGLE input's index is covered.
+    expect(committedOutputs).toEqual(new Set([1]));
+    expect(movement.atRisk).toBe(990_000 + 99_999_454);
+    expect(movement.backToYou).toBe(546);
+  });
+
+  it('prices an ALL|ANYONECANPAY input the same way, since it can also be dropped', () => {
+    const { committedOutputs, movement } = movementFor([ALL_ACP, SINGLE_ACP]);
+
+    expect(committedOutputs).toEqual(new Set([1]));
+    expect(movement.atRisk).toBe(990_000 + 99_999_454);
+  });
+
+  it('guarantees nothing when two SINGLE|ANYONECANPAY inputs cover different outputs', () => {
+    const { committedOutputs, movement } = movementFor([SINGLE_ACP, SINGLE_ACP]);
+
+    // Keeping either input alone honours only that input's output, so neither is assured.
+    expect(committedOutputs).toEqual(new Set());
+    expect(movement.atRisk).toBe(990_000 + 546 + 99_999_454);
+    expect(movement.backToYou).toBe(0);
+  });
+
+  it('does not report less exposure once an ALL input is added', () => {
+    const { movement: mixed } = movementFor([ALL, SINGLE_ACP]);
+    const { movement: uniform } = movementFor([SINGLE_ACP, SINGLE_ACP]);
+
+    expect(mixed.atRisk).toBeLessThanOrEqual(uniform.atRisk);
+    expect(mixed.atRisk).toBeGreaterThan(0);
+  });
+
+  it('still treats a fully committed request as change, not risk', () => {
+    const { committedOutputs, movement } = movementFor([ALL, ALL]);
+
+    expect(committedOutputs).toBeNull();
+    expect(movement.atRisk).toBe(0);
+    expect(movement.backToYou).toBe(990_000 + 546 + 99_999_454);
+  });
+});

--- a/src/components/domain/approval/money-movement.test.ts
+++ b/src/components/domain/approval/money-movement.test.ts
@@ -11,6 +11,7 @@ describe('computeMoneyMovement', () => {
         { address: 'me', value: 5000 }, // change
       ],
       fee: 5000,
+      committedOutputs: null,
     });
     expect(m).toMatchObject({ spent: 100000, backToYou: 5000, net: -95000, incomplete: false });
     expect(m.external).toEqual([{ address: 'them', value: 90000 }]);
@@ -25,6 +26,7 @@ describe('computeMoneyMovement', () => {
         { address: 'them', value: 39000 },
       ],
       fee: 1000,
+      committedOutputs: null,
     });
     expect(m).toMatchObject({ spent: 0, backToYou: 60000, net: 60000, incomplete: false });
   });
@@ -38,6 +40,7 @@ describe('computeMoneyMovement', () => {
         { value: 0, type: 'op_return' },
       ],
       fee: 10000,
+      committedOutputs: null,
     });
     expect(m.external).toEqual([{ address: 'them', value: 40000 }]);
   });
@@ -48,6 +51,7 @@ describe('computeMoneyMovement', () => {
       inputs: [{ address: 'me', value: 50000 }],
       outputs: [{ value: 40000 }],
       fee: 10000,
+      committedOutputs: null,
     });
     expect(m.external).toEqual([{ address: null, value: 40000 }]);
   });
@@ -58,6 +62,7 @@ describe('computeMoneyMovement', () => {
       inputs: [{ address: 'me' }], // no value
       outputs: [{ address: 'them', value: 10000 }],
       fee: 1000,
+      committedOutputs: null,
     }).incomplete).toBe(true);
 
     expect(computeMoneyMovement({
@@ -65,6 +70,7 @@ describe('computeMoneyMovement', () => {
       inputs: [{ value: 100000 }], // no address
       outputs: [{ address: 'them', value: 90000 }],
       fee: 10000,
+      committedOutputs: null,
     }).incomplete).toBe(true);
   });
 
@@ -74,6 +80,7 @@ describe('computeMoneyMovement', () => {
       inputs: [{ address: 'me', value: 100000 }],
       outputs: [{ address: 'them', value: 90000 }, { address: 'me', value: 5000 }],
       fee: 5000,
+      committedOutputs: null,
     });
     expect(m.atRisk).toBe(0);
     expect(m.backToYou).toBe(5000);
@@ -128,6 +135,7 @@ describe('computeMoneyMovement', () => {
       inputs: [{ address: 'bc1qme', value: 100000 }],
       outputs: [{ address: 'bc1qthem', value: 95000 }],
       fee: 5000,
+      committedOutputs: null,
     });
     expect(m.spent).toBe(100000);
     expect(m.net).toBe(-100000);

--- a/src/components/domain/approval/money-movement.ts
+++ b/src/components/domain/approval/money-movement.ts
@@ -58,10 +58,12 @@ export function computeMoneyMovement(params: {
   /** Network fee in sats. */
   fee: number;
   /**
-   * Output indices the signature commits to (see `committedOutputIndices`); omit when every output
-   * is committed. An uncommitted output back to you is reported as at-risk, not counted as change.
+   * Output indices the signature commits to (see `committedOutputIndices`), or `null` when every
+   * output is committed. An uncommitted output back to you is reported as at-risk rather than
+   * counted as change. Required, since `null` is the permissive value and must be chosen
+   * deliberately.
    */
-  committedOutputs?: Set<number> | null;
+  committedOutputs: Set<number> | null;
 }): MoneyMovement {
   const mine = new Set(params.myAddresses.map(normalizeAddressForComparison));
   const isMine = (address?: string) =>

--- a/src/components/ui/menus/balance-menu.test.tsx
+++ b/src/components/ui/menus/balance-menu.test.tsx
@@ -148,55 +148,21 @@ describe('BalanceMenu', () => {
     expect(mockOnClick).not.toHaveBeenCalled();
   });
 
-  it('offers Destroy for a Counterparty asset', async () => {
-    render(
-      <MemoryRouter>
-        <BalanceMenu asset="RAREPEPE" />
-      </MemoryRouter>
-    );
+  it.each(['RAREPEPE', 'XCP', 'BTC'])(
+    'keeps Destroy out of the quick-actions menu for %s',
+    async (asset) => {
+      // Destroying is irreversible, so it belongs on the balance page rather than
+      // one tap away in the list.
+      render(
+        <MemoryRouter>
+          <BalanceMenu asset={asset} />
+        </MemoryRouter>
+      );
 
-    openMenu();
+      openMenu();
 
-    fireEvent.click(await screen.findByText('Destroy'));
-    expect(mockNavigate).toHaveBeenCalledWith('/compose/issuance/destroy/RAREPEPE');
-  });
-
-  it('offers Destroy for XCP', async () => {
-    render(
-      <MemoryRouter>
-        <BalanceMenu asset="XCP" />
-      </MemoryRouter>
-    );
-
-    openMenu();
-
-    fireEvent.click(await screen.findByText('Destroy'));
-    expect(mockNavigate).toHaveBeenCalledWith('/compose/issuance/destroy/XCP');
-  });
-
-  it('does not offer Destroy for BTC, which is not a Counterparty asset', async () => {
-    render(
-      <MemoryRouter>
-        <BalanceMenu asset="BTC" />
-      </MemoryRouter>
-    );
-
-    openMenu();
-
-    await waitFor(() => expect(screen.getByText('Send')).toBeInTheDocument());
-    expect(screen.queryByText('Destroy')).not.toBeInTheDocument();
-  });
-
-  it('encodes an asset longname in the destroy route', async () => {
-    render(
-      <MemoryRouter>
-        <BalanceMenu asset="A95428956661682177.SUB" />
-      </MemoryRouter>
-    );
-
-    openMenu();
-
-    fireEvent.click(await screen.findByText('Destroy'));
-    expect(mockNavigate).toHaveBeenCalledWith('/compose/issuance/destroy/A95428956661682177.SUB');
-  });
+      await waitFor(() => expect(screen.getByText('Send')).toBeInTheDocument());
+      expect(screen.queryByText('Destroy')).not.toBeInTheDocument();
+    }
+  );
 });

--- a/src/components/ui/menus/balance-menu.tsx
+++ b/src/components/ui/menus/balance-menu.tsx
@@ -1,6 +1,6 @@
 import { useCallback, type ReactElement } from 'react';
 import { useNavigate } from 'react-router';
-import { BsThreeDots, FaBitcoin, FaCoins, FaExchangeAlt, FaPaperPlane, FaTrash } from '@/components/icons';
+import { BsThreeDots, FaBitcoin, FaCoins, FaExchangeAlt, FaPaperPlane } from '@/components/icons';
 import { MenuItem } from '@headlessui/react';
 import { BaseMenu } from './base-menu';
 import { Button } from '@/components/ui/button';
@@ -12,8 +12,10 @@ interface BalanceMenuProps {
 /**
  * Provides quick actions for token balances based on asset type:
  * - BTC: Send, Swap, Mint
- * - XCP: Send, Swap, Mint, Destroy
- * - Other assets: Send, Sell, Swap, Destroy
+ * - XCP: Send, Swap, Mint
+ * - Other assets: Send, Sell, Swap
+ *
+ * Destructive actions belong on the balance page, not in this list.
  */
 export function BalanceMenu({ asset }: BalanceMenuProps): ReactElement {
   const navigate = useNavigate();
@@ -35,10 +37,6 @@ export function BalanceMenu({ asset }: BalanceMenuProps): ReactElement {
 
   const handleSell = useCallback(() => {
     navigate(`/compose/dispenser/${encodedAsset}`);
-  }, [encodedAsset, navigate]);
-
-  const handleDestroy = useCallback(() => {
-    navigate(`/compose/issuance/destroy/${encodedAsset}`);
   }, [encodedAsset, navigate]);
 
   return (
@@ -78,15 +76,6 @@ export function BalanceMenu({ asset }: BalanceMenuProps): ReactElement {
         </MenuItem>
       )}
 
-      {/* Destroy burns a Counterparty asset; BTC is not one. Last, and the only destructive entry. */}
-      {!isBTC && (
-        <MenuItem>
-          <Button variant="menu-item" fullWidth onClick={handleDestroy}>
-            <FaTrash className="mr-3 size-4 text-danger-600" aria-hidden="true" />
-            Destroy
-          </Button>
-        </MenuItem>
-      )}
     </BaseMenu>
   );
 }

--- a/src/contexts/__tests__/composer-context.test.tsx
+++ b/src/contexts/__tests__/composer-context.test.tsx
@@ -3,6 +3,7 @@ import { renderHook, act, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import { ComposerProvider, useComposer } from '../composer-context';
 import type { ApiResponse } from '@/utils/blockchain/counterparty/compose';
+import { AddressFormat } from '@/utils/blockchain/bitcoin/address';
 
 // A real, parseable BTC-only transaction (1 input, one 95000-sat P2PKH output,
 // no OP_RETURN) so the composer's fee verification can decode it. Paired with
@@ -16,7 +17,7 @@ const VALID_BTC_ONLY_TX =
 vi.mock('@/contexts/wallet-context', () => ({
   useWallet: () => ({
     activeAddress: { address: 'test-address' },
-    activeWallet: { id: 'test-wallet' },
+    activeWallet: { id: 'test-wallet', addressFormat: AddressFormat.P2WPKH },
     authState: 'UNLOCKED',
     keychainLocked: false,
   }),

--- a/src/contexts/composer-context.tsx
+++ b/src/contexts/composer-context.tsx
@@ -54,7 +54,8 @@ import { useHeader } from "@/contexts/header-context";
 import { getComposeType, normalizeFormData } from "@/utils/blockchain/counterparty/normalize";
 import type { ApiResponse } from "@/utils/blockchain/counterparty/compose";
 import { checkReplayAttempt, recordTransaction } from "@/utils/security/replayPrevention";
-import { verifyTransaction, extractOpReturnData } from "@/utils/blockchain/counterparty/unpack/verify";
+import { verifyTransaction } from "@/utils/blockchain/counterparty/unpack/verify";
+import { extractCounterpartyPayload } from "@/utils/blockchain/counterparty/unpack/opReturn";
 import { checkTransactionFee } from "@/utils/blockchain/bitcoin/feeVerification";
 import { fetchInputValues } from "@/utils/blockchain/counterparty/transaction";
 import { isSegwitFormat } from "@/utils/blockchain/bitcoin/address";
@@ -93,6 +94,24 @@ interface ComposerState<T> {
   composedAt: number | null;
   /** Current fee rate in sat/vB (null = use network default, set once user interacts or FeeRateInput initializes) */
   feeRate: number | null;
+}
+
+/**
+ * A fresh composer state — the single definition every reset path uses. A function rather than a
+ * constant so each reset gets its own `verificationWarnings` array.
+ */
+function freshComposerState<T>(): ComposerState<T> {
+  return {
+    step: "form",
+    formData: null,
+    apiResponse: null,
+    error: null,
+    verificationWarnings: [],
+    isComposing: false,
+    isSigning: false,
+    composedAt: null,
+    feeRate: null,
+  };
 }
 
 /**
@@ -193,17 +212,7 @@ export function ComposerProvider<T>({
   const abortControllerRef = useRef<AbortController | null>(null);
 
   // Initialize state
-  const [state, setState] = useState<ComposerState<T>>({
-    step: "form",
-    formData: null,
-    apiResponse: null,
-    error: null,
-    verificationWarnings: [],
-    isComposing: false,
-    isSigning: false,
-    composedAt: null,
-    feeRate: null,
-  });
+  const [state, setState] = useState<ComposerState<T>>(freshComposerState);
 
 
   // Help text state (can be toggled locally)
@@ -226,17 +235,7 @@ export function ComposerProvider<T>({
       previousAddressRef.current &&
       activeAddress.address !== previousAddressRef.current
     ) {
-      setState({
-        step: "form",
-        formData: null,
-        apiResponse: null,
-        error: null,
-        verificationWarnings: [],
-        isComposing: false,
-        isSigning: false,
-        composedAt: null,
-        feeRate: null,
-      });
+      setState(freshComposerState<T>());
     }
     previousAddressRef.current = activeAddress?.address;
   }, [activeAddress?.address]);
@@ -251,17 +250,7 @@ export function ComposerProvider<T>({
                             (authState === "LOCKED" || previousAuthStateRef.current === "LOCKED");
 
     if (walletChanged || lockStateChanged) {
-      setState({
-        step: "form",
-        formData: null,
-        apiResponse: null,
-        error: null,
-        verificationWarnings: [],
-        isComposing: false,
-        isSigning: false,
-        composedAt: null,
-        feeRate: null,
-      });
+      setState(freshComposerState<T>());
     }
 
     previousWalletRef.current = activeWallet?.id;
@@ -333,11 +322,11 @@ export function ComposerProvider<T>({
 
       // Verify the transaction locally before showing review screen
       // This protects against a compromised API returning malicious transactions
-      const opReturnData = extractOpReturnData(response.result.rawtransaction);
+      const counterpartyData = extractCounterpartyPayload(response.result.rawtransaction);
       let verificationWarnings: string[] = [];
-      if (opReturnData) {
+      if (counterpartyData) {
         // Verify the composed transaction matches what we requested
-        const verification = verifyTransaction(opReturnData, composeType, dataForApi);
+        const verification = verifyTransaction(counterpartyData, composeType, dataForApi);
 
         if (!verification.valid) {
           // In strict mode (default), block the transaction
@@ -349,8 +338,8 @@ export function ComposerProvider<T>({
         // Differences too minor to block, shown on the review screen so the user can still see them.
         verificationWarnings = verification.warnings;
       }
-      // Note: If no OP_RETURN data found, this might be a non-Counterparty transaction
-      // which is allowed through (e.g., BTC-only transactions)
+      // Note: If no Counterparty payload was found, this might be a non-Counterparty
+      // transaction, which is allowed through (e.g., BTC-only transactions)
 
       // Independently bound the fee for every transaction type (including
       // BTC-only sends with no OP_RETURN), so a drain-to-fee response or a
@@ -568,17 +557,7 @@ export function ComposerProvider<T>({
 
   // Navigation actions
   const reset = useCallback(() => {
-    setState({
-      step: "form",
-      formData: null,
-      apiResponse: null,
-      error: null,
-      verificationWarnings: [],
-      isComposing: false,
-      isSigning: false,
-      composedAt: null,
-      feeRate: null,
-    });
+    setState(freshComposerState<T>());
     currentComposeTypeRef.current = composeType;
   }, [composeType]);
 

--- a/src/contexts/composer-context.tsx
+++ b/src/contexts/composer-context.tsx
@@ -56,6 +56,7 @@ import type { ApiResponse } from "@/utils/blockchain/counterparty/compose";
 import { checkReplayAttempt, recordTransaction } from "@/utils/security/replayPrevention";
 import { verifyTransaction, extractOpReturnData } from "@/utils/blockchain/counterparty/unpack/verify";
 import { checkTransactionFee } from "@/utils/blockchain/bitcoin/feeVerification";
+import { isSegwitFormat } from "@/utils/blockchain/bitcoin/address";
 import { analytics, getBtcBucket, classifyTransactionError } from "@/utils/fathom";
 
 /**
@@ -345,10 +346,14 @@ export function ComposerProvider<T>({
       // Independently bound the fee for every transaction type (including
       // BTC-only sends with no OP_RETURN), so a drain-to-fee response or a
       // buggy fee estimate is rejected before the review screen.
-      const feeCheck = checkTransactionFee({
+      const feeCheck = await checkTransactionFee({
         rawTransaction: response.result.rawtransaction,
         inputsValues: response.result.inputs_values,
-        declaredFee: response.result.btc_fee ?? 0,
+        // A SegWit signature commits to the amount it spends, so the response's input values
+        // cannot be understated without invalidating it. A legacy one commits to no amount.
+        signaturesCommitToInputValues: activeWallet
+          ? isSegwitFormat(activeWallet.addressFormat)
+          : false,
         // sat_per_vbyte arrives as a form string; checkTransactionFee coerces it.
         userFeeRate: dataForApi.sat_per_vbyte ?? null,
       });

--- a/src/contexts/composer-context.tsx
+++ b/src/contexts/composer-context.tsx
@@ -56,6 +56,7 @@ import type { ApiResponse } from "@/utils/blockchain/counterparty/compose";
 import { checkReplayAttempt, recordTransaction } from "@/utils/security/replayPrevention";
 import { verifyTransaction, extractOpReturnData } from "@/utils/blockchain/counterparty/unpack/verify";
 import { checkTransactionFee } from "@/utils/blockchain/bitcoin/feeVerification";
+import { fetchInputValues } from "@/utils/blockchain/counterparty/transaction";
 import { isSegwitFormat } from "@/utils/blockchain/bitcoin/address";
 import { analytics, getBtcBucket, classifyTransactionError } from "@/utils/fathom";
 
@@ -78,6 +79,12 @@ interface ComposerState<T> {
   apiResponse: ApiResponse | null;
   /** Error message to display */
   error: string | null;
+  /**
+   * Non-blocking differences between what was requested and what the API composed. Carried in
+   * state rather than logged: console output is stripped from production builds, so a logged
+   * warning reaches no user.
+   */
+  verificationWarnings: string[];
   /** True while calling compose API */
   isComposing: boolean;
   /** True while signing/broadcasting */
@@ -191,6 +198,7 @@ export function ComposerProvider<T>({
     formData: null,
     apiResponse: null,
     error: null,
+    verificationWarnings: [],
     isComposing: false,
     isSigning: false,
     composedAt: null,
@@ -223,6 +231,7 @@ export function ComposerProvider<T>({
         formData: null,
         apiResponse: null,
         error: null,
+        verificationWarnings: [],
         isComposing: false,
         isSigning: false,
         composedAt: null,
@@ -247,6 +256,7 @@ export function ComposerProvider<T>({
         formData: null,
         apiResponse: null,
         error: null,
+        verificationWarnings: [],
         isComposing: false,
         isSigning: false,
         composedAt: null,
@@ -324,6 +334,7 @@ export function ComposerProvider<T>({
       // Verify the transaction locally before showing review screen
       // This protects against a compromised API returning malicious transactions
       const opReturnData = extractOpReturnData(response.result.rawtransaction);
+      let verificationWarnings: string[] = [];
       if (opReturnData) {
         // Verify the composed transaction matches what we requested
         const verification = verifyTransaction(opReturnData, composeType, dataForApi);
@@ -335,10 +346,8 @@ export function ComposerProvider<T>({
           throw new Error(`Transaction verification failed: ${errorDetails}`);
         }
 
-        // Log any warnings (but don't block)
-        if (verification.warnings.length > 0) {
-          console.warn('Transaction verification warnings:', verification.warnings);
-        }
+        // Differences too minor to block, shown on the review screen so the user can still see them.
+        verificationWarnings = verification.warnings;
       }
       // Note: If no OP_RETURN data found, this might be a non-Counterparty transaction
       // which is allowed through (e.g., BTC-only transactions)
@@ -356,7 +365,7 @@ export function ComposerProvider<T>({
           : false,
         // sat_per_vbyte arrives as a form string; checkTransactionFee coerces it.
         userFeeRate: dataForApi.sat_per_vbyte ?? null,
-      });
+      }, fetchInputValues);
       if (!feeCheck.ok) {
         throw new Error(feeCheck.error || 'Transaction fee verification failed');
       }
@@ -374,6 +383,7 @@ export function ComposerProvider<T>({
         formData: userData,
         apiResponse: response,
         error: null,
+        verificationWarnings,
         isComposing: false,
         composedAt: Date.now(),
       }));
@@ -563,6 +573,7 @@ export function ComposerProvider<T>({
       formData: null,
       apiResponse: null,
       error: null,
+      verificationWarnings: [],
       isComposing: false,
       isSigning: false,
       composedAt: null,
@@ -579,6 +590,7 @@ export function ComposerProvider<T>({
         step: "form",
         apiResponse: null,
         error: null,
+        verificationWarnings: [],
       }));
     } else if (state.step === "success") {
       reset();

--- a/src/hooks/useSignPsbtRequest.ts
+++ b/src/hooks/useSignPsbtRequest.ts
@@ -20,8 +20,7 @@ import {
   decodeCounterpartyMessage,
   type CounterpartyMessage
 } from '@/utils/blockchain/counterparty/transaction';
-import { decryptOpReturnData } from '@/utils/blockchain/counterparty/unpack/opReturn';
-import { extractMultisigPayload } from '@/utils/blockchain/counterparty/unpack/multisig';
+import { extractPayloadFromOutputs } from '@/utils/blockchain/counterparty/unpack/opReturn';
 import {
   verifyProviderTransaction,
   type ProviderVerificationResult
@@ -92,25 +91,12 @@ export function useSignPsbtRequest(signerAddress?: string) {
     let txid: string | undefined;
     let decryptedDataHex: string | undefined;
 
+    // Resolve any Counterparty payload the outputs carry — plaintext or ARC4 OP_RETURN, or
+    // bare-multisig data outputs, which produce no OP_RETURN at all. Classifying every encoding
+    // here is what lets the sweep block apply regardless of how the message is carried.
     const firstInputTxid = psbtDetails.inputs[0]?.txid;
-
-    // ARC4 decrypt OP_RETURN data using the first input's txid as key
-    if (psbtDetails.hasOpReturn && psbtDetails.inputs.length > 0 && psbtDetails.inputs[0]!.txid) {
-      for (const output of psbtDetails.outputs) {
-        if (output.type === 'op_return' && output.script) {
-          const decrypted = decryptOpReturnData(output.script, psbtDetails.inputs[0]!.txid);
-          if (decrypted) {
-            decryptedDataHex = decrypted;
-            break;
-          }
-        }
-      }
-    }
-
-    // Counterparty also carries messages in bare-multisig outputs, which produce no OP_RETURN.
-    // Classifying them here is what lets the sweep block apply regardless of encoding.
-    if (!decryptedDataHex && firstInputTxid) {
-      decryptedDataHex = extractMultisigPayload(
+    if (firstInputTxid) {
+      decryptedDataHex = extractPayloadFromOutputs(
         psbtDetails.outputs.map((output) => output.script ?? ''),
         firstInputTxid
       ) ?? undefined;

--- a/src/hooks/useSignPsbtRequest.ts
+++ b/src/hooks/useSignPsbtRequest.ts
@@ -1,10 +1,10 @@
-/**
+﻿/**
  * Hook to handle PSBT signing requests from provider/dApps
  *
  * This hook centralizes the logic for:
  * - Loading PSBT request data from storage
  * - Decoding PSBT details (inputs, outputs, fee)
- * - ARC4 decryption of OP_RETURN data for Counterparty detection
+ * - Counterparty payload extraction (plaintext/ARC4 OP_RETURN, bare multisig)
  * - Safety analysis (block sweeps, warn on suspicious outputs)
  * - Handling success/cancel callbacks
  * - Cleaning up storage
@@ -89,23 +89,23 @@ export function useSignPsbtRequest(signerAddress?: string) {
 
     let counterpartyMessage: CounterpartyMessage | undefined;
     let txid: string | undefined;
-    let decryptedDataHex: string | undefined;
+    let counterpartyDataHex: string | undefined;
 
     // Resolve any Counterparty payload the outputs carry — plaintext or ARC4 OP_RETURN, or
     // bare-multisig data outputs, which produce no OP_RETURN at all. Classifying every encoding
     // here is what lets the sweep block apply regardless of how the message is carried.
     const firstInputTxid = psbtDetails.inputs[0]?.txid;
     if (firstInputTxid) {
-      decryptedDataHex = extractPayloadFromOutputs(
+      counterpartyDataHex = extractPayloadFromOutputs(
         psbtDetails.outputs.map((output) => output.script ?? ''),
         firstInputTxid
       ) ?? undefined;
     }
 
-    // If we decrypted Counterparty data, try API unpack for rich message info
-    if (decryptedDataHex) {
+    // If the outputs carried Counterparty data, try API unpack for rich message info
+    if (counterpartyDataHex) {
       try {
-        const msg = await decodeCounterpartyMessage(decryptedDataHex);
+        const msg = await decodeCounterpartyMessage(counterpartyDataHex);
         if (msg) {
           counterpartyMessage = msg;
         }
@@ -133,7 +133,7 @@ export function useSignPsbtRequest(signerAddress?: string) {
     }
 
     // Verify locally (compares local binary unpack against API result)
-    const verification = verifyProviderTransaction(decryptedDataHex, counterpartyMessage);
+    const verification = verifyProviderTransaction(counterpartyDataHex, counterpartyMessage);
 
     // Analyze for security risks (dangerous types, suspicious outputs)
     const messageType = counterpartyMessage?.messageType

--- a/src/hooks/useSignPsbtRequest.ts
+++ b/src/hooks/useSignPsbtRequest.ts
@@ -21,6 +21,7 @@ import {
   type CounterpartyMessage
 } from '@/utils/blockchain/counterparty/transaction';
 import { decryptOpReturnData } from '@/utils/blockchain/counterparty/unpack/opReturn';
+import { extractMultisigPayload } from '@/utils/blockchain/counterparty/unpack/multisig';
 import {
   verifyProviderTransaction,
   type ProviderVerificationResult
@@ -91,6 +92,8 @@ export function useSignPsbtRequest(signerAddress?: string) {
     let txid: string | undefined;
     let decryptedDataHex: string | undefined;
 
+    const firstInputTxid = psbtDetails.inputs[0]?.txid;
+
     // ARC4 decrypt OP_RETURN data using the first input's txid as key
     if (psbtDetails.hasOpReturn && psbtDetails.inputs.length > 0 && psbtDetails.inputs[0]!.txid) {
       for (const output of psbtDetails.outputs) {
@@ -102,6 +105,15 @@ export function useSignPsbtRequest(signerAddress?: string) {
           }
         }
       }
+    }
+
+    // Counterparty also carries messages in bare-multisig outputs, which produce no OP_RETURN.
+    // Classifying them here is what lets the sweep block apply regardless of encoding.
+    if (!decryptedDataHex && firstInputTxid) {
+      decryptedDataHex = extractMultisigPayload(
+        psbtDetails.outputs.map((output) => output.script ?? ''),
+        firstInputTxid
+      ) ?? undefined;
     }
 
     // If we decrypted Counterparty data, try API unpack for rich message info

--- a/src/hooks/useSignTransactionRequest.ts
+++ b/src/hooks/useSignTransactionRequest.ts
@@ -19,8 +19,7 @@ import {
   fetchInputValues,
   type CounterpartyMessage
 } from '@/utils/blockchain/counterparty/transaction';
-import { decryptOpReturnData } from '@/utils/blockchain/counterparty/unpack/opReturn';
-import { extractMultisigPayload } from '@/utils/blockchain/counterparty/unpack/multisig';
+import { extractPayloadFromOutputs } from '@/utils/blockchain/counterparty/unpack/opReturn';
 import {
   verifyProviderTransaction,
   type ProviderVerificationResult
@@ -147,24 +146,11 @@ export function useSignTransactionRequest(signerAddress?: string) {
     let counterpartyMessage: CounterpartyMessage | undefined;
     let decryptedDataHex: string | undefined;
 
-    // Counterparty encrypts OP_RETURN data with ARC4 using the first input's txid.
-    // Decrypt to get the CNTRPRTY-prefixed datahex for local verification and API decode.
-    if (hasOpReturn && inputs.length > 0 && inputs[0]!.txid) {
-      for (const output of outputs) {
-        if (output.opReturnData) {
-          const decrypted = decryptOpReturnData(output.opReturnData, inputs[0]!.txid);
-          if (decrypted) {
-            decryptedDataHex = decrypted;
-            break;
-          }
-        }
-      }
-    }
-
-    // Counterparty also carries messages in bare-multisig outputs, which produce no OP_RETURN.
-    // Classifying them here is what lets the sweep block apply regardless of encoding.
-    if (!decryptedDataHex && inputs.length > 0 && inputs[0]!.txid) {
-      decryptedDataHex = extractMultisigPayload(
+    // Resolve any Counterparty payload the outputs carry — plaintext or ARC4 OP_RETURN, or
+    // bare-multisig data outputs, which produce no OP_RETURN at all. Classifying every encoding
+    // here is what lets the sweep block apply regardless of how the message is carried.
+    if (inputs.length > 0 && inputs[0]!.txid) {
+      decryptedDataHex = extractPayloadFromOutputs(
         decoded.vout.map((vout: any) => vout.scriptPubKey?.hex ?? ''),
         inputs[0]!.txid
       ) ?? undefined;

--- a/src/hooks/useSignTransactionRequest.ts
+++ b/src/hooks/useSignTransactionRequest.ts
@@ -20,6 +20,7 @@ import {
   type CounterpartyMessage
 } from '@/utils/blockchain/counterparty/transaction';
 import { decryptOpReturnData } from '@/utils/blockchain/counterparty/unpack/opReturn';
+import { extractMultisigPayload } from '@/utils/blockchain/counterparty/unpack/multisig';
 import {
   verifyProviderTransaction,
   type ProviderVerificationResult
@@ -158,6 +159,15 @@ export function useSignTransactionRequest(signerAddress?: string) {
           }
         }
       }
+    }
+
+    // Counterparty also carries messages in bare-multisig outputs, which produce no OP_RETURN.
+    // Classifying them here is what lets the sweep block apply regardless of encoding.
+    if (!decryptedDataHex && inputs.length > 0 && inputs[0]!.txid) {
+      decryptedDataHex = extractMultisigPayload(
+        decoded.vout.map((vout: any) => vout.scriptPubKey?.hex ?? ''),
+        inputs[0]!.txid
+      ) ?? undefined;
     }
 
     // If we decrypted Counterparty data, try API unpack for rich message info

--- a/src/hooks/useSignTransactionRequest.ts
+++ b/src/hooks/useSignTransactionRequest.ts
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * Hook to handle raw transaction signing requests from provider/dApps
  *
  * This hook centralizes the logic for:
@@ -144,22 +144,22 @@ export function useSignTransactionRequest(signerAddress?: string) {
     const hasOpReturn = outputs.some(o => o.type === 'op_return');
 
     let counterpartyMessage: CounterpartyMessage | undefined;
-    let decryptedDataHex: string | undefined;
+    let counterpartyDataHex: string | undefined;
 
     // Resolve any Counterparty payload the outputs carry — plaintext or ARC4 OP_RETURN, or
     // bare-multisig data outputs, which produce no OP_RETURN at all. Classifying every encoding
     // here is what lets the sweep block apply regardless of how the message is carried.
     if (inputs.length > 0 && inputs[0]!.txid) {
-      decryptedDataHex = extractPayloadFromOutputs(
+      counterpartyDataHex = extractPayloadFromOutputs(
         decoded.vout.map((vout: any) => vout.scriptPubKey?.hex ?? ''),
         inputs[0]!.txid
       ) ?? undefined;
     }
 
-    // If we decrypted Counterparty data, try API unpack for rich message info
-    if (decryptedDataHex) {
+    // If the outputs carried Counterparty data, try API unpack for rich message info
+    if (counterpartyDataHex) {
       try {
-        const msg = await decodeCounterpartyMessage(decryptedDataHex);
+        const msg = await decodeCounterpartyMessage(counterpartyDataHex);
         if (msg) {
           counterpartyMessage = msg;
         }
@@ -169,7 +169,7 @@ export function useSignTransactionRequest(signerAddress?: string) {
     }
 
     // Verify locally (compares local binary unpack against API result)
-    const verification = verifyProviderTransaction(decryptedDataHex, counterpartyMessage);
+    const verification = verifyProviderTransaction(counterpartyDataHex, counterpartyMessage);
 
     // Analyze for security risks (dangerous types, suspicious outputs)
     const messageType = counterpartyMessage?.messageType

--- a/src/pages/assets/[asset]/balance.tsx
+++ b/src/pages/assets/[asset]/balance.tsx
@@ -89,6 +89,14 @@ export default function AssetBalancePage(): ReactElement {
       onClick: () => navigate(`${PATHS.COMPOSE}/dispenser/${encodedAsset}`),
     };
 
+    // Destroy burns the asset irreversibly; BTC is not a Counterparty asset, so it has none.
+    const destroyAction = {
+      id: "destroy",
+      title: "Destroy",
+      description: "Permanently burn this asset",
+      onClick: () => navigate(`${PATHS.COMPOSE}/issuance/destroy/${encodedAsset}`),
+    };
+
     const items = isBTC
       ? [
           sendAction,
@@ -108,8 +116,8 @@ export default function AssetBalancePage(): ReactElement {
           },
         ]
       : isXCP
-      ? [sendAction, swapAction, mintAction]
-      : [sendAction, sellAction, swapAction];
+      ? [sendAction, swapAction, mintAction, destroyAction]
+      : [sendAction, sellAction, swapAction, destroyAction];
     if (lpPool) {
       return [
         {

--- a/src/pages/requests/psbt/approve.tsx
+++ b/src/pages/requests/psbt/approve.tsx
@@ -139,10 +139,13 @@ export default function ApprovePsbtPage() {
       ),
     })
   );
+  // Without signInputs the signer works best-effort across every input with the active address's
+  // key, so an input whose prevout address cannot be decoded may still be signed. Those count as
+  // ours here, so their sighash reaches the at-risk calculation below.
   const requestedInputIndices = request.signInputs
     ? Object.values(request.signInputs).flat()
     : psbtDetails.inputs
-        .filter(input => input.address && normalizeAddressForComparison(input.address)
+        .filter(input => !input.address || normalizeAddressForComparison(input.address)
           === normalizeAddressForComparison(activeAddress.address))
         .map(input => input.index);
   const { withAssets: signedInputsWithAssets, unknownStatus: signedInputsUnknownStatus } =

--- a/src/pages/requests/transaction/approve.tsx
+++ b/src/pages/requests/transaction/approve.tsx
@@ -213,6 +213,8 @@ export default function ApproveTransactionPage() {
     outputs: decodedInfo.outputs,
     myAddresses: [activeAddress.address],
     fee: decodedInfo.fee,
+    // A raw transaction is signed SIGHASH_ALL throughout, so every output is committed.
+    committedOutputs: null,
   });
 
   const warningItems: WarningItem[] = safetyWarnings.map((warning, idx) => ({

--- a/src/utils/blockchain/bitcoin/__tests__/feeVerification.test.ts
+++ b/src/utils/blockchain/bitcoin/__tests__/feeVerification.test.ts
@@ -1,32 +1,43 @@
-import { describe, it, expect } from 'vitest';
-import { checkTransactionFee } from '../feeVerification';
+import { describe, it, expect, vi } from 'vitest';
+import { checkTransactionFee, type InputValueResolver } from '../feeVerification';
 
 // A real composed order: 1 input, an OP_RETURN output (0 sats) and a change
 // output of 0x60bf = 24767 sats. Input value chosen so the miner fee is modest.
 const RAW_TX = '020000000133997605bfe854fd8bdd784b47bd3b423488e64cc5fb5820e0f8d134670b0b670100000000ffffffff020000000000000000356a3380ada95da1b59fdc5a4ed690798435687c8f9060f0318d3f63009c00fe09da18780b4b57f245152a77e0b5ed88b3511ad1c5cfbf600000000000001976a9145c333992ab554e7573df3d2a412df750a60d1f5b88ac00000000';
 const OUTPUT_TOTAL = 24767; // 0 (OP_RETURN) + 24767 (change)
 
+/** A resolver that answers with a fixed value for whichever inputs it is asked about. */
+function resolverReturning(value: number): InputValueResolver {
+  const resolver: InputValueResolver = async (inputs) =>
+    new Map(inputs.map(({ txid, vout }) => [`${txid}:${vout}`, value]));
+  return vi.fn(resolver);
+}
+
+/** A resolver standing in for an explorer lookup that fails. */
+const failingResolver: InputValueResolver = vi.fn(async () => new Map());
+
 describe('checkTransactionFee', () => {
-  it('accepts a normal fee', () => {
-    // input = outputs + 2000 sat fee
-    const result = checkTransactionFee({
+  it('accepts a normal fee', async () => {
+    const result = await checkTransactionFee({
       rawTransaction: RAW_TX,
+      signaturesCommitToInputValues: true,
       inputsValues: [OUTPUT_TOTAL + 2000],
-      declaredFee: 2000,
       userFeeRate: 10,
-    });
+    }, failingResolver);
+
     expect(result.ok).toBe(true);
     expect(result.computedFee).toBe(2000);
   });
 
-  it('rejects a drain-to-fee transaction (implied rate absurd)', () => {
+  it('rejects a drain-to-fee transaction (implied rate absurd)', async () => {
     // Whole 1 BTC input, tiny outputs -> the rest is fee
-    const result = checkTransactionFee({
+    const result = await checkTransactionFee({
       rawTransaction: RAW_TX,
+      signaturesCommitToInputValues: true,
       inputsValues: [100_000_000],
-      declaredFee: 100_000_000 - OUTPUT_TOTAL,
       userFeeRate: 10,
-    });
+    }, failingResolver);
+
     expect(result.ok).toBe(false);
     expect(result.error).toMatch(/abnormally high|far exceeds/i);
   });
@@ -34,68 +45,161 @@ describe('checkTransactionFee', () => {
   it('coerces a string user rate (the form value) and still bounds the fee', () => {
     // Regression: the composer passes sat_per_vbyte as a form string. A numeric
     // typeof guard would silently disable this bound.
-    const result = checkTransactionFee({
+    return expect(checkTransactionFee({
       rawTransaction: RAW_TX,
+      signaturesCommitToInputValues: true,
       inputsValues: [OUTPUT_TOTAL + 150_000],
-      declaredFee: 150_000,
       userFeeRate: '10',
+    }, failingResolver)).resolves.toMatchObject({
+      ok: false,
+      error: expect.stringMatching(/exceeds your selected rate/i),
     });
-    expect(result.ok).toBe(false);
-    expect(result.error).toMatch(/exceeds your selected rate/i);
   });
 
-  it('rejects a fee far above the user-selected rate', () => {
+  it('rejects a fee far above the user-selected rate', async () => {
     // ~150k sat fee on a ~185 vbyte tx is ~800 sat/vB — under the absolute cap
     // but ~80x the user's 10 sat/vB selection.
-    const result = checkTransactionFee({
+    const result = await checkTransactionFee({
       rawTransaction: RAW_TX,
+      signaturesCommitToInputValues: true,
       inputsValues: [OUTPUT_TOTAL + 150_000],
-      declaredFee: 150_000,
       userFeeRate: 10,
-    });
+    }, failingResolver);
+
     expect(result.ok).toBe(false);
     expect(result.error).toMatch(/exceeds your selected rate/i);
   });
 
-  it('rejects outputs exceeding inputs', () => {
-    const result = checkTransactionFee({
+  it('rejects outputs exceeding inputs', async () => {
+    const result = await checkTransactionFee({
       rawTransaction: RAW_TX,
+      signaturesCommitToInputValues: true,
       inputsValues: [OUTPUT_TOTAL - 1],
-      declaredFee: 0,
       userFeeRate: 10,
-    });
+    }, failingResolver);
+
     expect(result.ok).toBe(false);
     expect(result.error).toMatch(/exceed inputs/i);
   });
 
-  it('falls back to the declared fee when input values are unavailable', () => {
-    const result = checkTransactionFee({
+  it('allows a modest fee when no user rate is set', async () => {
+    const result = await checkTransactionFee({
       rawTransaction: RAW_TX,
-      inputsValues: undefined,
-      declaredFee: 2000,
-      userFeeRate: 10,
-    });
+      signaturesCommitToInputValues: true,
+      inputsValues: [OUTPUT_TOTAL + 3000],
+      userFeeRate: null,
+    }, failingResolver);
+
     expect(result.ok).toBe(true);
-    expect(result.computedFee).toBeUndefined();
+  });
+});
+
+describe('input values the compose response did not supply', () => {
+  it('resolves them independently rather than trusting the response', async () => {
+    const resolve = resolverReturning(OUTPUT_TOTAL + 2000);
+    const result = await checkTransactionFee({
+      rawTransaction: RAW_TX,
+      signaturesCommitToInputValues: true,
+      inputsValues: undefined,
+      userFeeRate: 10,
+    }, resolve);
+
+    expect(resolve).toHaveBeenCalled();
+    expect(result.ok).toBe(true);
+    expect(result.computedFee).toBe(2000);
   });
 
-  it('bounds an absurd declared fee even without a user rate', () => {
-    const result = checkTransactionFee({
+  it('catches a drain the response tried to hide by omitting input values', async () => {
+    // The response declares a small fee and supplies no input values; the real
+    // input is a whole bitcoin, nearly all of which would go to the miner.
+    const result = await checkTransactionFee({
       rawTransaction: RAW_TX,
+      signaturesCommitToInputValues: true,
       inputsValues: undefined,
-      declaredFee: 5_000_000,
-      userFeeRate: null,
-    });
+      userFeeRate: 10,
+    }, resolverReturning(100_000_000));
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/abnormally high|far exceeds/i);
+  });
+
+  it('ignores an input-value list that does not cover every input', async () => {
+    // A length mismatch makes the hint unusable; the values must be resolved.
+    const resolve = resolverReturning(100_000_000);
+    const result = await checkTransactionFee({
+      rawTransaction: RAW_TX,
+      signaturesCommitToInputValues: true,
+      inputsValues: [OUTPUT_TOTAL + 2000, 12345],
+      userFeeRate: 10,
+    }, resolve);
+
+    expect(resolve).toHaveBeenCalled();
     expect(result.ok).toBe(false);
   });
 
-  it('allows a modest fee when no user rate is set', () => {
-    const result = checkTransactionFee({
+  it('refuses the transaction when the fee cannot be established', async () => {
+    const result = await checkTransactionFee({
       rawTransaction: RAW_TX,
-      inputsValues: [OUTPUT_TOTAL + 3000],
-      declaredFee: 3000,
-      userFeeRate: null,
-    });
+      signaturesCommitToInputValues: true,
+      inputsValues: undefined,
+      userFeeRate: 10,
+    }, failingResolver);
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/could not establish/i);
+  });
+
+  it('refuses when the resolver throws', async () => {
+    const result = await checkTransactionFee({
+      rawTransaction: RAW_TX,
+      signaturesCommitToInputValues: true,
+      inputsValues: undefined,
+      userFeeRate: 10,
+    }, async () => { throw new Error('network down'); });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/could not establish/i);
+  });
+});
+
+describe('legacy inputs, whose signatures commit to no amount', () => {
+  it('catches an understated input value the signature would not contradict', async () => {
+    // A legacy signature is valid whatever the prevout is worth, so a response can claim a small
+    // input, show a small fee, and still have the real UTXO drained to the miner.
+    const resolve = resolverReturning(100_000_000);
+    const result = await checkTransactionFee({
+      rawTransaction: RAW_TX,
+      signaturesCommitToInputValues: false,
+      inputsValues: [OUTPUT_TOTAL + 2000],
+      userFeeRate: 10,
+    }, resolve);
+
+    expect(resolve).toHaveBeenCalled();
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/abnormally high|far exceeds/i);
+  });
+
+  it('accepts a legacy transaction whose resolved fee is sane', async () => {
+    const result = await checkTransactionFee({
+      rawTransaction: RAW_TX,
+      signaturesCommitToInputValues: false,
+      inputsValues: [OUTPUT_TOTAL + 2000],
+      userFeeRate: 10,
+    }, resolverReturning(OUTPUT_TOTAL + 2000));
+
     expect(result.ok).toBe(true);
+    expect(result.computedFee).toBe(2000);
+  });
+
+  it('refuses a legacy transaction when the values cannot be resolved', async () => {
+    const result = await checkTransactionFee({
+      rawTransaction: RAW_TX,
+      signaturesCommitToInputValues: false,
+      inputsValues: [OUTPUT_TOTAL + 2000],
+      userFeeRate: 10,
+    }, failingResolver);
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/could not establish/i);
   });
 });

--- a/src/utils/blockchain/bitcoin/__tests__/psbt.test.ts
+++ b/src/utils/blockchain/bitcoin/__tests__/psbt.test.ts
@@ -870,12 +870,14 @@ describe('committedOutputIndices', () => {
     expect(committed).toEqual(new Set([0]));
   });
 
-  it('commits to each signed index when several inputs use SINGLE', () => {
+  it('guarantees nothing when two SINGLE inputs cover different outputs', () => {
+    // Either input can be kept while the other is dropped, so neither output is assured: keeping
+    // only input 2 leaves output 0 free, and vice versa.
     const committed = committedOutputIndices(
       [{ index: 0, sighashType: SINGLE_ACP }, { index: 2, sighashType: SINGLE_ACP }],
       4
     );
-    expect(committed).toEqual(new Set([0, 2]));
+    expect(committed).toEqual(new Set());
   });
 
   it('ignores a SINGLE input with no output at its index', () => {
@@ -887,13 +889,58 @@ describe('committedOutputIndices', () => {
     expect(committedOutputIndices([{ index: 0, sighashType: NONE }], 3)).toEqual(new Set());
   });
 
-  it('lets one SIGHASH_ALL input pin the whole output set', () => {
-
+  it('does not let a SIGHASH_ALL input pin outputs a detachable input leaves free', () => {
+    // The ALL signature only constrains transactions containing its own input. Dropping that
+    // input discards the signature with it, leaving the SINGLE|ANYONECANPAY input to be lifted
+    // into a transaction where only the output at its index is covered.
     const committed = committedOutputIndices(
       [{ index: 0, sighashType: SINGLE_ACP }, { index: 1, sighashType: ALL }],
       4
     );
-    expect(committed).toBeNull();
+    expect(committed).toEqual(new Set([0]));
+  });
+
+  it('does not let a SIGHASH_ALL input pin outputs when it is signed first', () => {
+    // The verdict must not depend on the order inputs appear in.
+    const committed = committedOutputIndices(
+      [{ index: 0, sighashType: ALL }, { index: 1, sighashType: SINGLE_ACP }],
+      3
+    );
+    expect(committed).toEqual(new Set([1]));
+  });
+
+  it('does not let an ALL|ANYONECANPAY input pin outputs a SINGLE input leaves free', () => {
+    // ALL|ANYONECANPAY covers every output but can itself be dropped, so it cannot vouch for
+    // outputs that the cheaper SINGLE signature leaves open.
+    const committed = committedOutputIndices(
+      [{ index: 0, sighashType: ALL_ACP }, { index: 1, sighashType: SINGLE_ACP }],
+      3
+    );
+    expect(committed).toEqual(new Set([1]));
+  });
+
+  it('guarantees nothing when a detachable SINGLE input has no output at its index', () => {
+    // That signature covers no output at all, so keeping only it leaves every output free.
+    const committed = committedOutputIndices(
+      [{ index: 0, sighashType: ALL_ACP }, { index: 3, sighashType: SINGLE_ACP }],
+      3
+    );
+    expect(committed).toEqual(new Set());
+  });
+
+  it('keeps the whole set pinned when every input commits to all outputs', () => {
+    expect(
+      committedOutputIndices(
+        [{ index: 0, sighashType: ALL }, { index: 1, sighashType: ALL }],
+        3
+      )
+    ).toBeNull();
+    expect(
+      committedOutputIndices(
+        [{ index: 0, sighashType: ALL_ACP }, { index: 1, sighashType: ALL_ACP }],
+        3
+      )
+    ).toBeNull();
   });
 });
 

--- a/src/utils/blockchain/bitcoin/feeVerification.ts
+++ b/src/utils/blockchain/bitcoin/feeVerification.ts
@@ -1,18 +1,21 @@
 /**
  * Independent fee sanity check for composed transactions.
  *
- * The compose API returns the raw transaction plus its own fee figure. This
- * recomputes the real miner fee locally (inputs minus outputs) and bounds it
- * against the fee rate the user actually chose (which the API cannot influence)
- * and an absolute ceiling. A transaction that drains the balance to fees, or a
- * buggy fee estimate, is rejected before signing.
+ * The miner fee is recomputed locally as inputs minus outputs, then bounded against the fee rate
+ * the user chose (which the API cannot influence) and an absolute ceiling, so a response that
+ * drains the balance to fees is rejected before signing.
  *
- * SegWit input amounts are committed to by the signature (BIP143), so a lying
- * API cannot both understate an input value here and produce a valid signature.
+ * The API's own fee figure is never the subject of the check, and its input values are trusted
+ * only where a signature will bind them. A SegWit signature commits to the amount it spends
+ * (BIP143), so an understated value cannot also produce a valid signature. A legacy signature
+ * commits to no amount at all, so those values are resolved from block explorers instead —
+ * signing fetches the same prevouts for legacy inputs regardless, so this costs no availability
+ * that signing did not already require. A fee that cannot be established is refused.
  */
 
 import { Transaction } from '@scure/btc-signer';
-import { hexToBytes } from '@noble/hashes/utils.js';
+import { hexToBytes, bytesToHex } from '@noble/hashes/utils.js';
+import { fetchInputValues } from '@/utils/blockchain/counterparty/transaction';
 
 /** A fee rate above this (sat/vByte) is treated as never legitimate. */
 export const MAX_SANE_FEE_RATE = 5000;
@@ -23,10 +26,16 @@ const MIN_BOUND_SATS = 10_000;
 
 export interface FeeCheckInput {
   rawTransaction: string;
-  /** Per-input values in sats (from the compose response). */
+  /**
+   * Per-input values in sats, as hinted by the compose response. Used only for SegWit inputs,
+   * whose signatures commit to the amount, and only when there is one value per input.
+   */
   inputsValues?: number[];
-  /** Fee the API claims, in sats. */
-  declaredFee: number;
+  /**
+   * Whether the spending signatures will commit to the input amounts. False for legacy
+   * (P2PKH-family) wallets, whose values must be resolved independently.
+   */
+  signaturesCommitToInputValues: boolean;
   /**
    * User-selected fee rate in sat/vByte, or null for network default. Accepts
    * a string because it arrives from a form field; coerced internally so a
@@ -38,9 +47,14 @@ export interface FeeCheckInput {
 export interface FeeCheckResult {
   ok: boolean;
   error?: string;
-  /** The miner fee actually implied by inputs minus outputs, when computable. */
+  /** The miner fee implied by inputs minus outputs. */
   computedFee?: number;
 }
+
+/** Resolves "txid:vout" → satoshi value for inputs the compose response did not cover. */
+export type InputValueResolver = (
+  inputs: Array<{ txid: string; vout: number }>
+) => Promise<Map<string, number>>;
 
 /**
  * Rough signed vsize: the (unsigned) serialized size plus a signature
@@ -53,8 +67,54 @@ function estimateVsize(tx: Transaction, rawBytesLength: number): number {
   return rawBytesLength + tx.inputsLength * perInputSignatureAllowance;
 }
 
-export function checkTransactionFee(input: FeeCheckInput): FeeCheckResult {
-  const { rawTransaction, inputsValues, declaredFee, userFeeRate } = input;
+/** Total input value in sats, from the compose hint or resolved independently. */
+async function resolveInputsTotal(
+  tx: Transaction,
+  inputsValues: number[] | undefined,
+  signaturesCommitToInputValues: boolean,
+  resolveInputValues: InputValueResolver
+): Promise<bigint | null> {
+  // A hint is usable when a signature will bind it and it covers every input with a whole
+  // number of sats.
+  if (
+    signaturesCommitToInputValues
+    && inputsValues
+    && inputsValues.length === tx.inputsLength
+    && inputsValues.every((value) => Number.isSafeInteger(value) && value >= 0)
+  ) {
+    return inputsValues.reduce((sum, value) => sum + BigInt(value), 0n);
+  }
+
+  const outpoints: Array<{ txid: string; vout: number }> = [];
+  for (let i = 0; i < tx.inputsLength; i++) {
+    const txInput = tx.getInput(i);
+    if (!txInput?.txid) return null;
+    outpoints.push({ txid: bytesToHex(txInput.txid), vout: txInput.index ?? 0 });
+  }
+  if (outpoints.length === 0) return null;
+
+  let resolved: Map<string, number>;
+  try {
+    resolved = await resolveInputValues(outpoints);
+  } catch {
+    return null;
+  }
+
+  let total = 0n;
+  for (const { txid, vout } of outpoints) {
+    const value = resolved.get(`${txid}:${vout}`);
+    // A partial answer cannot bound the fee; treat it as unresolved.
+    if (value === undefined) return null;
+    total += BigInt(value);
+  }
+  return total;
+}
+
+export async function checkTransactionFee(
+  input: FeeCheckInput,
+  resolveInputValues: InputValueResolver = fetchInputValues
+): Promise<FeeCheckResult> {
+  const { rawTransaction, inputsValues, signaturesCommitToInputValues, userFeeRate } = input;
 
   let tx: Transaction;
   let rawBytes: Uint8Array;
@@ -73,31 +133,37 @@ export function checkTransactionFee(input: FeeCheckInput): FeeCheckResult {
     return { ok: true };
   }
 
-  // Prefer the fee implied by inputs minus outputs; fall back to the declared fee
-  // when input values are unavailable.
-  let effectiveFee = declaredFee;
-  let computedFee: number | undefined;
-  if (inputsValues && inputsValues.length === tx.inputsLength) {
-    let outputsTotal = 0n;
-    for (let i = 0; i < tx.outputsLength; i++) {
-      outputsTotal += tx.getOutput(i)?.amount ?? 0n;
-    }
-    const inputsTotal = inputsValues.reduce((sum, value) => sum + BigInt(value), 0n);
-    const fee = inputsTotal - outputsTotal;
-    if (fee < 0n) {
-      return { ok: false, error: 'Transaction outputs exceed inputs — refusing to sign.' };
-    }
-    computedFee = Number(fee);
-    effectiveFee = computedFee;
+  const inputsTotal = await resolveInputsTotal(
+    tx,
+    inputsValues,
+    signaturesCommitToInputValues,
+    resolveInputValues
+  );
+  if (inputsTotal === null) {
+    return {
+      ok: false,
+      error: 'Could not establish this transaction\'s fee from the inputs it spends, so it was not '
+        + 'accepted. Check your connection and try again.',
+    };
   }
 
+  let outputsTotal = 0n;
+  for (let i = 0; i < tx.outputsLength; i++) {
+    outputsTotal += tx.getOutput(i)?.amount ?? 0n;
+  }
+  const fee = inputsTotal - outputsTotal;
+  if (fee < 0n) {
+    return { ok: false, error: 'Transaction outputs exceed inputs — refusing to sign.' };
+  }
+  const computedFee = Number(fee);
+
   const vsize = Math.max(1, estimateVsize(tx, rawBytes.length));
-  const impliedRate = effectiveFee / vsize;
+  const impliedRate = computedFee / vsize;
 
   if (impliedRate > MAX_SANE_FEE_RATE) {
     return {
       ok: false,
-      error: `Transaction fee (${effectiveFee} sats, ~${Math.round(impliedRate)} sat/vB) is abnormally high and was blocked.`,
+      error: `Transaction fee (${computedFee} sats, ~${Math.round(impliedRate)} sat/vB) is abnormally high and was blocked.`,
       computedFee,
     };
   }
@@ -105,10 +171,10 @@ export function checkTransactionFee(input: FeeCheckInput): FeeCheckResult {
   const rate = typeof userFeeRate === 'string' ? Number(userFeeRate) : userFeeRate;
   if (rate && Number.isFinite(rate) && rate > 0) {
     const bound = Math.max(MIN_BOUND_SATS, Math.ceil(rate * vsize * USER_FEE_RATE_TOLERANCE));
-    if (effectiveFee > bound) {
+    if (computedFee > bound) {
       return {
         ok: false,
-        error: `Transaction fee (${effectiveFee} sats) far exceeds your selected rate of ${rate} sat/vB.`,
+        error: `Transaction fee (${computedFee} sats) far exceeds your selected rate of ${rate} sat/vB.`,
         computedFee,
       };
     }

--- a/src/utils/blockchain/bitcoin/feeVerification.ts
+++ b/src/utils/blockchain/bitcoin/feeVerification.ts
@@ -15,7 +15,6 @@
 
 import { Transaction } from '@scure/btc-signer';
 import { hexToBytes, bytesToHex } from '@noble/hashes/utils.js';
-import { fetchInputValues } from '@/utils/blockchain/counterparty/transaction';
 
 /** A fee rate above this (sat/vByte) is treated as never legitimate. */
 export const MAX_SANE_FEE_RATE = 5000;
@@ -67,13 +66,17 @@ function estimateVsize(tx: Transaction, rawBytesLength: number): number {
   return rawBytesLength + tx.inputsLength * perInputSignatureAllowance;
 }
 
-/** Total input value in sats, from the compose hint or resolved independently. */
+/**
+ * Total input value in sats, from the compose hint or resolved independently. A failure says
+ * which kind it was, so the caller's error can distinguish a transaction whose inputs cannot be
+ * read from a value lookup that did not answer.
+ */
 async function resolveInputsTotal(
   tx: Transaction,
   inputsValues: number[] | undefined,
   signaturesCommitToInputValues: boolean,
   resolveInputValues: InputValueResolver
-): Promise<bigint | null> {
+): Promise<{ total: bigint } | { failed: 'unreadable-inputs' | 'lookup' }> {
   // A hint is usable when a signature will bind it and it covers every input with a whole
   // number of sats.
   if (
@@ -82,37 +85,39 @@ async function resolveInputsTotal(
     && inputsValues.length === tx.inputsLength
     && inputsValues.every((value) => Number.isSafeInteger(value) && value >= 0)
   ) {
-    return inputsValues.reduce((sum, value) => sum + BigInt(value), 0n);
+    return { total: inputsValues.reduce((sum, value) => sum + BigInt(value), 0n) };
   }
 
   const outpoints: Array<{ txid: string; vout: number }> = [];
   for (let i = 0; i < tx.inputsLength; i++) {
     const txInput = tx.getInput(i);
-    if (!txInput?.txid) return null;
-    outpoints.push({ txid: bytesToHex(txInput.txid), vout: txInput.index ?? 0 });
+    // A missing outpoint half cannot be guessed: pricing a different prevout would bound the
+    // fee against the wrong value.
+    if (!txInput?.txid || txInput.index == null) return { failed: 'unreadable-inputs' };
+    outpoints.push({ txid: bytesToHex(txInput.txid), vout: txInput.index });
   }
-  if (outpoints.length === 0) return null;
+  if (outpoints.length === 0) return { failed: 'unreadable-inputs' };
 
   let resolved: Map<string, number>;
   try {
     resolved = await resolveInputValues(outpoints);
   } catch {
-    return null;
+    return { failed: 'lookup' };
   }
 
   let total = 0n;
   for (const { txid, vout } of outpoints) {
     const value = resolved.get(`${txid}:${vout}`);
     // A partial answer cannot bound the fee; treat it as unresolved.
-    if (value === undefined) return null;
+    if (value === undefined) return { failed: 'lookup' };
     total += BigInt(value);
   }
-  return total;
+  return { total };
 }
 
 export async function checkTransactionFee(
   input: FeeCheckInput,
-  resolveInputValues: InputValueResolver = fetchInputValues
+  resolveInputValues: InputValueResolver
 ): Promise<FeeCheckResult> {
   const { rawTransaction, inputsValues, signaturesCommitToInputValues, userFeeRate } = input;
 
@@ -139,11 +144,14 @@ export async function checkTransactionFee(
     signaturesCommitToInputValues,
     resolveInputValues
   );
-  if (inputsTotal === null) {
+  if ('failed' in inputsTotal) {
     return {
       ok: false,
-      error: 'Could not establish this transaction\'s fee from the inputs it spends, so it was not '
-        + 'accepted. Check your connection and try again.',
+      error: inputsTotal.failed === 'lookup'
+        ? 'Could not establish this transaction\'s fee: the values of the inputs it spends could '
+          + 'not be fetched. Check your connection and try again.'
+        : 'Could not establish this transaction\'s fee: its inputs could not be read, so it was '
+          + 'not accepted.',
     };
   }
 
@@ -151,7 +159,7 @@ export async function checkTransactionFee(
   for (let i = 0; i < tx.outputsLength; i++) {
     outputsTotal += tx.getOutput(i)?.amount ?? 0n;
   }
-  const fee = inputsTotal - outputsTotal;
+  const fee = inputsTotal.total - outputsTotal;
   if (fee < 0n) {
     return { ok: false, error: 'Transaction outputs exceed inputs — refusing to sign.' };
   }

--- a/src/utils/blockchain/bitcoin/psbt.ts
+++ b/src/utils/blockchain/bitcoin/psbt.ts
@@ -77,17 +77,14 @@ export function committedOutputIndices(
     return committed;
   }
 
-  // Only what every detachable input covers survives. `null` stands for "all outputs" here, which
-  // is the identity for intersection and the value an ALL|ANYONECANPAY input contributes.
-  let committed: Set<number> | null = null;
-  for (const signedInput of detachable) {
-    if (commitsToEveryOutput(signedInput.sighashType)) continue;
-    const own = ownCommitment(signedInput);
-    committed = committed === null
-      ? own
-      : new Set([...own].filter((index) => committed!.has(index)));
-  }
-  return committed;
+  // Only what every detachable input covers survives. An ALL|ANYONECANPAY input covers every
+  // output, so it constrains nothing; when every detachable input is of that kind, the whole
+  // output set is committed.
+  const constraining = detachable.filter(({ sighashType }) => !commitsToEveryOutput(sighashType));
+  if (constraining.length === 0) return null;
+  return constraining
+    .map(ownCommitment)
+    .reduce((intersection, own) => new Set([...intersection].filter((index) => own.has(index))));
 }
 
 /**

--- a/src/utils/blockchain/bitcoin/psbt.ts
+++ b/src/utils/blockchain/bitcoin/psbt.ts
@@ -36,10 +36,15 @@ export const ALLOWED_PSBT_SIGHASH_TYPES: ReadonlySet<number> = new Set([
  * Which output indices a set of signatures commits to. `null` means every output is committed, so
  * the outputs cannot change without invalidating a signature.
  *
- * SINGLE|ANYONECANPAY covers only the output sharing the signed input's index and leaves the rest
- * free for whoever holds the partially-signed transaction to delete, replace or repoint. One signed
- * input committing to all outputs pins the whole set, since changing any output would invalidate
- * that signature and the transaction still needs that input.
+ * A signature binds only transactions that contain its own input. Without ANYONECANPAY it commits
+ * to the whole input set, so the reviewed transaction is the only broadcastable one. ANYONECANPAY
+ * lifts that restriction: such an input can be moved into a transaction built by whoever holds the
+ * PSBT, and the signatures left behind go with their inputs.
+ *
+ * Any one detachable input can therefore be kept while the rest are dropped, so only the outputs
+ * every detachable input covers on its own are guaranteed. SINGLE|ANYONECANPAY covers the output
+ * sharing its input's index and nothing when there is no such output; ALL|ANYONECANPAY covers
+ * every output.
  */
 export function committedOutputIndices(
   signedInputs: Array<{ index: number; sighashType: number }>,
@@ -47,12 +52,40 @@ export function committedOutputIndices(
 ): Set<number> | null {
   if (signedInputs.length === 0) return null;
 
-  const committed = new Set<number>();
-  for (const { index, sighashType } of signedInputs) {
+  const isDetachable = (sighashType: number) => (sighashType & 0x80) !== 0;
+  const commitsToEveryOutput = (sighashType: number) => {
     const base = sighashType & 0x1f;
-    if (base === SigHash.DEFAULT || base === SigHash.ALL) return null;
-    // SINGLE commits to the output sharing the input's index; NONE commits to none at all.
-    if (base === SigHash.SINGLE && index < outputCount) committed.add(index);
+    return base === SigHash.DEFAULT || base === SigHash.ALL;
+  };
+
+  /** Outputs one signature covers alone: SINGLE takes the output at its index, NONE takes none. */
+  const ownCommitment = ({ index, sighashType }: { index: number; sighashType: number }) =>
+    (sighashType & 0x1f) === SigHash.SINGLE && index < outputCount
+      ? new Set([index])
+      : new Set<number>();
+
+  const detachable = signedInputs.filter(({ sighashType }) => isDetachable(sighashType));
+
+  // With nothing detachable the whole input set has to be kept, so every signature keeps binding
+  // and their commitments combine.
+  if (detachable.length === 0) {
+    if (signedInputs.some(({ sighashType }) => commitsToEveryOutput(sighashType))) return null;
+    const committed = new Set<number>();
+    for (const signedInput of signedInputs) {
+      for (const index of ownCommitment(signedInput)) committed.add(index);
+    }
+    return committed;
+  }
+
+  // Only what every detachable input covers survives. `null` stands for "all outputs" here, which
+  // is the identity for intersection and the value an ALL|ANYONECANPAY input contributes.
+  let committed: Set<number> | null = null;
+  for (const signedInput of detachable) {
+    if (commitsToEveryOutput(signedInput.sighashType)) continue;
+    const own = ownCommitment(signedInput);
+    committed = committed === null
+      ? own
+      : new Set([...own].filter((index) => committed!.has(index)));
   }
   return committed;
 }

--- a/src/utils/blockchain/counterparty/transactionSafety.ts
+++ b/src/utils/blockchain/counterparty/transactionSafety.ts
@@ -67,6 +67,7 @@ const SAFE_MESSAGE_TYPES = new Set([
   'fairmint',
   'dividend',
   'broadcast',
+  'bet',
   'attach',
   'detach',
   'mpma_send',
@@ -81,6 +82,18 @@ const SAFE_MESSAGE_TYPES = new Set([
  * dispenser triggers).
  */
 const DUST_THRESHOLD = 546;
+
+/**
+ * Output script types that can carry a Counterparty payload. Reaching one of these without a
+ * resolved message type means the payload was not read, which is not the same as its absence.
+ * Covers both the PSBT decoder's vocabulary and the node's scriptPubKey types.
+ */
+const DATA_CARRYING_OUTPUT_TYPES = new Set([
+  'op_return',   // present but did not decrypt to a Counterparty message
+  'unknown',     // PSBT decoder: bare multisig lands here
+  'multisig',    // node scriptPubKey type
+  'nonstandard', // node scriptPubKey type
+]);
 
 /**
  * Analyze a decoded transaction for security risks.
@@ -125,6 +138,16 @@ export function analyzeTransactionSafety(
         message: `Unrecognized message type "${messageType}". Review the transaction details carefully before signing.`,
       });
     }
+  } else if (outputs.some((output) => DATA_CARRYING_OUTPUT_TYPES.has(output.type))) {
+    // Every check above is keyed on the message type, so a payload that could not be read
+    // reaches none of them. Say so rather than presenting it as an ordinary transfer.
+    warnings.push({
+      severity: 'warning',
+      title: 'Unrecognized Transaction',
+      message:
+        'This transaction could not be identified as a known Counterparty action. It may carry ' +
+        'protocol data in a form this screen cannot read. Review it carefully before signing.',
+    });
   }
 
   // ── Check for suspicious outputs ──

--- a/src/utils/blockchain/counterparty/unpack/__tests__/cbor-messages.test.ts
+++ b/src/utils/blockchain/counterparty/unpack/__tests__/cbor-messages.test.ts
@@ -1,0 +1,322 @@
+/**
+ * CBOR (taproot_support era) message unpacking.
+ *
+ * With the taproot_support protocol flag active, counterparty-core encodes
+ * every composed message as CBOR and packs addresses in the modern prefix
+ * format (0x01 P2PKH / 0x02 P2SH / 0x03 witness). These tests encode
+ * payloads exactly as core's cbor2.dumps does and assert the unpackers
+ * recover the composed parameters.
+ *
+ * Two fixtures come from mainnet compose calls: an XCP enhanced send to a
+ * Taproot address, and a 16-byte LANDMARKS issuance.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { base58 } from '@scure/base';
+import { unpackCounterpartyMessage } from '../index';
+import { verifyTransaction } from '../verify';
+import { unpackEnhancedSend } from '../messages/enhancedSend';
+import { unpackIssuance } from '../messages/issuance';
+import { unpackSweep } from '../messages/sweep';
+import { unpackBroadcast } from '../messages/broadcast';
+import { unpackFairmint } from '../messages/fairmint';
+import { packAddress, unpackAddress } from '../address';
+import { assetNameToId } from '../assetId';
+import { decodeCbor } from '../cbor';
+
+// --- Minimal CBOR encoder mirroring cbor2.dumps for the types core emits ---
+
+function uintBytes(value: bigint, byteCount: number): number[] {
+  const bytes: number[] = [];
+  for (let i = byteCount - 1; i >= 0; i -= 1) {
+    bytes.push(Number((value >> BigInt(8 * i)) & 0xffn));
+  }
+  return bytes;
+}
+
+function cborHead(majorType: number, value: bigint): number[] {
+  const base = majorType << 5;
+  if (value < 24n) return [base | Number(value)];
+  if (value < 256n) return [base | 24, ...uintBytes(value, 1)];
+  if (value < 65536n) return [base | 25, ...uintBytes(value, 2)];
+  if (value < 4294967296n) return [base | 26, ...uintBytes(value, 4)];
+  return [base | 27, ...uintBytes(value, 8)];
+}
+
+type Encodable = bigint | number | boolean | string | Uint8Array | null | Encodable[];
+
+function encodeCbor(value: Encodable): number[] {
+  if (value === null) return [0xf6];
+  if (value === false) return [0xf4];
+  if (value === true) return [0xf5];
+  if (typeof value === 'bigint') {
+    if (value < 0n) throw new Error('negative ints not needed in tests');
+    return cborHead(0, value);
+  }
+  if (typeof value === 'number') {
+    // Always encode JS numbers as float64, like cbor2.dumps does for floats.
+    const view = new DataView(new ArrayBuffer(8));
+    view.setFloat64(0, value, false);
+    return [0xfb, ...new Uint8Array(view.buffer)];
+  }
+  if (typeof value === 'string') {
+    const bytes = new TextEncoder().encode(value);
+    return [...cborHead(3, BigInt(bytes.length)), ...bytes];
+  }
+  if (value instanceof Uint8Array) {
+    return [...cborHead(2, BigInt(value.length)), ...value];
+  }
+  const items = value.flatMap((item) => encodeCbor(item));
+  return [...cborHead(4, BigInt(value.length)), ...items];
+}
+
+function payloadOf(value: Encodable): Uint8Array {
+  return new Uint8Array(encodeCbor(value));
+}
+
+const CNTRPRTY = [0x43, 0x4e, 0x54, 0x52, 0x50, 0x52, 0x54, 0x59];
+
+/** Modern (taproot_support) packed form of a mainnet P2PKH address. */
+function modernPackP2pkh(address: string): Uint8Array {
+  const hash = base58.decode(address).slice(1, -4);
+  return new Uint8Array([0x01, ...hash]);
+}
+
+describe('modern packed address format', () => {
+  const TAPROOT = 'bc1pcm9gfgcy8q45y4m0ryskyc5nczex8yn9jc5r0tpuacz897y5rlfqn2u02z';
+  const P2PKH = '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa';
+
+  it('round-trips a Taproot address through the 0x03 witness packing', () => {
+    const packed = packAddress(TAPROOT);
+    expect(packed[0]).toBe(0x03);
+    expect(packed[1]).toBe(0x01);
+    expect(packed.length).toBe(34);
+    expect(unpackAddress(packed)).toBe(TAPROOT);
+  });
+
+  it('unpacks a 0x01-prefixed P2PKH packing', () => {
+    expect(unpackAddress(modernPackP2pkh(P2PKH))).toBe(P2PKH);
+  });
+
+  it('unpacks a 0x03-prefixed witness v0 packing', () => {
+    const legacy = packAddress('bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4');
+    // Legacy marker packing still round-trips.
+    expect(unpackAddress(legacy)).toBe('bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4');
+    // Modern packing of the same program also unpacks.
+    const program = legacy.slice(1);
+    const modern = new Uint8Array([0x03, 0x00, ...program]);
+    expect(unpackAddress(modern)).toBe('bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4');
+  });
+
+  it('rejects a truncated witness packing', () => {
+    expect(() => unpackAddress(new Uint8Array([0x03, 0x01, 0xaa]))).toThrow();
+  });
+});
+
+describe('CBOR enhanced send', () => {
+  const DESTINATION = 'bc1pcm9gfgcy8q45y4m0ryskyc5nczex8yn9jc5r0tpuacz897y5rlfqn2u02z';
+
+  // The real 500 XCP send that v0.6.0 mis-verified: asset XCP (id 1),
+  // quantity 50000000000, Taproot destination, no memo.
+  function realSendPayload(): Uint8Array {
+    return payloadOf([1n, 50000000000n, packAddress(DESTINATION), new Uint8Array(0)]);
+  }
+
+  it('unpacks the real-world XCP send to a Taproot address', () => {
+    const data = unpackEnhancedSend(realSendPayload());
+    expect(data.asset).toBe('XCP');
+    expect(data.quantity).toBe(50000000000n);
+    expect(data.destination).toBe(DESTINATION);
+    expect(data.memo).toBeUndefined();
+  });
+
+  it('unpacks through the full message dispatcher', () => {
+    const message = new Uint8Array([...CNTRPRTY, 0x02, ...realSendPayload()]);
+    const result = unpackCounterpartyMessage(message);
+    expect(result.success).toBe(true);
+    expect(result.messageType).toBe('enhanced_send');
+    expect((result.data as { destination: string }).destination).toBe(DESTINATION);
+  });
+
+  it('carries a memo through', () => {
+    const memo = new TextEncoder().encode('hello');
+    const data = unpackEnhancedSend(
+      payloadOf([1n, 100n, packAddress(DESTINATION), memo])
+    );
+    expect(data.memo).toBe('hello');
+  });
+});
+
+describe('CBOR issuance', () => {
+  const LR_ISSUANCE = 22;
+  const LR_SUBASSET = 23;
+
+  it('unpacks the real-world 16-byte LANDMARKS issuance', () => {
+    // asset LANDMARKS, quantity 21, indivisible, no lock/reset, empty
+    // mime type, no description — encodes to exactly 16 bytes, one short
+    // of the legacy parser's minimum.
+    const payload = payloadOf([
+      assetNameToId('LANDMARKS'), 21n, false, false, false, '', null,
+    ]);
+    expect(payload.length).toBe(16);
+
+    const data = unpackIssuance(payload, LR_ISSUANCE);
+    expect(data.asset).toBe('LANDMARKS');
+    expect(data.quantity).toBe(21n);
+    expect(data.divisible).toBe(false);
+    expect(data.isLock).toBe(false);
+    expect(data.isReset).toBe(false);
+    expect(data.description).toBeUndefined();
+  });
+
+  it('takes lock/reset from the payload, not the message type', () => {
+    const payload = payloadOf([
+      assetNameToId('LANDMARKS'), 0n, true, true, false, '', null,
+    ]);
+    const data = unpackIssuance(payload, LR_ISSUANCE);
+    expect(data.isLock).toBe(true);
+    expect(data.isReset).toBe(false);
+  });
+
+  it('decodes a description', () => {
+    const description = new TextEncoder().encode('hello world');
+    const payload = payloadOf([
+      assetNameToId('LANDMARKS'), 21n, true, false, false, 'text/plain', description,
+    ]);
+    expect(unpackIssuance(payload, LR_ISSUANCE).description).toBe('hello world');
+  });
+
+  it('unpacks a subasset issuance with a base-68 compacted longname', () => {
+    // Port of core's compact_subasset_longname: base-68 big-endian integer
+    // over SUBASSET_DIGITS with digit values 1..68.
+    const DIGITS = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.-_@!';
+    const longname = 'LANDMARKS.paris';
+    let nameInt = 0n;
+    for (const c of longname) {
+      nameInt = nameInt * 68n + BigInt(DIGITS.indexOf(c) + 1);
+    }
+    const compactedBytes: number[] = [];
+    let n = nameInt;
+    while (n > 0n) {
+      compactedBytes.unshift(Number(n & 0xffn));
+      n >>= 8n;
+    }
+    const compacted = new Uint8Array(compactedBytes);
+
+    const payload = payloadOf([
+      assetNameToId('A95428956661682177'), 21n, 1n, 0n, 0n,
+      BigInt(compacted.length), compacted, '', null,
+    ]);
+    const data = unpackIssuance(payload, LR_SUBASSET);
+    expect(data.subassetLongname).toBe(longname);
+    expect(data.divisible).toBe(true);
+    expect(data.isLock).toBe(false);
+  });
+});
+
+describe('CBOR sweep', () => {
+  const DESTINATION = 'bc1pcm9gfgcy8q45y4m0ryskyc5nczex8yn9jc5r0tpuacz897y5rlfqn2u02z';
+
+  it('unpacks a sweep with a text memo', () => {
+    const payload = payloadOf([
+      packAddress(DESTINATION), 3n, new TextEncoder().encode('sweep memo'),
+    ]);
+    const data = unpackSweep(payload);
+    expect(data.destination).toBe(DESTINATION);
+    expect(data.flags).toBe(3);
+    expect(data.sweepBalances).toBe(true);
+    expect(data.sweepOwnership).toBe(true);
+    expect(data.memo).toBe('sweep memo');
+  });
+
+  it('unpacks a sweep with no memo', () => {
+    const payload = payloadOf([packAddress(DESTINATION), 1n, new Uint8Array(0)]);
+    const data = unpackSweep(payload);
+    expect(data.destination).toBe(DESTINATION);
+    expect(data.memo).toBeUndefined();
+  });
+});
+
+describe('CBOR broadcast', () => {
+  it('unpacks a broadcast with a float value', () => {
+    const payload = payloadOf([
+      1722000000n, 1.5, 0n, '', new TextEncoder().encode('price feed'),
+    ]);
+    const data = unpackBroadcast(payload);
+    expect(data.timestamp).toBe(1722000000);
+    expect(data.value).toBe(1.5);
+    expect(data.feeFractionInt).toBe(0);
+    expect(data.text).toBe('price feed');
+  });
+
+  it('unpacks a broadcast with an integer value', () => {
+    const payload = payloadOf([1722000000n, 100n, 0n, '', new Uint8Array(0)]);
+    expect(unpackBroadcast(payload).value).toBe(100);
+  });
+});
+
+describe('CBOR fairmint', () => {
+  it('unpacks an [asset_id, quantity] pair', () => {
+    const data = unpackFairmint(payloadOf([1n, 1000n]));
+    expect(data.asset).toBe('XCP');
+    expect(data.quantity).toBe(1000n);
+  });
+});
+
+describe('verifyTransaction over CBOR messages', () => {
+  const DESTINATION = 'bc1pcm9gfgcy8q45y4m0ryskyc5nczex8yn9jc5r0tpuacz897y5rlfqn2u02z';
+
+  it('passes a CBOR XCP send to a Taproot destination', () => {
+    const payload = payloadOf([1n, 50000000000n, packAddress(DESTINATION), new Uint8Array(0)]);
+    const message = new Uint8Array([...CNTRPRTY, 0x02, ...payload]);
+
+    const result = verifyTransaction(message, 'send', {
+      destination: DESTINATION,
+      asset: 'XCP',
+      quantity: 50000000000,
+    });
+    expect(result.criticalMismatches).toEqual([]);
+    expect(result.errors).toEqual([]);
+    expect(result.valid).toBe(true);
+  });
+
+  it('passes a CBOR indivisible issuance', () => {
+    const payload = payloadOf([
+      assetNameToId('LANDMARKS'), 21n, false, false, false, '', null,
+    ]);
+    const message = new Uint8Array([...CNTRPRTY, 22, ...payload]);
+
+    const result = verifyTransaction(message, 'issuance', {
+      asset: 'LANDMARKS',
+      quantity: 21,
+      divisible: false,
+    });
+    expect(result.criticalMismatches).toEqual([]);
+    expect(result.errors).toEqual([]);
+    expect(result.valid).toBe(true);
+  });
+
+  it('still flags a destination substitution', () => {
+    const other = '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa';
+    const payload = payloadOf([1n, 50000000000n, modernPackP2pkh(other), new Uint8Array(0)]);
+    const message = new Uint8Array([...CNTRPRTY, 0x02, ...payload]);
+
+    const result = verifyTransaction(message, 'send', {
+      destination: DESTINATION,
+      asset: 'XCP',
+      quantity: 50000000000,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.criticalMismatches.some((m) => m.field === 'destination')).toBe(true);
+  });
+});
+
+describe('CBOR float decoding', () => {
+  it('decodes half, single, and double precision', () => {
+    expect(decodeCbor(new Uint8Array([0xf9, 0x3c, 0x00]))).toBe(1);
+    expect(decodeCbor(new Uint8Array([0xfa, 0x3f, 0xc0, 0x00, 0x00]))).toBe(1.5);
+    const view = new DataView(new ArrayBuffer(8));
+    view.setFloat64(0, 2.75, false);
+    expect(decodeCbor(new Uint8Array([0xfb, ...new Uint8Array(view.buffer)]))).toBe(2.75);
+  });
+});

--- a/src/utils/blockchain/counterparty/unpack/__tests__/encoding-ambiguity.test.ts
+++ b/src/utils/blockchain/counterparty/unpack/__tests__/encoding-ambiguity.test.ts
@@ -1,0 +1,88 @@
+/**
+ * CBOR/legacy encoding ambiguity.
+ *
+ * The two wire encodings are not distinguishable by inspection: a legacy asset
+ * id can begin with a byte that is also a valid CBOR array header. Unpackers
+ * therefore try CBOR first and fall back to legacy, matching counterparty-core's
+ * unpack order. That precedence decides which of two readings the user is shown,
+ * so these tests pin it with payloads that are genuinely valid under BOTH
+ * readings, and with payloads that merely look CBOR-ish and must fall back.
+ *
+ * Enhanced send is the representative case: its legacy layout (asset id,
+ * quantity, packed address, memo) is permissive enough for a real CBOR message
+ * to double as a parseable legacy struct.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { unpackEnhancedSend } from '../messages/enhancedSend';
+import { unpackAddress } from '../address';
+import { assetIdToName } from '../assetId';
+
+describe('CBOR-first precedence on an ambiguous enhanced send', () => {
+  // A CBOR enhanced send [asset_id, quantity, address, memo], hand-laid so the
+  // same 42 bytes also parse as a legacy struct:
+  //
+  //   CBOR reading                          legacy reading (fixed offsets)
+  //   ------------------------------------  -----------------------------------
+  //   0x84            array(4)              bytes 0-7   asset id 0x841b…0f
+  //   0x1b + 8 bytes  asset id 1_000_000    bytes 8-15  quantity 0x42401b…
+  //   0x1b + 8 bytes  quantity 100          bytes 16-36 address (starts 0x00 ✓)
+  //   0x55 + 21 bytes packed P2PKH address  bytes 37-41 memo
+  //   0x40            empty memo
+  //
+  // The legacy address column starts at byte 16, which lands inside the CBOR
+  // quantity's zero padding — a version byte 0x00, so the legacy reading
+  // unpacks a plausible P2PKH destination of its own.
+  const cborAddress = new Uint8Array([0x00, ...Array(20).fill(0x11)]);
+  const payload = new Uint8Array([
+    0x84,
+    0x1b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0f, 0x42, 0x40, // asset id 1_000_000
+    0x1b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x64, // quantity 100
+    0x55, ...cborAddress,
+    0x40,
+  ]);
+
+  it('is genuinely ambiguous: the legacy reading also yields a valid address', () => {
+    // Not a tautology — proves the fixture would decode either way, so the
+    // assertion below is exercising precedence, not a parse failure.
+    const legacyDestination = unpackAddress(payload.slice(16, 37));
+    expect(legacyDestination).toMatch(/^1/);
+    expect(legacyDestination).not.toBe(unpackAddress(cborAddress));
+  });
+
+  it('decodes as the CBOR reading, matching core, not the legacy one', () => {
+    const result = unpackEnhancedSend(payload);
+
+    expect(result.assetId).toBe(1_000_000n);
+    expect(result.asset).toBe(assetIdToName(1_000_000n));
+    expect(result.quantity).toBe(100n);
+    expect(result.destination).toBe(unpackAddress(cborAddress));
+    expect(result.memo).toBeUndefined();
+
+    // And explicitly not the legacy reading's fields.
+    expect(result.assetId).not.toBe(0x841b0000_0000000fn);
+    expect(result.destination).not.toBe(unpackAddress(payload.slice(16, 37)));
+  });
+});
+
+describe('legacy fallback when the payload only looks like CBOR', () => {
+  it('falls back to legacy for an asset id that begins with a CBOR array header', () => {
+    // A real legacy enhanced send whose numeric asset id starts 0x84. The CBOR
+    // attempt reads an array of four zero-valued integers and then chokes on
+    // the 32 trailing bytes, so the fallback must recover the legacy fields.
+    const legacyAddress = new Uint8Array([0x00, ...Array(20).fill(0x22)]);
+    const payload = new Uint8Array([
+      0x84, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, // asset id 0x8400000000000001
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0xf4, // quantity 500
+      ...legacyAddress,
+    ]);
+
+    const result = unpackEnhancedSend(payload);
+
+    expect(result.assetId).toBe(0x8400000000000001n);
+    expect(result.asset).toBe(assetIdToName(0x8400000000000001n));
+    expect(result.quantity).toBe(500n);
+    expect(result.destination).toBe(unpackAddress(legacyAddress));
+    expect(result.memo).toBeUndefined();
+  });
+});

--- a/src/utils/blockchain/counterparty/unpack/__tests__/integration.test.ts
+++ b/src/utils/blockchain/counterparty/unpack/__tests__/integration.test.ts
@@ -466,8 +466,9 @@ describe('Contraexample Tests (Mocked)', () => {
     const assetId = '0000000000000001'; // XCP
     const quantity = '000000003b9aca00'; // 1 XCP
 
-    // Attacker's address packed (all 0xff = different from expected)
-    const attackerDest = 'ff'.repeat(21);
+    // A valid P2PKH packing for an address that is not the requested one, so the mismatch is
+    // caught by comparing destinations rather than by rejecting a malformed address.
+    const attackerDest = '00' + 'ff'.repeat(20);
 
     const data = CNTRPRTY + typeId + assetId + quantity + attackerDest;
 

--- a/src/utils/blockchain/counterparty/unpack/__tests__/integration.test.ts
+++ b/src/utils/blockchain/counterparty/unpack/__tests__/integration.test.ts
@@ -15,7 +15,6 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import {
   unpackCounterpartyMessage,
   verifyTransaction,
-  extractOpReturnData,
   MessageTypeId,
 } from '../index';
 

--- a/src/utils/blockchain/counterparty/unpack/__tests__/multisig-encoding.test.ts
+++ b/src/utils/blockchain/counterparty/unpack/__tests__/multisig-encoding.test.ts
@@ -196,8 +196,10 @@ describe('compose types with no field-level verifier', () => {
     const result = verifyTransaction(broadcastPayload, 'broadcast', {});
 
     expect(result.valid).toBe(true);
-    // The absence of field checks is recorded rather than presented as a clean verification.
-    expect(result.warnings.join(' ')).toContain('No field-level verification');
+    // The absence of field checks is recorded as coverage, not presented as a clean verification —
+    // and not pushed into `warnings`, which the review screen shows as detected differences.
+    expect(result.fieldVerification).toBe('type-only');
+    expect(result.warnings).toEqual([]);
   });
 
   it('rejects a response carrying a different message type than requested', () => {

--- a/src/utils/blockchain/counterparty/unpack/__tests__/multisig-encoding.test.ts
+++ b/src/utils/blockchain/counterparty/unpack/__tests__/multisig-encoding.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Counterparty payloads carried in bare-multisig outputs.
+ *
+ * Only the OP_RETURN encoding used to be classified, so a message in any other
+ * encoding reached the approval screen unidentified — and an unidentified
+ * message skipped the sweep block entirely. These tests build multisig outputs
+ * the way counterparty-core's composer does and assert the payload is recovered
+ * and classified, so the block applies regardless of encoding.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { extractMultisigPayload } from '../multisig';
+import { unpackCounterpartyMessage } from '../index';
+import { packAddress } from '../address';
+import { arc4, hexToBytes, bytesToHex } from '../binary';
+import { COUNTERPARTY_PREFIX_HEX } from '../messageTypes';
+import { analyzeTransactionSafety } from '../../transactionSafety';
+import { verifyTransaction } from '../verify';
+
+const FIRST_INPUT_TXID = 'a'.repeat(64);
+const SWEEP_DESTINATION = '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa';
+/** Data bytes one output carries: two fake pubkeys minus their sign and nonce bytes. */
+const DATA_BYTES_PER_OUTPUT = 62;
+/** Payload bytes per output: the 62 carried bytes minus the length byte and the prefix. */
+const CHUNK_SIZE = DATA_BYTES_PER_OUTPUT - 1 - 8;
+
+/** Encode one message chunk as a bare-multisig output script, as core's composer does. */
+function multisigOutputScript(chunk: Uint8Array, txid: string): string {
+  const prefix = hexToBytes(COUNTERPARTY_PREFIX_HEX);
+  const content = new Uint8Array([...prefix, ...chunk]);
+
+  // [length byte][CNTRPRTY][chunk][zero padding], ARC4-obfuscated as a whole.
+  const plain = new Uint8Array(DATA_BYTES_PER_OUTPUT);
+  plain[0] = content.length;
+  plain.set(content, 1);
+  const obfuscated = arc4(hexToBytes(txid), plain);
+
+  // Sign and nonce bytes only exist to land the fake pubkey on the curve; they are discarded
+  // on decode, so their values do not matter here.
+  const pubkey = (data: Uint8Array) => new Uint8Array([0x02, ...data, 0x00]);
+  const script = new Uint8Array([
+    0x51,
+    0x21, ...pubkey(obfuscated.slice(0, 31)),
+    0x21, ...pubkey(obfuscated.slice(31, 62)),
+    0x21, ...new Uint8Array(33).fill(0x03),
+    0x53,
+    0xae,
+  ]);
+  return bytesToHex(script);
+}
+
+/** Split a message into the chunks core would spread across multisig outputs. */
+function multisigScriptsFor(message: Uint8Array, txid: string): string[] {
+  const scripts: string[] = [];
+  for (let offset = 0; offset < message.length; offset += CHUNK_SIZE) {
+    scripts.push(multisigOutputScript(message.slice(offset, offset + CHUNK_SIZE), txid));
+  }
+  return scripts;
+}
+
+/** A legacy sweep message: type id 4, packed destination, flags. */
+function sweepMessage(flags = 3): Uint8Array {
+  return new Uint8Array([0x04, ...packAddress(SWEEP_DESTINATION), flags]);
+}
+
+describe('extractMultisigPayload', () => {
+  it('recovers a single-output payload', () => {
+    const message = sweepMessage();
+    const payload = extractMultisigPayload(
+      multisigScriptsFor(message, FIRST_INPUT_TXID),
+      FIRST_INPUT_TXID
+    );
+
+    expect(payload).toBe(COUNTERPARTY_PREFIX_HEX + bytesToHex(message));
+  });
+
+  it('reassembles a payload spread across several outputs', () => {
+    // An issuance with a long description needs more than one output.
+    const message = new Uint8Array([20, ...new Uint8Array(120).map((_, i) => (i * 7) & 0xff)]);
+    const scripts = multisigScriptsFor(message, FIRST_INPUT_TXID);
+    expect(scripts.length).toBeGreaterThan(1);
+
+    const payload = extractMultisigPayload(scripts, FIRST_INPUT_TXID);
+    expect(payload).toBe(COUNTERPARTY_PREFIX_HEX + bytesToHex(message));
+  });
+
+  it('ignores ordinary payment outputs alongside the data outputs', () => {
+    const message = sweepMessage();
+    const scripts = [
+      ...multisigScriptsFor(message, FIRST_INPUT_TXID),
+      '76a914' + '11'.repeat(20) + '88ac',
+      '0014' + '22'.repeat(20),
+    ];
+
+    expect(extractMultisigPayload(scripts, FIRST_INPUT_TXID))
+      .toBe(COUNTERPARTY_PREFIX_HEX + bytesToHex(message));
+  });
+
+  it('returns null for a transaction with no data outputs', () => {
+    const scripts = ['76a914' + '11'.repeat(20) + '88ac', '0014' + '22'.repeat(20)];
+    expect(extractMultisigPayload(scripts, FIRST_INPUT_TXID)).toBeNull();
+  });
+
+  it('returns null when the key does not match', () => {
+    const scripts = multisigScriptsFor(sweepMessage(), FIRST_INPUT_TXID);
+    expect(extractMultisigPayload(scripts, 'b'.repeat(64))).toBeNull();
+  });
+
+  it('reads the whole payload when a payment output is placed between data outputs', () => {
+    // Splitting the payload around an ordinary output must not truncate what we read, or the
+    // screen would classify a different message from the one the network parses.
+    const message = new Uint8Array([20, ...new Uint8Array(120).map((_, i) => (i * 7) & 0xff)]);
+    const [first, ...rest] = multisigScriptsFor(message, FIRST_INPUT_TXID);
+    const interleaved = [first!, '76a914' + '11'.repeat(20) + '88ac', ...rest];
+
+    expect(extractMultisigPayload(interleaved, FIRST_INPUT_TXID))
+      .toBe(COUNTERPARTY_PREFIX_HEX + bytesToHex(message));
+  });
+});
+
+describe('a sweep is classified in either encoding', () => {
+  it('unpacks a multisig-encoded sweep to the sweep message type', () => {
+    const payload = extractMultisigPayload(
+      multisigScriptsFor(sweepMessage(), FIRST_INPUT_TXID),
+      FIRST_INPUT_TXID
+    );
+
+    const result = unpackCounterpartyMessage(payload!);
+    expect(result.success).toBe(true);
+    expect(result.messageType).toBe('sweep');
+    expect((result.data as { destination: string }).destination).toBe(SWEEP_DESTINATION);
+  });
+
+  it('blocks signing once the message type is resolved', () => {
+    const payload = extractMultisigPayload(
+      multisigScriptsFor(sweepMessage(), FIRST_INPUT_TXID),
+      FIRST_INPUT_TXID
+    );
+    const messageType = unpackCounterpartyMessage(payload!).messageType;
+
+    const safety = analyzeTransactionSafety(messageType, [], 'bc1qsigner');
+    expect(safety.blocked).toBe(true);
+    expect(safety.warnings[0]?.title).toBe('Blocked: Sweep Transaction');
+  });
+});
+
+describe('every message type counterparty-core can compose is decodable', () => {
+  // Blocking an undecodable message only stays workable while the set of decodable types matches
+  // what core can produce. Burn is absent because it carries no message — it is a plain BTC send
+  // to the unspendable address — and rps/rpsresolve have no compose endpoint.
+  const COMPOSABLE_TYPE_IDS = [
+    0, 2, 3, 4, 10, 11, 12, 13, 20, 21, 22, 23, 30, 40, 50, 70, 90, 91, 100, 101, 102, 110, 120, 121,
+  ];
+
+  it.each(COMPOSABLE_TYPE_IDS)('dispatches message type %i', (typeId) => {
+    // A deliberately malformed payload: the point is that dispatch reaches an unpacker, so the
+    // error is about the payload rather than the type being unsupported.
+    const result = unpackCounterpartyMessage(
+      new Uint8Array([...hexToBytes(COUNTERPARTY_PREFIX_HEX), typeId, 0, 0, 0, 0])
+    );
+
+    expect(result.messageTypeId).toBe(typeId);
+    expect(result.error ?? '').not.toMatch(/unsupported message type/i);
+  });
+});
+
+describe('a message type with no unpacker is not a successful decode', () => {
+  // Type id 200 is unassigned, standing in for a protocol message this build predates. The
+  // raw bytes come back for display, but reporting success would render the approval screen's
+  // "verified locally, no tampering" badge over a message nothing had actually read.
+  const undecodable = COUNTERPARTY_PREFIX_HEX + 'c8' + 'deadbeef';
+
+  it('reports failure and keeps the raw payload', () => {
+    const result = unpackCounterpartyMessage(undecodable);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/unsupported message type/i);
+    expect(result.data).toBeDefined();
+  });
+
+  it('still reports success for a type it can decode', () => {
+    const payload = extractMultisigPayload(
+      multisigScriptsFor(sweepMessage(), FIRST_INPUT_TXID),
+      FIRST_INPUT_TXID
+    );
+
+    expect(unpackCounterpartyMessage(payload!).success).toBe(true);
+  });
+});
+
+describe('compose types with no field-level verifier', () => {
+  // A broadcast message: type id 30, then the CBOR body. Only the type id matters here.
+  const broadcastPayload = COUNTERPARTY_PREFIX_HEX + '1e' + '850001006040';
+
+  it('accepts a response whose message type is the one requested', () => {
+    const result = verifyTransaction(broadcastPayload, 'broadcast', {});
+
+    expect(result.valid).toBe(true);
+    // The absence of field checks is recorded rather than presented as a clean verification.
+    expect(result.warnings.join(' ')).toContain('No field-level verification');
+  });
+
+  it('rejects a response carrying a different message type than requested', () => {
+    // The user asked to broadcast; the response is a sweep, which no verifier would have compared.
+    const sweepPayload = COUNTERPARTY_PREFIX_HEX + bytesToHex(sweepMessage());
+    const result = verifyTransaction(sweepPayload, 'broadcast', {});
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.join(' ')).toContain('Message type mismatch');
+  });
+});
+
+describe('unclassified transactions fail toward unknown', () => {
+  // Each output type that can hide a payload, in both decoders' vocabularies.
+  it.each(['unknown', 'multisig', 'nonstandard', 'op_return'])(
+    'warns when a %s output carries a payload that could not be read',
+    (type) => {
+      const safety = analyzeTransactionSafety(
+        undefined,
+        [{ value: 546, address: 'bc1qother', type }],
+        'bc1qsigner'
+      );
+
+      expect(safety.warnings.some((w) => w.title === 'Unrecognized Transaction')).toBe(true);
+    }
+  );
+
+  it('stays quiet for an ordinary transfer carrying no protocol data', () => {
+    const safety = analyzeTransactionSafety(
+      undefined,
+      [{ value: 50_000, address: 'bc1qsigner', type: 'p2wpkh' }],
+      'bc1qsigner'
+    );
+
+    expect(safety.warnings).toEqual([]);
+    expect(safety.blocked).toBe(false);
+  });
+});

--- a/src/utils/blockchain/counterparty/unpack/__tests__/verifyMultiSend.test.ts
+++ b/src/utils/blockchain/counterparty/unpack/__tests__/verifyMultiSend.test.ts
@@ -14,6 +14,7 @@ function emptyResult(): VerificationResult {
     infoMismatches: [],
     errors: [],
     warnings: [],
+    fieldVerification: 'full',
     expected: {},
     actual: {},
   };

--- a/src/utils/blockchain/counterparty/unpack/address.ts
+++ b/src/utils/blockchain/counterparty/unpack/address.ts
@@ -1,28 +1,28 @@
 /**
  * Counterparty Address Packing/Unpacking
  *
- * Counterparty uses a 21-byte packed address format in messages:
+ * Two packed-address encodings exist on the wire.
  *
- * For P2PKH (legacy) addresses:
- *   - Byte 0: Version byte (0x00 for mainnet P2PKH, 0x05 for P2SH)
- *   - Bytes 1-20: 20-byte pubkey hash (HASH160)
+ * Legacy (pre-taproot_support), always 21 bytes:
+ *   - P2PKH/P2SH: base58 version byte (0x00/0x05 mainnet) + 20-byte hash
+ *   - SegWit v0:  0x80 + witness_version, + 20-byte witness program
+ *   Taproot cannot be represented (a 32-byte program does not fit).
  *
- * For SegWit (P2WPKH) addresses:
- *   - Byte 0: 0x80 + witness_version (0x80 for witness v0)
- *   - Bytes 1-20: 20-byte witness program
+ * Modern (taproot_support, counterparty-rs utils::pack), variable length:
+ *   - 0x01 + 20-byte pubkey hash            → P2PKH
+ *   - 0x02 + 20-byte script hash            → P2SH
+ *   - 0x03 + witness_version + program      → any SegWit, including Taproot
  *
- * For Taproot (P2TR) addresses:
- *   - Byte 0: 0x80 + witness_version (0x81 for witness v1)
- *   - Bytes 1-20: First 20 bytes of 32-byte witness program (truncated)
- *   - Note: This is lossy - we cannot fully reconstruct P2TR addresses from packed form
- *
- * The pack/unpack functions convert between Bitcoin addresses and this 21-byte format.
+ * The modern prefixes cannot collide with legacy mainnet version bytes
+ * (0x00/0x05) or the SegWit marker range (0x80+), so unpackAddress accepts
+ * both encodings; packAddress emits the legacy form where it is expressible
+ * and the modern form for witness programs longer than 20 bytes.
  */
 
 import { bech32, bech32m, base58 } from '@scure/base';
 import { sha256 } from '@noble/hashes/sha2.js';
 
-/** Length of packed address in bytes */
+/** Length of a legacy packed address in bytes */
 export const PACKED_ADDRESS_LENGTH = 21;
 
 /** Version byte prefixes for mainnet */
@@ -31,6 +31,16 @@ const VERSION = {
   P2SH: 0x05,        // Pay-to-script-hash
   SEGWIT_MARKER: 0x80, // Added to witness version for SegWit
 } as const;
+
+/** Modern (taproot_support) packed-address type prefixes */
+const MODERN = {
+  P2PKH: 0x01,
+  P2SH: 0x02,
+  WITNESS: 0x03,
+} as const;
+
+/** Defined base58 version bytes: mainnet P2PKH/P2SH and their testnet counterparts. */
+const BASE58_VERSIONS = new Set<number>([VERSION.P2PKH, VERSION.P2SH, 0x6f, 0xc4]);
 
 /**
  * Error thrown when address packing/unpacking fails
@@ -167,22 +177,23 @@ export function packAddress(address: string): Uint8Array {
   if (address.toLowerCase().startsWith('bc1') || address.toLowerCase().startsWith('tb1')) {
     const { version, program } = decodeBech32(address);
 
-    // Mark as SegWit with version
-    packed[0] = VERSION.SEGWIT_MARKER + version;
-
-    // P2WPKH has 20-byte program, P2TR has 32-byte program
     if (program.length === 20) {
-      // P2WPKH - fits exactly
+      // Fits the legacy 21-byte packing: SegWit marker + program.
+      packed[0] = VERSION.SEGWIT_MARKER + version;
       packed.set(program, 1);
-    } else if (program.length === 32) {
-      // P2TR - truncate to 20 bytes (lossy!)
-      // Note: This means we can't fully reconstruct P2TR addresses
-      packed.set(program.slice(0, 20), 1);
-    } else {
-      throw new AddressPackError(`Unsupported witness program length: ${program.length}`);
+      return packed;
     }
 
-    return packed;
+    if (program.length === 32) {
+      // Taproot/P2WSH programs only exist in the modern packing.
+      const modern = new Uint8Array(2 + program.length);
+      modern[0] = MODERN.WITNESS;
+      modern[1] = version;
+      modern.set(program, 2);
+      return modern;
+    }
+
+    throw new AddressPackError(`Unsupported witness program length: ${program.length}`);
   }
 
   // Check for base58 (legacy) address
@@ -204,9 +215,10 @@ export function packAddress(address: string): Uint8Array {
 }
 
 /**
- * Unpack a 21-byte Counterparty packed address to a Bitcoin address string.
+ * Unpack a Counterparty packed address (legacy or modern encoding) to a
+ * Bitcoin address string.
  *
- * @param packed - 21-byte packed address
+ * @param packed - Packed address bytes
  * @param network - 'mainnet' or 'testnet' (default: 'mainnet')
  * @returns Bitcoin address string
  * @throws AddressPackError if the packed address is invalid
@@ -216,32 +228,59 @@ export function unpackAddress(packed: Uint8Array, network: 'mainnet' | 'testnet'
     throw new AddressPackError('Empty packed address');
   }
 
+  const firstByte = packed[0]!;
+  const rest = packed.slice(1);
+  const bech32Prefix = network === 'mainnet' ? 'bc' : 'tb';
+
+  // Modern encoding: type prefix + payload.
+  if (firstByte === MODERN.P2PKH && packed.length === PACKED_ADDRESS_LENGTH) {
+    return encodeBase58Check(network === 'mainnet' ? 0x00 : 0x6f, rest);
+  }
+  if (firstByte === MODERN.P2SH && packed.length === PACKED_ADDRESS_LENGTH) {
+    return encodeBase58Check(network === 'mainnet' ? 0x05 : 0xc4, rest);
+  }
+  if (firstByte === MODERN.WITNESS && packed.length >= 4) {
+    const witnessVersion = packed[1]!;
+    const program = packed.slice(2);
+    if (witnessVersion > 16) {
+      throw new AddressPackError(`Invalid witness version: ${witnessVersion}`);
+    }
+    // BIP141 allows 2..40 bytes, but v0 is only defined for 20 (P2WPKH) and 32 (P2WSH), and v1
+    // only for 32 (P2TR). Anything else would render as a plausible address nobody can spend.
+    const validForVersion = witnessVersion === 0
+      ? program.length === 20 || program.length === 32
+      : witnessVersion === 1
+        ? program.length === 32
+        : program.length >= 2 && program.length <= 40;
+    if (!validForVersion) {
+      throw new AddressPackError(
+        `Invalid witness program length for v${witnessVersion}: ${program.length}`
+      );
+    }
+    return encodeBech32(witnessVersion, program, bech32Prefix);
+  }
+
+  // Legacy SegWit marker (0x80 - 0x8F): fixed 21-byte packing, 20-byte program.
+  if (firstByte >= VERSION.SEGWIT_MARKER && firstByte <= VERSION.SEGWIT_MARKER + 0x0F) {
+    if (packed.length !== PACKED_ADDRESS_LENGTH) {
+      throw new AddressPackError(
+        `Invalid packed SegWit address length: ${packed.length} (expected ${PACKED_ADDRESS_LENGTH})`
+      );
+    }
+    return encodeBech32(firstByte - VERSION.SEGWIT_MARKER, rest, bech32Prefix);
+  }
+
+  // Legacy P2PKH/P2SH: base58 version byte + 20-byte hash.
   if (packed.length !== PACKED_ADDRESS_LENGTH) {
     throw new AddressPackError(`Invalid packed address length: ${packed.length} (expected ${PACKED_ADDRESS_LENGTH})`);
   }
-
-  const firstByte = packed[0]!;
-  const hashOrProgram = packed.slice(1);
-
-  // Check for SegWit marker (0x80 - 0x8F)
-  if (firstByte >= VERSION.SEGWIT_MARKER && firstByte <= VERSION.SEGWIT_MARKER + 0x0F) {
-    const witnessVersion = firstByte - VERSION.SEGWIT_MARKER;
-    const prefix = network === 'mainnet' ? 'bc' : 'tb';
-
-    // Note: For P2TR (witness v1), the packed format only contains 20 bytes
-    // of the 32-byte witness program, so we cannot fully reconstruct it.
-    // We assume P2WPKH (20-byte program) for unpacking.
-    if (witnessVersion === 1) {
-      // This is P2TR but we only have 20 bytes - cannot reconstruct
-      // For now, treat it as if we have the full program (caller should be aware)
-      console.warn('P2TR address unpacking may be incomplete (only 20 of 32 bytes available)');
-    }
-
-    return encodeBech32(witnessVersion, hashOrProgram, prefix);
+  // The version byte itself carries the network, so accept the four defined values rather than
+  // scoping by the `network` argument. Any other leading byte would still base58-encode,
+  // producing something that reads as an address and is not one.
+  if (!BASE58_VERSIONS.has(firstByte)) {
+    throw new AddressPackError(`Unrecognized packed address version byte: 0x${firstByte.toString(16)}`);
   }
-
-  // Legacy address (P2PKH or P2SH)
-  return encodeBase58Check(firstByte, hashOrProgram);
+  return encodeBase58Check(firstByte, rest);
 }
 
 /**

--- a/src/utils/blockchain/counterparty/unpack/address.ts
+++ b/src/utils/blockchain/counterparty/unpack/address.ts
@@ -239,19 +239,21 @@ export function unpackAddress(packed: Uint8Array, network: 'mainnet' | 'testnet'
   if (firstByte === MODERN.P2SH && packed.length === PACKED_ADDRESS_LENGTH) {
     return encodeBase58Check(network === 'mainnet' ? 0x05 : 0xc4, rest);
   }
-  if (firstByte === MODERN.WITNESS && packed.length >= 4) {
+  // Core's unpacker (counterparty-rs utils.rs) requires prefix + version + a program of at
+  // least 20 bytes; accepting less would render an address core itself refuses to unpack.
+  if (firstByte === MODERN.WITNESS && packed.length >= 22) {
     const witnessVersion = packed[1]!;
     const program = packed.slice(2);
     if (witnessVersion > 16) {
       throw new AddressPackError(`Invalid witness version: ${witnessVersion}`);
     }
-    // BIP141 allows 2..40 bytes, but v0 is only defined for 20 (P2WPKH) and 32 (P2WSH), and v1
-    // only for 32 (P2TR). Anything else would render as a plausible address nobody can spend.
+    // BIP141 allows up to 40 bytes, but v0 is only defined for 20 (P2WPKH) and 32 (P2WSH), and
+    // v1 only for 32 (P2TR). Anything else would render as a plausible address nobody can spend.
     const validForVersion = witnessVersion === 0
       ? program.length === 20 || program.length === 32
       : witnessVersion === 1
         ? program.length === 32
-        : program.length >= 2 && program.length <= 40;
+        : program.length <= 40;
     if (!validForVersion) {
       throw new AddressPackError(
         `Invalid witness program length for v${witnessVersion}: ${program.length}`

--- a/src/utils/blockchain/counterparty/unpack/binary.ts
+++ b/src/utils/blockchain/counterparty/unpack/binary.ts
@@ -199,6 +199,18 @@ export function bytesToHex(bytes: Uint8Array): string {
 }
 
 /**
+ * Render free-form bytes for display: text when they are valid UTF-8, hex otherwise.
+ * Used for memos, descriptions and broadcast text, which carry either.
+ */
+export function bytesToTextOrHex(bytes: Uint8Array): string {
+  try {
+    return new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+  } catch {
+    return bytesToHex(bytes);
+  }
+}
+
+/**
  * ARC4 (RC4) decrypt/encrypt. ARC4 is symmetric — same operation for both.
  * Used by Counterparty to encrypt OP_RETURN data with the first input's txid.
  */

--- a/src/utils/blockchain/counterparty/unpack/cbor.ts
+++ b/src/utils/blockchain/counterparty/unpack/cbor.ts
@@ -1,4 +1,4 @@
-export type CborValue = bigint | boolean | string | Uint8Array | CborValue[] | null;
+export type CborValue = bigint | number | boolean | string | Uint8Array | CborValue[] | null;
 
 interface DecodedValue {
   value: CborValue;
@@ -25,7 +25,20 @@ function toSafeLength(value: bigint): number {
   return Number(value);
 }
 
-function decodeValue(data: Uint8Array, offset: number): DecodedValue {
+function decodeFloat16(bits: number): number {
+  const sign = bits & 0x8000 ? -1 : 1;
+  const exponent = (bits >> 10) & 0x1f;
+  const fraction = bits & 0x3ff;
+  if (exponent === 0) return sign * fraction * 2 ** -24;
+  if (exponent === 31) return fraction ? NaN : sign * Infinity;
+  return sign * (1 + fraction / 1024) * 2 ** (exponent - 15);
+}
+
+/** Counterparty messages are flat arrays; a deep payload is malformed, not merely unusual. */
+const MAX_CBOR_DEPTH = 16;
+
+function decodeValue(data: Uint8Array, offset: number, depth = 0): DecodedValue {
+  if (depth > MAX_CBOR_DEPTH) throw new Error('CBOR nesting too deep');
   if (offset >= data.length) throw new Error('Unexpected end of CBOR data');
 
   const initial = data[offset]!;
@@ -49,9 +62,10 @@ function decodeValue(data: Uint8Array, offset: number): DecodedValue {
 
   if (majorType === 4) {
     const values: CborValue[] = [];
+    const itemCount = toSafeLength(length);
     let itemOffset = valueOffset;
-    for (let index = 0; index < toSafeLength(length); index += 1) {
-      const decoded = decodeValue(data, itemOffset);
+    for (let index = 0; index < itemCount; index += 1) {
+      const decoded = decodeValue(data, itemOffset, depth + 1);
       values.push(decoded.value);
       itemOffset = decoded.offset;
     }
@@ -61,6 +75,22 @@ function decodeValue(data: Uint8Array, offset: number): DecodedValue {
   if (majorType === 7 && additionalInfo === 20) return { value: false, offset: offset + 1 };
   if (majorType === 7 && additionalInfo === 21) return { value: true, offset: offset + 1 };
   if (majorType === 7 && additionalInfo === 22) return { value: null, offset: offset + 1 };
+
+  // Floats: additionalInfo 25/26/27 = half/single/double precision.
+  // readLength already consumed the raw big-endian bits into `length`.
+  if (majorType === 7 && additionalInfo === 25) {
+    return { value: decodeFloat16(Number(length)), offset: valueOffset };
+  }
+  if (majorType === 7 && additionalInfo === 26) {
+    const view = new DataView(new ArrayBuffer(4));
+    view.setUint32(0, Number(length), false);
+    return { value: view.getFloat32(0, false), offset: valueOffset };
+  }
+  if (majorType === 7 && additionalInfo === 27) {
+    const view = new DataView(new ArrayBuffer(8));
+    view.setBigUint64(0, length, false);
+    return { value: view.getFloat64(0, false), offset: valueOffset };
+  }
 
   throw new Error(`Unsupported CBOR type ${majorType}`);
 }

--- a/src/utils/blockchain/counterparty/unpack/cbor.ts
+++ b/src/utils/blockchain/counterparty/unpack/cbor.ts
@@ -100,3 +100,21 @@ export function decodeCbor(data: Uint8Array): CborValue {
   if (decoded.offset !== data.length) throw new Error('Unexpected trailing CBOR data');
   return decoded.value;
 }
+
+/**
+ * Decode a payload expected to be a definite-length CBOR array of exactly `arity` elements — the
+ * shape of every taproot_support-era Counterparty message. Returns the elements, or null when the
+ * payload is not such an array, so message unpackers can fall back to legacy struct parsing.
+ */
+export function tryDecodeCborArray(payload: Uint8Array, arity: number): CborValue[] | null {
+  // Definite-length array header (major type 4); anything else is not a modern message.
+  if (payload.length < 2 || (payload[0]! & 0xe0) !== 0x80) return null;
+
+  let decoded: CborValue;
+  try {
+    decoded = decodeCbor(payload);
+  } catch {
+    return null;
+  }
+  return Array.isArray(decoded) && decoded.length === arity ? decoded : null;
+}

--- a/src/utils/blockchain/counterparty/unpack/index.ts
+++ b/src/utils/blockchain/counterparty/unpack/index.ts
@@ -311,7 +311,6 @@ export type { PoolDepositData, PoolWithdrawData } from './messages/pool';
 export {
   verifyTransaction,
   verifyTransactionLegacy,
-  extractOpReturnData,
   type ComposeRequest,
   type ComposeParams,
   type VerificationResult,

--- a/src/utils/blockchain/counterparty/unpack/index.ts
+++ b/src/utils/blockchain/counterparty/unpack/index.ts
@@ -28,6 +28,7 @@ import { unpackMPMA, type MPMAData, type MPMASend } from './messages/mpma';
 import { unpackBTCPay, type BTCPayData } from './messages/btcpay';
 import { unpackDispense, type DispenseData } from './messages/dispense';
 import { unpackBroadcast, type BroadcastData } from './messages/broadcast';
+import { unpackBet, type BetData } from './messages/bet';
 import { unpackDividend, type DividendData } from './messages/dividend';
 import { unpackFairminter, type FairminterData } from './messages/fairminter';
 import { unpackFairmint, type FairmintData } from './messages/fairmint';
@@ -50,6 +51,7 @@ export type UnpackedMessageData =
   | BTCPayData
   | DispenseData
   | BroadcastData
+  | BetData
   | DividendData
   | FairminterData
   | FairmintData
@@ -209,6 +211,10 @@ export function unpackCounterpartyMessage(data: string | Uint8Array): UnpackResu
           unpackedData = unpackBroadcast(rawPayload);
           break;
 
+        case MessageTypeId.BET:
+          unpackedData = unpackBet(rawPayload);
+          break;
+
         case MessageTypeId.DIVIDEND:
           unpackedData = unpackDividend(rawPayload);
           break;
@@ -237,7 +243,7 @@ export function unpackCounterpartyMessage(data: string | Uint8Array): UnpackResu
           break;
 
         default:
-          // Return raw payload for unsupported types
+          // Keep the raw payload for display, but this is not a decode.
           unpackedData = { _raw: Array.from(rawPayload) };
           unpackError = `Unsupported message type: ${messageType} (ID: ${messageTypeId})`;
       }
@@ -246,7 +252,9 @@ export function unpackCounterpartyMessage(data: string | Uint8Array): UnpackResu
     }
 
     return {
-      success: !unpackError || unpackedData !== undefined,
+      // Success means the message was decoded. An unsupported type still returns data — the raw
+      // bytes, for display — so the presence of data is not itself a decode.
+      success: !unpackError,
       error: unpackError,
       messageTypeId,
       messageType,

--- a/src/utils/blockchain/counterparty/unpack/messages/bet.ts
+++ b/src/utils/blockchain/counterparty/unpack/messages/bet.ts
@@ -1,0 +1,91 @@
+/**
+ * Bet Message Unpacker
+ *
+ * Message ID: 40
+ * Format: ">HIQQdII" (38 bytes)
+ *   - bet_type (H): 2 bytes — 0 BullCFD, 1 BearCFD, 2 Equal, 3 NotEqual
+ *   - deadline (I): 4 bytes — unix timestamp the feed must report against
+ *   - wager_quantity (Q): 8 bytes — XCP staked, in base units
+ *   - counterwager_quantity (Q): 8 bytes — XCP required from the other side
+ *   - target_value (d): 8 bytes — IEEE 754 double the feed is compared to
+ *   - leverage (I): 4 bytes — fixed point, 5040 = 1x
+ *   - expiration (I): 4 bytes — blocks the order stays open
+ *
+ * The feed address is a transaction output, not part of this payload.
+ */
+
+import { BinaryReader } from '../binary';
+
+/** Exact length of a bet payload; core rejects any other size. */
+const BET_LENGTH = 2 + 4 + 8 + 8 + 8 + 4 + 4;
+
+/** Bet types, as encoded in the two-byte bet_type field. */
+export const BetType: Record<number, string> = {
+  0: 'BullCFD',
+  1: 'BearCFD',
+  2: 'Equal',
+  3: 'NotEqual',
+};
+
+/**
+ * Unpacked bet data
+ */
+export interface BetData {
+  /** Raw bet type */
+  betType: number;
+  /** Human-readable bet type, or undefined if the value is not a known type */
+  betTypeName?: string;
+  /** Unix timestamp the feed must report against */
+  deadline: number;
+  /** XCP staked, in base units */
+  wagerQuantity: bigint;
+  /** XCP required from the other side, in base units */
+  counterwagerQuantity: bigint;
+  /** Value the feed is compared to */
+  targetValue: number;
+  /** Leverage in fixed point, 5040 = 1x */
+  leverage: number;
+  /** Blocks the order stays open */
+  expiration: number;
+}
+
+/**
+ * Unpack a bet message.
+ *
+ * @param payload - Message payload (after prefix and type ID)
+ * @returns Unpacked bet data
+ * @throws Error if payload is invalid
+ */
+export function unpackBet(payload: Uint8Array): BetData {
+  if (payload.length !== BET_LENGTH) {
+    throw new Error(`Invalid bet payload length: ${payload.length} (expected ${BET_LENGTH})`);
+  }
+
+  const reader = new BinaryReader(payload);
+
+  const betType = reader.readUint16BE();
+  const deadline = reader.readUint32BE();
+  const wagerQuantity = reader.readUint64BE();
+  const counterwagerQuantity = reader.readUint64BE();
+
+  const targetBytes = reader.readBytes(8);
+  const targetValue = new DataView(
+    targetBytes.buffer,
+    targetBytes.byteOffset,
+    8
+  ).getFloat64(0, false);
+
+  const leverage = reader.readUint32BE();
+  const expiration = reader.readUint32BE();
+
+  return {
+    betType,
+    betTypeName: BetType[betType],
+    deadline,
+    wagerQuantity,
+    counterwagerQuantity,
+    targetValue,
+    leverage,
+    expiration,
+  };
+}

--- a/src/utils/blockchain/counterparty/unpack/messages/broadcast.ts
+++ b/src/utils/blockchain/counterparty/unpack/messages/broadcast.ts
@@ -8,13 +8,16 @@
  *   - fee_fraction_int (I): 4 bytes unsigned int
  *   - text: Variable length string
  *
- * Modern format uses CBOR encoding with additional fields.
+ * Modern (taproot_support) Format: CBOR array
+ *   [timestamp, value, fee_fraction_int, mime_type, text]
+ *
  * Legacy format uses Pascal strings or variable-length encoding.
  */
 
-import { BinaryReader } from '../binary';
+import { BinaryReader, bytesToTextOrHex } from '../binary';
+import { decodeCbor, type CborValue } from '../cbor';
 
-/** Minimum length of broadcast message (timestamp + value + fee_fraction) */
+/** Minimum length of legacy broadcast message (timestamp + value + fee_fraction) */
 const BROADCAST_MIN_LENGTH = 16; // 4 + 8 + 4
 
 /**
@@ -34,22 +37,44 @@ export interface BroadcastData {
 }
 
 /**
- * Try to decode CBOR-encoded broadcast (modern format)
- * Returns null if not CBOR format
+ * Try to decode a CBOR-encoded broadcast (taproot_support era).
+ *
+ * Format: [timestamp, value, fee_fraction_int, mime_type, text]
+ * where text is bytes (or null) and value may be an integer or float.
+ *
+ * Returns null if the payload is not CBOR, so the caller falls back to legacy.
  */
 function tryDecodeCBOR(payload: Uint8Array): BroadcastData | null {
-  try {
-    // Basic CBOR array detection - starts with 0x85 (5-element array)
-    if (payload[0] !== 0x85) {
-      return null;
-    }
+  // 0x85 = definite-length array of 5.
+  if (payload.length < 2 || payload[0] !== 0x85) return null;
 
-    // For now, skip CBOR parsing and return null to fall back to legacy
-    // Full CBOR parsing would require a CBOR library
-    return null;
+  let decoded: CborValue;
+  try {
+    decoded = decodeCbor(payload);
   } catch {
     return null;
   }
+  if (!Array.isArray(decoded) || decoded.length !== 5) return null;
+
+  const [timestampValue, valueValue, feeFractionValue, mimeTypeValue, textValue] = decoded;
+  if (typeof timestampValue !== 'bigint' || typeof feeFractionValue !== 'bigint') return null;
+  if (typeof valueValue !== 'bigint' && typeof valueValue !== 'number') return null;
+
+  // Core encodes the text as bytes; a null means the broadcast carries none.
+  let text = '';
+  if (textValue instanceof Uint8Array) {
+    text = bytesToTextOrHex(textValue);
+  } else if (typeof textValue === 'string') {
+    text = textValue;
+  }
+
+  return {
+    timestamp: Number(timestampValue),
+    value: Number(valueValue),
+    feeFractionInt: Number(feeFractionValue),
+    text,
+    mimeType: typeof mimeTypeValue === 'string' && mimeTypeValue !== '' ? mimeTypeValue : undefined,
+  };
 }
 
 /**
@@ -60,16 +85,16 @@ function tryDecodeCBOR(payload: Uint8Array): BroadcastData | null {
  * @throws Error if payload is invalid
  */
 export function unpackBroadcast(payload: Uint8Array): BroadcastData {
+  // CBOR (taproot_support era) first; it can be shorter than the legacy minimum.
+  const cborResult = tryDecodeCBOR(payload);
+  if (cborResult) {
+    return cborResult;
+  }
+
   if (payload.length < BROADCAST_MIN_LENGTH) {
     throw new Error(
       `Invalid broadcast payload length: ${payload.length} (minimum ${BROADCAST_MIN_LENGTH})`
     );
-  }
-
-  // Try CBOR first (modern format)
-  const cborResult = tryDecodeCBOR(payload);
-  if (cborResult) {
-    return cborResult;
   }
 
   // Legacy format: ">IdI" + text

--- a/src/utils/blockchain/counterparty/unpack/messages/broadcast.ts
+++ b/src/utils/blockchain/counterparty/unpack/messages/broadcast.ts
@@ -15,7 +15,7 @@
  */
 
 import { BinaryReader, bytesToTextOrHex } from '../binary';
-import { decodeCbor, type CborValue } from '../cbor';
+import { tryDecodeCborArray } from '../cbor';
 
 /** Minimum length of legacy broadcast message (timestamp + value + fee_fraction) */
 const BROADCAST_MIN_LENGTH = 16; // 4 + 8 + 4
@@ -45,16 +45,8 @@ export interface BroadcastData {
  * Returns null if the payload is not CBOR, so the caller falls back to legacy.
  */
 function tryDecodeCBOR(payload: Uint8Array): BroadcastData | null {
-  // 0x85 = definite-length array of 5.
-  if (payload.length < 2 || payload[0] !== 0x85) return null;
-
-  let decoded: CborValue;
-  try {
-    decoded = decodeCbor(payload);
-  } catch {
-    return null;
-  }
-  if (!Array.isArray(decoded) || decoded.length !== 5) return null;
+  const decoded = tryDecodeCborArray(payload, 5);
+  if (!decoded) return null;
 
   const [timestampValue, valueValue, feeFractionValue, mimeTypeValue, textValue] = decoded;
   if (typeof timestampValue !== 'bigint' || typeof feeFractionValue !== 'bigint') return null;

--- a/src/utils/blockchain/counterparty/unpack/messages/enhancedSend.ts
+++ b/src/utils/blockchain/counterparty/unpack/messages/enhancedSend.ts
@@ -17,7 +17,7 @@
 import { BinaryReader, bytesToTextOrHex } from '../binary';
 import { assetIdToName } from '../assetId';
 import { unpackAddress, PACKED_ADDRESS_LENGTH } from '../address';
-import { decodeCbor, type CborValue } from '../cbor';
+import { tryDecodeCborArray } from '../cbor';
 
 /** Minimum length of legacy enhanced send (without memo) */
 const MIN_LEGACY_LENGTH = 8 + 8 + 21; // 37 bytes
@@ -50,17 +50,9 @@ export interface EnhancedSendData {
  * Returns null if the payload is not CBOR, so the caller falls back to legacy.
  */
 function tryCbor2Decode(payload: Uint8Array): EnhancedSendData | null {
-  // 0x84 = definite-length array of 4.
-  if (payload.length < 4 || payload[0] !== 0x84) return null;
+  const decoded = tryDecodeCborArray(payload, 4);
+  if (!decoded) return null;
 
-  let decoded: CborValue;
-  try {
-    decoded = decodeCbor(payload);
-  } catch {
-    return null;
-  }
-
-  if (!Array.isArray(decoded) || decoded.length !== 4) return null;
   const [assetIdValue, quantityValue, addressValue, memoValue] = decoded;
   if (typeof assetIdValue !== 'bigint' || typeof quantityValue !== 'bigint') return null;
   if (!(addressValue instanceof Uint8Array)) return null;

--- a/src/utils/blockchain/counterparty/unpack/messages/enhancedSend.ts
+++ b/src/utils/blockchain/counterparty/unpack/messages/enhancedSend.ts
@@ -14,9 +14,10 @@
  * The unpacker attempts CBOR2 first, then falls back to legacy format.
  */
 
-import { BinaryReader } from '../binary';
+import { BinaryReader, bytesToTextOrHex } from '../binary';
 import { assetIdToName } from '../assetId';
 import { unpackAddress, PACKED_ADDRESS_LENGTH } from '../address';
+import { decodeCbor, type CborValue } from '../cbor';
 
 /** Minimum length of legacy enhanced send (without memo) */
 const MIN_LEGACY_LENGTH = 8 + 8 + 21; // 37 bytes
@@ -42,27 +43,42 @@ export interface EnhancedSendData {
 }
 
 /**
- * Try to decode CBOR2 format (modern Taproot-era messages).
- * Returns null if not valid CBOR2.
+ * Try to decode a CBOR-encoded enhanced send (taproot_support era).
+ *
+ * Format: [asset_id, quantity, short_address_bytes, memo_bytes]
+ *
+ * Returns null if the payload is not CBOR, so the caller falls back to legacy.
  */
 function tryCbor2Decode(payload: Uint8Array): EnhancedSendData | null {
-  // CBOR2 arrays start with specific bytes:
-  // 0x84 = array of 4 elements
-  // 0x83 = array of 3 elements
-  if (payload.length < 4) return null;
-  if (payload[0] !== 0x84 && payload[0] !== 0x83) return null;
+  // 0x84 = definite-length array of 4.
+  if (payload.length < 4 || payload[0] !== 0x84) return null;
 
+  let decoded: CborValue;
   try {
-    // Simple CBOR2 decoder for the specific format we expect
-    // Full CBOR2 parsing would require a library, but we can handle
-    // the specific case of [bigint, bigint, bytes, bytes]
-
-    // For now, return null and use legacy parsing
-    // TODO: Implement CBOR2 parsing if needed
-    return null;
+    decoded = decodeCbor(payload);
   } catch {
     return null;
   }
+
+  if (!Array.isArray(decoded) || decoded.length !== 4) return null;
+  const [assetIdValue, quantityValue, addressValue, memoValue] = decoded;
+  if (typeof assetIdValue !== 'bigint' || typeof quantityValue !== 'bigint') return null;
+  if (!(addressValue instanceof Uint8Array)) return null;
+
+  if (assetIdValue === 0n) {
+    throw new Error('Invalid enhanced send: BTC (asset_id 0) is not allowed');
+  }
+
+  const memoBytes = memoValue instanceof Uint8Array && memoValue.length > 0 ? memoValue : undefined;
+
+  return {
+    asset: assetIdToName(assetIdValue),
+    assetId: assetIdValue,
+    quantity: quantityValue,
+    destination: unpackAddress(addressValue),
+    memo: memoBytes ? bytesToTextOrHex(memoBytes) : undefined,
+    memoBytes,
+  };
 }
 
 /**
@@ -89,13 +105,7 @@ function unpackLegacy(payload: Uint8Array): EnhancedSendData {
 
   if (memoLength > 0) {
     memoBytes = reader.readBytes(memoLength);
-    // Try to decode as UTF-8 text
-    try {
-      memo = new TextDecoder('utf-8', { fatal: true }).decode(memoBytes);
-    } catch {
-      // Not valid UTF-8, store as hex
-      memo = Array.from(memoBytes).map(b => b.toString(16).padStart(2, '0')).join('');
-    }
+    memo = bytesToTextOrHex(memoBytes);
   }
 
   // Core rejects asset_id 0 (BTC) for enhanced sends; reject it here too.

--- a/src/utils/blockchain/counterparty/unpack/messages/fairmint.ts
+++ b/src/utils/blockchain/counterparty/unpack/messages/fairmint.ts
@@ -11,7 +11,7 @@
  */
 
 import { assetIdToName } from '../assetId';
-import { decodeCbor, type CborValue } from '../cbor';
+import { tryDecodeCborArray } from '../cbor';
 
 /**
  * Unpacked Fairmint data
@@ -28,16 +28,8 @@ export interface FairmintData {
  * Returns null if the payload is not CBOR, so the caller falls back to legacy.
  */
 function tryCborDecode(payload: Uint8Array): FairmintData | null {
-  // 0x82 = definite-length array of 2.
-  if (payload.length < 2 || payload[0] !== 0x82) return null;
-
-  let decoded: CborValue;
-  try {
-    decoded = decodeCbor(payload);
-  } catch {
-    return null;
-  }
-  if (!Array.isArray(decoded) || decoded.length !== 2) return null;
+  const decoded = tryDecodeCborArray(payload, 2);
+  if (!decoded) return null;
 
   const [assetIdValue, quantityValue] = decoded;
   if (typeof assetIdValue !== 'bigint' || typeof quantityValue !== 'bigint') return null;

--- a/src/utils/blockchain/counterparty/unpack/messages/fairmint.ts
+++ b/src/utils/blockchain/counterparty/unpack/messages/fairmint.ts
@@ -11,6 +11,7 @@
  */
 
 import { assetIdToName } from '../assetId';
+import { decodeCbor, type CborValue } from '../cbor';
 
 /**
  * Unpacked Fairmint data
@@ -23,81 +24,28 @@ export interface FairmintData {
 }
 
 /**
- * Try to decode CBOR array (basic implementation for fairmint)
+ * Try to decode a CBOR-encoded fairmint (fairminter_v2).
+ * Returns null if the payload is not CBOR, so the caller falls back to legacy.
  */
-function tryDecodeCBORFairmint(payload: Uint8Array): FairmintData | null {
+function tryCborDecode(payload: Uint8Array): FairmintData | null {
+  // 0x82 = definite-length array of 2.
+  if (payload.length < 2 || payload[0] !== 0x82) return null;
+
+  let decoded: CborValue;
   try {
-    // Check for CBOR array marker (0x82 = 2-element array)
-    if (payload[0] !== 0x82) {
-      return null;
-    }
-
-    // Simple CBOR parsing for 2-element array with integers
-    let pos = 1;
-
-    // Parse asset_id (positive integer)
-    const assetIdResult = parseCBORInt(payload, pos);
-    if (!assetIdResult) return null;
-    const [assetId, newPos1] = assetIdResult;
-    pos = newPos1;
-
-    // Parse quantity (positive integer)
-    const quantityResult = parseCBORInt(payload, pos);
-    if (!quantityResult) return null;
-    const [quantity] = quantityResult;
-
-    return {
-      asset: assetIdToName(assetId),
-      quantity,
-    };
+    decoded = decodeCbor(payload);
   } catch {
     return null;
   }
-}
+  if (!Array.isArray(decoded) || decoded.length !== 2) return null;
 
-/**
- * Parse a CBOR positive integer starting at position
- * Returns [value, newPosition] or null if failed
- */
-function parseCBORInt(data: Uint8Array, pos: number): [bigint, number] | null {
-  if (pos >= data.length) return null;
+  const [assetIdValue, quantityValue] = decoded;
+  if (typeof assetIdValue !== 'bigint' || typeof quantityValue !== 'bigint') return null;
 
-  const firstByte = data[pos]!;
-
-  // Major type 0: positive integer
-  if ((firstByte & 0xe0) !== 0x00) return null;
-
-  const additionalInfo = firstByte & 0x1f;
-
-  if (additionalInfo < 24) {
-    // Direct value
-    return [BigInt(additionalInfo), pos + 1];
-  } else if (additionalInfo === 24) {
-    // 1-byte value
-    if (pos + 1 >= data.length) return null;
-    return [BigInt(data[pos + 1]!), pos + 2];
-  } else if (additionalInfo === 25) {
-    // 2-byte value
-    if (pos + 2 >= data.length) return null;
-    const value = (data[pos + 1]! << 8) | data[pos + 2]!;
-    return [BigInt(value), pos + 3];
-  } else if (additionalInfo === 26) {
-    // 4-byte value
-    if (pos + 4 >= data.length) return null;
-    const value =
-      (data[pos + 1]! << 24) | (data[pos + 2]! << 16) | (data[pos + 3]! << 8) | data[pos + 4]!;
-    return [BigInt(value >>> 0), pos + 5];
-  } else if (additionalInfo === 27) {
-    // 8-byte value
-    if (pos + 8 >= data.length) return null;
-    let value = 0n;
-    for (let i = 0; i < 8; i++) {
-      value = (value << 8n) | BigInt(data[pos + 1 + i]!);
-    }
-    return [value, pos + 9];
-  }
-
-  return null;
+  return {
+    asset: assetIdToName(assetIdValue),
+    quantity: quantityValue,
+  };
 }
 
 /**
@@ -113,7 +61,7 @@ export function unpackFairmint(payload: Uint8Array): FairmintData {
   }
 
   // Try CBOR first (modern format)
-  const cborResult = tryDecodeCBORFairmint(payload);
+  const cborResult = tryCborDecode(payload);
   if (cborResult) {
     return cborResult;
   }

--- a/src/utils/blockchain/counterparty/unpack/messages/issuance.ts
+++ b/src/utils/blockchain/counterparty/unpack/messages/issuance.ts
@@ -18,14 +18,16 @@
  * SUBASSET_FORMAT: ">QQ?B" + compacted_subasset + description
  *   - asset_id, quantity, divisible, compacted_length, compacted_name, description
  *
- * Modern (Taproot): CBOR2 encoded
- *
- * This unpacker handles the most common formats.
+ * Modern (taproot_support): CBOR array
+ *   Standard: [asset_id, quantity, divisible, lock, reset, mime_type, description]
+ *   Subasset: [asset_id, quantity, divisible, lock, reset,
+ *              compacted_length, compacted_name, mime_type, description]
  */
 
-import { BinaryReader } from '../binary';
+import { BinaryReader, bytesToTextOrHex } from '../binary';
 import { assetIdToName } from '../assetId';
 import { MessageTypeId } from '../messageTypes';
+import { decodeCbor, type CborValue } from '../cbor';
 
 /** Minimum length of issuance (FORMAT_1) */
 const MIN_ISSUANCE_LENGTH = 17;
@@ -65,17 +67,91 @@ export interface IssuanceData {
  * Subassets use a variable-length encoding.
  */
 function decodeCompactedSubasset(bytes: Uint8Array): string {
-  // Subasset names are encoded as a series of bytes where each character
-  // is mapped to a value 1-68 (for the SUBASSET_DIGITS charset)
+  // Compacted subasset names are a base-68 big-endian integer over the
+  // SUBASSET_DIGITS charset, where digit value d maps to SUBASSET_DIGITS[d-1]
+  // and d === 0 maps to the final character (Python's DIGITS[-1]).
   const SUBASSET_DIGITS = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.-_@!';
 
-  let result = '';
+  let integer = 0n;
   for (const byte of bytes) {
-    if (byte === 0) break; // Null terminator
-    if (byte <= SUBASSET_DIGITS.length) {
-      result += SUBASSET_DIGITS[byte - 1];
-    }
+    integer = (integer << 8n) | BigInt(byte);
   }
+
+  let result = '';
+  while (integer !== 0n) {
+    const digit = Number(integer % 68n);
+    result = SUBASSET_DIGITS[digit === 0 ? SUBASSET_DIGITS.length - 1 : digit - 1] + result;
+    integer /= 68n;
+  }
+  return result;
+}
+
+/** Coerce a CBOR boolean-or-integer flag (core encodes both) to boolean. */
+function cborFlag(value: CborValue): boolean | null {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'bigint') return value !== 0n;
+  return null;
+}
+
+/** A CBOR description field is bytes, or null when the issuance carries none. */
+function cborDescription(value: CborValue): string | undefined {
+  return value instanceof Uint8Array ? bytesToTextOrHex(value) : undefined;
+}
+
+/**
+ * Try to decode a CBOR-encoded issuance (taproot_support era).
+ *
+ * Standard (IDs 20/22): [asset_id, quantity, divisible, lock, reset, mime_type, description]
+ * Subasset (IDs 21/23): [asset_id, quantity, divisible, lock, reset,
+ *                        compacted_length, compacted_name, mime_type, description]
+ *
+ * Returns null if the payload is not CBOR, so the caller falls back to legacy parsing.
+ */
+function tryCborDecode(payload: Uint8Array, messageTypeId: number): IssuanceData | null {
+  if (payload.length < 2) return null;
+  // CBOR definite-length array header (major type 4).
+  if ((payload[0]! & 0xe0) !== 0x80) return null;
+
+  let decoded: CborValue;
+  try {
+    decoded = decodeCbor(payload);
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(decoded)) return null;
+
+  const isSubasset = messageTypeId === MessageTypeId.SUBASSET_ISSUANCE ||
+                     messageTypeId === MessageTypeId.LR_SUBASSET;
+
+  if (decoded.length !== (isSubasset ? 9 : 7)) return null;
+
+  const [assetIdValue, quantityValue, divisibleValue, lockValue, resetValue] = decoded;
+  if (typeof assetIdValue !== 'bigint' || typeof quantityValue !== 'bigint') return null;
+  const divisible = cborFlag(divisibleValue ?? null);
+  const lock = cborFlag(lockValue ?? null);
+  const reset = cborFlag(resetValue ?? null);
+  if (divisible === null || lock === null || reset === null) return null;
+
+  const result: IssuanceData = {
+    asset: assetIdToName(assetIdValue),
+    assetId: assetIdValue,
+    quantity: quantityValue,
+    divisible,
+    isLock: lock,
+    isReset: reset,
+    messageTypeId,
+  };
+
+  if (isSubasset) {
+    const compactedName = decoded[6];
+    if (compactedName instanceof Uint8Array) {
+      result.subassetLongname = decodeCompactedSubasset(compactedName);
+    }
+    result.description = cborDescription(decoded[8] ?? null);
+  } else {
+    result.description = cborDescription(decoded[6] ?? null);
+  }
+
   return result;
 }
 
@@ -88,6 +164,12 @@ function decodeCompactedSubasset(bytes: Uint8Array): string {
  * @throws Error if payload is invalid
  */
 export function unpackIssuance(payload: Uint8Array, messageTypeId: number): IssuanceData {
+  // CBOR (taproot_support era) first, matching core's unpack order.
+  const cborResult = tryCborDecode(payload, messageTypeId);
+  if (cborResult) {
+    return cborResult;
+  }
+
   if (payload.length < MIN_ISSUANCE_LENGTH) {
     throw new Error(`Invalid issuance payload length: ${payload.length} (minimum ${MIN_ISSUANCE_LENGTH})`);
   }

--- a/src/utils/blockchain/counterparty/unpack/messages/issuance.ts
+++ b/src/utils/blockchain/counterparty/unpack/messages/issuance.ts
@@ -27,7 +27,7 @@
 import { BinaryReader, bytesToTextOrHex } from '../binary';
 import { assetIdToName } from '../assetId';
 import { MessageTypeId } from '../messageTypes';
-import { decodeCbor, type CborValue } from '../cbor';
+import { tryDecodeCborArray, type CborValue } from '../cbor';
 
 /** Minimum length of issuance (FORMAT_1) */
 const MIN_ISSUANCE_LENGTH = 17;
@@ -108,22 +108,11 @@ function cborDescription(value: CborValue): string | undefined {
  * Returns null if the payload is not CBOR, so the caller falls back to legacy parsing.
  */
 function tryCborDecode(payload: Uint8Array, messageTypeId: number): IssuanceData | null {
-  if (payload.length < 2) return null;
-  // CBOR definite-length array header (major type 4).
-  if ((payload[0]! & 0xe0) !== 0x80) return null;
-
-  let decoded: CborValue;
-  try {
-    decoded = decodeCbor(payload);
-  } catch {
-    return null;
-  }
-  if (!Array.isArray(decoded)) return null;
-
   const isSubasset = messageTypeId === MessageTypeId.SUBASSET_ISSUANCE ||
                      messageTypeId === MessageTypeId.LR_SUBASSET;
 
-  if (decoded.length !== (isSubasset ? 9 : 7)) return null;
+  const decoded = tryDecodeCborArray(payload, isSubasset ? 9 : 7);
+  if (!decoded) return null;
 
   const [assetIdValue, quantityValue, divisibleValue, lockValue, resetValue] = decoded;
   if (typeof assetIdValue !== 'bigint' || typeof quantityValue !== 'bigint') return null;

--- a/src/utils/blockchain/counterparty/unpack/messages/sweep.ts
+++ b/src/utils/blockchain/counterparty/unpack/messages/sweep.ts
@@ -12,11 +12,13 @@
  *   0x02 (FLAG_OWNERSHIP): Include asset ownership
  *   0x04 (FLAG_BINARY_MEMO): Memo is binary (not text)
  *
- * Modern (Taproot) Format: CBOR2 encoded
+ * Modern (taproot_support) Format: CBOR array
+ *   [short_address_bytes, flags, memo_bytes]
  */
 
-import { BinaryReader } from '../binary';
+import { BinaryReader, bytesToHex } from '../binary';
 import { unpackAddress, PACKED_ADDRESS_LENGTH } from '../address';
+import { decodeCbor, type CborValue } from '../cbor';
 
 /** Minimum length of sweep message (destination + flags) */
 const SWEEP_MIN_LENGTH = 22;
@@ -50,6 +52,56 @@ export interface SweepData {
   memoBytes?: Uint8Array;
 }
 
+/** Build the flag-derived fields shared by both decode paths. */
+function sweepFromParts(destination: string, flags: number, memoBytes?: Uint8Array): SweepData {
+  const memoIsBinary = (flags & SweepFlags.BINARY_MEMO) !== 0;
+
+  const result: SweepData = {
+    destination,
+    flags,
+    sweepBalances: (flags & SweepFlags.BALANCES) !== 0,
+    sweepOwnership: (flags & SweepFlags.OWNERSHIP) !== 0,
+    memoIsBinary,
+  };
+
+  if (memoBytes && memoBytes.length > 0) {
+    result.memoBytes = memoBytes;
+    // The flag says how to read the memo. Core decodes a non-binary one as strict UTF-8 and
+    // aborts on invalid bytes; let it throw rather than masking with a hex fallback.
+    result.memo = memoIsBinary
+      ? bytesToHex(memoBytes)
+      : new TextDecoder('utf-8', { fatal: true }).decode(memoBytes);
+  }
+
+  return result;
+}
+
+/**
+ * Try to decode a CBOR-encoded sweep (taproot_support era).
+ *
+ * Format: [short_address_bytes, flags, memo_bytes]
+ *
+ * Returns null if the payload is not CBOR, so the caller falls back to legacy.
+ */
+function tryCborDecode(payload: Uint8Array): SweepData | null {
+  // 0x83 = definite-length array of 3.
+  if (payload.length < 2 || payload[0] !== 0x83) return null;
+
+  let decoded: CborValue;
+  try {
+    decoded = decodeCbor(payload);
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(decoded) || decoded.length !== 3) return null;
+
+  const [addressValue, flagsValue, memoValue] = decoded;
+  if (!(addressValue instanceof Uint8Array) || typeof flagsValue !== 'bigint') return null;
+
+  const memoBytes = memoValue instanceof Uint8Array ? memoValue : undefined;
+  return sweepFromParts(unpackAddress(addressValue), Number(flagsValue), memoBytes);
+}
+
 /**
  * Unpack a sweep message.
  *
@@ -58,6 +110,12 @@ export interface SweepData {
  * @throws Error if payload is invalid
  */
 export function unpackSweep(payload: Uint8Array): SweepData {
+  // CBOR (taproot_support era) first, matching core's unpack order.
+  const cborResult = tryCborDecode(payload);
+  if (cborResult) {
+    return cborResult;
+  }
+
   if (payload.length < SWEEP_MIN_LENGTH) {
     throw new Error(`Invalid sweep payload length: ${payload.length} (minimum ${SWEEP_MIN_LENGTH})`);
   }
@@ -71,36 +129,7 @@ export function unpackSweep(payload: Uint8Array): SweepData {
 
   const packedAddress = reader.readBytes(PACKED_ADDRESS_LENGTH);
   const flags = reader.readUint8();
+  const memoBytes = memoLength > 0 ? reader.readBytes(memoLength) : undefined;
 
-  // Unpack destination address
-  const destination = unpackAddress(packedAddress);
-
-  // Parse flags
-  const sweepBalances = (flags & SweepFlags.BALANCES) !== 0;
-  const sweepOwnership = (flags & SweepFlags.OWNERSHIP) !== 0;
-  const memoIsBinary = (flags & SweepFlags.BINARY_MEMO) !== 0;
-
-  const result: SweepData = {
-    destination,
-    flags,
-    sweepBalances,
-    sweepOwnership,
-    memoIsBinary,
-  };
-
-  // Read optional memo
-  if (memoLength > 0) {
-    result.memoBytes = reader.readBytes(memoLength);
-
-    if (memoIsBinary) {
-      // Binary memo - store as hex
-      result.memo = Array.from(result.memoBytes).map(b => b.toString(16).padStart(2, '0')).join('');
-    } else {
-      // Non-binary memo: core decodes strict UTF-8 and aborts on invalid bytes;
-      // let it throw rather than masking with a hex fallback.
-      result.memo = new TextDecoder('utf-8', { fatal: true }).decode(result.memoBytes);
-    }
-  }
-
-  return result;
+  return sweepFromParts(unpackAddress(packedAddress), flags, memoBytes);
 }

--- a/src/utils/blockchain/counterparty/unpack/messages/sweep.ts
+++ b/src/utils/blockchain/counterparty/unpack/messages/sweep.ts
@@ -18,7 +18,7 @@
 
 import { BinaryReader, bytesToHex } from '../binary';
 import { unpackAddress, PACKED_ADDRESS_LENGTH } from '../address';
-import { decodeCbor, type CborValue } from '../cbor';
+import { tryDecodeCborArray } from '../cbor';
 
 /** Minimum length of sweep message (destination + flags) */
 const SWEEP_MIN_LENGTH = 22;
@@ -84,16 +84,8 @@ function sweepFromParts(destination: string, flags: number, memoBytes?: Uint8Arr
  * Returns null if the payload is not CBOR, so the caller falls back to legacy.
  */
 function tryCborDecode(payload: Uint8Array): SweepData | null {
-  // 0x83 = definite-length array of 3.
-  if (payload.length < 2 || payload[0] !== 0x83) return null;
-
-  let decoded: CborValue;
-  try {
-    decoded = decodeCbor(payload);
-  } catch {
-    return null;
-  }
-  if (!Array.isArray(decoded) || decoded.length !== 3) return null;
+  const decoded = tryDecodeCborArray(payload, 3);
+  if (!decoded) return null;
 
   const [addressValue, flagsValue, memoValue] = decoded;
   if (!(addressValue instanceof Uint8Array) || typeof flagsValue !== 'bigint') return null;

--- a/src/utils/blockchain/counterparty/unpack/multisig.ts
+++ b/src/utils/blockchain/counterparty/unpack/multisig.ts
@@ -1,0 +1,102 @@
+/**
+ * Local extraction of a Counterparty payload carried in bare-multisig outputs.
+ *
+ * Counterparty's `multisig` encoding stores the message in 1-of-3 bare multisig
+ * outputs, using two fake pubkeys per output as data carriers:
+ *
+ *   OP_1 <data_pubkey_1> <data_pubkey_2> <source_pubkey> OP_3 OP_CHECKMULTISIG
+ *
+ * Each fake pubkey is a sign byte, 31 data bytes, and a nonce byte; the sign and
+ * nonce exist only to land on the curve and are discarded. The 62 data bytes are
+ * ARC4-obfuscated with the first input's txid, and decrypt to:
+ *
+ *   [length byte] [CNTRPRTY prefix] [chunk] [zero padding]
+ *
+ * Chunks concatenate across outputs, in output order, to form the message. Each
+ * output is encrypted with its own keystream, so each decrypts independently.
+ */
+
+import { arc4, hexToBytes, bytesToHex } from './binary';
+import { COUNTERPARTY_PREFIX_HEX } from './messageTypes';
+
+/** Byte length of a bare-multisig data output script. */
+const MULTISIG_SCRIPT_LENGTH = 105;
+/** Data bytes carried by one fake pubkey (33 minus sign and nonce). */
+const DATA_BYTES_PER_PUBKEY = 31;
+
+/**
+ * Pull the 62 obfuscated data bytes out of a bare-multisig data output.
+ *
+ * @param scriptHex - Full scriptPubKey hex
+ * @returns The data bytes, or null if this is not a bare-multisig data output
+ */
+function extractMultisigDataBytes(scriptHex: string): Uint8Array | null {
+  let bytes: Uint8Array;
+  try {
+    bytes = hexToBytes(scriptHex);
+  } catch {
+    return null;
+  }
+
+  if (bytes.length !== MULTISIG_SCRIPT_LENGTH) return null;
+  // OP_1 ... OP_3 OP_CHECKMULTISIG, with three 33-byte pushes between.
+  if (bytes[0] !== 0x51 || bytes[103] !== 0x53 || bytes[104] !== 0xae) return null;
+  if (bytes[1] !== 0x21 || bytes[35] !== 0x21 || bytes[69] !== 0x21) return null;
+
+  const data = new Uint8Array(DATA_BYTES_PER_PUBKEY * 2);
+  // Skip each pubkey's leading sign byte and trailing nonce byte.
+  data.set(bytes.slice(3, 3 + DATA_BYTES_PER_PUBKEY), 0);
+  data.set(bytes.slice(37, 37 + DATA_BYTES_PER_PUBKEY), DATA_BYTES_PER_PUBKEY);
+  return data;
+}
+
+/**
+ * Decode one bare-multisig data output into its message chunk.
+ *
+ * @param scriptHex - Full scriptPubKey hex
+ * @param firstInputTxid - First input txid in display (big-endian) order
+ * @returns The chunk hex without the CNTRPRTY prefix, or null
+ */
+function decodeMultisigChunk(scriptHex: string, firstInputTxid: string): string | null {
+  const dataBytes = extractMultisigDataBytes(scriptHex);
+  if (!dataBytes) return null;
+
+  let decrypted: Uint8Array;
+  try {
+    decrypted = arc4(hexToBytes(firstInputTxid), dataBytes);
+  } catch {
+    return null;
+  }
+
+  const contentLength = decrypted[0]!;
+  if (contentLength === 0 || contentLength > decrypted.length - 1) return null;
+
+  const contentHex = bytesToHex(decrypted.slice(1, 1 + contentLength));
+  if (!contentHex.startsWith(COUNTERPARTY_PREFIX_HEX)) return null;
+
+  return contentHex.slice(COUNTERPARTY_PREFIX_HEX.length);
+}
+
+/**
+ * Extract a Counterparty payload from a transaction's bare-multisig outputs.
+ *
+ * @param outputScriptHexes - All output scriptPubKey hexes, in output order
+ * @param firstInputTxid - First input txid in display (big-endian) order
+ * @returns Counterparty datahex with the CNTRPRTY prefix, or null if no
+ *          multisig-encoded payload is present
+ */
+export function extractMultisigPayload(
+  outputScriptHexes: readonly string[],
+  firstInputTxid: string
+): string | null {
+  let payload = '';
+
+  // Every data output counts, wherever it sits. Stopping at the first ordinary output would let a
+  // payload be split around one and read as only its prefix — a different message from the one the
+  // network will parse.
+  for (const scriptHex of outputScriptHexes) {
+    payload += decodeMultisigChunk(scriptHex, firstInputTxid) ?? '';
+  }
+
+  return payload ? COUNTERPARTY_PREFIX_HEX + payload : null;
+}

--- a/src/utils/blockchain/counterparty/unpack/opReturn.ts
+++ b/src/utils/blockchain/counterparty/unpack/opReturn.ts
@@ -11,6 +11,7 @@
 import { Transaction } from '@scure/btc-signer';
 import { arc4, hexToBytes, bytesToHex } from './binary';
 import { COUNTERPARTY_PREFIX_HEX } from './messageTypes';
+import { extractMultisigPayload } from './multisig';
 
 /**
  * Strip the OP_RETURN opcode (0x6a) and push-data length prefix from an
@@ -78,13 +79,13 @@ export function decryptOpReturnData(
 
 /**
  * Extract the Counterparty message payload from a raw transaction hex by
- * parsing its structure locally: locate the OP_RETURN output and the first
- * input's txid, then resolve the payload as plaintext (future protocol) or
- * ARC4-obfuscated (current protocol).
+ * parsing its structure locally: locate the first input's txid, then resolve the
+ * payload from an OP_RETURN output — as plaintext (future protocol) or
+ * ARC4-obfuscated (current protocol) — or from bare-multisig data outputs.
  *
  * @param rawTxHex - Raw (unsigned or signed) transaction hex
  * @returns Counterparty datahex with the CNTRPRTY prefix, or null if the
- *          transaction carries no recognizable Counterparty OP_RETURN
+ *          transaction carries no recognizable Counterparty payload
  */
 export function extractCounterpartyPayload(rawTxHex: string): string | null {
   let tx: Transaction;
@@ -107,10 +108,14 @@ export function extractCounterpartyPayload(rawTxHex: string): string | null {
   if (!firstInput?.txid) return null;
   const firstInputTxid = bytesToHex(firstInput.txid);
 
+  const outputScriptHexes: string[] = [];
+
   for (let i = 0; i < tx.outputsLength; i++) {
     const script = tx.getOutput(i)?.script;
+    const scriptHex = script ? bytesToHex(script) : '';
+    outputScriptHexes.push(scriptHex);
+
     if (!script || script[0] !== 0x6a) continue;
-    const scriptHex = bytesToHex(script);
 
     // Plaintext first (future protocol), then ARC4 (current protocol)
     const payload = extractOpReturnPayload(scriptHex);
@@ -120,5 +125,8 @@ export function extractCounterpartyPayload(rawTxHex: string): string | null {
     if (decrypted) return decrypted;
   }
 
-  return null;
+  // The message may instead be spread across bare-multisig outputs, which carry no OP_RETURN.
+  // Callers read a null return as "no Counterparty data" and skip verification, so every
+  // encoding that can carry a message has to be looked for here.
+  return extractMultisigPayload(outputScriptHexes, firstInputTxid);
 }

--- a/src/utils/blockchain/counterparty/unpack/opReturn.ts
+++ b/src/utils/blockchain/counterparty/unpack/opReturn.ts
@@ -78,10 +78,42 @@ export function decryptOpReturnData(
 }
 
 /**
+ * Resolve a Counterparty payload from a transaction's output scripts: from an OP_RETURN output —
+ * as plaintext (future protocol) or ARC4-obfuscated (current protocol) — or from bare-multisig
+ * data outputs. The single home for that encoding order, so every caller (composer verification
+ * and both dapp sign-request paths) recognizes exactly the same payloads.
+ *
+ * A null return is read as "no Counterparty data" and skips verification, so every encoding that
+ * can carry a message has to be looked for here.
+ *
+ * @param outputScriptHexes - All output scriptPubKey hexes, in output order
+ * @param firstInputTxid - First input txid in display (big-endian) order
+ * @returns Counterparty datahex with the CNTRPRTY prefix, or null if the
+ *          outputs carry no recognizable Counterparty payload
+ */
+export function extractPayloadFromOutputs(
+  outputScriptHexes: readonly string[],
+  firstInputTxid: string
+): string | null {
+  for (const scriptHex of outputScriptHexes) {
+    // extractOpReturnPayload returns null for anything that is not an OP_RETURN output.
+    // Plaintext first (future protocol), then ARC4 (current protocol).
+    const payload = extractOpReturnPayload(scriptHex);
+    if (!payload) continue;
+    if (payload.startsWith(COUNTERPARTY_PREFIX_HEX)) return payload;
+
+    const decrypted = decryptOpReturnData(scriptHex, firstInputTxid);
+    if (decrypted) return decrypted;
+  }
+
+  // The message may instead be spread across bare-multisig outputs, which carry no OP_RETURN.
+  return extractMultisigPayload(outputScriptHexes, firstInputTxid);
+}
+
+/**
  * Extract the Counterparty message payload from a raw transaction hex by
- * parsing its structure locally: locate the first input's txid, then resolve the
- * payload from an OP_RETURN output — as plaintext (future protocol) or
- * ARC4-obfuscated (current protocol) — or from bare-multisig data outputs.
+ * parsing its structure locally: locate the first input's txid and hand the
+ * output scripts to `extractPayloadFromOutputs`.
  *
  * @param rawTxHex - Raw (unsigned or signed) transaction hex
  * @returns Counterparty datahex with the CNTRPRTY prefix, or null if the
@@ -109,24 +141,10 @@ export function extractCounterpartyPayload(rawTxHex: string): string | null {
   const firstInputTxid = bytesToHex(firstInput.txid);
 
   const outputScriptHexes: string[] = [];
-
   for (let i = 0; i < tx.outputsLength; i++) {
     const script = tx.getOutput(i)?.script;
-    const scriptHex = script ? bytesToHex(script) : '';
-    outputScriptHexes.push(scriptHex);
-
-    if (!script || script[0] !== 0x6a) continue;
-
-    // Plaintext first (future protocol), then ARC4 (current protocol)
-    const payload = extractOpReturnPayload(scriptHex);
-    if (payload?.startsWith(COUNTERPARTY_PREFIX_HEX)) return payload;
-
-    const decrypted = decryptOpReturnData(scriptHex, firstInputTxid);
-    if (decrypted) return decrypted;
+    outputScriptHexes.push(script ? bytesToHex(script) : '');
   }
 
-  // The message may instead be spread across bare-multisig outputs, which carry no OP_RETURN.
-  // Callers read a null return as "no Counterparty data" and skip verification, so every
-  // encoding that can carry a message has to be looked for here.
-  return extractMultisigPayload(outputScriptHexes, firstInputTxid);
+  return extractPayloadFromOutputs(outputScriptHexes, firstInputTxid);
 }

--- a/src/utils/blockchain/counterparty/unpack/verify.ts
+++ b/src/utils/blockchain/counterparty/unpack/verify.ts
@@ -619,6 +619,15 @@ function verifyPoolWithdraw(
  * @param params - The params (only for new API)
  * @returns Verification result with any mismatches found
  */
+/**
+ * Compose types whose message is named differently on the wire. Types not listed here use the
+ * compose type as the message type name.
+ */
+const COMPOSE_TYPE_MESSAGE_NAMES: Record<string, string> = {
+  mpma: 'mpma_send',
+  move: 'utxo',
+};
+
 export function verifyTransaction(
   opReturnData: string | Uint8Array,
   composeTypeOrRequest: VerifiableComposeType | string | ComposeRequest,
@@ -744,11 +753,21 @@ export function verifyTransaction(
       verifyPoolWithdraw(unpacked.data as PoolWithdrawData, actualParams, result);
       break;
 
-    default:
-      // Unknown compose type - can't verify, but don't fail
-      result.warnings.push(`Unknown compose type: ${composeType}, skipping verification`);
+    default: {
+      // No field-level verifier exists for this compose type, so its fields go unchecked. The
+      // message type must still be the one that was requested, or a response substituting any
+      // other message — a sweep, say — would be reported as verified.
+      const expectedMessageType = COMPOSE_TYPE_MESSAGE_NAMES[composeType] ?? composeType;
+      if (unpacked.messageType !== expectedMessageType) {
+        result.errors.push(
+          `Message type mismatch: expected ${expectedMessageType}, got ${unpacked.messageType}`
+        );
+        return result;
+      }
+      result.warnings.push(`No field-level verification for compose type: ${composeType}`);
       result.valid = true;
       return result;
+    }
   }
 
   // Transaction is valid if no critical or dangerous mismatches

--- a/src/utils/blockchain/counterparty/unpack/verify.ts
+++ b/src/utils/blockchain/counterparty/unpack/verify.ts
@@ -608,6 +608,15 @@ function verifyPoolWithdraw(
 }
 
 /**
+ * Compose types whose message is named differently on the wire. Types not listed here use the
+ * compose type as the message type name.
+ */
+const COMPOSE_TYPE_MESSAGE_NAMES: Record<string, string> = {
+  mpma: 'mpma_send',
+  move: 'utxo',
+};
+
+/**
  * Verify a composed transaction matches the request params.
  *
  * Supports two call signatures for backward compatibility:
@@ -619,15 +628,6 @@ function verifyPoolWithdraw(
  * @param params - The params (only for new API)
  * @returns Verification result with any mismatches found
  */
-/**
- * Compose types whose message is named differently on the wire. Types not listed here use the
- * compose type as the message type name.
- */
-const COMPOSE_TYPE_MESSAGE_NAMES: Record<string, string> = {
-  mpma: 'mpma_send',
-  move: 'utxo',
-};
-
 export function verifyTransaction(
   opReturnData: string | Uint8Array,
   composeTypeOrRequest: VerifiableComposeType | string | ComposeRequest,

--- a/src/utils/blockchain/counterparty/unpack/verify.ts
+++ b/src/utils/blockchain/counterparty/unpack/verify.ts
@@ -21,7 +21,6 @@ import type { MPMAData } from './messages/mpma';
 import type { IssuanceData } from './messages/issuance';
 import type { PoolDepositData, PoolWithdrawData } from './messages/pool';
 import { addressesEqual } from './address';
-import { extractCounterpartyPayload } from './opReturn';
 import { getMessageSchema, type Criticality } from './paramSchema';
 
 // Import compose types directly
@@ -99,6 +98,13 @@ export interface VerificationResult {
   errors: string[];
   /** Legacy: all warnings (informational) */
   warnings: string[];
+  /**
+   * Whether the message's fields were compared against the request. 'type-only' means no
+   * field-level verifier exists for the compose type: the message type was confirmed and nothing
+   * else. That is an absence of checking, not a detected difference, so it is carried here rather
+   * than in `warnings`, which surface to the user as differences.
+   */
+  fieldVerification: 'full' | 'type-only';
   /** The unpacked transaction data */
   unpacked?: UnpackedMessageData;
   /** The message type that was unpacked */
@@ -653,6 +659,7 @@ export function verifyTransaction(
     infoMismatches: [],
     errors: [],
     warnings: [],
+    fieldVerification: 'full',
     expected: actualParams,
     actual: {},
   };
@@ -764,7 +771,7 @@ export function verifyTransaction(
         );
         return result;
       }
-      result.warnings.push(`No field-level verification for compose type: ${composeType}`);
+      result.fieldVerification = 'type-only';
       result.valid = true;
       return result;
     }
@@ -795,18 +802,3 @@ export function verifyTransactionLegacy(
   return verifyTransaction(opReturnData, request.type, request.params);
 }
 
-/**
- * Extract the Counterparty OP_RETURN payload from a raw transaction hex.
- *
- * Parses the transaction structurally and resolves the payload as plaintext
- * or ARC4-obfuscated (keyed on the first input txid). Returns the datahex with
- * the CNTRPRTY prefix, or null if the transaction carries no Counterparty
- * OP_RETURN — so verifyTransaction runs on real composed transactions, whose
- * OP_RETURN is obfuscated, rather than being skipped.
- *
- * @param rawTxHex - Raw transaction hex
- * @returns Counterparty datahex with the CNTRPRTY prefix, or null
- */
-export function extractOpReturnData(rawTxHex: string): string | null {
-  return extractCounterpartyPayload(rawTxHex);
-}


### PR DESCRIPTION
## Summary

0.6.1 restores compatibility with Counterparty's `taproot_support` upgrade and closes a family of "unknown reported as safe" defects, then hardens the work from two review passes.

- **Decode CBOR-encoded Counterparty messages** (enhanced send, issuance, sweep, broadcast, fairmint, plus a new bet unpacker), the modern packed-address format (`0x01`/`0x02`/`0x03`), and bare-multisig data outputs. Strict verification was rejecting correct transactions because the local verifier only spoke the legacy struct layouts.
- **Fail closed where the code previously answered "safe" for "unknown"**: sighash output commitments under mixed `ANYONECANPAY` inputs, unsupported message types, compose types without field verifiers, unreadable payloads, and the fee check — which now establishes the fee from signature-bound or independently resolved input values and never from the API's own figure.
- **Show compose differences on the review screen** instead of a console.warn that production builds strip; verification coverage ("no field verifier for this type") is carried as data, not presented as a detected difference.
- **Wire formats verified against counterparty-core `ca2496dd`**: CBOR field orders, try-CBOR-first decode precedence, per-output multisig chunking, bet layout, and modern address prefixes all match; the one divergence found (witness packings shorter than core accepts) is closed.
- Destroy moved from the balance list menu to the balance page actions; LICENSE file added.

## Test plan

- [x] Unit tests across all touched modules (581 unpack/counterparty, plus fee, PSBT, composer, context suites) pass locally
- [x] `tsc --noEmit` clean; production `wxt build` succeeds
- [x] New adversarial fixtures: dual-valid CBOR/legacy payload pins decode precedence; all 24 composable type ids decode; type-only verification shows no differences banner
- [ ] Full CI matrix (unit shards, E2E batches) on this PR

https://claude.ai/code/session_01DotMhkRqDVrxwFARURquii
