### PR TITLE
Make inscriptions work end to end, and verify them

### DIFF
--- a/src/contexts/composer-context.tsx
+++ b/src/contexts/composer-context.tsx
@@ -59,6 +59,10 @@ import { extractCounterpartyPayload } from "@/utils/blockchain/counterparty/unpa
 import { packAddress } from "@/utils/blockchain/counterparty/unpack/address";
 import { checkOutputPolicy, type IntendedDestination } from "@/utils/blockchain/counterparty/outputPolicy";
 import { packComposeMessage } from "@/utils/blockchain/counterparty/pack/messages";
+import {
+  verifyInscriptionEnvelope,
+  verifyRevealTransaction,
+} from "@/utils/blockchain/counterparty/inscriptionEnvelope";
 import { unpackCounterpartyMessage } from "@/utils/blockchain/counterparty/unpack";
 import { bytesToHex } from "@/utils/blockchain/counterparty/unpack/binary";
 import { checkTransactionFee } from "@/utils/blockchain/bitcoin/feeVerification";
@@ -382,6 +386,37 @@ export function ComposerProvider<T>({
       const counterpartyData = extractCounterpartyPayload(response.result.rawtransaction);
       let verificationWarnings: string[] = [];
       let decodedMessage: DecodedMessage | null = null;
+
+      // An inscription compose carries its message in an ord envelope rather than an OP_RETURN, so
+      // the transaction being signed is a commit paying a P2TR address derived from that envelope.
+      // Rebuild the envelope from the message this request should produce and require the composed
+      // one to match, then let the derived address explain the commit output. Verified here rather
+      // than exempted, so a substituted inscription still fails (`inscriptionEnvelope.ts`).
+      let inscriptionCommitAddress: string | null = null;
+      const envelopeScript = response.result.envelope_script;
+      if (typeof envelopeScript === 'string' && envelopeScript.length > 0) {
+        const expectedMessage = packComposeMessage(composeType, dataForApi);
+        if (!expectedMessage) {
+          throw new Error(
+            'Transaction verification failed: this inscription could not be rebuilt for checking.'
+          );
+        }
+        const envelopeCheck = verifyInscriptionEnvelope(envelopeScript, expectedMessage.bytes);
+        if (!envelopeCheck.ok || !envelopeCheck.commitAddress) {
+          throw new Error(envelopeCheck.error || 'Transaction verification failed: bad inscription.');
+        }
+        // The reveal is signed by the composer, so its outputs are checked rather than trusted.
+        const revealHex = response.result.signed_reveal_rawtransaction;
+        if (typeof revealHex !== 'string' || revealHex.length === 0) {
+          throw new Error('The composer did not return the reveal transaction for this inscription.');
+        }
+        const revealCheck = verifyRevealTransaction(revealHex, [activeAddress.address]);
+        if (!revealCheck.ok) {
+          throw new Error(revealCheck.error || 'Transaction verification failed: bad reveal.');
+        }
+        inscriptionCommitAddress = envelopeCheck.commitAddress;
+      }
+
       if (counterpartyData) {
         // Read the message out of the transaction so the review screen can render what the bytes
         // say rather than what the response claims they say.
@@ -444,6 +479,12 @@ export function ComposerProvider<T>({
       if (activeAddress && !SERVER_DERIVED_DESTINATION_TYPES.has(composeType)) {
         const intendedDestinations: IntendedDestination[] =
           addressesNamedIn(dataForApi).map(address => ({ address }));
+        // The inscription commit output pays an address the request cannot name, but one that was
+        // just derived from an envelope verified to carry this request's message — so it is
+        // explained by proof rather than by exemption.
+        if (inscriptionCommitAddress) {
+          intendedDestinations.push({ address: inscriptionCommitAddress });
+        }
         if (composeType === 'burn') {
           // A burn carries no Counterparty message at all, so the outputs are the only thing that
           // can be checked — and pinning the amount here is the only verification a burn gets.
@@ -576,10 +617,38 @@ export function ComposerProvider<T>({
       );
     }
 
+    // An inscription is two transactions. The commit just went out; the reveal — already signed by
+    // the composer with the ephemeral key that owns the commit output, and checked at compose time
+    // to pay only us — is what actually publishes the content. Broadcasting it immediately is safe
+    // because it spends the commit's output, and the commit's txid is fixed before signing (its
+    // inputs are segwit, which is why taproot encoding requires a segwit source). Without this the
+    // content never lands and the committed sats are stranded.
+    const revealHex = state.apiResponse.result.signed_reveal_rawtransaction;
+    let revealBroadcast: { txid?: string } | undefined;
+    if (typeof revealHex === 'string' && revealHex.length > 0) {
+      try {
+        revealBroadcast = await broadcastTransaction(revealHex);
+      } catch (error) {
+        // The commit is already on the network and cannot be recalled, so this must not throw:
+        // surface it as a warning with the reveal hex so the inscription can still be completed.
+        const detail = error instanceof Error ? error.message : String(error);
+        setState(prev => ({
+          ...prev,
+          verificationWarnings: [
+            ...prev.verificationWarnings,
+            `The inscription's commit transaction was broadcast, but the reveal that publishes the `
+            + `content was not accepted (${detail}). The content is not on chain yet. Reveal `
+            + `transaction: ${revealHex}`,
+          ],
+        }));
+      }
+    }
+
     // Return the updated apiResponse with broadcast info
     return {
       ...state.apiResponse,
-      broadcast: broadcastResponse
+      broadcast: broadcastResponse,
+      ...(revealBroadcast ? { revealBroadcast } : {}),
     };
   }, [state.apiResponse, activeAddress, activeWallet, signTransaction, broadcastTransaction, setHardwareOperationInProgress]);
 

--- a/src/pages/compose/broadcast/form.tsx
+++ b/src/pages/compose/broadcast/form.tsx
@@ -7,6 +7,7 @@ import { InscriptionUploadInput } from "@/components/ui/inputs/file-upload-input
 import { TextField } from "@/components/ui/inputs/text-field";
 import { useComposer } from "@/contexts/composer-context";
 import { isSegwitFormat } from '@/utils/blockchain/bitcoin/address';
+import { encodeInscriptionContent } from '@/utils/blockchain/counterparty/inscriptionEnvelope';
 import type { BroadcastOptions } from "@/utils/blockchain/counterparty/compose";
 import type { ReactElement } from "react";
 
@@ -60,17 +61,14 @@ export function BroadcastForm({
     setSelectedFile(file);
   };
   
-  const fileToBase64 = (file: File): Promise<string> => {
-    return new Promise((resolve, reject) => {
-      const reader = new FileReader();
-      reader.readAsDataURL(file);
-      reader.onload = () => {
-        const base64 = reader.result as string;
-        const base64Data = base64.split(',')[1]!;
-        resolve(base64Data);
-      };
-      reader.onerror = error => reject(error);
-    });
+  /**
+   * The content as a compose request must carry it: hex for binary types, the decoded string for
+   * textual ones. Core unhexlifies non-text content (`helpers.content_to_bytes`), so sending
+   * anything else makes it reject the compose.
+   */
+  const fileToInscriptionContent = async (file: File): Promise<string> => {
+    const bytes = new Uint8Array(await file.arrayBuffer());
+    return encodeInscriptionContent(bytes, file.type || "application/octet-stream");
   };
 
   return (
@@ -84,15 +82,14 @@ export function BroadcastForm({
             formData.set("fee_fraction", "0");
           }
           
-          // Handle inscription mode
+          // Handle inscription mode. `inscription` is a boolean flag to core — the content itself
+          // travels in `text`, hex-encoded unless the MIME type is textual.
           if (inscribeEnabled && selectedFile) {
             try {
-              // Convert file to base64 for inscription
-              const base64Data = await fileToBase64(selectedFile);
-              formData.set("inscription", base64Data);
+              formData.set("text", await fileToInscriptionContent(selectedFile));
+              formData.set("inscription", "true");
               formData.set("mime_type", selectedFile.type || "application/octet-stream");
               formData.set("encoding", "taproot");
-              formData.set("text", `Inscribed ${selectedFile.name}`); // Description for the broadcast
             } catch (error) {
               setFileError("Failed to process file");
               return;

--- a/src/pages/compose/issuance/form.tsx
+++ b/src/pages/compose/issuance/form.tsx
@@ -13,6 +13,7 @@ import { useComposer } from "@/contexts/composer-context";
 import { useAssetDetails } from "@/hooks/useAssetDetails";
 import { toBigNumber } from "@/utils/numeric";
 import { isSegwitFormat } from '@/utils/blockchain/bitcoin/address';
+import { encodeInscriptionContent } from '@/utils/blockchain/counterparty/inscriptionEnvelope';
 import type { IssuanceOptions } from "@/utils/blockchain/counterparty/compose";
 import type { ReactElement } from "react";
 
@@ -105,33 +106,23 @@ export function IssuanceForm({
     setSelectedFile(file);
   };
   
-  // Convert file to base64
-  const fileToBase64 = (file: File): Promise<string> => {
-    return new Promise((resolve, reject) => {
-      const reader = new FileReader();
-      reader.readAsDataURL(file);
-      reader.onload = () => {
-        const base64 = reader.result as string;
-        // Remove data URL prefix
-        const base64Data = base64.split(',')[1]!;
-        resolve(base64Data);
-      };
-      reader.onerror = error => reject(error);
-    });
-  };
+
 
   const processedFormAction = async (formData: FormData) => {
     formData.set('quantity', amount);
     formData.set('divisible', String(isDivisible));
     formData.set('lock', String(isLocked));
 
-    // If inscribing, convert file to base64 and set as description
+    // If inscribing, the content travels in `description` — hex-encoded unless the MIME type is
+    // textual — and `inscription` is the boolean flag that selects core's ord envelope path.
     if (inscribeEnabled) {
       if (selectedFile) {
         try {
-          const base64Data = await fileToBase64(selectedFile);
-          formData.set("description", base64Data);
-          formData.set("mime_type", selectedFile.type);
+          const bytes = new Uint8Array(await selectedFile.arrayBuffer());
+          const mimeType = selectedFile.type || "application/octet-stream";
+          formData.set("description", encodeInscriptionContent(bytes, mimeType));
+          formData.set("inscription", "true");
+          formData.set("mime_type", mimeType);
           formData.set("encoding", "taproot");
         } catch (error) {
           setFileError("Failed to process file");

--- a/src/utils/blockchain/counterparty/__tests__/inscriptionEnvelope.test.ts
+++ b/src/utils/blockchain/counterparty/__tests__/inscriptionEnvelope.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Inscription envelope verification, checked against a real compose response.
+ *
+ * The fixtures below are a genuine `encoding=taproot` broadcast composed by api.counterparty.io —
+ * an image/png inscription of "hello" from a P2WPKH source. Rebuilding the envelope locally and
+ * getting the server's bytes back proves the mirror is exact; deriving the commit address and
+ * getting the transaction's actual output proves the taproot derivation is right. Together they
+ * are the same assertion core makes about its own output in `check_transaction_sanity`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { hexToBytes } from '@noble/hashes/utils.js';
+import { verifyInscriptionEnvelope, verifyRevealTransaction } from '../inscriptionEnvelope';
+
+const SOURCE = 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4';
+
+/** CNTRPRTY + type 30 + CBOR [timestamp, value, fee_fraction_int, mime_type, content]. */
+const DATA = '434e5452505254591e851a66ae50e0fb00000000000000000069696d6167652f706e674568656c6c6f';
+
+const ENVELOPE = '0063036f7264010703786370010109696d6167652f706e6701051284181e1a66ae50e0fb0000'
+  + '00000000000000000568656c6c6f6820bbec263aa627fab2cc458b46b4b0193d8dfd7169906b48f5ee12c8bc8'
+  + 'bc62693ac';
+
+/** The commit transaction's output 0 pays this P2TR address (875 sats). */
+const COMMIT_ADDRESS = 'bc1pk828a69sm0lycjve30m8yhrnuhh4vpks34w2qejtckp28m27pfkqzm0l0a';
+
+const REVEAL = '02000000000101a6511addc5e6d2135ef26767f4f81555d5cbbf68aabc09753fa72f3e6c859b8c00'
+  + '00000000ffffffff0200000000000000000a6a08434e5452505254592202000000000000160014751e76e8199'
+  + '196d454941c45d1b3a323f1433bd603400e7730b94c4fa3029b93f7347e365b6d1279e80b85cf1ed23ab041a5'
+  + '8c294de9ec1a0731924221b27af39b90b49e763e4cb20083277e07c3a236a778c253f0c6570063036f7264010'
+  + '703786370010109696d6167652f706e6701051284181e1a66ae50e0fb000000000000000000000568656c6c6f'
+  + '6820bbec263aa627fab2cc458b46b4b0193d8dfd7169906b48f5ee12c8bc8bc62693ac21c1bbec263aa627fab'
+  + '2cc458b46b4b0193d8dfd7169906b48f5ee12c8bc8bc6269300000000';
+
+describe('rebuilding a real inscription envelope', () => {
+  it('reproduces the composed envelope byte for byte and derives its commit address', () => {
+    const result = verifyInscriptionEnvelope(ENVELOPE, hexToBytes(DATA));
+
+    expect(result.error).toBeUndefined();
+    expect(result.ok).toBe(true);
+    // The address the real commit transaction actually pays.
+    expect(result.commitAddress).toBe(COMMIT_ADDRESS);
+  });
+
+  it('rejects an envelope carrying different content than the request', () => {
+    // "hello" -> "hellp": one byte of the inscribed content.
+    const tampered = hexToBytes(DATA.replace('68656c6c6f', '68656c6c70'));
+    const result = verifyInscriptionEnvelope(ENVELOPE, tampered);
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/does not match your request/);
+  });
+
+  it('rejects an envelope carrying a different mime type', () => {
+    // image/png -> image/pnq, changing only the declared content type.
+    const tampered = hexToBytes(DATA.replace('696d6167652f706e67', '696d6167652f706e71'));
+    const result = verifyInscriptionEnvelope(ENVELOPE, tampered);
+
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects a script that does not end in the expected pubkey and OP_CHECKSIG', () => {
+    const result = verifyInscriptionEnvelope('0063036f726468', hexToBytes(DATA));
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/unexpected structure/);
+  });
+});
+
+describe('the pre-signed reveal transaction', () => {
+  it('accepts the real reveal, which returns value to the source', () => {
+    const result = verifyRevealTransaction(REVEAL, [SOURCE]);
+
+    expect(result.error).toBeUndefined();
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects the same reveal when the source is not ours', () => {
+    const result = verifyRevealTransaction(REVEAL, ['bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq']);
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/not yours/);
+  });
+});

--- a/src/utils/blockchain/counterparty/compose.ts
+++ b/src/utils/blockchain/counterparty/compose.ts
@@ -96,6 +96,14 @@ export interface ComposeResult {
   inputs_values: number[];
   signed_tx_estimated_size: SignedTxEstimatedSize;
   psbt: string;
+  /**
+   * Present only for `encoding=taproot` composes. The ord envelope script carrying the message,
+   * and the reveal transaction — already signed by the composer's ephemeral key — that spends the
+   * commit output and publishes the content. `rawtransaction` is only the commit, so an
+   * inscription is not complete until the reveal is broadcast too.
+   */
+  envelope_script?: string;
+  signed_reveal_rawtransaction?: string;
   params: ComposeParams & {
     asset_dest_quant_list?: [string, string, string | number][];
     memos?: string[];

--- a/src/utils/blockchain/counterparty/inscriptionEnvelope.ts
+++ b/src/utils/blockchain/counterparty/inscriptionEnvelope.ts
@@ -1,0 +1,278 @@
+/**
+ * Verification for ord-style inscription composes.
+ *
+ * When a compose sets `inscription`, core does not put the Counterparty message in an OP_RETURN.
+ * It builds an ord envelope script carrying the message, commits to that script in a P2TR output,
+ * and returns a pre-signed *reveal* transaction that spends the commit and publishes the content
+ * (`lib/api/composer.py`, `generate_ordinal_envelope_script` / `prepare_taproot_output`). The
+ * transaction the wallet signs is only the commit.
+ *
+ * That makes the ordinary checks inapplicable: there is no OP_RETURN to unpack, and the commit
+ * output pays an address no request names. Rather than exempt the type — which would leave the
+ * whole flow unverified — this rebuilds the envelope from the message the request should produce
+ * and requires the composed one to match, then derives the commit address from that envelope and
+ * requires the commit output to pay exactly it. counterparty-core applies the same test to its own
+ * output in `check_transaction_sanity`, comparing a regenerated envelope script against the
+ * composed one.
+ *
+ * Envelope layout, verified against the ord reference implementation (`src/inscriptions/tag.rs`:
+ * ContentType = 1, Metadata = 5, Metaprotocol = 7, and Metadata is chunked so each 520-byte piece
+ * repeats its tag) and against core's construction:
+ *
+ *   OP_FALSE OP_IF
+ *     "ord" 0x07 "xcp"          — metaprotocol tag and identifier
+ *     0x01 <mime type>          — content type
+ *     (0x05 <metadata chunk>)*  — CBOR [message_type_id, ...message fields except mime and content]
+ *     OP_0 (<content chunk>)*   — the body
+ *   OP_ENDIF
+ *   <32-byte x-only pubkey> OP_CHECKSIG
+ *
+ * The trailing pubkey is chosen randomly by the server per compose, so it cannot be predicted and
+ * is read from the composed script — the same allowance core makes when it strips the last two
+ * elements before comparing. It is safe to accept because it does not decide where value goes: the
+ * commit address is derived from it *and* the verified envelope, and the reveal's outputs are
+ * checked separately (`verifyRevealTransaction`).
+ */
+
+import { p2tr, Transaction } from '@scure/btc-signer';
+import { hexToBytes, bytesToHex } from '@noble/hashes/utils.js';
+import { encodeCbor, type CborEncodable } from './pack/cbor';
+import { decodeCbor } from './unpack/cbor';
+import { COUNTERPARTY_PREFIX_HEX } from './unpack/messageTypes';
+import { decodeAddressFromScript } from '@/utils/blockchain/bitcoin/address';
+
+/** Core chunks both metadata and content at this size (`helpers.chunkify`). */
+const CHUNK_SIZE = 520;
+
+/**
+ * Application types core treats as text (`helpers.TEXTUAL_APPLICATION_MIME_TYPES`). Everything
+ * outside this list, `text/*`, `message/*` and the `+xml` / `+json` suffixes is binary.
+ */
+const TEXTUAL_APPLICATION_MIME_TYPES = new Set([
+  'application/xml', 'application/javascript', 'application/ecmascript',
+  'application/x-javascript', 'application/json', 'application/manifest+json',
+  'application/x-python-code', 'application/x-sh', 'application/x-csh',
+  'application/x-tex', 'application/x-latex', 'application/postscript',
+  'application/yaml', 'application/x-yaml', 'application/sql',
+]);
+
+/**
+ * Whether core will read this MIME type's content as UTF-8 text rather than hex
+ * (`helpers.classify_mime_type`). This decides how a request must carry the content: text types
+ * send it verbatim, everything else sends it hex-encoded, because `content_to_bytes` unhexlifies
+ * for binary types. Getting it wrong makes core reject the compose outright.
+ */
+export function isTextualMimeType(mimeType: string): boolean {
+  if (typeof mimeType !== 'string') return false;
+  const target = mimeType.split(';')[0]!.trim().toLowerCase();
+  if (target.startsWith('text/') || target.startsWith('message/')) return true;
+  if (target.endsWith('+xml') || target.endsWith('+json')) return true;
+  return TEXTUAL_APPLICATION_MIME_TYPES.has(target);
+}
+
+/**
+ * Encode a file's bytes the way a compose request must carry them for the given MIME type.
+ * Binary content goes as hex; textual content goes as the decoded string.
+ */
+export function encodeInscriptionContent(bytes: Uint8Array, mimeType: string): string {
+  if (isTextualMimeType(mimeType)) {
+    return new TextDecoder('utf-8').decode(bytes);
+  }
+  return bytesToHex(bytes);
+}
+
+/** Bitcoin script push of arbitrary data, matching python-bitcoin-utils' Script serialization. */
+function pushData(data: Uint8Array): number[] {
+  if (data.length < 0x4c) return [data.length, ...data];
+  if (data.length <= 0xff) return [0x4c, data.length, ...data];
+  if (data.length <= 0xffff) return [0x4d, data.length & 0xff, data.length >> 8, ...data];
+  throw new Error('envelope: push too large');
+}
+
+function chunkify(data: Uint8Array, size: number): Uint8Array[] {
+  if (data.length === 0) return [];
+  const chunks: Uint8Array[] = [];
+  for (let i = 0; i < data.length; i += size) chunks.push(data.slice(i, i + size));
+  return chunks;
+}
+
+/**
+ * Split a packed Counterparty message into the pieces the envelope carries.
+ *
+ * Core pops the content (last CBOR field) and then the mime type (the new last), prefixes the
+ * remainder with the message type id, and CBOR-encodes that as the metadata.
+ */
+function splitMessage(messageBytes: Uint8Array): {
+  messageTypeId: number;
+  metadata: Uint8Array;
+  mimeType: string;
+  content: Uint8Array;
+} | null {
+  const prefix = hexToBytes(COUNTERPARTY_PREFIX_HEX);
+  if (messageBytes.length <= prefix.length + 1) return null;
+  for (let i = 0; i < prefix.length; i += 1) {
+    if (messageBytes[i] !== prefix[i]) return null;
+  }
+  const messageTypeId = messageBytes[prefix.length]!;
+  const body = messageBytes.slice(prefix.length + 1);
+
+  let decoded;
+  try {
+    decoded = decodeCbor(body);
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(decoded) || decoded.length < 2) return null;
+  const fields = [...decoded];
+
+  const contentValue = fields.pop();
+  const mimeValue = fields.pop();
+  if (typeof mimeValue !== 'string') return null;
+  const content = contentValue instanceof Uint8Array
+    ? contentValue
+    : contentValue === null ? new Uint8Array(0) : null;
+  if (content === null) return null;
+
+  // Core writes `mime_type or "text/plain"` into the envelope, so an empty mime becomes the default.
+  const mimeType = mimeValue === '' ? 'text/plain' : mimeValue;
+
+  const metadataFields: CborEncodable[] = [BigInt(messageTypeId), ...(fields as CborEncodable[])];
+  return { messageTypeId, metadata: encodeCbor(metadataFields), mimeType, content };
+}
+
+/** Build the envelope script core would produce for this message and ephemeral pubkey. */
+function buildEnvelopeScript(messageBytes: Uint8Array, xOnlyPubkey: Uint8Array): Uint8Array | null {
+  const split = splitMessage(messageBytes);
+  if (!split) return null;
+  const encoder = new TextEncoder();
+
+  const bytes: number[] = [
+    0x00, // OP_FALSE
+    0x63, // OP_IF
+    ...pushData(encoder.encode('ord')),
+    ...pushData(new Uint8Array([0x07])),
+    ...pushData(encoder.encode('xcp')),
+    ...pushData(new Uint8Array([0x01])),
+    ...pushData(encoder.encode(split.mimeType)),
+  ];
+  for (const chunk of chunkify(split.metadata, CHUNK_SIZE)) {
+    bytes.push(...pushData(new Uint8Array([0x05])), ...pushData(chunk));
+  }
+  bytes.push(0x00); // OP_0 — start of body
+  for (const chunk of chunkify(split.content, CHUNK_SIZE)) {
+    bytes.push(...pushData(chunk));
+  }
+  bytes.push(0x68); // OP_ENDIF
+  bytes.push(...pushData(xOnlyPubkey), 0xac); // pubkey, OP_CHECKSIG
+
+  return new Uint8Array(bytes);
+}
+
+/**
+ * The ephemeral x-only pubkey is the last push before the trailing OP_CHECKSIG.
+ * Returns null when the script does not end in the expected `<32 bytes> OP_CHECKSIG` shape.
+ */
+function extractEnvelopePubkey(envelope: Uint8Array): Uint8Array | null {
+  if (envelope.length < 34) return null;
+  if (envelope[envelope.length - 1] !== 0xac) return null;
+  if (envelope[envelope.length - 34] !== 0x20) return null;
+  return envelope.slice(envelope.length - 33, envelope.length - 1);
+}
+
+export interface EnvelopeCheck {
+  ok: boolean;
+  error?: string;
+  /** The P2TR address the commit output must pay, when the envelope verified. */
+  commitAddress?: string;
+}
+
+/**
+ * Verify a composed envelope script carries exactly the message the request should produce, and
+ * report the commit address that envelope commits to.
+ */
+export function verifyInscriptionEnvelope(
+  envelopeScriptHex: string,
+  expectedMessage: Uint8Array,
+  network: 'mainnet' | 'testnet' = 'mainnet'
+): EnvelopeCheck {
+  let composed: Uint8Array;
+  try {
+    composed = hexToBytes(envelopeScriptHex.replace(/^0x/, ''));
+  } catch {
+    return { ok: false, error: 'The composed envelope script could not be read.' };
+  }
+
+  const pubkey = extractEnvelopePubkey(composed);
+  if (!pubkey) {
+    return { ok: false, error: 'The composed envelope script has an unexpected structure.' };
+  }
+
+  const expected = buildEnvelopeScript(expectedMessage, pubkey);
+  if (!expected) {
+    return { ok: false, error: 'This inscription could not be rebuilt locally for comparison.' };
+  }
+
+  if (bytesToHex(expected) !== bytesToHex(composed)) {
+    return {
+      ok: false,
+      error: 'Transaction verification failed: the inscription does not match your request.',
+    };
+  }
+
+  try {
+    const payment = p2tr(
+      pubkey,
+      { script: composed },
+      network === 'mainnet' ? undefined : { bech32: 'tb', pubKeyHash: 0x6f, scriptHash: 0xc4, wif: 0xef },
+      true
+    );
+    if (!payment.address) {
+      return { ok: false, error: 'The inscription commit address could not be derived.' };
+    }
+    return { ok: true, commitAddress: payment.address };
+  } catch {
+    return { ok: false, error: 'The inscription commit address could not be derived.' };
+  }
+}
+
+/**
+ * Check the pre-signed reveal transaction only moves value back to the signer.
+ *
+ * The reveal is built and signed by the server, so its outputs are not the user's choice — but they
+ * are checkable: core pays an OP_RETURN marker plus dust to the source's change address
+ * (`get_reveal_outputs`). Anything else means the reveal would carry value somewhere the user never
+ * asked for, and the commit that funds it must not be signed.
+ */
+export function verifyRevealTransaction(
+  revealHex: string,
+  ownAddresses: string[],
+  network: 'mainnet' | 'testnet' = 'mainnet'
+): { ok: boolean; error?: string } {
+  let tx: Transaction;
+  try {
+    tx = Transaction.fromRaw(hexToBytes(revealHex), {
+      allowUnknownInputs: true,
+      allowUnknownOutputs: true,
+      allowLegacyWitnessUtxo: true,
+      disableScriptCheck: true,
+    });
+  } catch {
+    return { ok: false, error: 'The inscription reveal transaction could not be read.' };
+  }
+
+  const own = new Set(ownAddresses.map((address) => address.toLowerCase()));
+  for (let index = 0; index < tx.outputsLength; index += 1) {
+    const script = tx.getOutput(index)?.script;
+    if (!script) return { ok: false, error: 'The inscription reveal has an unreadable output.' };
+    if (script[0] === 0x6a) continue; // OP_RETURN marker carries no value
+
+    const address = decodeAddressFromScript(bytesToHex(script));
+    if (!address || !own.has(address.toLowerCase())) {
+      return {
+        ok: false,
+        error: 'The inscription reveal pays an address that is not yours, so it was not accepted.',
+      };
+    }
+  }
+  return { ok: true };
+}

--- a/src/utils/blockchain/counterparty/pack/__tests__/messages.test.ts
+++ b/src/utils/blockchain/counterparty/pack/__tests__/messages.test.ts
@@ -246,6 +246,36 @@ describe('packing matches bytes generated with core\'s MPMA encoder', () => {
   });
 });
 
+describe('inscription composes pack the same message, only carried differently', () => {
+  it('hex-decodes binary content, so the packed message matches what core composes', () => {
+    // An inscription's content reaches the API as hex when the MIME type is binary, because core
+    // unhexlifies it (`helpers.content_to_bytes`). The message is otherwise an ordinary broadcast.
+    const packed = packComposeMessage('broadcast', {
+      text: '89504e470d0a1a0a', mime_type: 'image/png', inscription: 'true',
+      value: '0', fee_fraction: '0', timestamp: 1722700000,
+    });
+
+    expect(packed).not.toBeNull();
+    const body = encodeCbor([
+      1722700000n, 0, 0n, 'image/png',
+      new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    ]);
+    expect(bytesToHex(packed!.bytes)).toBe(expectedMessage(30, body));
+  });
+
+  it('encodes textual content as UTF-8 rather than hex', () => {
+    const packed = packComposeMessage('broadcast', {
+      text: 'hello', mime_type: 'text/plain', inscription: 'true',
+      value: '0', fee_fraction: '0', timestamp: 1722700000,
+    });
+
+    const body = encodeCbor([
+      1722700000n, 0, 0n, 'text/plain', new TextEncoder().encode('hello'),
+    ]);
+    expect(bytesToHex(packed!.bytes)).toBe(expectedMessage(30, body));
+  });
+});
+
 describe('borrowing only what the request cannot determine', () => {
   it('packs a reissuance by taking divisibility from the composed message', () => {
     // update-description and transfer-ownership omit `divisible` because the asset already fixes
@@ -344,8 +374,9 @@ describe('refusing to pack is not the same as agreeing', () => {
     ['a broadcast that lets the server continue the feed', 'broadcast', {
       text: 'hello', value: 0, fee_fraction: 0, timestamp: 0,
     }],
-    ['an inscription broadcast, whose content moves into a tapscript envelope', 'broadcast', {
-      text: 'deadbeef', mime_type: 'image/png', inscription: 'ZGVhZGJlZWY=', timestamp: 1722700000,
+    // Binary content rides the request as hex; anything else is not what core would unhexlify.
+    ['a binary-mime broadcast whose content is not hex', 'broadcast', {
+      text: 'not hex at all', mime_type: 'image/png', inscription: 'true', timestamp: 1722700000,
     }],
     // At nbits zero (one distinct destination) the count field has no bits, so a second send of
     // the same asset is not expressible; core's own encoder would raise on `uint:0=1`.

--- a/src/utils/blockchain/counterparty/pack/messages.ts
+++ b/src/utils/blockchain/counterparty/pack/messages.ts
@@ -16,6 +16,7 @@ import { assetNameToId } from '../unpack/assetId';
 import { packAddress, packAddressLegacy } from '../unpack/address';
 import { MessageTypeId, COUNTERPARTY_PREFIX_HEX } from '../unpack/messageTypes';
 import { hexToBytes } from '../unpack/binary';
+import { isTextualMimeType } from '../inscriptionEnvelope';
 
 /** The message types this module can construct. */
 export type PackableComposeType =
@@ -75,6 +76,21 @@ function requireQuantity(params: Params, key: string): bigint | null {
   return null;
 }
 
+/**
+ * Message content as core encodes it: UTF-8 for textual MIME types, hex-decoded for everything
+ * else (`helpers.content_to_bytes`). This is what lets an inscription — whose content is a binary
+ * file carried as hex in the request — pack to the same bytes core composes.
+ *
+ * Returns null when a binary type's content is not valid hex, which core would reject outright.
+ */
+function encodeMessageContent(content: string, mimeType: string): Uint8Array | null {
+  if (isTextualMimeType(mimeType || 'text/plain')) {
+    return new TextEncoder().encode(content);
+  }
+  if (content.length % 2 !== 0 || !/^[0-9a-fA-F]*$/.test(content)) return null;
+  return hexToBytes(content.toLowerCase());
+}
+
 function withPrefix(messageTypeId: number, body: Uint8Array): PackedMessage {
   const prefix = hexToBytes(COUNTERPARTY_PREFIX_HEX);
   return {
@@ -130,11 +146,9 @@ function packIssuance(params: Params, observed: Observed): PackedMessage | null 
   if (!asset || quantity === null) return null;
   // A dotted asset is a subasset request, which needs its asset id borrowed from the response.
   if (asset.includes('.')) return packSubasset(asset, quantity, params, observed);
-  // The ord-inscription path restructures the message, and a non-text MIME type makes core
-  // hex-decode the description (`helpers.content_to_bytes`); neither variant is packed here.
-  if (params.inscription) return null;
+  // An inscription carries the same message; only its transport differs (an ord envelope instead
+  // of an OP_RETURN), so it is packed normally and `inscriptionEnvelope.ts` checks the envelope.
   const mimeType = typeof params.mime_type === 'string' ? params.mime_type : '';
-  if (mimeType !== '' && mimeType !== 'text/plain') return null;
 
   let assetId: bigint;
   try {
@@ -168,6 +182,11 @@ function packStandardIssuanceBody(
   if (divisible === null) return null;
 
   const description = typeof params.description === 'string' ? params.description : '';
+  let descriptionBytes: Uint8Array | null = null;
+  if (description.length > 0) {
+    descriptionBytes = encodeMessageContent(description, mimeType);
+    if (descriptionBytes === null) return null;
+  }
 
   const body: CborEncodable = [
     assetId,
@@ -176,7 +195,7 @@ function packStandardIssuanceBody(
     params.lock === true,
     params.reset === true,
     mimeType,
-    description.length > 0 ? new TextEncoder().encode(description) : null,
+    descriptionBytes,
   ];
   return withPrefix(MessageTypeId.LR_ISSUANCE, encodeCbor(body));
 }
@@ -235,11 +254,9 @@ function packSubasset(
   params: Params,
   observed: Observed
 ): PackedMessage | null {
-  // The ord-inscription path restructures the message, and a non-text MIME type makes core
-  // hex-decode the description (`helpers.content_to_bytes`); neither variant is packed here.
-  if (params.inscription) return null;
+  // An inscription carries the same message; only its transport differs (an ord envelope instead
+  // of an OP_RETURN), so it is packed normally and `inscriptionEnvelope.ts` checks the envelope.
   const mimeType = typeof params.mime_type === 'string' ? params.mime_type : '';
-  if (mimeType !== '' && mimeType !== 'text/plain') return null;
 
   // Irreversible against a substituted id — see the borrow argument above.
   if (params.lock === true || params.lock === 'true') return null;
@@ -530,9 +547,7 @@ function floatParam(params: Params, key: string): number | null {
  */
 function packBroadcast(params: Params, observed: Observed): PackedMessage | null {
   if (typeof params.text !== 'string') return null;
-  if (params.inscription) return null;
   const mimeType = typeof params.mime_type === 'string' ? params.mime_type : '';
-  if (mimeType !== '' && mimeType !== 'text/plain') return null;
 
   const value = floatParam(params, 'value');
   const feeFraction = floatParam(params, 'fee_fraction');
@@ -551,12 +566,15 @@ function packBroadcast(params: Params, observed: Observed): PackedMessage | null
     timestamp = BigInt(seen);
   }
 
+  const textBytes = encodeMessageContent(params.text, mimeType);
+  if (textBytes === null) return null;
+
   const body: CborEncodable = [
     timestamp,
     value,
     BigInt(feeFractionInt),
     mimeType,
-    new TextEncoder().encode(params.text),
+    textBytes,
   ];
   return withPrefix(MessageTypeId.BROADCAST, encodeCbor(body));
 }


### PR DESCRIPTION
Inscriptions have never worked. This makes them work, and verifies them rather than exempting them.

Three independent defects, each confirmed against a live node rather than inferred.

## 1. The request was malformed, so nothing ever composed

`inscription` is a **boolean** construct param to core, but both forms put the file content in it. Composing with the extension's exact parameter shape returns:

```
"Invalid boolean: inscription"
```

The content belongs in `text` (broadcast) or `description` (issuance), **hex-encoded unless the MIME type is textual** — core unhexlifies binary content in `content_to_bytes`. Issuance additionally never set the flag at all. Both forms now send what core expects, using a MIME classifier mirroring `helpers.classify_mime_type`.

## 2. The message was unverifiable

The packers declined anything carrying an inscription, so byte equality had nothing to say about the one compose type whose payload is a user-supplied file. They now encode content the way core does and pack normally — an inscription is the *same* message, carried in an ord envelope instead of an OP_RETURN.

## 3. The commit output read as an unexplained payment

Verified rather than exempted. `inscriptionEnvelope.ts` rebuilds the ord envelope from the message the request should produce, requires the composed one to match byte for byte, and derives the commit address from it; that address is passed to the output policy as an intended destination. A substituted inscription still fails closed. This is the same test core applies to its own output in `check_transaction_sanity`.

The envelope layout was verified against the **ord reference implementation** (`src/inscriptions/tag.rs`: ContentType 1, Metadata 5 and chunked, Metaprotocol 7), not core alone.

## 4. And the reveal is now broadcast

`signed_reveal_rawtransaction` was read nowhere in the codebase, so the content never reached the chain and the committed sats sat at an address only the reveal can spend. It now goes out immediately after the commit — sound because it spends the commit's output and the commit txid is fixed before signing, its inputs being segwit (which is *why* taproot encoding requires a segwit source). Its outputs are verified at compose time to pay only the signer. A rejected reveal cannot un-broadcast the commit, so that surfaces as a warning carrying the reveal hex rather than throwing.

## Verification

End to end against a live compose, through the real code path:

```
pack: ok
envelope ok: true
commit address: bc1pw5je3kxca8t4da85n4xx65c8gslm9wcz4af03297npxdsfjp558qwv5r2n
reveal ok: true
output policy ok: true      <- previously: rejected
```

Unit tests run against a captured real response: the local rebuild reproduces the server's `envelope_script` byte for byte, the derived commit address equals the address the real commit transaction pays, and tampering with content or MIME type is caught.

- `tsc --noEmit` clean; 734 counterparty + contexts tests pass.
- 72 pack tests including both oracles live against `api.counterparty.io` — no packer regression.
- E2E locally, one file at a time: `compose/broadcast/index.spec.ts` (10/10), `compose/issuance/index.spec.ts` (10/10).

## Notes for review

- The ephemeral pubkey is read from the composed envelope because the server draws it at random. It cannot redirect value: the commit address is derived from it *together with* the verified envelope, and the reveal's outputs are checked independently.
- Inscriptions require a segwit source; core rejects taproot encoding from legacy addresses. The existing `isSegwitAddress` gate on both toggles is what enforces this.
- Not covered here: the "pending reveal" case if the reveal is rejected is surfaced as a warning, not retried. Worth a follow-up if it happens in practice.

https://claude.ai/code/session_01CcjnCrgosSeshymXLBxdGj
