### PR TITLE
Show the fee the transaction pays, not the one the response claims

### DIFF
--- a/src/contexts/__tests__/composer-context.test.tsx
+++ b/src/contexts/__tests__/composer-context.test.tsx
@@ -176,8 +176,17 @@ describe('ComposerContext', () => {
 
       await waitFor(() => {
         expect(result.current.state.step).toBe('review');
-        expect(result.current.state.apiResponse).toEqual(apiResponse);
       });
+
+      // The composer stores the fee the transaction actually pays, not the one the response
+      // claims. This fixture is a good example of why: it asserts btc_fee 5000, while its inputs
+      // (100,000, from the stubbed resolver) minus its single 95,160 sat output leave 4,840. Every
+      // review screen renders `result.btc_fee`, so substituting it here is what makes them honest.
+      expect(result.current.state.apiResponse).toEqual({
+        ...apiResponse,
+        result: { ...apiResponse.result, btc_fee: 4840 },
+      });
+      expect(result.current.state.verificationWarnings.join(' ')).toContain('4840');
 
       // The context converts FormData to plain object before calling composeApi
       const expectedData = {

--- a/src/contexts/composer-context.tsx
+++ b/src/contexts/composer-context.tsx
@@ -362,7 +362,8 @@ export function ComposerProvider<T>({
       if (signal.aborted) return;
 
       // Call compose API (UTXO selection is handled internally by compose functions)
-      const response = await composeApi(dataForApi);
+      // Reassigned below if verification finds the reported fee differs from the real one.
+      let response = await composeApi(dataForApi);
 
       // Check if aborted after API call
       if (signal.aborted) return;
@@ -471,6 +472,29 @@ export function ComposerProvider<T>({
       }, fetchInputValues);
       if (!feeCheck.ok) {
         throw new Error(feeCheck.error || 'Transaction fee verification failed');
+      }
+
+      // The fee the review screen shows must be the one just computed from the transaction's own
+      // inputs and outputs, not `btc_fee` as the response asserts it. The bound above is
+      // deliberately loose enough to accommodate legitimate composers, so a response can pass it
+      // while claiming a smaller fee than the transaction actually pays — and the user would sign
+      // against the claim. Replacing the field here fixes every review screen at once, since they
+      // all render `result.btc_fee`.
+      if (feeCheck.computedFee !== undefined) {
+        const reportedFee = response.result.btc_fee;
+        // Contradicting a stated fee is worth telling the user about; filling in one the response
+        // never stated is not, so absence is corrected silently rather than reported as a
+        // discrepancy.
+        if (typeof reportedFee === 'number' && reportedFee !== feeCheck.computedFee) {
+          verificationWarnings.push(
+            `This transaction pays a ${feeCheck.computedFee} sat miner fee, though the composer `
+            + `reported ${reportedFee}. The amount shown is the one the transaction pays.`
+          );
+        }
+        response = {
+          ...response,
+          result: { ...response.result, btc_fee: feeCheck.computedFee },
+        };
       }
 
       // Account for every output: each must be the data output, an address the request names, or


### PR DESCRIPTION
PRIORITIES.md item 1.

## The problem

`checkTransactionFee` already recomputes the miner fee from the transaction's own inputs and outputs, resolving input values from the chain rather than from the response (ADR-019 layer 3). That number was used to accept or reject the transaction — and then **discarded**. The review screen rendered `result.btc_fee`: the composer's own assertion about itself.

The bound that is enforced is deliberately loose, because a legitimate composer needs room:

`max(10_000, rate × vsize × 10)`

| transaction | honest fee | max that still passes | overpay |
|---|---|---|---|
| 250 vB @ 2 sat/vB | 500 | 10,000 | 9,500 (20×) |
| 400 vB @ 10 sat/vB | 4,000 | 40,000 | 36,000 (10×) |

So a response could pass verification while reporting a smaller fee than the transaction actually pays, and the user would sign against the number on screen. Value goes to miners rather than an attacker, so this is griefing rather than theft — but the displayed number was simply not the truth.

## The change

The composer stores the **computed** fee in place of the reported one. Because all 28 review screens render `result.btc_fee`, that corrects every one of them at a single point rather than touching each screen.

- A response that stated a *different* fee also produces a warning — contradicting a stated value is worth surfacing to the user.
- A response that stated *no* fee is corrected silently. Filling in a value nobody claimed is not a discrepancy, and warning about it would be noise. (This distinction is why two composer tests initially failed: their fixtures omit `btc_fee` entirely.)

## The test that was already broken

The existing `should compose transaction` test turned out to be a live example of the bug. Its fixture asserts `btc_fee: 5000`, while its stubbed input value (100,000) minus its single 95,160-sat output leaves **4,840**. The fixture had been internally inconsistent all along and nothing checked — the defect in miniature. The test now asserts the corrected value and the warning.

## Verification

- `tsc --noEmit` clean.
- 2524 unit tests across contexts/components/pages/blockchain.
- E2E locally: `compose/send/index.spec.ts` 20/20, which includes "review page shows correct transaction details".

https://claude.ai/code/session_01CcjnCrgosSeshymXLBxdGj
