### PR TITLE
Extend byte equality to broadcast and initial subasset issuance

### DIFF
--- a/src/utils/blockchain/counterparty/pack/__tests__/coreOracle.test.ts
+++ b/src/utils/blockchain/counterparty/pack/__tests__/coreOracle.test.ts
@@ -29,6 +29,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { packComposeMessage } from '../messages';
+import { unpackCounterpartyMessage } from '../../unpack';
 import { bytesToHex } from '../../unpack/binary';
 
 const API_URL = process.env.COUNTERPARTY_API_URL;
@@ -43,6 +44,12 @@ interface OracleCase {
   params: Record<string, unknown>;
   /** Query string for core's compose endpoint. */
   query: Record<string, string>;
+  /**
+   * Decode core's response and hand it to the packer as the observed message, exactly as
+   * production does — for types with a value the request cannot determine, such as the random
+   * numeric asset id core draws for a new subasset. Equality then proves every *other* byte.
+   */
+  observedFromResponse?: boolean;
 }
 
 const CASES: OracleCase[] = [
@@ -109,6 +116,27 @@ const CASES: OracleCase[] = [
     query: { offer_hash: 'a'.repeat(64) },
   },
   {
+    label: 'text broadcast',
+    composeType: 'broadcast',
+    params: { text: 'BLOCKCHAIN IS THE FUTURE', value: '0', fee_fraction: '0', timestamp: 1722700000 },
+    query: { text: 'BLOCKCHAIN IS THE FUTURE', value: '0', fee_fraction: '0', timestamp: '1722700000' },
+  },
+  {
+    label: 'valued broadcast with a fee fraction',
+    composeType: 'broadcast',
+    params: { text: 'price feed', value: '1.5', fee_fraction: '0.05', timestamp: 1722700000 },
+    query: { text: 'price feed', value: '1.5', fee_fraction: '0.05', timestamp: '1722700000' },
+  },
+  {
+    label: 'initial subasset issuance',
+    composeType: 'issuance',
+    params: { asset: 'PEPECASH.oracle-check', quantity: 1000, divisible: false, description: 'a subasset' },
+    query: { asset: 'PEPECASH.oracle-check', quantity: '1000', divisible: 'false', description: 'a subasset' },
+    // Core names the subasset by drawing a random numeric asset per compose, so the id differs on
+    // every call and can only come from the response.
+    observedFromResponse: true,
+  },
+  {
     label: 'DEX order',
     composeType: 'order',
     params: {
@@ -143,10 +171,17 @@ async function composeDataFromCore(testCase: OracleCase): Promise<string> {
 
 describe.skipIf(!API_URL)('local packing matches counterparty-core', () => {
   it.each(CASES)('$label', async (testCase) => {
-    const packed = packComposeMessage(testCase.composeType, testCase.params);
-    expect(packed, 'this case should be packable locally').not.toBeNull();
-
     const fromCore = await composeDataFromCore(testCase);
+
+    let observed: Record<string, unknown> | undefined;
+    if (testCase.observedFromResponse) {
+      const unpacked = unpackCounterpartyMessage(fromCore);
+      expect(unpacked.success, 'the response should decode before anything can be borrowed').toBe(true);
+      observed = unpacked.data as Record<string, unknown>;
+    }
+
+    const packed = packComposeMessage(testCase.composeType, testCase.params, observed);
+    expect(packed, 'this case should be packable locally').not.toBeNull();
     expect(bytesToHex(packed!.bytes).toLowerCase()).toBe(fromCore);
   }, 30_000);
 });

--- a/src/utils/blockchain/counterparty/pack/__tests__/messages.test.ts
+++ b/src/utils/blockchain/counterparty/pack/__tests__/messages.test.ts
@@ -74,6 +74,60 @@ describe('packing produces the bytes core composes', () => {
   });
 });
 
+describe('packing matches bytes generated with cbor2 5.9.0, the version core pins', () => {
+  // These hexes come from running core's own arithmetic — `cbor2.dumps` plus
+  // `assetnames.compact_subasset_longname` copied verbatim — under cbor2==5.9.0.
+
+  it('reproduces a text broadcast', () => {
+    const packed = packComposeMessage('broadcast', {
+      text: 'BLOCKCHAIN IS THE FUTURE', value: '0', fee_fraction: '0', timestamp: 1722700000,
+    });
+
+    expect(packed).not.toBeNull();
+    expect(bytesToHex(packed!.bytes)).toBe(
+      '434e5452505254591e851a66ae50e0fb000000000000000000605818424c4f434b434841494e2049532054484520465554555245'
+    );
+  });
+
+  it('reproduces a valued broadcast, with the value as a float and the fee fraction scaled', () => {
+    // value 1.5 must ride the wire as an 8-byte double, and fee_fraction 0.05 as int(0.05 * 1e8).
+    const packed = packComposeMessage('broadcast', {
+      text: 'price feed', value: '1.5', fee_fraction: '0.05', timestamp: 1722700000,
+    });
+
+    expect(packed).not.toBeNull();
+    expect(bytesToHex(packed!.bytes)).toBe(
+      '434e5452505254591e851a66ae50e0fb3ff80000000000001a004c4b40604a70726963652066656564'
+    );
+  });
+
+  it('reproduces an initial subasset issuance, flags as ints and the longname compacted', () => {
+    const packed = packComposeMessage(
+      'issuance',
+      { asset: 'JPJA.HELLOKITTY', quantity: 1000, divisible: false, description: 'a subasset' },
+      { messageTypeId: 23, assetId: 95428956661682177n }
+    );
+
+    expect(packed).not.toBeNull();
+    expect(bytesToHex(packed!.bytes)).toBe(
+      '434e54525052545917891b01530821671b10011903e80000000c4c05595523c6457390627d610b604a61207375626173736574'
+    );
+  });
+
+  it('reproduces a divisible locked subasset issuance with no description', () => {
+    const packed = packComposeMessage(
+      'issuance',
+      { asset: 'PEPE.rare-pepe_2026', quantity: 100_000_000, divisible: true, lock: true },
+      { messageTypeId: 23, assetId: 18446744073709551615n }
+    );
+
+    expect(packed).not.toBeNull();
+    expect(bytesToHex(packed!.bytes)).toBe(
+      '434e54525052545917891bffffffffffffffff1a05f5e1000101000f4f07e75b9a418da186050a715c3ec2e760f6'
+    );
+  });
+});
+
 describe('borrowing only what the request cannot determine', () => {
   it('packs a reissuance by taking divisibility from the composed message', () => {
     // update-description and transfer-ownership omit `divisible` because the asset already fixes
@@ -91,6 +145,46 @@ describe('borrowing only what the request cannot determine', () => {
       new TextEncoder().encode('updated text'),
     ]);
     expect(bytesToHex(packed!.bytes)).toBe(expectedMessage(22, body));
+  });
+
+  it('packs a broadcast by taking the wallet-stamped timestamp from the composed message', () => {
+    // The broadcast form carries no timestamp; composeBroadcast stamps the wallet clock into the
+    // request, so the packer reads it back from the decoded message. 1722700000 is in the past,
+    // which the borrow allows — only the future direction is dangerous.
+    const packed = packComposeMessage(
+      'broadcast',
+      { text: 'BLOCKCHAIN IS THE FUTURE', value: '0', fee_fraction: '0' },
+      { timestamp: 1722700000 }
+    );
+
+    expect(packed).not.toBeNull();
+    expect(bytesToHex(packed!.bytes)).toBe(
+      '434e5452505254591e851a66ae50e0fb000000000000000000605818424c4f434b434841494e2049532054484520465554555245'
+    );
+  });
+
+  it('refuses to borrow a broadcast timestamp from the far future', () => {
+    // Bets settle once a broadcast's timestamp reaches their deadline, so a substituted future
+    // timestamp settles a feed's open bets early. The wallet stamped its own clock moments before
+    // this runs, so an honest response cannot be out here.
+    const packed = packComposeMessage(
+      'broadcast',
+      { text: 'hello', value: '0', fee_fraction: '0' },
+      { timestamp: Math.floor(Date.now() / 1000) + 86_400 }
+    );
+
+    expect(packed).toBeNull();
+  });
+
+  it('refuses a subasset asset id outside the numeric space core draws from', () => {
+    // generate_random_asset draws from (26^12, 2^64); anything else is not a value core chose.
+    for (const assetId of [26n ** 12n, 1n << 64n, 1n]) {
+      expect(packComposeMessage(
+        'issuance',
+        { asset: 'JPJA.HELLOKITTY', quantity: 1000, divisible: false },
+        { messageTypeId: 23, assetId }
+      )).toBeNull();
+    }
   });
 
   it('still compares the description the user wrote, rather than borrowing it', () => {
@@ -114,8 +208,7 @@ describe('refusing to pack is not the same as agreeing', () => {
   // Each of these must return null so the caller reports "cannot verify by equality" rather than
   // treating an unpackable request as verified.
   it.each([
-    // Broadcast carries a server-chosen timestamp, so its bytes are not predictable from a request.
-    ['an unsupported compose type', 'broadcast', { text: 'hello', value: 0, fee_fraction: 0 }],
+    ['an unsupported compose type', 'attach', { asset: 'XCP', quantity: 1 }],
     ['a multi-destination send', 'send', { asset: 'XCP', destination: 'bc1qa,bc1qb', quantity: 1 }],
     ['a hex memo, which core encodes differently', 'send', {
       asset: 'XCP', destination: TAPROOT_DESTINATION, quantity: 1, memo: 'ff00', memo_is_hex: true,
@@ -123,8 +216,18 @@ describe('refusing to pack is not the same as agreeing', () => {
     ['a BTC "send", which is not a Counterparty message', 'send', {
       asset: 'BTC', destination: TAPROOT_DESTINATION, quantity: 1,
     }],
-    ['a subasset issuance, whose parent name is compacted', 'issuance', {
+    ['a subasset issuance with no composed message to borrow the asset id from', 'issuance', {
       asset: 'PARENT.child', quantity: 1, divisible: false,
+    }],
+    ['a broadcast with no timestamp and no composed message to borrow one from', 'broadcast', {
+      text: 'hello', value: 0, fee_fraction: 0,
+    }],
+    // timestamp=0 asks the server to continue the feed from ledger state, which is unknowable here.
+    ['a broadcast that lets the server continue the feed', 'broadcast', {
+      text: 'hello', value: 0, fee_fraction: 0, timestamp: 0,
+    }],
+    ['an inscription broadcast, whose content moves into a tapscript envelope', 'broadcast', {
+      text: 'deadbeef', mime_type: 'image/png', inscription: 'ZGVhZGJlZWY=', timestamp: 1722700000,
     }],
     ['a reissuance with no observed message to borrow divisibility from', 'issuance', {
       asset: 'LANDMARKS', quantity: 0, description: 'new text',
@@ -138,6 +241,16 @@ describe('refusing to pack is not the same as agreeing', () => {
   ])('returns null for %s', (_label, composeType, params) => {
     expect(packComposeMessage(composeType, params as Record<string, unknown>)).toBeNull();
   });
+
+  it('returns null for a subasset reissuance, which core composes in the standard layout', () => {
+    // Reissuing PARENT.child produces a standard-layout message whose asset id resolves through
+    // the ledger; only a composed message in the subasset layout is accepted for the subasset form.
+    expect(packComposeMessage(
+      'issuance',
+      { asset: 'PARENT.child', quantity: 0, divisible: false, description: 'updated' },
+      { messageTypeId: 22, assetId: 95428956661682177n }
+    )).toBeNull();
+  });
 });
 
 describe('CBOR encoding matches cbor2 canonical choices', () => {
@@ -149,6 +262,16 @@ describe('CBOR encoding matches cbor2 canonical choices', () => {
     expect(bytesToHex(encodeCbor(256n))).toBe('190100');
     expect(bytesToHex(encodeCbor(65_536n))).toBe('1a00010000');
     expect(bytesToHex(encodeCbor(4_294_967_296n))).toBe('1b0000000100000000');
+  });
+
+  it('encodes floats as 8-byte doubles, as cbor2.dumps does with core\'s default options', () => {
+    // Verified against cbor2 5.9.0 (core's pin): default dumps never shortens a finite float.
+    expect(bytesToHex(encodeCbor(0))).toBe('fb0000000000000000');
+    expect(bytesToHex(encodeCbor(1.5))).toBe('fb3ff8000000000000');
+    expect(bytesToHex(encodeCbor(0.1))).toBe('fb3fb999999999999a');
+    // Core's compose refuses non-finite values, so bytes for them would be meaningless.
+    expect(() => encodeCbor(Number.NaN)).toThrow();
+    expect(() => encodeCbor(Number.POSITIVE_INFINITY)).toThrow();
   });
 
   it('encodes null, booleans, byte strings and arrays as core does', () => {

--- a/src/utils/blockchain/counterparty/pack/__tests__/onchainRoundTrip.test.ts
+++ b/src/utils/blockchain/counterparty/pack/__tests__/onchainRoundTrip.test.ts
@@ -95,14 +95,31 @@ const PARAMS_FROM_DECODED: Record<string, (data: Record<string, any>) => Record<
     mime_type: data.mimeType,
     description: data.description,
   }),
-  issuance: (data) => (data.subassetLongname ? null : {
-    asset: data.asset,
+  issuance: (data) => ({
+    // A subasset issuance composes from the longname; the numeric asset id it carries is the
+    // random draw the packer borrows from the decoded message, which the harness already passes.
+    asset: data.subassetLongname ?? data.asset,
     quantity: data.quantity,
     divisible: data.divisible,
     lock: data.isLock,
     reset: data.isReset,
     description: data.description ?? '',
+    mime_type: data.mimeType ?? '',
   }),
+  broadcast: (data) => {
+    // The wire stores the scaled integer; undo it so the packer can redo core's arithmetic. Skip
+    // the rare value whose double round-trip does not survive — a mismatch there would be
+    // arithmetic noise, not an encoding defect.
+    const feeFraction = data.feeFractionInt / 1e8;
+    if (Math.trunc(feeFraction * 1e8) !== data.feeFractionInt) return null;
+    return {
+      text: data.text,
+      value: String(data.value),
+      fee_fraction: String(feeFraction),
+      timestamp: data.timestamp,
+      mime_type: data.mimeType ?? '',
+    };
+  },
 };
 
 /** API transaction type → the compose type our packers are keyed by. */
@@ -116,6 +133,7 @@ const COMPOSE_TYPE_FOR: Record<string, string> = {
   fairmint: 'fairmint',
   issuance: 'issuance',
   fairminter: 'fairminter',
+  broadcast: 'broadcast',
 };
 
 async function recentTransactions(type: string): Promise<OnChainTransaction[]> {

--- a/src/utils/blockchain/counterparty/pack/cbor.ts
+++ b/src/utils/blockchain/counterparty/pack/cbor.ts
@@ -9,15 +9,22 @@
  *   - integers use the shortest head that fits (cbor2's default),
  *   - byte strings and text strings carry a definite length,
  *   - arrays are definite-length,
- *   - `None` encodes as `null` (0xf6), and booleans as 0xf4 / 0xf5.
+ *   - `None` encodes as `null` (0xf6), and booleans as 0xf4 / 0xf5,
+ *   - floats are always 8-byte doubles (0xfb).
  *
- * Floats are deliberately unsupported: core emits them only for a broadcast's value, which this
- * module does not pack, and guessing between float16/32/64 would silently produce bytes that differ
- * from core's.
+ * The float choice is cbor2's default, not its canonical mode: `dumps` with no options emits every
+ * finite float as a big-endian float64, and canonical mode (which shortens to float16/32 when
+ * lossless) is something core never enables. Verified empirically against cbor2 5.9.0, the version
+ * core pins. Core emits floats only for a broadcast's value. Non-finite floats are refused — core's
+ * compose rejects them before packing, so bytes for them have no meaning here.
+ *
+ * A JavaScript `number` therefore always encodes as a float, even when integral: integers must be
+ * passed as `bigint`, which is what keeps 1 and 1.0 — different bytes on the wire — distinct.
  */
 
 export type CborEncodable =
   | bigint
+  | number
   | boolean
   | string
   | Uint8Array
@@ -48,6 +55,12 @@ function encodeValue(value: CborEncodable): number[] {
   if (value === false) return [0xf4];
   if (value === true) return [0xf5];
   if (typeof value === 'bigint') return encodeHead(0, value);
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) throw new Error('CBOR: non-finite floats are rejected by core');
+    const bytes = new Uint8Array(8);
+    new DataView(bytes.buffer).setFloat64(0, value, false);
+    return [0xfb, ...bytes];
+  }
   if (typeof value === 'string') {
     const bytes = new TextEncoder().encode(value);
     return [...encodeHead(3, BigInt(bytes.length)), ...bytes];

--- a/src/utils/blockchain/counterparty/pack/messages.ts
+++ b/src/utils/blockchain/counterparty/pack/messages.ts
@@ -24,7 +24,9 @@ import { MessageTypeId, COUNTERPARTY_PREFIX_HEX } from '../unpack/messageTypes';
 import { hexToBytes } from '../unpack/binary';
 
 /** The message types this module can construct. */
-export type PackableComposeType = 'send' | 'issuance' | 'sweep' | 'destroy' | 'cancel' | 'order';
+export type PackableComposeType =
+  | 'send' | 'issuance' | 'sweep' | 'destroy' | 'cancel' | 'order'
+  | 'dividend' | 'fairmint' | 'fairminter' | 'dispense' | 'broadcast';
 
 /**
  * Not every message is CBOR. The taproot_support upgrade moved enhanced send, issuance, sweep,
@@ -133,10 +135,15 @@ function packIssuance(params: Params, observed: Observed): PackedMessage | null 
   const asset = requireString(params, 'asset');
   const quantity = requireQuantity(params, 'quantity');
   if (!asset || quantity === null) return null;
-  // Subassets carry a compacted parent name this module does not construct.
-  if (asset.includes('.')) return null;
   // A transfer moves ownership via an output; equality on the message alone would not cover it.
   if (requireString(params, 'transfer_destination')) return null;
+  // A dotted asset is a subasset request, which composes a different layout.
+  if (asset.includes('.')) return packSubassetIssuance(asset, quantity, params, observed);
+  // The ord-inscription path restructures the message, and a non-text MIME type makes core
+  // hex-decode the description (`helpers.content_to_bytes`); neither variant is packed here.
+  if (params.inscription) return null;
+  const mimeType = typeof params.mime_type === 'string' ? params.mime_type : '';
+  if (mimeType !== '' && mimeType !== 'text/plain') return null;
 
   // Divisibility is the user's choice on a first issuance and the ledger's on a reissuance, where
   // the form omits it. Borrowing it from the response keeps reissuances — update description,
@@ -156,7 +163,6 @@ function packIssuance(params: Params, observed: Observed): PackedMessage | null 
   }
 
   const description = typeof params.description === 'string' ? params.description : '';
-  const mimeType = typeof params.mime_type === 'string' ? params.mime_type : '';
 
   const body: CborEncodable = [
     assetId,
@@ -168,6 +174,95 @@ function packIssuance(params: Params, observed: Observed): PackedMessage | null 
     description.length > 0 ? new TextEncoder().encode(description) : null,
   ];
   return withPrefix(MessageTypeId.LR_ISSUANCE, encodeCbor(body));
+}
+
+/**
+ * The subasset name charset, in digit order: digit d encodes SUBASSET_DIGITS[d-1], and the digits
+ * run 1..68 with no zero (core `assetnames.py`, SUBASSET_REVERSE). The decoder in
+ * `unpack/messages/issuance.ts` is the inverse of this.
+ */
+const SUBASSET_DIGITS = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.-_@!';
+
+/**
+ * Compact a subasset longname to core's wire form: the name read as a base-68 big-endian integer,
+ * emitted as its minimal big-endian bytes (`assetnames.compact_subasset_longname`). Minimality
+ * matters — core's unpack rejects non-canonical compactions (`canonical_subasset_compact`), and a
+ * leading zero byte would also fail byte equality against core's own output.
+ *
+ * Returns null for a character outside the charset, which core would refuse to compose anyway.
+ */
+function compactSubassetLongname(longname: string): Uint8Array | null {
+  let integer = 0n;
+  for (const char of longname) {
+    const digit = SUBASSET_DIGITS.indexOf(char) + 1;
+    if (digit === 0) return null;
+    integer = integer * 68n + BigInt(digit);
+  }
+  const bytes: number[] = [];
+  for (let rest = integer; rest > 0n; rest >>= 8n) {
+    bytes.unshift(Number(rest & 0xffn));
+  }
+  return new Uint8Array(bytes);
+}
+
+/**
+ * Initial subasset issuance: CBOR `[asset_id, quantity, divisible, lock, reset, compacted_length,
+ * compacted_name, mime_type, description]` under LR_SUBASSET, since
+ * `issuance_backwards_compatibility` is active on mainnet. The flags are packed as ints — core's
+ * subasset branch writes `1 if divisible else 0` where the standard branch passes booleans
+ * (`issuance.py`), and int versus bool is a byte-level difference in CBOR.
+ *
+ * Only the *initial* issuance takes this layout. Core composes a reissuance of an existing
+ * subasset as a standard-layout message whose asset id resolves through the ledger, so a response
+ * that decodes to anything but a subasset layout is declined here and falls back to field
+ * comparison.
+ *
+ * The asset id is borrowed from the composed message: core names a new subasset by drawing a
+ * random unused numeric asset at compose time (`assetnames.generate_random_asset`), so the request
+ * cannot determine it. Safe to borrow: the longname — which the user did author — is still
+ * byte-compared through its compaction, and a substituted id cannot pay an attacker. An id naming
+ * someone else's asset is consensus-rejected ("issued by another address"), and an id naming an
+ * asset the source already owns degrades the transaction into a reissuance of the user's own asset
+ * to themselves. The range guard pins the id to the numeric space core draws from.
+ */
+function packSubassetIssuance(
+  longname: string,
+  quantity: bigint,
+  params: Params,
+  observed: Observed
+): PackedMessage | null {
+  const observedType = observed?.messageTypeId;
+  if (observedType !== MessageTypeId.SUBASSET_ISSUANCE && observedType !== MessageTypeId.LR_SUBASSET) {
+    return null;
+  }
+  // Divisibility is always the user's choice here: only a first issuance packs this layout.
+  if (typeof params.divisible !== 'boolean') return null;
+  // The ord-inscription path restructures the message, and a non-text MIME type makes core
+  // hex-decode the description (`helpers.content_to_bytes`); neither variant is packed here.
+  if (params.inscription) return null;
+  const mimeType = typeof params.mime_type === 'string' ? params.mime_type : '';
+  if (mimeType !== '' && mimeType !== 'text/plain') return null;
+
+  const assetId = typeof observed?.assetId === 'bigint' ? observed.assetId : null;
+  if (assetId === null || assetId <= 26n ** 12n || assetId >= 1n << 64n) return null;
+
+  const compacted = compactSubassetLongname(longname);
+  if (!compacted) return null;
+
+  const description = typeof params.description === 'string' ? params.description : '';
+
+  const body: CborEncodable = [
+    assetId,
+    quantity,
+    params.divisible ? 1n : 0n,
+    params.lock === true ? 1n : 0n,
+    params.reset === true ? 1n : 0n,
+    BigInt(compacted.length),
+    compacted,
+    mimeType,
+    description.length > 0 ? new TextEncoder().encode(description) : null,
+  ];
+  return withPrefix(MessageTypeId.LR_SUBASSET, encodeCbor(body));
 }
 
 /** Sweep: CBOR `[short_address_bytes, flags, memo_bytes]` (core `sweep.py`). */
@@ -386,6 +481,78 @@ function packDispense(): PackedMessage {
 }
 
 /**
+ * How far into the future a borrowed broadcast timestamp may sit before the borrow is refused.
+ * `verifyBroadcast` in `unpack/verify.ts` applies the same bound to the field-comparison fallback,
+ * so a refusal here does not become an allowance there.
+ */
+const MAX_BORROWED_TIMESTAMP_FUTURE_SECONDS = 3600n;
+
+/**
+ * A float param as core's API receives it: absent means the compose function's default, and a
+ * present value goes through Python's `float()`. JavaScript's Number() performs the same
+ * correctly-rounded decimal parse, and both sides then share IEEE-754 double arithmetic, so the
+ * wire bytes agree.
+ */
+function floatParam(params: Params, key: string): number | null {
+  const value = params[key];
+  if (value === undefined || value === '') return 0;
+  const parsed = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : NaN;
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+/**
+ * Broadcast: CBOR `[timestamp, value, fee_fraction_int, mime_type, text_bytes]` (core
+ * `broadcast.py`, taproot branch). `value` rides the wire as a float — the API coerces the param
+ * with `float()` and cbor2 emits every finite float as an 8-byte double — so it must stay a
+ * `number` here, where an integral bigint would encode differently.
+ *
+ * The timestamp is the one field the form does not carry: when the caller supplies none,
+ * `composeBroadcast` stamps the wallet's own clock into the request, and that value never reaches
+ * `params`. It is borrowed from the composed message instead, bounded against the same clock that
+ * stamped it — an honest response echoes a timestamp taken moments earlier, while a substituted
+ * future timestamp is how a feed's open bets get settled before their deadline (`broadcast.py`
+ * settles once `timestamp >= deadline`). Past the bound the borrow is refused and verification
+ * falls back to field comparison, which applies the same bound. A request that explicitly passes
+ * `timestamp=0` asks the server to continue the feed from ledger state, which cannot be
+ * reconstructed here.
+ *
+ * Inscriptions and non-text MIME types are declined: the ord path restructures the content into a
+ * tapscript envelope, and a non-text MIME makes core hex-decode the text (`content_to_bytes`).
+ */
+function packBroadcast(params: Params, observed: Observed): PackedMessage | null {
+  if (typeof params.text !== 'string') return null;
+  if (params.inscription) return null;
+  const mimeType = typeof params.mime_type === 'string' ? params.mime_type : '';
+  if (mimeType !== '' && mimeType !== 'text/plain') return null;
+
+  const value = floatParam(params, 'value');
+  const feeFraction = floatParam(params, 'fee_fraction');
+  if (value === null || feeFraction === null) return null;
+  // int(fee_fraction * 1e8), the same float arithmetic core performs.
+  const feeFractionInt = Math.trunc(feeFraction * 1e8);
+  if (!Number.isSafeInteger(feeFractionInt) || feeFractionInt < 0) return null;
+
+  let timestamp = requireQuantity(params, 'timestamp');
+  if (timestamp === 0n) return null;
+  if (timestamp === null) {
+    const seen = observed?.timestamp;
+    if (typeof seen !== 'number' || !Number.isSafeInteger(seen) || seen <= 0) return null;
+    const now = BigInt(Math.floor(Date.now() / 1000));
+    if (BigInt(seen) > now + MAX_BORROWED_TIMESTAMP_FUTURE_SECONDS) return null;
+    timestamp = BigInt(seen);
+  }
+
+  const body: CborEncodable = [
+    timestamp,
+    value,
+    BigInt(feeFractionInt),
+    mimeType,
+    new TextEncoder().encode(params.text),
+  ];
+  return withPrefix(MessageTypeId.BROADCAST, encodeCbor(body));
+}
+
+/**
  * Build the message bytes a compose request should produce, or null when this build cannot
  * construct them (unsupported type, or a value the request does not determine).
  *
@@ -417,6 +584,8 @@ export function packComposeMessage(
       return packFairminter(params);
     case 'dispense':
       return packDispense();
+    case 'broadcast':
+      return packBroadcast(params, observed);
     default:
       return null;
   }

--- a/src/utils/blockchain/counterparty/unpack/messages/issuance.ts
+++ b/src/utils/blockchain/counterparty/unpack/messages/issuance.ts
@@ -52,6 +52,8 @@ export interface IssuanceData {
   callPrice?: number;
   /** Asset description */
   description?: string;
+  /** MIME type of the description content (CBOR formats carry it; legacy formats have none) */
+  mimeType?: string;
   /** Subasset long name (for subasset issuances) */
   subassetLongname?: string;
   /** Whether this is a lock operation */
@@ -148,6 +150,12 @@ function tryCborDecode(payload: Uint8Array, messageTypeId: number): IssuanceData
     result.description = cborDescription(decoded[8] ?? null);
   } else {
     result.description = cborDescription(decoded[6] ?? null);
+  }
+
+  // The wire carries "" for the default MIME type; only a stated one is reported.
+  const mimeType = decoded[isSubasset ? 7 : 5];
+  if (typeof mimeType === 'string' && mimeType !== '') {
+    result.mimeType = mimeType;
   }
 
   return result;

--- a/src/utils/blockchain/counterparty/unpack/verify.ts
+++ b/src/utils/blockchain/counterparty/unpack/verify.ts
@@ -25,13 +25,17 @@
  * mirroring what counterparty-core itself asserts in `check_transaction_sanity`:
  *
  * 1. **Message payload** — where the message can be built locally (`pack/messages.ts`: send,
- *    issuance, sweep, destroy, cancel, order, dividend and fairmint), verification is byte equality
- *    and any difference is fatal, with no severity gradation: equality asks whether the composer
- *    produced what was asked, and that answer is binary. Severity belongs only to the field-by-field
- *    fallback used for types we cannot build — broadcast takes a server-chosen timestamp, a
- *    reissuance takes its divisibility from the ledger — because that path can speak only to fields
- *    it was taught about. Packing returns null rather than guess, so equality applies only where the
- *    bytes are known exactly.
+ *    issuance including initial subassets, sweep, destroy, cancel, order, dividend, fairmint,
+ *    fairminter, dispense and broadcast), verification is byte equality and any difference is
+ *    fatal, with no severity gradation: equality asks whether the composer produced what was asked,
+ *    and that answer is binary. A few values the request cannot determine — a reissuance's
+ *    divisibility, a new subasset's randomly drawn asset id, a wallet-stamped broadcast timestamp —
+ *    are borrowed from the composed message under the argued conditions in `pack/messages.ts`
+ *    (`Observed`), and everything the user authored still has to match byte for byte. Severity
+ *    belongs only to the field-by-field fallback used for what still cannot be built — an
+ *    inscription's tapscript envelope, a subasset reissuance's ledger-resolved asset id — because
+ *    that path can speak only to fields it was taught about. Packing returns null rather than
+ *    guess, so equality applies only where the bytes are known exactly.
  *
  *    Two oracles keep the packers honest, both nightly:
  *    `coreOracle.test.ts` asks a live node what it would compose for a set of params and requires
@@ -743,8 +747,10 @@ function verifyDetach(
 }
 
 /**
- * Verify a broadcast publishes what was written. The timestamp is chosen by the composer and so is
- * not comparable; everything the user authored is.
+ * Verify a broadcast publishes what was written. Everything the user authored is compared; the
+ * timestamp is stamped into the request by `composeBroadcast` from the wallet's own clock when the
+ * caller supplies none, so it is not in `params` — but that also means an honest response echoes a
+ * timestamp taken moments ago, and one far in the future can only be a substitution.
  */
 function verifyBroadcast(
   data: BroadcastData,
@@ -754,6 +760,18 @@ function verifyBroadcast(
   if (params.text !== undefined && !valuesEqual(data.text, params.text)) {
     addMismatch(result, 'text', params.text, data.text, 'critical',
       'Different text = publishing something you did not write');
+  }
+
+  // Same bound as the byte-equality packer's borrowed timestamp (`pack/messages.ts`), so a
+  // broadcast the packer declines does not sail through here with a timestamp the packer refused.
+  // The future direction is the dangerous one: bets settle once a broadcast's timestamp reaches
+  // their deadline, so a substituted future timestamp settles a feed's open bets early.
+  if (params.timestamp === undefined && typeof data.timestamp === 'number') {
+    const now = Math.floor(Date.now() / 1000);
+    if (data.timestamp > now + 3600) {
+      addMismatch(result, 'timestamp', 'the wallet clock at compose time', data.timestamp, 'critical',
+        'A future timestamp settles bets against this feed before their deadline');
+    }
   }
 
   verifyOptional(result, 'value', params.value, data.value, 0, 'dangerous',


### PR DESCRIPTION
Continues the verification architecture (#214, ADR-019): two more compose types move from field-by-field comparison to whole-message byte equality.

## Broadcast

CBOR `[timestamp, value, fee_fraction_int, mime_type, text]` after type id 30. Two format facts checked against counterparty-core (ca2496d) rather than recalled:

- **`value` is always an 8-byte double.** The API coerces the param with `float()` and core calls `cbor2.dumps` with *default* options — default, not canonical, meaning finite floats are never shortened to float16/32. Verified empirically under `cbor2==5.9.0`, the version core pins. The pack-side CBOR encoder gains float64 support (`number` = float, `bigint` = int) and refuses non-finite values, which core's compose rejects anyway.
- **The timestamp never reaches the packer's params.** The form doesn't carry one; `composeBroadcast` stamps the wallet's own clock into the request. It is borrowed from the decoded message through the `Observed` channel, bounded to ≤ 1 hour ahead of the same clock that stamped it — an honest response echoes a timestamp taken moments earlier, while a substituted future timestamp settles a feed's open bets before their deadline (`broadcast.py` settles once `timestamp >= deadline`). `verifyBroadcast` applies the same bound on the field-comparison fallback, so a refused borrow doesn't become an allowance. An explicit `timestamp=0` (server continues the feed from ledger state) is declined.

## Initial subasset issuance

Nine-element CBOR layout under LR_SUBASSET (23), with two byte-level details that differ from the standard layout:

- **Flags are ints.** Core's subasset branch writes `1 if divisible else 0` where the standard branch passes booleans — different bytes in CBOR.
- **The longname is compacted** by a new base-68 encoder mirroring the existing decoder in `unpack/messages/issuance.ts`, emitting minimal big-endian bytes as core's `canonical_subasset_compact` gate requires.

The numeric asset id is drawn by `random.randint` at compose time — server-chosen, so it's borrowed from the composed message under a range guard pinning it to the space core draws from. Safety argument (verified in core's `validate()`): an id naming someone else's asset is consensus-rejected ("issued by another address"); an id naming an asset the user already owns degrades the transaction into a reissuance of the user's own asset to themselves. Neither pays an attacker, and the longname, quantity, flags and description all stay byte-compared.

Still deliberately declined to the field fallback: subasset *reissuance* (standard layout, ledger-resolved id), ord-inscription composes, and non-text MIME types (core restructures or hex-decodes their content) — the last now declined across standard issuance too, where the packer previously assumed UTF-8.

## Oracles and tests

- Compose oracle: broadcast cases with explicit timestamps, plus a subasset case that decodes core's response and borrows the random asset id from it exactly as production does — equality then proves every other byte.
- Round-trip oracle: rebuilds recent on-chain broadcasts and subasset issuances (the issuance decoder now surfaces the wire's `mime_type` — CBOR layouts only, never invented — which the glue and display can both use).
- Unit fixtures generated with `cbor2==5.9.0` plus core's own compaction arithmetic, embedded as byte-exact expectations, alongside borrow-bound and decline tests.

## Verification

- `tsc --noEmit` clean; counterparty unit suite 638 passing.
- Both oracles run against `api.counterparty.io:4000`: 49/49, including the new cases.
- E2E locally, one file at a time: `compose/broadcast/index.spec.ts` (10/10), `compose/issuance/index.spec.ts` (10/10).

https://claude.ai/code/session_01CcjnCrgosSeshymXLBxdGj
