### PR TITLE
Show the destination the transaction encodes, not the one echoed back

### DIFF
--- a/src/components/screens/review-screen.test.tsx
+++ b/src/components/screens/review-screen.test.tsx
@@ -23,6 +23,15 @@ vi.mock('@/hooks/useMarketPrices', () => ({
   })
 }));
 
+// The screen reads the decoded transaction when a compose flow provides one. Mocked rather than
+// wrapped in a real provider so this stays a component test — the real module reaches for
+// webext-bridge. `decodedMessage` is overwritten per test via `setDecodedMessage`.
+let mockDecodedMessage: { messageType: string; data: Record<string, unknown> } | null = null;
+const setDecodedMessage = (value: typeof mockDecodedMessage) => { mockDecodedMessage = value; };
+vi.mock('@/contexts/composer-context', () => ({
+  useComposerOptional: () => ({ state: { decodedMessage: mockDecodedMessage } }),
+}));
+
 describe('ReviewScreen', () => {
   const mockApiResponse = {
     result: {
@@ -56,6 +65,49 @@ describe('ReviewScreen', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    setDecodedMessage(null);
+  });
+
+  describe('showing what the transaction encodes rather than what was echoed', () => {
+    it('prefers the decoded destination over the response params', () => {
+      // The response echoes the requested recipient while the transaction actually encodes a
+      // different one. The screen must show what will be signed, not what was asked for.
+      setDecodedMessage({
+        messageType: 'move',
+        data: { destination: 'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq' },
+      });
+
+      render(
+        <ReviewScreen
+          apiResponse={mockApiResponse}
+          onSign={vi.fn()}
+          onBack={vi.fn()}
+          error={null}
+          isSigning={false}
+        />
+      );
+
+      expect(screen.getByText('bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq')).toBeInTheDocument();
+      expect(
+        screen.queryByText('bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh')
+      ).not.toBeInTheDocument();
+    });
+
+    it('falls back to the response when the transaction carries no decodable destination', () => {
+      setDecodedMessage({ messageType: 'issuance', data: { asset: 'LANDMARKS' } });
+
+      render(
+        <ReviewScreen
+          apiResponse={mockApiResponse}
+          onSign={vi.fn()}
+          onBack={vi.fn()}
+          error={null}
+          isSigning={false}
+        />
+      );
+
+      expect(screen.getByText('bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh')).toBeInTheDocument();
+    });
   });
 
   it('renders transaction details correctly', () => {

--- a/src/components/screens/review-screen.tsx
+++ b/src/components/screens/review-screen.tsx
@@ -6,6 +6,7 @@ import { formatAddress, formatAmount } from "@/utils/format";
 import { fromSatoshis, formatFeeRate } from "@/utils/numeric";
 import { useMarketPrices } from "@/hooks/useMarketPrices";
 import { useSettings } from "@/contexts/settings-context";
+import { useComposerOptional } from "@/contexts/composer-context";
 
 /**
  * Transaction result from API response
@@ -94,8 +95,24 @@ export function ReviewScreen({
   const { result } = apiResponse;
   const { settings } = useSettings();
   const { btc: btcPrice, xcp: xcpPrice } = useMarketPrices(settings.fiat);
+
+  // Prefer the destination the transaction actually encodes over the API's echo of the request.
+  // `result.params` is the composer repeating what it was asked for, so it cannot testify about
+  // the composer (ADR-019): a response that composed a different recipient than it echoed would
+  // otherwise display as correct. Types with byte equality are already proven, but the ones
+  // verified only field by field — btcpay, dispenser, the pool and UTXO screens — are exactly
+  // where an unenumerated difference could hide, and they all render through here.
+  //
+  // Optional context because this component is also rendered outside a compose flow.
+  const decoded = useComposerOptional()?.state.decodedMessage?.data as
+    | { destination?: string; source?: string }
+    | undefined;
+
   const sourceAddress = result.name === "dispense" ? result.params.address : result.params.source;
-  const destinationAddress = result.name === "dispense" ? result.params.dispenser : result.params.destination;
+  const destinationAddress = result.name === "dispense"
+    ? result.params.dispenser
+    // A move encodes "txid:vout"; anything else the decoder reports is an address.
+    : decoded?.destination ?? result.params.destination;
 
   // Calculate fee in fiat
   const feeInBtc = fromSatoshis(result.btc_fee, true);

--- a/src/contexts/composer-context.tsx
+++ b/src/contexts/composer-context.tsx
@@ -249,6 +249,16 @@ export function useComposer<T>(): ComposerContextType<T> {
 }
 
 /**
+ * The composer context if there is one, otherwise null.
+ *
+ * For shared components that are normally rendered inside a compose flow but must not require it —
+ * they can prefer the decoded transaction when it is available and fall back when it is not.
+ */
+export function useComposerOptional<T>(): ComposerContextType<T> | null {
+  return (use(ComposerContext) as ComposerContextType<T> | null) ?? null;
+}
+
+/**
  * Provides transaction composition workflow to child components.
  * Handles the form → review → success flow with automatic state management.
  * @template T - Type of the form data


### PR DESCRIPTION
PRIORITIES.md item 2.

## The problem

ADR-019 layer 4 says the approval screen must be derived from the decoded transaction, never from `result.params` — the composer repeating what it was asked for cannot testify about the composer. In practice only `compose/send/review.tsx` did that; the other 27 rendered the echo.

Severity depends on whether byte equality covers the type. Where it does, the echo is sound: matching bytes prove the params describe the message. Where it doesn't — **btcpay, dispenser, both pool screens, and the three UTXO screens** — field comparison speaks only to fields it was taught about, and the screen showed the request's version of everything else.

## The change

All seven of those screens render their recipient through the shared `ReviewScreen`, so preferring the decoded destination *there* fixes them at one point rather than rewriting seven UIs — and every other screen inherits it.

- The composer context is read **optionally** (new `useComposerOptional`), because `ReviewScreen` is also rendered outside a compose flow.
- The response remains the fallback when a transaction carries no decodable destination: an issuance has none, and a dispense names its dispenser rather than a payee, so that path is left alone explicitly.

## Tests

Two new cases in `review-screen.test.tsx` covering the substitution directly: when the response echoes one recipient and the transaction encodes another, the screen shows the encoded one and **not** the echoed one; when the decoded message carries no destination, it falls back.

The context is mocked rather than wrapped in a real provider — the real module reaches for `webext-bridge`, and this stays a component test.

- `tsc --noEmit` clean; 1205 tests across components/pages/contexts.
- E2E locally: `compose/utxo` 9/9, `compose/dispenser/index.spec.ts` 7/7 (which includes "full flow: dispenser form → review → verify content").

## Note

This closes the *destination* half of item 2, which is where value routing is visible. Per-type amount and asset fields on those screens still come from params; they are covered by the field verifier and by output accounting, and correcting them needs per-type field mapping — the enumeration problem ADR-019 warns about. Worth doing per screen if it proves necessary, but it is a different shape of work than this one-point fix.

https://claude.ai/code/session_01CcjnCrgosSeshymXLBxdGj
