### PR TITLE
Byte-verify ownership transfers and subasset reissuances; guard the borrow

### DIFF
--- a/src/utils/blockchain/counterparty/pack/__tests__/coreOracle.test.ts
+++ b/src/utils/blockchain/counterparty/pack/__tests__/coreOracle.test.ts
@@ -99,6 +99,20 @@ const CASES: OracleCase[] = [
     },
   },
   {
+    // The new owner rides in an output, not the message, so the composed data is byte-for-byte a
+    // reissuance — this proves core agrees the transfer changes nothing about the message.
+    label: 'issuance transferring ownership',
+    composeType: 'issuance',
+    params: {
+      asset: 'LANDMARKS', quantity: 0, divisible: false,
+      transfer_destination: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa',
+    },
+    query: {
+      asset: 'LANDMARKS', quantity: '0', divisible: 'false',
+      transfer_destination: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa',
+    },
+  },
+  {
     label: 'sweep of balances and ownership',
     composeType: 'sweep',
     params: { destination: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa', flags: 3, memo: 'moving' },

--- a/src/utils/blockchain/counterparty/pack/__tests__/messages.test.ts
+++ b/src/utils/blockchain/counterparty/pack/__tests__/messages.test.ts
@@ -114,17 +114,33 @@ describe('packing matches bytes generated with cbor2 5.9.0, the version core pin
     );
   });
 
-  it('reproduces a divisible locked subasset issuance with no description', () => {
+  it('reproduces a divisible subasset issuance with no description', () => {
     const packed = packComposeMessage(
       'issuance',
-      { asset: 'PEPE.rare-pepe_2026', quantity: 100_000_000, divisible: true, lock: true },
+      { asset: 'PEPE.rare-pepe_2026', quantity: 100_000_000, divisible: true },
       { messageTypeId: 23, assetId: 18446744073709551615n }
     );
 
     expect(packed).not.toBeNull();
     expect(bytesToHex(packed!.bytes)).toBe(
-      '434e54525052545917891bffffffffffffffff1a05f5e1000101000f4f07e75b9a418da186050a715c3ec2e760f6'
+      '434e54525052545917891bffffffffffffffff1a05f5e1000100000f4f07e75b9a418da186050a715c3ec2e760f6'
     );
+  });
+
+  it('packs an ownership transfer as the reissuance message core composes for it', () => {
+    // The new owner lives only in an output paying transfer_destination; the message is
+    // byte-for-byte a reissuance, and the output policy pins the ownership output.
+    const packed = packComposeMessage(
+      'issuance',
+      {
+        asset: 'LANDMARKS', quantity: 0, divisible: false,
+        transfer_destination: TAPROOT_DESTINATION,
+      }
+    );
+
+    expect(packed).not.toBeNull();
+    const body = encodeCbor([assetNameToId('LANDMARKS'), 0n, false, false, false, '', null]);
+    expect(bytesToHex(packed!.bytes)).toBe(expectedMessage(22, body));
   });
 });
 
