### PR TITLE
Extend byte equality to MPMA, and fix memo transport the API ignored

### DIFF
--- a/src/pages/compose/send/mpma/index.tsx
+++ b/src/pages/compose/send/mpma/index.tsx
@@ -2,8 +2,6 @@ import { MPMAForm } from "./form";
 import { ReviewMPMA } from "./review";
 import { Composer } from "@/components/composer/composer";
 import { composeMPMA } from "@/utils/blockchain/counterparty/compose";
-import { fetchAssetDetails } from "@/utils/blockchain/counterparty/api";
-import { toSatoshis } from "@/utils/numeric";
 import type { MPMAOptions, ApiResponse } from "@/utils/blockchain/counterparty/compose";
 
 interface MPMAData {
@@ -18,7 +16,9 @@ interface MPMAData {
 
 function ComposeMpmaPage() {
   const composeTransaction = async (data: MPMAData): Promise<ApiResponse> => {
-    // Parse the comma-separated values
+    // Parse the comma-separated values. Quantities arrive in base units: normalizeFormData
+    // resolves each asset's divisibility before compose, so that message verification can
+    // rebuild the message from the same data the API receives (`pack/messages.ts`).
     const assets = data.assets.split(',');
     const destinations = data.destinations.split(',');
     const quantities = data.quantities.split(',');
@@ -31,46 +31,17 @@ function ComposeMpmaPage() {
       throw new Error('Mismatched MPMA form data: assets, destinations, and quantities must align');
     }
 
-    // Build divisibility cache: fetch unique assets in parallel
-    const knownDivisible: Record<string, boolean> = { BTC: true, XCP: true };
-    const uniqueAssets = [...new Set(assets)].filter(a => !(a in knownDivisible));
-
-    const assetInfos = await Promise.all(
-      uniqueAssets.map(async (asset) => {
-        try {
-          const info = await fetchAssetDetails(asset);
-          return { asset, divisible: info?.divisible ?? false };
-        } catch {
-          return { asset, divisible: false };
-        }
-      })
-    );
-
-    const divisibilityCache: Record<string, boolean> = {
-      ...knownDivisible,
-      ...Object.fromEntries(assetInfos.map(({ asset, divisible }) => [asset, divisible]))
-    };
-
-    // Normalize quantities based on divisibility
-    const normalizedQuantities = assets.map((asset, i) => {
-      const isDivisible = divisibilityCache[asset];
-      return isDivisible ? toSatoshis(quantities[i]!) : quantities[i]!;
-    });
-
-    // Create MPMA options with normalized quantities
     const mpmaOptions: MPMAOptions = {
       sourceAddress: data.sourceAddress,
       assets,
       destinations,
-      quantities: normalizedQuantities,
+      quantities,
       sat_per_vbyte: data.sat_per_vbyte,
       ...(memos && { memos }),
       ...(memosAreHex && { memos_are_hex: memosAreHex })
     };
 
-    // Compose MPMA transaction
-    const response = await composeMPMA(mpmaOptions);
-    return response;
+    return composeMPMA(mpmaOptions);
   };
 
   return (

--- a/src/utils/blockchain/counterparty/__tests__/compose.send.test.ts
+++ b/src/utils/blockchain/counterparty/__tests__/compose.send.test.ts
@@ -214,9 +214,13 @@ describe('Compose Send Operations', () => {
       });
 
       const actualUrl = mockedApiClient.get.mock.calls[0]![0] as string;
-      // Should have memo arrays
-      expect(actualUrl).toContain(`memos[]=${encodeURIComponent(testMemos.TEXT)}`);
-      expect(actualUrl).toContain('memos_are_hex[]=false');
+      // The memo is identical for every destination, so it travels once as the whole-send memo.
+      // (It must NOT travel as `memos[]=`: core's query_params() ignores a PHP-style [] suffix.)
+      // URLSearchParams encodes a space as '+'.
+      expect(actualUrl).toContain(`memo=${encodeURIComponent(testMemos.TEXT).replace(/%20/g, '+')}`);
+      expect(actualUrl).toContain('memo_is_hex=false');
+      expect(actualUrl).not.toContain('memos%5B%5D');
+      expect(actualUrl).not.toContain('memos[]');
     });
 
     it('should treat single destination without comma as regular send', async () => {

--- a/src/utils/blockchain/counterparty/__tests__/compose.specialized.test.ts
+++ b/src/utils/blockchain/counterparty/__tests__/compose.specialized.test.ts
@@ -213,7 +213,10 @@ describe('Compose Specialized Operations', () => {
       assertComposeUrlCalled(mockedApiClient, 'mpma', defaultParams);
     });
 
-    it('should include optional parameters', async () => {
+    it('sends per-send memos as repeated plain keys with one memos_are_hex flag', async () => {
+      // Core's query_params() builds lists from repeated keys and does nothing with a PHP-style
+      // [] suffix — `memos[]` is a different parameter that silently never reaches compose. The
+      // hex flag is singular because core applies one flag to every memo in the list.
       const optionalParams = {
         memos: ['memo1', 'memo2'],
         memos_are_hex: [false, false],
@@ -228,10 +231,21 @@ describe('Compose Specialized Operations', () => {
 
       const actualCall = mockedApiClient.get.mock.calls[0]!;
       const url = actualCall[0] as string;
-      expect(url).toContain('memos[]=memo1');
-      expect(url).toContain('memos[]=memo2');
-      expect(url).toContain('memos_are_hex[]=');
-      expect(url).toContain('memos_are_hex[]=');
+      expect(url).toContain('&memos=memo1');
+      expect(url).toContain('&memos=memo2');
+      expect(url).toContain('memos_are_hex=false');
+      expect(url).not.toContain('memos[]');
+      expect(url).not.toContain('memos%5B%5D');
+    });
+
+    it('refuses memos that mix hex and text, which one memos_are_hex flag cannot express', async () => {
+      await expect(composeMPMA({
+        sourceAddress: mockAddress,
+        sat_per_vbyte: mockSatPerVbyte,
+        ...defaultParams,
+        memos: ['beef', 'plain text'],
+        memos_are_hex: [true, false],
+      })).rejects.toThrow(/all hex or all text/);
     });
 
     it('should handle different message data', async () => {

--- a/src/utils/blockchain/counterparty/compose.ts
+++ b/src/utils/blockchain/counterparty/compose.ts
@@ -187,8 +187,13 @@ export interface MPMAOptions extends BaseComposeOptions {
   assets: string[];
   destinations: string[];
   quantities: string[];
+  /** Per-send memos, one entry per send; empty string means no memo for that send. */
   memos?: string[];
+  /** Hex flags for `memos`. Core applies a single flag to every memo, so these must agree. */
   memos_are_hex?: boolean[];
+  /** Whole-send memo, used for every send when `memos` is not given; encoded once. */
+  memo?: string;
+  memo_is_hex?: boolean;
 }
 
 export interface OrderOptions extends BaseComposeOptions {
@@ -504,12 +509,15 @@ async function composeTransactionWithArrays<T extends Record<string, unknown>>(
       ...(inputsSet && { inputs_set: inputsSet }),
     }));
 
-    // Append array params with [] notation
+    // Append array params as repeated plain keys: core's `query_params()` builds lists from
+    // repeated keys via `request.args.to_dict(flat=False)` and does nothing with a PHP-style
+    // `[]` suffix — `memos[]` is a different, ignored parameter, and the memos silently
+    // never reach compose.
     let url = `${apiUrl}?${params.toString()}`;
     for (const [key, values] of Object.entries(arrayParams)) {
       if (Array.isArray(values)) {
         for (const value of values) {
-          url += `&${key}[]=${encodeURIComponent(String(value ?? ''))}`;
+          url += `&${key}=${encodeURIComponent(String(value ?? ''))}`;
         }
       }
     }
@@ -792,6 +800,8 @@ export async function composeMPMA(options: MPMAOptions): Promise<ApiResponse> {
     quantities,
     memos,
     memos_are_hex,
+    memo,
+    memo_is_hex,
     sat_per_vbyte,
     max_fee,
     encoding,
@@ -806,19 +816,34 @@ export async function composeMPMA(options: MPMAOptions): Promise<ApiResponse> {
     throw new Error('Assets, destinations, and quantities must be arrays of the same length.');
   }
 
-  if (memos && memos.length > 0) {
+  if (memos && memos.some((memo) => memo !== '')) {
+    // Core applies one `memos_are_hex` flag to every memo in the list (`compose_mpma` appends the
+    // same boolean to each send tuple), so a mix of hex and text memos cannot be expressed over
+    // the API. Refusing loudly beats composing a transaction whose memos mean something else.
+    const hexFlags = new Set((memos_are_hex ?? []).filter((_, i) => memos[i] !== ''));
+    if (hexFlags.size > 1) {
+      throw new Error(
+        'MPMA memos must be all hex or all text: the API applies a single memos_are_hex flag to every memo.'
+      );
+    }
+    // Core requires exactly one memos entry per send; empty entries mean "no memo for this send".
+    if (memos.length !== assets.length) {
+      throw new Error('The number of memos must equal the number of sends.');
+    }
     return composeTransactionWithArrays('mpma', {
       assets: assets.join(','),
       destinations: destinations.join(','),
       quantities: quantities.join(','),
+      memos_are_hex: (hexFlags.values().next().value ?? false).toString(),
       ...(max_fee !== undefined && { max_fee: max_fee.toString() }),
-    }, { memos, memos_are_hex }, sourceAddress, sat_per_vbyte, encoding);
+    }, { memos }, sourceAddress, sat_per_vbyte, encoding);
   }
 
   const paramsObj = {
     assets: assets.join(','),
     destinations: destinations.join(','),
     quantities: quantities.join(','),
+    ...(memo && { memo, memo_is_hex: (memo_is_hex ?? false).toString() }),
     ...(max_fee !== undefined && { max_fee: max_fee.toString() }),
   };
   return composeTransaction('mpma', paramsObj, sourceAddress, sat_per_vbyte, encoding);
@@ -905,7 +930,9 @@ export async function composeSendOrMPMA(options: SendOrMPMAOptions): Promise<Api
   if (destinations && destinations.includes(',')) {
     const destArray = destinations.split(',').map((d: string) => d.trim());
 
-    // Create MPMA options - same asset/quantity/memo for each destination
+    // Create MPMA options - same asset/quantity for each destination. A memo shared by every
+    // send travels as the whole-send memo (core's `memo` param, encoded once in the message)
+    // rather than as a per-send list saying the same thing n times.
     const mpmaOptions: MPMAOptions = {
       sourceAddress: options.sourceAddress,
       assets: destArray.map(() => options.asset),
@@ -913,8 +940,8 @@ export async function composeSendOrMPMA(options: SendOrMPMAOptions): Promise<Api
       quantities: destArray.map(() => options.quantity.toString()),
       sat_per_vbyte: options.sat_per_vbyte,
       ...(options.memo && {
-        memos: destArray.map(() => options.memo as string),
-        memos_are_hex: destArray.map(() => options.memo_is_hex ?? false)
+        memo: options.memo,
+        memo_is_hex: options.memo_is_hex ?? false,
       })
     };
 

--- a/src/utils/blockchain/counterparty/normalize.ts
+++ b/src/utils/blockchain/counterparty/normalize.ts
@@ -229,7 +229,51 @@ export async function normalizeFormData(
   const rawData = Object.fromEntries(formData);
   const normalizedData: Record<string, any> = { ...rawData };
   const assetInfoCache: AssetInfoCache = new Map();
-  
+
+  // MPMA carries parallel CSV lists, which the per-field table above cannot describe: each
+  // quantity is normalized by its own asset's divisibility. Base units must be resolved here,
+  // before compose, because message verification rebuilds the message from this same data
+  // (`pack/messages.ts`) — display units would make every quantity wrong by a factor of 1e8.
+  if (composeType === 'mpma'
+      && typeof rawData.assets === 'string' && typeof rawData.quantities === 'string') {
+    const assets = rawData.assets.split(',');
+    const quantities = rawData.quantities.split(',');
+    if (assets.length === quantities.length) {
+      const normalizedQuantities: string[] = [];
+      for (let i = 0; i < assets.length; i += 1) {
+        const assetName = assets[i]!.trim();
+        const value = quantities[i]!.toString();
+        // Always divisible, no lookup needed. (BTC is not sendable by MPMA; compose rejects it
+        // with a better error than an asset-info lookup failure would produce here.)
+        if (assetName === 'BTC' || assetName === 'XCP') {
+          normalizedQuantities.push(toSatoshis(value));
+          continue;
+        }
+        let assetInfo = assetInfoCache.get(assetName);
+        if (assetInfo === undefined) {
+          try {
+            const details = await fetchAssetDetails(assetName);
+            if (!details) {
+              throw new Error(`Asset "${assetName}" not found`);
+            }
+            assetInfo = details;
+            assetInfoCache.set(assetName, assetInfo);
+          } catch (error) {
+            // Fail fast: guessing divisibility would compose a quantity wrong by 1e8.
+            const message = error instanceof Error
+              ? error.message
+              : `Failed to fetch asset info for ${assetName}`;
+            throw new Error(message);
+          }
+        }
+        normalizedQuantities.push(assetInfo?.divisible
+          ? toSatoshis(value)
+          : toBigNumber(value).integerValue().toString());
+      }
+      normalizedData.quantities = normalizedQuantities.join(',');
+    }
+  }
+
   // Process quantity fields
   for (const quantityField of config.quantityFields) {
     const value = rawData[quantityField];

--- a/src/utils/blockchain/counterparty/pack/__tests__/coreOracle.test.ts
+++ b/src/utils/blockchain/counterparty/pack/__tests__/coreOracle.test.ts
@@ -42,8 +42,9 @@ interface OracleCase {
   composeType: string;
   /** Params as the wallet's forms normalize them, fed to the local packer. */
   params: Record<string, unknown>;
-  /** Query string for core's compose endpoint. */
-  query: Record<string, string>;
+  /** Query string for core's compose endpoint. An array value becomes repeated keys, which is
+   * how core's `query_params()` receives a list (MPMA per-send memos travel this way). */
+  query: Record<string, string | string[]>;
   /**
    * Decode core's response and hand it to the packer as the observed message, exactly as
    * production does — for types with a value the request cannot determine, such as the random
@@ -137,6 +138,78 @@ const CASES: OracleCase[] = [
     observedFromResponse: true,
   },
   {
+    label: 'MPMA send of two assets to two addresses',
+    composeType: 'mpma',
+    params: {
+      assets: 'XCP,PEPECASH',
+      destinations: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa,1CounterpartyXXXXXXXXXXXXXXXUWLpVr',
+      quantities: '100,500',
+    },
+    query: {
+      assets: 'XCP,PEPECASH',
+      destinations: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa,1CounterpartyXXXXXXXXXXXXXXXUWLpVr',
+      quantities: '100,500',
+    },
+  },
+  {
+    // One distinct destination: nbits is zero and the count/index fields occupy no bits. This is
+    // the dominant shape of real MPMA traffic (airdropping several assets to one address).
+    label: 'MPMA send of two assets to one address',
+    composeType: 'mpma',
+    params: {
+      assets: 'XCP,PEPECASH',
+      destinations: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa,1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa',
+      quantities: '3,5',
+    },
+    query: {
+      assets: 'XCP,PEPECASH',
+      destinations: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa,1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa',
+      quantities: '3,5',
+    },
+  },
+  {
+    // The memos travel as repeated `memos=` keys — the transport `composeMPMA` uses — so this
+    // case also proves the API actually receives them (a `memos[]=` suffix would be ignored).
+    label: 'MPMA send with per-send memos',
+    composeType: 'mpma',
+    params: {
+      assets: 'XCP,XCP',
+      destinations: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa,'
+        + 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
+      quantities: '7,9',
+      memos: 'first,second',
+      memos_are_hex: 'false,false',
+    },
+    query: {
+      assets: 'XCP,XCP',
+      destinations: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa,'
+        + 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
+      quantities: '7,9',
+      memos: ['first', 'second'],
+      memos_are_hex: 'false',
+    },
+  },
+  {
+    label: 'MPMA send with a whole-send memo',
+    composeType: 'mpma',
+    params: {
+      assets: 'XCP,XCP',
+      destinations: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa,'
+        + 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
+      quantities: '1,2',
+      memo: 'thanks',
+      memo_is_hex: false,
+    },
+    query: {
+      assets: 'XCP,XCP',
+      destinations: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa,'
+        + 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
+      quantities: '1,2',
+      memo: 'thanks',
+      memo_is_hex: 'false',
+    },
+  },
+  {
     label: 'DEX order',
     composeType: 'order',
     params: {
@@ -153,11 +226,12 @@ const CASES: OracleCase[] = [
 ];
 
 async function composeDataFromCore(testCase: OracleCase): Promise<string> {
-  const query = new URLSearchParams({
-    ...testCase.query,
-    return_only_data: 'true',
-    validate: 'false',
-  });
+  const query = new URLSearchParams({ return_only_data: 'true', validate: 'false' });
+  for (const [key, value] of Object.entries(testCase.query)) {
+    for (const entry of Array.isArray(value) ? value : [value]) {
+      query.append(key, entry);
+    }
+  }
   const url = `${API_URL}/v2/addresses/${SOURCE}/compose/${testCase.composeType}?${query}`;
   const response = await fetch(url);
   if (!response.ok) {

--- a/src/utils/blockchain/counterparty/pack/__tests__/messages.test.ts
+++ b/src/utils/blockchain/counterparty/pack/__tests__/messages.test.ts
@@ -128,6 +128,108 @@ describe('packing matches bytes generated with cbor2 5.9.0, the version core pin
   });
 });
 
+describe('packing matches bytes generated with core\'s MPMA encoder', () => {
+  // These hexes come from running core's own `mpmaencoding` functions (copied verbatim, with
+  // `address.pack_legacy` and the ledger asset lookup replaced by pure equivalents) under the
+  // same bitstring library core uses.
+  const P2PKH_A = '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa';
+  const P2PKH_B = '1CounterpartyXXXXXXXXXXXXXXXUWLpVr';
+  const P2WPKH = 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4';
+
+  it('reproduces a two-asset MPMA send with no memos', () => {
+    const packed = packComposeMessage('mpma', {
+      assets: 'XCP,PEPECASH',
+      destinations: `${P2PKH_A},${P2PKH_B}`,
+      quantities: '100,500',
+    });
+
+    expect(packed).not.toBeNull();
+    expect(bytesToHex(packed!.bytes)).toBe(
+      '434e5452505254590300020062e907b15cbf27d5425399ebf6f0fb50ebb88f1800818895f3dc2c178629d3d2d8fa3ec4a3f81798214000000718588312d00000000000001f440000000000000004000000000000006400'
+    );
+  });
+
+  it('reproduces a whole-send memo, encoded once ahead of the send lists', () => {
+    const packed = packComposeMessage('mpma', {
+      assets: 'XCP,XCP',
+      destinations: `${P2PKH_A},${P2WPKH}`,
+      quantities: '1,2',
+      memo: 'thanks',
+      memo_is_hex: false,
+    });
+
+    expect(packed).not.toBeNull();
+    expect(bytesToHex(packed!.bytes)).toBe(
+      '434e5452505254590300020062e907b15cbf27d5425399ebf6f0fb50ebb88f1880751e76e8199196d454941c45d1b3a323f1433bd6867468616e6b738000000000000000c000000000000000280000000000000010'
+    );
+  });
+
+  it('reproduces per-send hex memos, pinning the is_hex bit and byte-length encoding', () => {
+    const packed = packComposeMessage('mpma', {
+      assets: 'XCP,XCP',
+      destinations: `${P2PKH_A},${P2WPKH}`,
+      quantities: '7,9',
+      memos: 'beef,68656c6c6f',
+      memos_are_hex: 'true,true',
+    });
+
+    expect(packed).not.toBeNull();
+    expect(bytesToHex(packed!.bytes)).toBe(
+      '434e5452505254590300020062e907b15cbf27d5425399ebf6f0fb50ebb88f1880751e76e8199196d454941c45d1b3a323f1433bd6400000000000000060000000000000007c2beef8000000000000004e2b432b636378'
+    );
+  });
+
+  it('packs the send form\'s comma-separated destinations as the same MPMA message', () => {
+    // composeSendOrMPMA replicates the asset and quantity per destination and carries the memo
+    // once as the whole-send memo; the fixture is core's encoding of exactly that request.
+    const packed = packComposeMessage('send', {
+      asset: 'XCP',
+      destinations: `${P2PKH_A},${P2WPKH}`,
+      quantity: 1,
+      memo: 'thanks',
+    });
+
+    expect(packed).not.toBeNull();
+    expect(bytesToHex(packed!.bytes)).toBe(
+      '434e5452505254590300020062e907b15cbf27d5425399ebf6f0fb50ebb88f1880751e76e8199196d454941c45d1b3a323f1433bd6867468616e6b738000000000000000c000000000000000280000000000000008'
+    );
+  });
+
+  it('reproduces a single-destination send, whose count and index fields occupy no bits', () => {
+    // One distinct destination makes nbits zero. Core's pinned bitstring (4.1.4) appends nothing
+    // for a zero-width field — newer versions raise, so this shape looked uncomposable until the
+    // fixture generator ran under the pin. Every recent on-chain MPMA is this shape.
+    const packed = packComposeMessage('mpma', {
+      assets: 'PEPECASH,XCP',
+      destinations: `${P2PKH_A},${P2PKH_A}`,
+      quantities: '5,3',
+    });
+
+    expect(packed).not.toBeNull();
+    expect(bytesToHex(packed!.bytes)).toBe(
+      '434e5452505254590300010062e907b15cbf27d5425399ebf6f0fb50ebb88f184000000718588312c0000000000000015000000000000000100000000000000030'
+    );
+  });
+
+  it('round-trips through the MPMA unpacker, which was verified against core independently', () => {
+    const packed = packComposeMessage('mpma', {
+      assets: 'XCP,PEPECASH',
+      destinations: `${P2PKH_A},${P2PKH_B}`,
+      quantities: '100,500',
+    });
+
+    const result = unpackCounterpartyMessage(packed!.bytes);
+    expect(result.success).toBe(true);
+    expect(result.messageType).toBe('mpma_send');
+    const data = result.data as { sends: Array<{ asset: string; destination: string; quantity: bigint }> };
+    // The wire orders asset groups by name; each send keeps its request destination.
+    expect(data.sends).toEqual([
+      { asset: 'PEPECASH', destination: P2PKH_B, quantity: 500n },
+      { asset: 'XCP', destination: P2PKH_A, quantity: 100n },
+    ]);
+  });
+});
+
 describe('borrowing only what the request cannot determine', () => {
   it('packs a reissuance by taking divisibility from the composed message', () => {
     // update-description and transfer-ownership omit `divisible` because the asset already fixes
@@ -228,6 +330,55 @@ describe('refusing to pack is not the same as agreeing', () => {
     }],
     ['an inscription broadcast, whose content moves into a tapscript envelope', 'broadcast', {
       text: 'deadbeef', mime_type: 'image/png', inscription: 'ZGVhZGJlZWY=', timestamp: 1722700000,
+    }],
+    // At nbits zero (one distinct destination) the count field has no bits, so a second send of
+    // the same asset is not expressible; core's own encoder would raise on `uint:0=1`.
+    ['an MPMA send repeating an asset to one distinct destination', 'mpma', {
+      assets: 'XCP,XCP',
+      destinations: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa,1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa',
+      quantities: '1,2',
+    }],
+    // A 32-byte witness program does not fit the 21-byte legacy LUT slot.
+    ['an MPMA send to a Taproot destination', 'mpma', {
+      assets: 'XCP,XCP',
+      destinations: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa,'
+        + 'bc1pcm9gfgcy8q45y4m0ryskyc5nczex8yn9jc5r0tpuacz897y5rlfqn2u02z',
+      quantities: '1,2',
+    }],
+    // Core's encoder silently drops a memo its 6-bit length cannot carry; declining is the
+    // honest mirror — agreeing with a message that ignored the memo would verify a substitution.
+    ['an MPMA memo longer than 63 bytes', 'mpma', {
+      assets: 'XCP,XCP',
+      destinations: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa,1CounterpartyXXXXXXXXXXXXXXXUWLpVr',
+      quantities: '1,2',
+      memos: `${'x'.repeat(64)},`,
+      memos_are_hex: 'false,false',
+    }],
+    ['an MPMA hex memo with an odd length', 'mpma', {
+      assets: 'XCP,XCP',
+      destinations: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa,1CounterpartyXXXXXXXXXXXXXXXUWLpVr',
+      quantities: '1,2',
+      memos: 'abc,',
+      memos_are_hex: 'true,true',
+    }],
+    // One memos_are_hex flag covers every memo on the API, so a mix is not expressible.
+    ['MPMA memos mixing hex and text', 'mpma', {
+      assets: 'XCP,XCP',
+      destinations: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa,1CounterpartyXXXXXXXXXXXXXXXUWLpVr',
+      quantities: '1,2',
+      memos: 'beef,hello',
+      memos_are_hex: 'true,false',
+    }],
+    // A subasset in the list resolves to its numeric id through the ledger.
+    ['an MPMA send that includes a subasset', 'mpma', {
+      assets: 'XCP,PARENT.child',
+      destinations: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa,1CounterpartyXXXXXXXXXXXXXXXUWLpVr',
+      quantities: '1,2',
+    }],
+    ['an MPMA send that includes BTC', 'mpma', {
+      assets: 'XCP,BTC',
+      destinations: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa,1CounterpartyXXXXXXXXXXXXXXXUWLpVr',
+      quantities: '1,2',
     }],
     ['a reissuance with no observed message to borrow divisibility from', 'issuance', {
       asset: 'LANDMARKS', quantity: 0, description: 'new text',

--- a/src/utils/blockchain/counterparty/pack/__tests__/onchainRoundTrip.test.ts
+++ b/src/utils/blockchain/counterparty/pack/__tests__/onchainRoundTrip.test.ts
@@ -120,6 +120,33 @@ const PARAMS_FROM_DECODED: Record<string, (data: Record<string, any>) => Record<
       mime_type: data.mimeType ?? '',
     };
   },
+  mpma_send: (data) => {
+    // A whole-send memo is copied into each send by the decoder, indistinguishable from per-send
+    // memos that happen to agree — the original layout cannot be recovered, so skip. A
+    // present-but-empty memo (its bit set, zero length) is also inexpressible from params.
+    if (data.globalMemo !== undefined) return null;
+    const sends = data.sends as Array<{
+      asset: string; destination: string; quantity: bigint; memo?: string; memoIsHex?: boolean;
+    }>;
+    if (sends.some((send) => send.memo === '')) return null;
+    // Params are comma-separated, so a memo containing a comma cannot travel that way.
+    if (sends.some((send) => (send.memo ?? '').includes(','))) return null;
+    const withMemos = sends.filter((send) => send.memo);
+    const hexFlags = new Set(withMemos.map((send) => send.memoIsHex === true));
+    if (hexFlags.size > 1) return null; // one flag covers all memos on the API
+
+    return {
+      assets: sends.map((send) => send.asset).join(','),
+      destinations: sends.map((send) => send.destination).join(','),
+      quantities: sends.map((send) => send.quantity).join(','),
+      ...(withMemos.length > 0
+        ? {
+          memos: sends.map((send) => send.memo ?? '').join(','),
+          memos_are_hex: String(hexFlags.values().next().value ?? false),
+        }
+        : {}),
+    };
+  },
 };
 
 /** API transaction type → the compose type our packers are keyed by. */
@@ -134,6 +161,7 @@ const COMPOSE_TYPE_FOR: Record<string, string> = {
   issuance: 'issuance',
   fairminter: 'fairminter',
   broadcast: 'broadcast',
+  mpma: 'mpma',
 };
 
 async function recentTransactions(type: string): Promise<OnChainTransaction[]> {

--- a/src/utils/blockchain/counterparty/pack/messages.ts
+++ b/src/utils/blockchain/counterparty/pack/messages.ts
@@ -19,14 +19,14 @@
 
 import { encodeCbor, type CborEncodable } from './cbor';
 import { assetNameToId } from '../unpack/assetId';
-import { packAddress } from '../unpack/address';
+import { packAddress, packAddressLegacy } from '../unpack/address';
 import { MessageTypeId, COUNTERPARTY_PREFIX_HEX } from '../unpack/messageTypes';
 import { hexToBytes } from '../unpack/binary';
 
 /** The message types this module can construct. */
 export type PackableComposeType =
   | 'send' | 'issuance' | 'sweep' | 'destroy' | 'cancel' | 'order'
-  | 'dividend' | 'fairmint' | 'fairminter' | 'dispense' | 'broadcast';
+  | 'dividend' | 'fairmint' | 'fairminter' | 'dispense' | 'broadcast' | 'mpma';
 
 /**
  * Not every message is CBOR. The taproot_support upgrade moved enhanced send, issuance, sweep,
@@ -104,7 +104,8 @@ function packEnhancedSend(params: Params): PackedMessage | null {
   const destination = requireString(params, 'destination');
   const quantity = requireQuantity(params, 'quantity');
   if (!asset || !destination || quantity === null) return null;
-  // A multi-destination send composes as MPMA, which this module does not pack.
+  // Several destinations arrive in `destinations` and pack as MPMA (`packSendAsMpma`); a comma
+  // inside the singular field is not an address and cannot be an enhanced send.
   if (destination.includes(',')) return null;
   // memo_is_hex changes how core encodes the memo; only the plain-text form is packed here.
   if (params.memo_is_hex === true || params.memo_is_hex === 'true') return null;
@@ -552,6 +553,219 @@ function packBroadcast(params: Params, observed: Observed): PackedMessage | null
   return withPrefix(MessageTypeId.BROADCAST, encodeCbor(body));
 }
 
+/** MSB-first bit accumulator, the mirror of the unpacker's BitReader (`unpack/messages/mpma.ts`). */
+class BitWriter {
+  private bits: number[] = [];
+
+  writeBit(bit: boolean): void {
+    this.bits.push(bit ? 1 : 0);
+  }
+
+  writeUint(value: bigint, bitCount: number): void {
+    for (let i = bitCount - 1; i >= 0; i -= 1) {
+      this.bits.push(Number((value >> BigInt(i)) & 1n));
+    }
+  }
+
+  writeBytes(bytes: Uint8Array): void {
+    for (const byte of bytes) this.writeUint(BigInt(byte), 8);
+  }
+
+  /** Zero-pad to a byte boundary and return the bytes, as core's BitArray-to-bytes does. */
+  toBytes(): Uint8Array {
+    const out = new Uint8Array(Math.ceil(this.bits.length / 8));
+    this.bits.forEach((bit, index) => {
+      if (bit) out[index >> 3]! |= 0x80 >> (index & 7);
+    });
+    return out;
+  }
+}
+
+/** One send of an MPMA message, after the params have been parsed and validated. */
+interface MpmaSend {
+  asset: string;
+  destination: string;
+  quantity: bigint;
+  memo: string | null;
+  memoIsHex: boolean;
+}
+
+/**
+ * Append a memo in core's bit format: a presence bit, then is_hex, a 6-bit *byte* length, and the
+ * bytes (`mpmaencoding._encode_memo`). Returns false for a memo core cannot encode — over 63
+ * bytes, or hex with an odd length or a non-hex character. Core's encoder wraps this step in a
+ * bare `except` and silently drops such memos from the message; declining to pack is the honest
+ * mirror, because byte-agreeing with a message that ignored the user's memo would verify the
+ * very substitution this comparison exists to catch.
+ */
+function writeMemo(writer: BitWriter, memo: string | null, isHex: boolean): boolean {
+  if (memo === null || memo === '') {
+    writer.writeBit(false);
+    return true;
+  }
+  let bytes: Uint8Array;
+  if (isHex) {
+    if (memo.length % 2 !== 0 || !/^[0-9a-fA-F]+$/.test(memo)) return false;
+    bytes = hexToBytes(memo.toLowerCase());
+  } else {
+    bytes = new TextEncoder().encode(memo);
+  }
+  if (bytes.length > 63) return false;
+
+  writer.writeBit(true);
+  writer.writeBit(isHex);
+  writer.writeUint(BigInt(bytes.length), 6);
+  writer.writeBytes(bytes);
+  return true;
+}
+
+/**
+ * MPMA send: a `>H`-counted LUT of legacy-packed destination addresses sorted lexicographically,
+ * then a bit stream — a global memo, and per asset (sorted by name) a `1` continuation bit, the
+ * 64-bit asset id, an nbits-wide send count less one, and each send's nbits-wide LUT index, 64-bit
+ * quantity and memo — terminated by a `0` bit and zero-padded to a byte
+ * (core `mpmaencoding._encode_mpma_send`; nbits is ceil(log2(LUT size))).
+ *
+ * A single distinct destination makes nbits zero: the count and index fields occupy no bits at
+ * all (bitstring 4.1.4, core's pin, appends nothing for `uint:0` — newer versions raise, so this
+ * was checked against the pinned version) and the decoder infers one recipient per asset. That
+ * also means an asset group with several sends cannot be expressed at nbits zero; core's encoder
+ * would raise, and its validate rejects duplicate asset-destination pairs anyway.
+ *
+ * Declined when core could not compose the same request: a Taproot or P2WSH destination does not
+ * fit the 21-byte legacy packing; a subasset resolves through the ledger; and BTC cannot be sent
+ * by message. Order matters twice — the LUT and the asset groups are sorted, but sends within an
+ * asset keep request order — and both are what the decoder round-trips.
+ */
+function packMpma(sends: MpmaSend[], globalMemo: string | null, globalMemoIsHex: boolean): PackedMessage | null {
+  if (sends.length < 2) return null;
+  for (const send of sends) {
+    if (!send.asset || send.asset === 'BTC' || send.asset.includes('.')) return null;
+    if (send.quantity <= 0n || send.quantity >= 1n << 64n) return null;
+  }
+
+  const lutAddresses = [...new Set(sends.map((send) => send.destination))].sort();
+  const nbits = lutAddresses.length > 1 ? Math.ceil(Math.log2(lutAddresses.length)) : 0;
+
+  let lut: Uint8Array[];
+  try {
+    lut = lutAddresses.map((address) => packAddressLegacy(address));
+  } catch {
+    return null;
+  }
+
+  const writer = new BitWriter();
+  if (!writeMemo(writer, globalMemo, globalMemoIsHex)) return null;
+
+  const assets = [...new Set(sends.map((send) => send.asset))].sort();
+  for (const asset of assets) {
+    const assetSends = sends.filter((send) => send.asset === asset);
+    // At nbits zero the count field has no bits, so only one send per asset is expressible.
+    if (nbits === 0 && assetSends.length > 1) return null;
+    writer.writeBit(true);
+    try {
+      writer.writeUint(assetNameToId(asset), 64);
+    } catch {
+      return null;
+    }
+    writer.writeUint(BigInt(assetSends.length - 1), nbits);
+    for (const send of assetSends) {
+      writer.writeUint(BigInt(lutAddresses.indexOf(send.destination)), nbits);
+      writer.writeUint(send.quantity, 64);
+      if (!writeMemo(writer, send.memo, send.memoIsHex)) return null;
+    }
+  }
+  writer.writeBit(false);
+
+  const lutBytes = new Uint8Array(2 + lut.length * 21);
+  lutBytes[0] = lut.length >> 8;
+  lutBytes[1] = lut.length & 0xff;
+  lut.forEach((packed, index) => lutBytes.set(packed, 2 + index * 21));
+
+  const body = new Uint8Array([...lutBytes, ...writer.toBytes()]);
+  return withPrefix(MessageTypeId.MPMA_SEND, body);
+}
+
+/**
+ * Parse MPMA params as the wallet's forms produce them: parallel comma-separated `assets`,
+ * `destinations` and `quantities`, optional per-send `memos` (empty entries mean none) with a
+ * `memos_are_hex` flag, and an optional whole-send `memo`/`memo_is_hex` used when no per-send
+ * memos are given. Quantities are whole base units — normalization happens before compose — so a
+ * non-integral value means divisibility was not resolved and equality must not be attempted.
+ *
+ * `memos_are_hex` may arrive as one value or a comma-separated list from the form; core's API
+ * applies a single flag to every memo, so a mixed list is not expressible and `composeMPMA`
+ * refuses to send it — mirrored here by declining.
+ */
+function packMpmaFromParams(params: Params): PackedMessage | null {
+  const assetsCsv = requireString(params, 'assets');
+  const destinationsCsv = requireString(params, 'destinations');
+  const quantitiesCsv = requireString(params, 'quantities');
+  if (!assetsCsv || !destinationsCsv || !quantitiesCsv) return null;
+
+  const assets = assetsCsv.split(',');
+  const destinations = destinationsCsv.split(',');
+  const quantities = quantitiesCsv.split(',');
+  if (assets.length !== destinations.length || assets.length !== quantities.length) return null;
+
+  const memosCsv = typeof params.memos === 'string' && params.memos !== ''
+    ? params.memos.split(',')
+    : null;
+  if (memosCsv && memosCsv.length !== assets.length) return null;
+
+  let memosAreHex = false;
+  if (memosCsv) {
+    const flagValues = typeof params.memos_are_hex === 'string'
+      ? params.memos_are_hex.split(',').map((value) => value === 'true')
+      : [params.memos_are_hex === true];
+    if (new Set(flagValues).size > 1) return null;
+    memosAreHex = flagValues[0] ?? false;
+  }
+
+  const sends: MpmaSend[] = [];
+  for (let i = 0; i < assets.length; i += 1) {
+    const quantity = requireQuantity({ quantity: quantities[i]!.trim() }, 'quantity');
+    if (quantity === null) return null;
+    const memo = memosCsv ? memosCsv[i]! : null;
+    sends.push({
+      asset: assets[i]!.trim(),
+      destination: destinations[i]!.trim(),
+      quantity,
+      memo: memo === '' ? null : memo,
+      memoIsHex: memosAreHex,
+    });
+  }
+
+  const globalMemo = !memosCsv && typeof params.memo === 'string' && params.memo !== ''
+    ? params.memo
+    : null;
+  const globalMemoIsHex = params.memo_is_hex === true || params.memo_is_hex === 'true';
+
+  return packMpma(sends, globalMemo, globalMemo === null ? false : globalMemoIsHex);
+}
+
+/**
+ * The send form's multi-destination convenience: `composeSendOrMPMA` turns comma-separated
+ * destinations into an MPMA send of the same asset, quantity and memo to each, with the memo
+ * carried once as the whole-send memo.
+ */
+function packSendAsMpma(params: Params): PackedMessage | null {
+  const asset = requireString(params, 'asset');
+  const quantity = requireQuantity(params, 'quantity');
+  const destinations = requireString(params, 'destinations');
+  if (!asset || quantity === null || !destinations) return null;
+
+  const list = destinations.split(',').map((destination) => destination.trim());
+  return packMpmaFromParams({
+    assets: list.map(() => asset).join(','),
+    destinations: list.join(','),
+    quantities: list.map(() => quantity.toString()).join(','),
+    ...(typeof params.memo === 'string' && params.memo !== ''
+      ? { memo: params.memo, memo_is_hex: params.memo_is_hex }
+      : {}),
+  });
+}
+
 /**
  * Build the message bytes a compose request should produce, or null when this build cannot
  * construct them (unsupported type, or a value the request does not determine).
@@ -565,7 +779,13 @@ export function packComposeMessage(
 ): PackedMessage | null {
   switch (composeType) {
     case 'send':
+      // Several comma-separated destinations compose as MPMA (`composeSendOrMPMA`).
+      if (typeof params.destinations === 'string' && params.destinations.includes(',')) {
+        return packSendAsMpma(params);
+      }
       return packEnhancedSend(params);
+    case 'mpma':
+      return packMpmaFromParams(params);
     case 'issuance':
       return packIssuance(params, observed);
     case 'sweep':

--- a/src/utils/blockchain/counterparty/unpack/address.ts
+++ b/src/utils/blockchain/counterparty/unpack/address.ts
@@ -221,6 +221,47 @@ export function packAddress(address: string): Uint8Array {
 }
 
 /**
+ * Pack a Bitcoin address into the **legacy** 21-byte format.
+ *
+ * MPMA is the one message that still composes with this encoding: core's
+ * `mpmaencoding._encode_compress_lut` calls `address.pack_legacy` for every LUT entry, and the
+ * decoder reads fixed 21-byte slots. Base58 addresses pack as version byte + 20-byte hash; SegWit
+ * v0 packs as `0x80 + witness_version` + the 20-byte program. A 32-byte program does not fit, so
+ * Taproot and P2WSH destinations are rejected exactly as core rejects them
+ * ("p2wsh still not supported for sending").
+ *
+ * @throws AddressPackError if the address is invalid or not representable in 21 bytes
+ */
+export function packAddressLegacy(address: string): Uint8Array {
+  if (!address || typeof address !== 'string') {
+    throw new AddressPackError('Address is required');
+  }
+
+  if (address.toLowerCase().startsWith('bc1') || address.toLowerCase().startsWith('tb1')) {
+    const { version, program } = decodeBech32(address);
+    if (program.length > 20) {
+      throw new AddressPackError('Witness programs over 20 bytes do not fit the legacy packing');
+    }
+    const packed = new Uint8Array(1 + program.length);
+    packed[0] = VERSION.SEGWIT_MARKER + version;
+    packed.set(program, 1);
+    return packed;
+  }
+
+  const { version, hash } = decodeBase58Check(address);
+  if (hash.length !== 20) {
+    throw new AddressPackError(`Invalid hash length: ${hash.length}`);
+  }
+  if (!BASE58_VERSIONS.has(version)) {
+    throw new AddressPackError(`Unrecognized base58 version byte: 0x${version.toString(16)}`);
+  }
+  const packed = new Uint8Array(PACKED_ADDRESS_LENGTH);
+  packed[0] = version;
+  packed.set(hash, 1);
+  return packed;
+}
+
+/**
  * Unpack a Counterparty packed address (legacy or modern encoding) to a
  * Bitcoin address string.
  *

--- a/src/utils/blockchain/counterparty/unpack/verify.ts
+++ b/src/utils/blockchain/counterparty/unpack/verify.ts
@@ -25,7 +25,8 @@
  * mirroring what counterparty-core itself asserts in `check_transaction_sanity`:
  *
  * 1. **Message payload** — where the message can be built locally (`pack/messages.ts`: send,
- *    issuance including initial subassets, sweep, destroy, cancel, order, dividend, fairmint,
+ *    MPMA including the send form's multi-destination flow, issuance including initial subassets,
+ *    sweep, destroy, cancel, order, dividend, fairmint,
  *    fairminter, dispense and broadcast), verification is byte equality and any difference is
  *    fatal, with no severity gradation: equality asks whether the composer produced what was asked,
  *    and that answer is binary. A few values the request cannot determine — a reissuance's


### PR DESCRIPTION
Continues the verification architecture (#214, #215): MPMA moves from field-by-field comparison to whole-message byte equality — and fixing the packer surfaced a real compose bug.

## The bug: MPMA memos never reached the API

`composeMPMA` sent per-send memos as `memos[]=` query params. Core's `query_params()` builds lists from **repeated plain keys** (`request.args.to_dict(flat=False)`) and does nothing with a PHP-style `[]` suffix — `memos[]` is a different, ignored parameter. So compose silently proceeded memo-less: the user typed memos, the transaction composed without them. Fixed by sending repeated `memos=` keys, verified against a live node by a new oracle case that composes with per-send memos and requires our bytes (which include them) to match core's.

Two related transport fixes:
- A memo shared by every destination (the send form's multi-destination flow) now travels once as the whole-send `memo` param instead of a per-send list saying the same thing n times.
- Mixed hex/text memo lists are refused with a clear error: core applies a **single** `memos_are_hex` flag to the whole list, so the mix is not expressible — an error beats composing memos that mean something else.

## The packer

MPMA (id 3) per core's `mpmaencoding.py`: a `>H`-counted LUT of legacy 21-byte packed addresses sorted lexicographically, then a bit stream — whole-send memo, and per asset (sorted by name) a continuation bit, 64-bit asset id, nbits-wide count−1, and each send's nbits-wide LUT index, 64-bit quantity, and memo bits — terminated by a `0` bit, zero-padded to a byte.

The subtle finding: **one distinct destination makes nbits zero**, and the count/index fields occupy *no bits at all*. Core's pinned bitstring (4.1.4) appends nothing for `uint:0`; newer versions raise, which made the shape look uncomposable until the fixture generator ran under the pin — same version lesson as cbor2 in #215. This matters because several-assets-to-one-address is the dominant real MPMA traffic (all five most recent on-chain samples).

Both wallet flows byte-verify:
- the dedicated MPMA page — its quantity normalization moves from the page's compose method into `normalizeFormData`, so verification sees the same base units the API receives;
- the send form's comma-separated destinations, packed as the equivalent MPMA message.

Declined to the field fallback, with reasons in the code: Taproot/P2WSH destinations (32-byte programs don't fit the legacy packing), subassets (ledger-resolved), BTC, and any memo core's encoder would **silently drop** (over 63 bytes, odd-length hex — core wraps memo encoding in a bare `except`). Declining is the honest mirror: byte-agreeing with a message that ignored the user's memo would verify the very substitution the comparison exists to catch.

`unpack/address.ts` gains `packAddressLegacy`, the mirror of the 21-byte LUT slots the decoder already reads.

## Oracles and tests

- Unit fixtures generated with core's own `mpmaencoding` functions under bitstring 4.1.4 (LUT + bit layout, per-send hex memos, whole-send memo, the nbits-zero shape).
- Compose oracle: four MPMA cases, including the repeated-key memo transport proof and the nbits-zero shape.
- Round-trip oracle: rebuilds recent on-chain MPMA sends byte-for-byte (with documented skips for shapes that decode ambiguously, e.g. a whole-send memo copied into every send).

## Verification

- `tsc --noEmit` clean; all 678 counterparty tests pass with the oracles running against `api.counterparty.io:4000`; contexts/pages/components subsets pass.
- E2E locally, one file at a time: `compose/send/mpma.spec.ts` (6/6), `compose/send/index.spec.ts` (20/20).

https://claude.ai/code/session_01CcjnCrgosSeshymXLBxdGj
