### PR TITLE
Release 0.6.2: stop reporting a blank memo as a compose difference

### DIFF
--- a/PROVIDER.md
+++ b/PROVIDER.md
@@ -158,7 +158,10 @@ const result = await xcpwallet.request({
 When `signInputs` is supplied, it must contain at least one input. Every index must be
 unique, in range, and assigned to the address found in that input's embedded prevout.
 The provider rejects mismatches before opening the approval popup. Omitting `signInputs`
-preserves the legacy best-effort behavior for the active address only.
+preserves the legacy best-effort behavior for the active address only. For pricing, an
+input whose embedded prevout cannot be attributed to an address is treated as
+potentially the signer's, so its sighash reaches the at-risk calculation rather than
+being skipped.
 
 `sighashTypes` is indexed by absolute PSBT input index, not by `signInputs` entry
 or subset order. When supplied, it must cover every input the wallet is asked to
@@ -203,6 +206,22 @@ For a marketplace listing this means:
   price it as change.
 
 A listing built that way has nothing at risk and signs with no extra prompt.
+
+**Mixed sighash flags.** When signed inputs carry different flags, the summary
+prices only the outputs that every `ANYONECANPAY` input covers on its own. Such
+an input is detachable — whoever holds the PSBT can keep it, drop the rest, and
+its signature travels with it — so an additional `SIGHASH_ALL` input cannot
+vouch for outputs a detachable input leaves free. In practice: batching two
+`SINGLE | ANYONECANPAY` listings into one PSBT prices **both** proceeds outputs
+as at risk, since each signature covers only the output at its own index and
+neither covers the other's. Submit one listing per PSBT to keep the
+no-extra-prompt path.
+
+**Counterparty classification.** The wallet reads Counterparty data from an
+OP_RETURN output — plaintext or ARC4-obfuscated — and from bare-multisig data
+outputs, so message classification and the sweep block apply regardless of
+encoding. A payload that cannot be decoded is surfaced as an unrecognized
+transaction rather than rendered as an ordinary transfer.
 
 **Unfunded PSBTs.** A PSBT whose outputs exceed its inputs — the normal shape of
 a listing awaiting a buyer's funding inputs — is accepted. No fee is claimed for

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "xcp-wallet",
   "description": "Counterparty Web3 Wallet",
   "private": true,
-  "version": "0.6.1",
+  "version": "0.6.2",
   "license": "MIT",
   "type": "module",
   "engines": {

--- a/src/utils/blockchain/counterparty/unpack/__tests__/cbor-messages.test.ts
+++ b/src/utils/blockchain/counterparty/unpack/__tests__/cbor-messages.test.ts
@@ -296,6 +296,38 @@ describe('verifyTransaction over CBOR messages', () => {
     expect(result.valid).toBe(true);
   });
 
+  it('does not report a difference for a blank memo field against an absent memo', () => {
+    // The send form submits an untouched memo input as "", and a composed send without a memo
+    // unpacks it as undefined. Both mean "no memo"; reporting them as a mismatch put a
+    // "differs from your request" warning on every plain send.
+    const payload = payloadOf([1n, 50000000000n, packAddress(DESTINATION), new Uint8Array(0)]);
+    const message = new Uint8Array([...CNTRPRTY, 0x02, ...payload]);
+
+    const result = verifyTransaction(message, 'send', {
+      destination: DESTINATION,
+      asset: 'XCP',
+      quantity: 50000000000,
+      memo: '',
+    });
+    expect(result.valid).toBe(true);
+    expect(result.warnings).toEqual([]);
+    expect(result.infoMismatches).toEqual([]);
+  });
+
+  it('still flags a composed memo the request did not ask for', () => {
+    const memoBytes = new TextEncoder().encode('planted memo');
+    const payload = payloadOf([1n, 50000000000n, packAddress(DESTINATION), memoBytes]);
+    const message = new Uint8Array([...CNTRPRTY, 0x02, ...payload]);
+
+    const result = verifyTransaction(message, 'send', {
+      destination: DESTINATION,
+      asset: 'XCP',
+      quantity: 50000000000,
+      memo: '',
+    });
+    expect(result.infoMismatches.some((m) => m.field === 'memo')).toBe(true);
+  });
+
   it('still flags a destination substitution', () => {
     const other = '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa';
     const payload = payloadOf([1n, 50000000000n, modernPackP2pkh(other), new Uint8Array(0)]);

--- a/src/utils/blockchain/counterparty/unpack/verify.ts
+++ b/src/utils/blockchain/counterparty/unpack/verify.ts
@@ -134,11 +134,13 @@ function toBigInt(value: number | string | bigint | boolean | undefined | null):
  * Compare two values, handling bigint/number/string conversions
  */
 function valuesEqual(a: unknown, b: unknown): boolean {
-  // Handle null/undefined
-  if (a === null || a === undefined) {
-    return b === null || b === undefined;
+  // Absence: null, undefined and the empty string all mean "not provided". Form fields submit ""
+  // for an input left blank, while unpackers report the same field as undefined — those must not
+  // read as a difference. A present value against any absent one still does.
+  const absent = (value: unknown) => value === null || value === undefined || value === '';
+  if (absent(a) || absent(b)) {
+    return absent(a) && absent(b);
   }
-  if (b === null || b === undefined) return false;
 
   // Handle booleans
   if (typeof a === 'boolean' || typeof b === 'boolean') {


### PR DESCRIPTION
## Summary

0.6.2 fixes a false positive that 0.6.1's review-screen banner made visible on every plain send: a blank memo field (submitted as `""`) compared unequal to a composed transaction with no memo (unpacked as `undefined`), producing "Memo mismatch: expected "", got undefined".

`valuesEqual` now treats `null`, `undefined` and the empty string as "not provided", and absence compares equal only to absence — a composed value the request did not ask for still flags, in either direction. The same rule cures the matching false positives for an empty issuance description, broadcast text and mime type.

## Test plan

- [x] New test: blank memo param against a memo-less CBOR send produces no warnings and no info mismatches
- [x] New test: a planted memo against a blank request still reports the informational mismatch
- [x] 594 counterparty + composer tests pass locally; `tsc --noEmit` clean
- [ ] Full CI matrix on this PR

https://claude.ai/code/session_01DotMhkRqDVrxwFARURquii
