### PR TITLE
Stop claiming no tampering was detected when nothing was compared

### DIFF
--- a/src/components/domain/tx/verification-status.test.tsx
+++ b/src/components/domain/tx/verification-status.test.tsx
@@ -1,0 +1,42 @@
+/**
+ * The distinction under test is the point of the component: passing a comparison and having no
+ * comparison to pass are different facts, and only the first justifies telling the user that no
+ * tampering was detected.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { VerificationStatus } from './verification-status';
+
+describe('VerificationStatus', () => {
+  it('claims no tampering only when a comparison actually happened', () => {
+    render(<VerificationStatus passed comparedAgainstApi />);
+    expect(screen.getByText(/no tampering detected/i)).toBeInTheDocument();
+  });
+
+  it('does not claim verification when there was nothing to compare against', () => {
+    render(<VerificationStatus passed comparedAgainstApi={false} />);
+
+    expect(screen.queryByText(/no tampering detected/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/no second source/i)).toBeInTheDocument();
+  });
+
+  it('renders nothing when verification was not attempted', () => {
+    const { container } = render(<VerificationStatus />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('blocks loudly on failure in strict mode', () => {
+    render(<VerificationStatus passed={false} isStrict warning="Quantity differs" />);
+
+    expect(screen.getByText(/signing blocked/i)).toBeInTheDocument();
+    expect(screen.getByText('Quantity differs')).toBeInTheDocument();
+  });
+
+  it('warns rather than blocks when strict mode is off', () => {
+    render(<VerificationStatus passed={false} isStrict={false} warning="Quantity differs" />);
+
+    expect(screen.getByText(/verification warning/i)).toBeInTheDocument();
+    expect(screen.queryByText(/signing blocked/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/domain/tx/verification-status.tsx
+++ b/src/components/domain/tx/verification-status.tsx
@@ -7,7 +7,7 @@
  */
 
 import type { ReactElement } from 'react';
-import { FiShield, FiShieldOff } from '@/components/icons';
+import { FiShield, FiShieldOff, FiInfo } from '@/components/icons';
 
 /*
  * The passed state is intentionally low-weight — a small inline badge, not a
@@ -18,6 +18,14 @@ import { FiShield, FiShieldOff } from '@/components/icons';
 export interface VerificationStatusProps {
   /** Whether verification passed */
   passed?: boolean;
+  /**
+   * Whether a second decoding was actually compared against the local one.
+   *
+   * Passing with nothing to compare against is not the same as passing a comparison: when the API
+   * decode is unavailable, the message decoded locally and that is all. Claiming "no tampering
+   * detected" there asserts most where least was checked, so the two are shown differently.
+   */
+  comparedAgainstApi?: boolean;
   /** Warning/error message to display */
   warning?: string;
   /** Whether strict mode is enabled (blocks signing on failure) */