@@ -383,9 +399,6 @@ describe('refusing to pack is not the same as agreeing', () => {
     ['a reissuance with no observed message to borrow divisibility from', 'issuance', {
       asset: 'LANDMARKS', quantity: 0, description: 'new text',
     }],
-    ['an ownership transfer, which moves via an output', 'issuance', {
-      asset: 'LANDMARKS', quantity: 0, divisible: false, transfer_destination: TAPROOT_DESTINATION,
-    }],
     ['a quantity that is not whole base units', 'send', {
       asset: 'XCP', destination: TAPROOT_DESTINATION, quantity: '1.5',
     }],
@@ -393,14 +406,55 @@ describe('refusing to pack is not the same as agreeing', () => {
     expect(packComposeMessage(composeType, params as Record<string, unknown>)).toBeNull();
   });
 
-  it('returns null for a subasset reissuance, which core composes in the standard layout', () => {
-    // Reissuing PARENT.child produces a standard-layout message whose asset id resolves through
-    // the ledger; only a composed message in the subasset layout is accepted for the subasset form.
-    expect(packComposeMessage(
+  it('refuses the subasset borrow for operations irreversible against a substituted id', () => {
+    // A wrong borrowed id lands the operation on a different numeric asset the user owns. Issue
+    // and describe are recoverable there; lock, reset and an ownership transfer are not, so the
+    // borrow refuses them and those flows stay on the field fallback.
+    const irreversible: Array<Record<string, unknown>> = [
+      { asset: 'PEPE.rare', quantity: 1, divisible: false, lock: true },
+      { asset: 'PEPE.rare', quantity: 0, divisible: false, reset: true },
+      { asset: 'PEPE.rare', quantity: 0, divisible: false, transfer_destination: TAPROOT_DESTINATION },
+    ];
+    for (const params of irreversible) {
+      for (const messageTypeId of [22, 23]) {
+        expect(packComposeMessage(
+          'issuance', params, { messageTypeId, assetId: 95428956661682177n, divisible: false }
+        )).toBeNull();
+      }
+    }
+  });
+});
+
+describe('subasset reissuance borrows the ledger-resolved asset id', () => {
+  it('packs a description update in the standard layout under the borrowed id', () => {
+    // Core resolves PARENT.child to its numeric asset through the ledger and composes the
+    // standard layout; the id is borrowed, and every field the user authored is byte-compared.
+    const packed = packComposeMessage(
       'issuance',
-      { asset: 'PARENT.child', quantity: 0, divisible: false, description: 'updated' },
-      { messageTypeId: 22, assetId: 95428956661682177n }
-    )).toBeNull();
+      { asset: 'PARENT.child', quantity: 0, description: 'updated text' },
+      { messageTypeId: 22, assetId: 95428956661682177n, divisible: true }
+    );
+
+    expect(packed).not.toBeNull();
+    const body = encodeCbor([
+      95428956661682177n, 0n, true, false, false, '',
+      new TextEncoder().encode('updated text'),
+    ]);
+    expect(bytesToHex(packed!.bytes)).toBe(expectedMessage(22, body));
+  });
+
+  it('still compares the description against what the user wrote', () => {
+    const packed = packComposeMessage(
+      'issuance',
+      { asset: 'PARENT.child', quantity: 0, description: 'what the user wrote' },
+      { messageTypeId: 22, assetId: 95428956661682177n, divisible: true, description: 'substituted' }
+    );
+
+    const substituted = encodeCbor([
+      95428956661682177n, 0n, true, false, false, '',
+      new TextEncoder().encode('substituted'),
+    ]);
+    expect(bytesToHex(packed!.bytes)).not.toBe(expectedMessage(22, substituted));
   });
 });
 

--- a/src/utils/blockchain/counterparty/pack/messages.ts
+++ b/src/utils/blockchain/counterparty/pack/messages.ts
@@ -131,30 +131,24 @@ function packEnhancedSend(params: Params): PackedMessage | null {
  * Issuance (standard, non-subasset): `[asset_id, quantity, divisible, lock, reset, mime_type,
  * description]` (core `issuance.py`, taproot_support branch). Core packs LR_ISSUANCE_ID whenever
  * `issuance_backwards_compatibility` is active, which it is on mainnet.
+ *
+ * An ownership transfer packs the same message: core carries the new owner only in an output that
+ * pays `transfer_destination` (`compose` returns `(source, [(destination, None)], data)`), so the
+ * message is byte-for-byte a reissuance. Equality here covers every message field, and the output
+ * policy — which requires each output to be an address the request names — is what pins the
+ * ownership output to the requested destination, the same division of labor dispense relies on.
  */
 function packIssuance(params: Params, observed: Observed): PackedMessage | null {
   const asset = requireString(params, 'asset');
   const quantity = requireQuantity(params, 'quantity');
   if (!asset || quantity === null) return null;
-  // A transfer moves ownership via an output; equality on the message alone would not cover it.
-  if (requireString(params, 'transfer_destination')) return null;
-  // A dotted asset is a subasset request, which composes a different layout.
-  if (asset.includes('.')) return packSubassetIssuance(asset, quantity, params, observed);
+  // A dotted asset is a subasset request, which needs its asset id borrowed from the response.
+  if (asset.includes('.')) return packSubasset(asset, quantity, params, observed);
   // The ord-inscription path restructures the message, and a non-text MIME type makes core
   // hex-decode the description (`helpers.content_to_bytes`); neither variant is packed here.
   if (params.inscription) return null;
   const mimeType = typeof params.mime_type === 'string' ? params.mime_type : '';
   if (mimeType !== '' && mimeType !== 'text/plain') return null;
-
-  // Divisibility is the user's choice on a first issuance and the ledger's on a reissuance, where
-  // the form omits it. Borrowing it from the response keeps reissuances — update description,
-  // transfer ownership — byte-verified in every other field. Safe to borrow: core requires a
-  // reissuance's divisibility to match the existing asset, so a substituted value yields a
-  // transaction consensus rejects rather than one that moves value.
-  const divisible = typeof params.divisible === 'boolean'
-    ? params.divisible
-    : typeof observed?.divisible === 'boolean' ? observed.divisible : null;
-  if (divisible === null) return null;
 
   let assetId: bigint;
   try {
@@ -162,6 +156,31 @@ function packIssuance(params: Params, observed: Observed): PackedMessage | null 
   } catch {
     return null;
   }
+
+  return packStandardIssuanceBody(assetId, quantity, mimeType, params, observed);
+}
+
+/**
+ * The standard issuance body, shared by named-asset issuances and subasset reissuances (whose
+ * borrowed asset id is resolved by the caller).
+ *
+ * Divisibility is the user's choice on a first issuance and the ledger's on a reissuance, where
+ * the form omits it. Borrowing it from the response keeps reissuances — update description,
+ * transfer ownership — byte-verified in every other field. Safe to borrow: core requires a
+ * reissuance's divisibility to match the existing asset, so a substituted value yields a
+ * transaction consensus rejects rather than one that moves value.
+ */
+function packStandardIssuanceBody(
+  assetId: bigint,
+  quantity: bigint,
+  mimeType: string,
+  params: Params,
+  observed: Observed
+): PackedMessage | null {
+  const divisible = typeof params.divisible === 'boolean'
+    ? params.divisible
+    : typeof observed?.divisible === 'boolean' ? observed.divisible : null;
+  if (divisible === null) return null;
 
   const description = typeof params.description === 'string' ? params.description : '';
 
@@ -207,45 +226,63 @@ function compactSubassetLongname(longname: string): Uint8Array | null {
 }
 
 /**
- * Initial subasset issuance: CBOR `[asset_id, quantity, divisible, lock, reset, compacted_length,
- * compacted_name, mime_type, description]` under LR_SUBASSET, since
- * `issuance_backwards_compatibility` is active on mainnet. The flags are packed as ints — core's
- * subasset branch writes `1 if divisible else 0` where the standard branch passes booleans
- * (`issuance.py`), and int versus bool is a byte-level difference in CBOR.
+ * Subasset issuance, initial or reissuance. Both need the numeric asset id borrowed from the
+ * composed message — core draws a random unused numeric asset for a new subasset
+ * (`assetnames.generate_random_asset`) and resolves an existing longname through the ledger for a
+ * reissuance — so the request cannot determine it either way.
  *
- * Only the *initial* issuance takes this layout. Core composes a reissuance of an existing
- * subasset as a standard-layout message whose asset id resolves through the ledger, so a response
- * that decodes to anything but a subasset layout is declined here and falls back to field
- * comparison.
+ * The borrow's blast radius sets the terms. A substituted id cannot pay an attacker: an id naming
+ * someone else's asset is consensus-rejected ("issued by another address"), and neither the field
+ * fallback nor any other verifier without an independent ledger view could detect the
+ * substitution anyway — the fallback compares the longname the user typed, which the response
+ * echoes faithfully. What a substituted id *can* do is land the operation on a different numeric
+ * asset the user owns, so the borrow is limited to operations that are recoverable when that
+ * happens: issue and describe, whose worst case is supply the user can destroy and a description
+ * they can rewrite. `lock`, `reset` and an ownership transfer are permanent against the wrong
+ * asset, so those decline to the field fallback — which is no blinder, but does not put this
+ * module's signature on the bytes. The range guard pins the id to the numeric space subassets
+ * live in.
  *
- * The asset id is borrowed from the composed message: core names a new subasset by drawing a
- * random unused numeric asset at compose time (`assetnames.generate_random_asset`), so the request
- * cannot determine it. Safe to borrow: the longname — which the user did author — is still
- * byte-compared through its compaction, and a substituted id cannot pay an attacker. An id naming
- * someone else's asset is consensus-rejected ("issued by another address"), and an id naming an
- * asset the source already owns degrades the transaction into a reissuance of the user's own asset
- * to themselves. The range guard pins the id to the numeric space core draws from.
+ * The layout follows the composed message, gated on its decoded type. An *initial* issuance
+ * (SUBASSET_ISSUANCE / LR_SUBASSET) carries the compacted longname:
+ * `[asset_id, quantity, divisible, lock, reset, compacted_length, compacted_name, mime_type,
+ * description]`, flags as ints — core's subasset branch writes `1 if divisible else 0` where the
+ * standard branch passes booleans, a byte-level difference in CBOR. A *reissuance* (ISSUANCE /
+ * LR_ISSUANCE) is the standard layout under the borrowed id.
  */
-function packSubassetIssuance(
+function packSubasset(
   longname: string,
   quantity: bigint,
   params: Params,
   observed: Observed
 ): PackedMessage | null {
-  const observedType = observed?.messageTypeId;
-  if (observedType !== MessageTypeId.SUBASSET_ISSUANCE && observedType !== MessageTypeId.LR_SUBASSET) {
-    return null;
-  }
-  // Divisibility is always the user's choice here: only a first issuance packs this layout.
-  if (typeof params.divisible !== 'boolean') return null;
   // The ord-inscription path restructures the message, and a non-text MIME type makes core
   // hex-decode the description (`helpers.content_to_bytes`); neither variant is packed here.
   if (params.inscription) return null;
   const mimeType = typeof params.mime_type === 'string' ? params.mime_type : '';
   if (mimeType !== '' && mimeType !== 'text/plain') return null;
 
+  // Irreversible against a substituted id — see the borrow argument above.
+  if (params.lock === true || params.lock === 'true') return null;
+  if (params.reset === true || params.reset === 'true') return null;
+  if (requireString(params, 'transfer_destination')) return null;
+
   const assetId = typeof observed?.assetId === 'bigint' ? observed.assetId : null;
   if (assetId === null || assetId <= 26n ** 12n || assetId >= 1n << 64n) return null;
+
+  const observedType = observed?.messageTypeId;
+
+  if (observedType === MessageTypeId.ISSUANCE || observedType === MessageTypeId.LR_ISSUANCE) {
+    // Reissuance of an existing subasset: the standard layout under the borrowed id.
+    return packStandardIssuanceBody(assetId, quantity, mimeType, params, observed);
+  }
+
+  if (observedType !== MessageTypeId.SUBASSET_ISSUANCE && observedType !== MessageTypeId.LR_SUBASSET) {
+    return null;
+  }
+
+  // Divisibility is always the user's choice on a first issuance.
+  if (typeof params.divisible !== 'boolean') return null;
 
   const compacted = compactSubassetLongname(longname);
   if (!compacted) return null;
@@ -256,8 +293,8 @@ function packSubassetIssuance(
     assetId,
     quantity,
     params.divisible ? 1n : 0n,
-    params.lock === true ? 1n : 0n,
-    params.reset === true ? 1n : 0n,
+    0n, // lock — the borrow refuses irreversible operations, so these are always clear
+    0n, // reset
     BigInt(compacted.length),
     compacted,
     mimeType,

--- a/src/utils/blockchain/counterparty/unpack/verify.ts
+++ b/src/utils/blockchain/counterparty/unpack/verify.ts
@@ -34,9 +34,10 @@
  *    are borrowed from the composed message under the argued conditions in `pack/messages.ts`
  *    (`Observed`), and everything the user authored still has to match byte for byte. Severity
  *    belongs only to the field-by-field fallback used for what still cannot be built — an
- *    inscription's tapscript envelope, a subasset reissuance's ledger-resolved asset id — because
- *    that path can speak only to fields it was taught about. Packing returns null rather than
- *    guess, so equality applies only where the bytes are known exactly.
+ *    inscription's tapscript envelope, or a subasset lock/reset/transfer, where a substituted
+ *    borrowed id would do irreversible harm and the borrow refuses — because that path can speak
+ *    only to fields it was taught about. Packing returns null rather than guess, so equality
+ *    applies only where the bytes are known exactly.
  *
  *    Two oracles keep the packers honest, both nightly:
  *    `coreOracle.test.ts` asks a live node what it would compose for a set of params and requires


### PR DESCRIPTION
Stacked on #216. Closes two of the three deliberate byte-equality gaps, and tightens a borrow shipped in #215.

## Ownership transfers now byte-verify

The decline was over-conservative. A transfer's *message* is byte-for-byte a reissuance — core carries the new owner only in an output paying `transfer_destination` (`issuance.py` returns `(source, [(destination, None)], data)`). A new compose-oracle case proves it against a live node: core composes identical data with and without the transfer. So the message packs, equality covers every field, and the output policy — which already picks up `transfer_destination` via `addressesNamedIn` and requires every output to be explained — is what pins the ownership output. Same division of labor dispense relies on.

## Subasset reissuances now byte-verify, under a borrowed id

Updating a subasset's description composes the **standard** layout under the ledger-resolved numeric id, which the request cannot determine. It's now borrowed from the composed message, like the initial issuance's random draw. The honest accounting: the field fallback is *equally blind* to a substituted id (it compares the longname the user typed, which the response echoes faithfully), so borrowing makes nothing worse and buys byte equality on the description, quantity, flags and MIME type.

## The borrow refuses irreversible operations — on both subasset paths

A substituted id can land the operation on a different numeric asset the user owns (matching divisibility required; the range guard limits targets to numeric assets). For issue-and-describe the wrong outcome is recoverable — destroy the supply, rewrite the description. For **lock, reset, and transfer it is permanent against the wrong asset**, so the borrow refuses those and they stay on the field fallback: no blinder, but byte equality does not sign off on them.

This retroactively tightens #215's initial-issuance borrow, whose safety argument under-weighted the lock case. The full analysis is an addendum in the (deliberately uncommitted) audit log; the vector's real fix — an independent ledger view or local composition — is folded into the local-compose decision.

## Verification

- `tsc --noEmit` clean; all 681 counterparty tests pass with both oracles live against `api.counterparty.io:4000`, including the new transfer oracle case.
- Fixtures regenerated with core's exact arithmetic for the unlocked subasset shape.
- E2E locally, one file at a time: `issuance/index.spec.ts` (10/10), `transfer-ownership.spec.ts` (3/3), `update-description.spec.ts` (3/3).

https://claude.ai/code/session_01CcjnCrgosSeshymXLBxdGj