@@ -27,12 +35,14 @@ export interface VerificationStatusProps {
 /**
  * Displays verification status with appropriate styling.
  *
- * - Green: Verification passed
+ * - Green: cross-checked and agreed
+ * - Neutral: decoded locally, but no second source to compare against
  * - Orange: Verification failed (non-strict mode, warning only)
  * - Red: Verification failed (strict mode, signing blocked)
  */
 export function VerificationStatus({
   passed,
+  comparedAgainstApi = true,
   warning,
   isStrict = true,
 }: VerificationStatusProps): ReactElement | null {
@@ -40,6 +50,16 @@ export function VerificationStatus({
   // (e.g., non-Counterparty transactions)
   if (passed === undefined) {
     return null;
+  }
+
+  // Decoded, but nothing to compare it against. Neither an error nor a clean bill of health.
+  if (passed === true && !comparedAgainstApi) {
+    return (
+      <div className="flex items-center justify-center gap-1.5 text-xs font-medium text-gray-600">
+        <FiInfo className="size-4 flex-shrink-0" aria-hidden="true" />
+        Decoded locally — no second source to check it against
+      </div>
+    );
   }
 
   // Verification passed — compact inline badge, not a full banner.

--- a/src/pages/requests/psbt/approve.tsx
+++ b/src/pages/requests/psbt/approve.tsx
@@ -135,6 +135,7 @@ export default function ApprovePsbtPage() {
 
 
   const verificationPassed = verification?.passed;
+  const verificationComparedAgainstApi = verification?.comparedAgainstApi ?? false;
   const verificationWarning = verification?.warning;
   const verificationFailed = verificationPassed === false;
   const isStrictMode = settings?.strictTransactionVerification !== false;
@@ -394,6 +395,7 @@ export default function ApprovePsbtPage() {
           {/* Verification Status (compact badge when passed) */}
           <VerificationStatus
             passed={verificationPassed}
+            comparedAgainstApi={verificationComparedAgainstApi}
             warning={verificationWarning}
             isStrict={isStrictMode}
           />

--- a/src/pages/requests/transaction/approve.tsx
+++ b/src/pages/requests/transaction/approve.tsx
@@ -196,6 +196,7 @@ export default function ApproveTransactionPage() {
   const feeRateAbsurd = exceedsSaneFeeRate(decodedInfo.fee, decodedInfo.vsize);
   const hasHighFee = decodedInfo.fee > 10000000 || feeRateAbsurd; // > 0.1 BTC, or an absurd rate
   const verificationPassed = decodedInfo.verification?.passed;
+  const verificationComparedAgainstApi = decodedInfo.verification?.comparedAgainstApi ?? false;
   const verificationWarning = decodedInfo.verification?.warning;
   const verificationFailed = verificationPassed === false;
   const isStrictMode = settings?.strictTransactionVerification !== false;
@@ -425,6 +426,7 @@ export default function ApproveTransactionPage() {
           {/* Verification Status (compact badge when passed) */}
           <VerificationStatus
             passed={verificationPassed}
+            comparedAgainstApi={verificationComparedAgainstApi}
             warning={verificationWarning}
             isStrict={isStrictMode}
           />

--- a/src/utils/blockchain/counterparty/unpack/__tests__/providerVerify.test.ts
+++ b/src/utils/blockchain/counterparty/unpack/__tests__/providerVerify.test.ts
@@ -80,6 +80,31 @@ describe('verifyProviderTransaction', () => {
       expect(result.passed).toBe(true);
       expect(result.mismatches).toEqual([]);
       expect(result.localUnpack).toBeDefined();
+      // ...but nothing was cross-checked, and the caller must be able to tell the difference.
+      // The API decode is unavailable whenever the endpoint errors or rejects the payload, which
+      // is exactly when an affirmative "no tampering detected" would be least earned.
+      expect(result.comparedAgainstApi).toBe(false);
+    });
+
+    it('reports comparedAgainstApi=true only when a comparison actually happened', () => {
+      const payload = bigintHex(XCP_ID) + bigintHex(1000n) + packedAddressHex(TEST_HASH);
+      const data = buildMessage(MessageTypeId.ENHANCED_SEND, payload);
+      const apiMessage: ApiCounterpartyMessage = {
+        messageType: 'enhanced_send',
+        messageTypeId: MessageTypeId.ENHANCED_SEND,
+        messageData: { asset: 'XCP', quantity: 1000 },
+        description: 'send',
+      };
+
+      const result = verifyProviderTransaction(data, apiMessage);
+      expect(result.passed).toBe(true);
+      expect(result.comparedAgainstApi).toBe(true);
+    });
+
+    it('reports comparedAgainstApi=false when the payload is not Counterparty data', () => {
+      const result = verifyProviderTransaction('deadbeef');
+      expect(result.passed).toBeUndefined();
+      expect(result.comparedAgainstApi).toBe(false);
     });
   });
 

--- a/src/utils/blockchain/counterparty/unpack/providerVerify.ts
+++ b/src/utils/blockchain/counterparty/unpack/providerVerify.ts
@@ -41,6 +41,15 @@ export interface ApiCounterpartyMessage {
 export interface ProviderVerificationResult {
   /** Whether verification passed (no critical mismatches). undefined = not attempted. */
   passed: boolean | undefined;
+  /**
+   * Whether a second decoding was actually compared against the local one.
+   *
+   * `passed: true` alone does not mean anything was cross-checked: when the API decode is
+   * unavailable — a network error, a non-200, or a payload core rejects — there is nothing to
+   * compare and a successful local unpack is all that happened. Reporting that as verified
+   * overstates it precisely when the least checking occurred, so the display distinguishes the two.
+   */
+  comparedAgainstApi: boolean;
   /** Warning message if verification failed or had issues */
   warning?: string;
   /** Detailed list of mismatches found */
@@ -590,6 +599,7 @@ export function verifyProviderTransaction(
   if (!opReturnData || !isCounterpartyData(opReturnData)) {
     return {
       passed: undefined,
+      comparedAgainstApi: false,
       mismatches: [],
       warning: undefined,
     };
@@ -602,16 +612,19 @@ export function verifyProviderTransaction(
   if (!localUnpack.success || !localUnpack.data) {
     return {
       passed: false,
+      comparedAgainstApi: false,
       warning: localUnpack.error || 'Failed to unpack transaction locally',
       mismatches: ['Local unpack failed'],
       localUnpack,
     };
   }
 
-  // If no API message to compare against, local unpack success is enough
+  // Nothing to compare against: the message decoded locally, but no second opinion was obtained.
+  // Not a failure — the transaction is not blocked — but the display must not call it verified.
   if (!apiMessage) {
     return {
       passed: true,
+      comparedAgainstApi: false,
       mismatches: [],
       localUnpack,
     };
@@ -726,6 +739,7 @@ export function verifyProviderTransaction(
 
   return {
     passed,
+    comparedAgainstApi: true,
     warning: passed ? undefined : `Verification failed: ${mismatches.join('; ')}`,
     mismatches,
     localUnpack,


### PR DESCRIPTION
PRIORITIES.md item 3a. Small fix, removes a false assurance.

## The problem

`verifyProviderTransaction` returns `passed: true` in two very different situations:

- the local decode was compared against the API's decode and they agreed, or
- **there was no API decode to compare against at all**:

```ts
// If no API message to compare against, local unpack success is enough
if (!apiMessage) {
  return { passed: true, mismatches: [], localUnpack };
}
```
(`providerVerify.ts`)

The second case happens whenever `decodeCounterpartyMessage` returns null — a network error, a non-200, or an `error` field in the response — and the caller swallows that exception (`useSignTransactionRequest.ts`). The approval screen rendered the same green shield for both:

> 🛡 **Verified locally — no tampering detected**

So the wallet's one affirmative security claim was made most confidently in the case where it had checked least, including when an attacker submits a payload our unpacker accepts but core rejects.

## The change

The result now carries `comparedAgainstApi`, and the two cases render differently:

- cross-checked and agreed → unchanged green shield, "Verified locally — no tampering detected"
- decoded with nothing to compare against → neutral badge, "Decoded locally — no second source to check it against"

**Signing behaviour is unchanged.** Neither case was ever blocked, and this does not start blocking one — only the claim made to the user changes. Both approval screens default the flag to `false` when absent, so a path that forgets to report it understates rather than overstates.

## Tests

- New `verification-status.test.tsx` covers all four states, including that the "no tampering" text is *absent* when nothing was compared.
- `providerVerify.test.ts` extended: `comparedAgainstApi` is false with no API message, false for non-Counterparty data, true only when a comparison ran.
- 1795 unit tests pass across components/pages/counterparty; `tsc --noEmit` clean.
- E2E: `provider-transaction-signing.spec.ts` 11/11 locally.

## Not addressed here

The deeper issue behind this one is item 3: the raw-transaction approval screen renders from the API's decode rather than a local parse, so the "local" unpack is not independent of the API either. That is a larger change and is next.

https://claude.ai/code/session_01CcjnCrgosSeshymXLBxdGj
