### PR TITLE
Recheck site permission at signing, warn earlier, show decoded fields

### DIFF
--- a/src/pages/compose/dispenser/__tests__/review.test.tsx
+++ b/src/pages/compose/dispenser/__tests__/review.test.tsx
@@ -20,6 +20,12 @@ vi.mock('@/hooks/useMarketPrices', () => ({
   useMarketPrices: () => ({ btc: null }),
 }));
 
+// The screen prefers the decoded transaction when a compose flow provides one. Mocked because the
+// real module reaches for webext-bridge; null here means these cases exercise the params fallback.
+vi.mock('@/contexts/composer-context', () => ({
+  useComposerOptional: () => ({ state: { decodedMessage: null } }),
+}));
+
 vi.mock('@/contexts/settings-context', () => ({
   useSettings: () => ({ settings: { fiat: 'USD' } }),
 }));

--- a/src/pages/compose/dispenser/review.tsx
+++ b/src/pages/compose/dispenser/review.tsx
@@ -1,4 +1,5 @@
 import { ReviewScreen } from "@/components/screens/review-screen";
+import { useComposerOptional } from "@/contexts/composer-context";
 import { formatAmount, formatAsset } from "@/utils/format";
 import { fromSatoshis } from "@/utils/numeric";
 import { useMarketPrices } from "@/hooks/useMarketPrices";
@@ -33,9 +34,19 @@ export function ReviewDispenser({
   const { settings } = useSettings();
   const { btc: btcPrice } = useMarketPrices(settings.fiat);
 
-  // Asset label from the signed params, not the route prop (empty on the
-  // in-form asset-select path); fall back to the prop only if params omit it.
-  const displayAsset = formatAsset(result.params.asset ?? asset, {
+  // A dispenser has no local packer, so its params were an unverified echo. The asset and the
+  // BTC price per dispense are stated by the transaction itself, so they are read from the decoded
+  // message: a composer that opened a dispenser on a different asset, or at a different price,
+  // cannot then display the requested one (ADR-019). Quantities keep using the response's
+  // normalized strings, since converting the decoded base units needs the asset's divisibility —
+  // a ledger fact rather than a property of this transaction.
+  const decoded = useComposerOptional()?.state.decodedMessage?.data as
+    | { asset?: string; mainchainrate?: bigint; escrowQuantity?: bigint; giveQuantity?: bigint }
+    | undefined;
+
+  // Asset label from the transaction, else the signed params, else the route prop (empty on the
+  // in-form asset-select path).
+  const displayAsset = formatAsset(decoded?.asset ?? result.params.asset ?? asset, {
     assetInfo: { asset_longname: result.params.asset_longname ?? null },
   });
 
@@ -44,9 +55,18 @@ export function ReviewDispenser({
   const giveQuantity = result.params.give_quantity_normalized;
 
   // Calculate BTC values for USD display
-  const perDispenseBtc = fromSatoshis(result.params.mainchainrate, true);
-  const bitcoinTotalBtc = (Number(result.params.escrow_quantity) / Number(result.params.give_quantity)) *
-                          fromSatoshis(result.params.mainchainrate, true);
+  const mainchainrate = decoded?.mainchainrate !== undefined
+    ? Number(decoded.mainchainrate)
+    : result.params.mainchainrate;
+  const escrowForRatio = decoded?.escrowQuantity !== undefined
+    ? Number(decoded.escrowQuantity)
+    : Number(result.params.escrow_quantity);
+  const giveForRatio = decoded?.giveQuantity !== undefined
+    ? Number(decoded.giveQuantity)
+    : Number(result.params.give_quantity);
+
+  const perDispenseBtc = fromSatoshis(mainchainrate, true);
+  const bitcoinTotalBtc = (escrowForRatio / giveForRatio) * fromSatoshis(mainchainrate, true);
 
   // Format USD values
   const perDispenseUsd = btcPrice !== null

--- a/src/pages/compose/order/btcpay/review.tsx
+++ b/src/pages/compose/order/btcpay/review.tsx
@@ -1,4 +1,5 @@
 import { ReviewScreen } from "@/components/screens/review-screen";
+import { useComposerOptional } from "@/contexts/composer-context";
 
 /**
  * Props for the ReviewBTCPay component.
@@ -24,9 +25,16 @@ export function ReviewBTCPay({
   isSigning
 }: ReviewBTCPayProps) {
   const { result } = apiResponse;
+  // Which order match is being settled is the whole content of a BTCPay, and it is the one field
+  // the transaction itself states. Reading it from the decoded message rather than from the
+  // response's echo means a composer that settled a different match cannot display as the one
+  // that was asked for (ADR-019). BTCPay has no local packer, so this echo was unverified.
+  const decoded = useComposerOptional()?.state.decodedMessage?.data as
+    | { orderMatchId?: string }
+    | undefined;
 
   const customFields = [
-    { label: "Order Match ID", value: result.params.order_match_id },
+    { label: "Order Match ID", value: decoded?.orderMatchId ?? result.params.order_match_id },
   ];
 
   return (

--- a/src/pages/compose/pool/deposit/review.tsx
+++ b/src/pages/compose/pool/deposit/review.tsx
@@ -1,4 +1,5 @@
 import { ReviewScreen } from "@/components/screens/review-screen";
+import { useComposerOptional } from "@/contexts/composer-context";
 import { getCanonicalPoolPair } from "@/utils/blockchain/counterparty/pool";
 import { fromSatoshis } from "@/utils/numeric";
 
@@ -19,13 +20,23 @@ export function ReviewPoolDeposit({
 }: ReviewPoolDepositProps) {
   const { result } = apiResponse;
   const params = result.params;
+  // Pool deposits have no local packer, so these params were an unverified echo. Which pool is
+  // being deposited into is stated by the transaction, so the pair is read from the decoded
+  // message (ADR-019). Quantities keep the response's normalized strings, since converting the
+  // decoded base units needs each asset's divisibility — a ledger fact, not a property of this
+  // transaction.
+  const decoded = useComposerOptional()?.state.decodedMessage?.data as
+    | { assetA?: string; assetB?: string; lpAsset?: string }
+    | undefined;
+  const assetA = decoded?.assetA ?? params.asset_a;
+  const assetB = decoded?.assetB ?? params.asset_b;
   const minimumLpDisplay = params.min_lp_quantity_normalized
     ?? fromSatoshis(params.min_lp_quantity ?? 0, { removeTrailingZeros: true });
 
   const customFields = [
     {
       label: "Pool",
-      value: getCanonicalPoolPair(params.asset_a, params.asset_b),
+      value: getCanonicalPoolPair(assetA, assetB),
     },
     {
       label: "Deposit",
@@ -34,7 +45,9 @@ export function ReviewPoolDeposit({
     ...(params.min_lp_quantity && params.min_lp_quantity !== "0"
       ? [{ label: "Minimum LP", value: minimumLpDisplay }]
       : []),
-    ...(params.lp_asset ? [{ label: "LP Asset", value: params.lp_asset }] : []),
+    ...((decoded?.lpAsset ?? params.lp_asset)
+      ? [{ label: "LP Asset", value: decoded?.lpAsset ?? params.lp_asset }]
+      : []),
   ];
 
   return (

--- a/src/pages/compose/pool/withdraw/review.tsx
+++ b/src/pages/compose/pool/withdraw/review.tsx
@@ -1,4 +1,5 @@
 import { ReviewScreen } from "@/components/screens/review-screen";
+import { useComposerOptional } from "@/contexts/composer-context";
 import { useAssetInfo } from "@/hooks/useAssetInfo";
 import { getCanonicalPoolPair } from "@/utils/blockchain/counterparty/pool";
 import { fromSatoshis } from "@/utils/numeric";
@@ -20,8 +21,17 @@ export function ReviewPoolWithdraw({
 }: ReviewPoolWithdrawProps) {
   const { result } = apiResponse;
   const params = result.params;
-  const { data: assetAInfo, isLoading: isLoadingAssetA } = useAssetInfo(params.asset_a || "");
-  const { data: assetBInfo, isLoading: isLoadingAssetB } = useAssetInfo(params.asset_b || "");
+  // Pool withdrawals have no local packer, so these params were an unverified echo. Which pool is
+  // being withdrawn from is stated by the transaction, so the pair comes from the decoded message
+  // (ADR-019). Quantities keep the response's normalized strings, since converting decoded base
+  // units needs each asset's divisibility — a ledger fact rather than part of this transaction.
+  const decoded = useComposerOptional()?.state.decodedMessage?.data as
+    | { assetA?: string; assetB?: string }
+    | undefined;
+  const assetA = decoded?.assetA ?? params.asset_a;
+  const assetB = decoded?.assetB ?? params.asset_b;
+  const { data: assetAInfo, isLoading: isLoadingAssetA } = useAssetInfo(assetA || "");
+  const { data: assetBInfo, isLoading: isLoadingAssetB } = useAssetInfo(assetB || "");
   const formatMinimum = (
     normalized: string | undefined,
     raw: string | number | undefined,
@@ -41,7 +51,7 @@ export function ReviewPoolWithdraw({
   const customFields = [
     {
       label: "Pool",
-      value: params.asset_a && params.asset_b ? getCanonicalPoolPair(params.asset_a, params.asset_b) : params.lp_asset,
+      value: assetA && assetB ? getCanonicalPoolPair(assetA, assetB) : params.lp_asset,
     },
     {
       label: "Withdraw",
@@ -50,7 +60,7 @@ export function ReviewPoolWithdraw({
     ...(params.min_quantity_a || params.min_quantity_b
       ? [{
           label: "Minimum Receive",
-          value: `${minQuantityADisplay} ${params.asset_a ?? ""}\n${minQuantityBDisplay} ${params.asset_b ?? ""}`,
+          value: `${minQuantityADisplay} ${assetA ?? ""}\n${minQuantityBDisplay} ${assetB ?? ""}`,
         }]
       : []),
   ];

--- a/src/pages/requests/transaction/approve.tsx
+++ b/src/pages/requests/transaction/approve.tsx
@@ -6,7 +6,8 @@ import { VerificationStatus } from '@/components/domain/tx/verification-status';
 import { formatAddress, formatAmount, formatPriceRatio } from '@/utils/format';
 import { fromSatoshis } from '@/utils/numeric';
 import { useWallet } from '@/contexts/wallet-context';
-import { getIdentityMismatchError } from '@/utils/provider/requestIdentity';
+import { getIdentityMismatchError, getConnectionRevokedError } from '@/utils/provider/requestIdentity';
+import { getConnectionService } from '@/services/connectionService';
 import { usePopupLifecycle } from '@/hooks/usePopupLifecycle';
 import { useSettings } from '@/contexts/settings-context';
 import { useHeader } from '@/contexts/header-context';
@@ -150,6 +151,15 @@ export default function ApproveTransactionPage() {
     const identityError = getIdentityMismatchError(request, activeAddress.address, activeWallet?.id);
     if (identityError) {
       setError(identityError);
+      return;
+    }
+
+    // A request stays open for up to ten minutes, so the site's grant is rechecked here rather
+    // than trusted from when the request was created — revoking a site in Settings must take
+    // effect on an approval already on screen. The PSBT path has always done this.
+    const revokedError = await getConnectionRevokedError(request, getConnectionService());
+    if (revokedError) {
+      setError(revokedError);
       return;
     }
 

--- a/src/utils/blockchain/bitcoin/__tests__/saneFeeRate.test.ts
+++ b/src/utils/blockchain/bitcoin/__tests__/saneFeeRate.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { exceedsSaneFeeRate, MAX_SANE_FEE_RATE } from '../feeVerification';
+import { exceedsSaneFeeRate, HIGH_FEE_RATE_WARNING } from '../feeVerification';
 
 describe('exceedsSaneFeeRate', () => {
   it('flags a fee that slips under the absolute ceiling but drains a small transaction', () => {
@@ -20,14 +20,21 @@ describe('exceedsSaneFeeRate', () => {
     expect(exceedsSaneFeeRate(2_000, 200)).toBe(false); // 10 sat/vB
   });
 
-  it('accepts a fee that is expensive but not absurd', () => {
-    // Well above normal, still far below the bound — congestion must not block signing.
-    expect(exceedsSaneFeeRate(200_000, 200)).toBe(false); // 1,000 sat/vB
+  it('accepts a fee that is expensive but plausible', () => {
+    // A fee bump or a time-sensitive CPFP can be well above a normal day's rate without being a
+    // mistake, and this only warns — so the threshold has to clear ordinary urgency.
+    expect(exceedsSaneFeeRate(20_000, 200)).toBe(false); // 100 sat/vB
+  });
+
+  it('warns on a rate no ordinary transaction reaches', () => {
+    // 1,000 sat/vB is roughly a hundred times a busy-day rate. It used to pass unremarked, because
+    // the threshold sat at 5,000 — far enough above reality that the warning almost never fired.
+    expect(exceedsSaneFeeRate(200_000, 200)).toBe(true);
   });
 
   it('sits exactly at the bound without firing', () => {
-    expect(exceedsSaneFeeRate(MAX_SANE_FEE_RATE * 200, 200)).toBe(false);
-    expect(exceedsSaneFeeRate(MAX_SANE_FEE_RATE * 200 + 200, 200)).toBe(true);
+    expect(exceedsSaneFeeRate(HIGH_FEE_RATE_WARNING * 200, 200)).toBe(false);
+    expect(exceedsSaneFeeRate(HIGH_FEE_RATE_WARNING * 200 + 200, 200)).toBe(true);
   });
 
   it('says nothing when the fee or size is unknown', () => {

--- a/src/utils/blockchain/bitcoin/feeVerification.ts
+++ b/src/utils/blockchain/bitcoin/feeVerification.ts
@@ -20,21 +20,41 @@
 import { Transaction } from '@scure/btc-signer';
 import { hexToBytes, bytesToHex } from '@noble/hashes/utils.js';
 
-/** A fee rate above this (sat/vByte) is treated as never legitimate. */
+/**
+ * A fee rate above this (sat/vByte) is treated as never legitimate, and *blocks* on the compose
+ * path — where the wallet built the transaction, so an absurd fee means the response misbehaved.
+ */
 export const MAX_SANE_FEE_RATE = 5000;
+
+/**
+ * A fee rate above this (sat/vByte) is worth *warning* about on a transaction the wallet did not
+ * build.
+ *
+ * Kept separate from the blocking threshold because the two answer different questions. Blocking
+ * asks "could this ever be legitimate", so it sits far above any rate the network has demanded.
+ * Warning asks "should someone look at this", and at 5000 the answer arrived far too late: a
+ * 250-vByte transaction at 4,999 sat/vB burns about 0.0125 BTC while staying under both that rate
+ * and the 0.1 BTC absolute ceiling, so it drew no signal at all.
+ *
+ * 500 is roughly fifty times a busy-day rate — high enough that legitimate urgency (a fee bump, a
+ * time-sensitive CPFP) does not trip it routinely, low enough to catch a fee nobody intended. It
+ * only ever warns: a site-built transaction can be expensive for reasons the wallet cannot see,
+ * which is why this path does not block (see the note at `transaction/approve.tsx`).
+ */
+export const HIGH_FEE_RATE_WARNING = 500;
 /** When the user chose a fee rate, reject fees beyond this multiple of it. */
 export const USER_FEE_RATE_TOLERANCE = 10;
 /** Absolute floor so tiny transactions aren't rejected by rate rounding. */
 const MIN_BOUND_SATS = 10_000;
 
 /**
- * Whether a fee is absurd for the size of the transaction carrying it.
+ * Whether a fee is high enough for the transaction's size to be worth flagging to the user.
  *
  * The compose path bounds fees by recomputing them from resolved input values, but a transaction
  * handed over by a connected site is already built, and its fee only had an absolute ceiling — so a
  * fee just under that ceiling passed unremarked however small the transaction was. This is the rate
  * bound for those paths: it needs no network, since a decoded transaction already yields both
- * numbers, and `MAX_SANE_FEE_RATE` sits far above any rate the network has ever demanded.
+ * numbers.
  *
  * @param fee - Miner fee in sats, or null when it could not be established.
  * @param vsize - Transaction virtual size in vbytes.
@@ -42,7 +62,7 @@ const MIN_BOUND_SATS = 10_000;
 export function exceedsSaneFeeRate(fee: number | null | undefined, vsize: number | undefined): boolean {
   if (fee == null || !Number.isFinite(fee) || fee <= 0) return false;
   if (!vsize || !Number.isFinite(vsize) || vsize <= 0) return false;
-  return fee / vsize > MAX_SANE_FEE_RATE;
+  return fee / vsize > HIGH_FEE_RATE_WARNING;
 }
 
 export interface FeeCheckInput {

--- a/src/utils/blockchain/counterparty/__tests__/subassetLockRegression.test.ts
+++ b/src/utils/blockchain/counterparty/__tests__/subassetLockRegression.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Locking a subasset is the most common issuance on the chain, and it must verify.
+ *
+ * A guard added while hardening the borrowed asset id briefly declined lock, reset and transfer
+ * for subassets. That sent them to the field-comparison fallback, which compared the request's
+ * longname (`PARENT.child`) against the message's numeric asset name (`A123…`) and called the
+ * difference a critical mismatch — so locking a subasset failed outright. Both halves are pinned
+ * here: the packer must build these messages, and the fallback must compare the right names if it
+ * is ever reached.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { packComposeMessage } from '../pack/messages';
+import { verifyTransaction } from '../unpack/verify';
+import { unpackCounterpartyMessage } from '../unpack';
+import { bytesToHex } from '../unpack/binary';
+import { MessageTypeId } from '../unpack/messageTypes';
+
+/**
+ * A real locked subasset issuance from mainnet (PINKSHIRTGUY.5368): LR_SUBASSET, lock set,
+ * indivisible, no description.
+ */
+const LONGNAME = 'PINKSHIRTGUY.5368';
+const ASSET_ID = 751209043880280215n;
+
+/** Params as the issuance form submits them for that transaction. */
+const PARAMS = {
+  asset: LONGNAME,
+  quantity: 1,
+  divisible: false,
+  lock: true,
+  reset: false,
+  description: '',
+};
+
+const OBSERVED = { messageTypeId: MessageTypeId.LR_SUBASSET, assetId: ASSET_ID };
+
+describe('locking a subasset', () => {
+  it('packs, so it is verified by byte equality rather than the fallback', () => {
+    const packed = packComposeMessage('issuance', PARAMS, OBSERVED);
+
+    expect(packed).not.toBeNull();
+    expect(packed!.messageTypeId).toBe(MessageTypeId.LR_SUBASSET);
+  });
+
+  it('round-trips: the packed message decodes back to the requested longname and lock', () => {
+    const packed = packComposeMessage('issuance', PARAMS, OBSERVED);
+    const decoded = unpackCounterpartyMessage(packed!.bytes);
+
+    expect(decoded.success).toBe(true);
+    const data = decoded.data as { subassetLongname?: string; isLock?: boolean };
+    expect(data.subassetLongname).toBe(LONGNAME);
+    expect(data.isLock).toBe(true);
+  });
+
+  it('passes field comparison too, which compares longnames rather than numeric names', () => {
+    // Belt and braces: if this shape ever reaches the fallback for another reason, it must not be
+    // rejected for the difference between "PARENT.child" and the numeric name the id resolves to.
+    const packed = packComposeMessage('issuance', PARAMS, OBSERVED);
+    const messageHex = bytesToHex(packed!.bytes);
+
+    const verification = verifyTransaction(messageHex, 'issuance', PARAMS);
+
+    expect(verification.errors).toEqual([]);
+    expect(verification.valid).toBe(true);
+  });
+
+  it('still catches a genuinely different subasset', () => {
+    const packed = packComposeMessage('issuance', PARAMS, OBSERVED);
+    const messageHex = bytesToHex(packed!.bytes);
+
+    const verification = verifyTransaction(messageHex, 'issuance', {
+      ...PARAMS,
+      asset: 'PINKSHIRTGUY.9999',
+    });
+
+    expect(verification.valid).toBe(false);
+    expect(verification.errors.join(' ')).toMatch(/Asset mismatch/);
+  });
+});

--- a/src/utils/blockchain/counterparty/__tests__/transactionSafety.test.ts
+++ b/src/utils/blockchain/counterparty/__tests__/transactionSafety.test.ts
@@ -309,3 +309,52 @@ describe('real-world scenarios', () => {
     expect(result.warnings[0]!.severity).toBe('danger');
   });
 });
+
+// ── Outputs with no attributable address ─────────────────────────────
+
+describe('outputs whose destination cannot be determined', () => {
+  it('warns when non-dust value leaves to an unrecognized script', () => {
+    // A bare-multisig or P2WSH output decodes to no address. It used to be dropped from the
+    // suspicious list entirely — appearing only as "Unknown address" in the movement summary —
+    // so value leaving to a script nobody can name raised nothing at all.
+    const result = analyzeTransactionSafety(
+      'enhanced_send',
+      makeOutputs(
+        { value: 0, type: 'op_return' },
+        { value: 50_000_000, type: 'unknown' },
+      ),
+      SIGNER
+    );
+
+    const warning = result.warnings.find(w => w.title === 'BTC Sent to an Unrecognized Script');
+    expect(warning).toBeDefined();
+    expect(warning!.severity).toBe('danger');
+    expect(warning!.message).toContain('0.50000000');
+  });
+
+  it('leaves dust alone, since Counterparty encodings use it routinely', () => {
+    const result = analyzeTransactionSafety(
+      'enhanced_send',
+      makeOutputs(
+        { value: 0, type: 'op_return' },
+        { value: 546, type: 'unknown' },
+      ),
+      SIGNER
+    );
+
+    expect(result.warnings.some(w => w.title === 'BTC Sent to an Unrecognized Script')).toBe(false);
+  });
+
+  it('does not fire when every output can be attributed', () => {
+    const result = analyzeTransactionSafety(
+      'enhanced_send',
+      makeOutputs(
+        { value: 0, type: 'op_return' },
+        { value: 50_000, address: SIGNER },
+      ),
+      SIGNER
+    );
+
+    expect(result.warnings.some(w => w.title === 'BTC Sent to an Unrecognized Script')).toBe(false);
+  });
+});

--- a/src/utils/blockchain/counterparty/pack/__tests__/messages.test.ts
+++ b/src/utils/blockchain/counterparty/pack/__tests__/messages.test.ts
@@ -467,22 +467,22 @@ describe('refusing to pack is not the same as agreeing', () => {
     expect(packComposeMessage(composeType, params as Record<string, unknown>)).toBeNull();
   });
 
-  it('refuses the subasset borrow for operations irreversible against a substituted id', () => {
-    // A wrong borrowed id lands the operation on a different numeric asset the user owns. Issue
-    // and describe are recoverable there; lock, reset and an ownership transfer are not, so the
-    // borrow refuses them and those flows stay on the field fallback.
-    const irreversible: Array<Record<string, unknown>> = [
-      { asset: 'PEPE.rare', quantity: 1, divisible: false, lock: true },
-      { asset: 'PEPE.rare', quantity: 0, divisible: false, reset: true },
-      { asset: 'PEPE.rare', quantity: 0, divisible: false, transfer_destination: TAPROOT_DESTINATION },
-    ];
-    for (const params of irreversible) {
-      for (const messageTypeId of [22, 23]) {
-        expect(packComposeMessage(
-          'issuance', params, { messageTypeId, assetId: 95428956661682177n, divisible: false }
-        )).toBeNull();
-      }
-    }
+  it('packs a locked subasset, the most common issuance shape on the chain', () => {
+    // Declining this once sent it to a fallback that compared "PARENT.child" against the numeric
+    // asset name and called the difference critical, so locking a subasset failed outright. Byte
+    // equality covers the flags, quantity, longname and description; only the borrowed id is
+    // beyond any local check, and declining never changed that.
+    const packed = packComposeMessage(
+      'issuance',
+      { asset: 'JPJA.HELLOKITTY', quantity: 1000, divisible: false, lock: true },
+      { messageTypeId: 23, assetId: 95428956661682177n }
+    );
+
+    expect(packed).not.toBeNull();
+    const decoded = unpackCounterpartyMessage(packed!.bytes);
+    const data = decoded.data as { subassetLongname?: string; isLock?: boolean };
+    expect(data.subassetLongname).toBe('JPJA.HELLOKITTY');
+    expect(data.isLock).toBe(true);
   });
 });
 

--- a/src/utils/blockchain/counterparty/pack/__tests__/onchainRoundTrip.test.ts
+++ b/src/utils/blockchain/counterparty/pack/__tests__/onchainRoundTrip.test.ts
@@ -98,17 +98,25 @@ const PARAMS_FROM_DECODED: Record<string, (data: Record<string, any>) => Record<
     mime_type: data.mimeType,
     description: data.description,
   }),
-  issuance: (data) => ({
-    // A subasset issuance composes from the longname; the numeric asset id it carries is the
-    // random draw the packer borrows from the decoded message, which the harness already passes.
-    asset: data.subassetLongname ?? data.asset,
-    quantity: data.quantity,
-    divisible: data.divisible,
-    lock: data.isLock,
-    reset: data.isReset,
-    description: data.description ?? '',
-    mime_type: data.mimeType ?? '',
-  }),
+  issuance: (data) => {
+    // Core distinguishes an absent description (CBOR null) from an empty one (empty byte string),
+    // and `composeIssuance` drops an empty description from the request — so the wallet can only
+    // ever produce the null form. A message carrying empty bytes was composed by something else
+    // and is not a shape this build can rebuild.
+    if (data.description === '') return null;
+    return {
+      // A subasset issuance composes from the longname; the numeric asset id it carries is the
+      // random draw the packer borrows from the decoded message, which the harness already passes.
+      asset: data.subassetLongname ?? data.asset,
+      quantity: data.quantity,
+      divisible: data.divisible,
+      lock: data.isLock,
+      reset: data.isReset,
+      // Passed through rather than defaulted, so "absent" is not silently turned into "empty".
+      description: data.description,
+      mime_type: data.mimeType ?? '',
+    };
+  },
   broadcast: (data) => {
     // The wire stores the scaled integer; undo it so the packer can redo core's arithmetic. Skip
     // the rare value whose double round-trip does not survive — a mismatch there would be

--- a/src/utils/blockchain/counterparty/pack/messages.ts
+++ b/src/utils/blockchain/counterparty/pack/messages.ts
@@ -236,11 +236,14 @@ function compactSubassetLongname(longname: string): Uint8Array | null {
  *
  * Borrow safety: a substituted id cannot pay an attacker — an id naming someone else's asset is
  * consensus-rejected ("issued by another address") — but it can land the operation on a different
- * numeric asset the user owns. The borrow is therefore limited to operations recoverable in that
- * case (issue, describe); `lock`, `reset` and ownership transfer are permanent against the wrong
- * asset and decline to the field fallback. The range guard restricts the id to the numeric space
- * subassets live in. No verifier without an independent ledger view can detect the substitution
- * itself; the fallback compares the longname, which the response echoes.
+ * numeric asset the user already owns, whose divisibility happens to match. That is vandalism
+ * with no profit motive, and it is **not detectable locally by any means**: the id is precisely
+ * the field no local check can predict, which is why it is borrowed. Declining to pack does not
+ * avoid it, because the field-comparison fallback is equally blind. Closing it needs an
+ * independent ledger view — a second API source or a local index — or local composition.
+ *
+ * The range guard restricts the id to the numeric space subassets live in, which bounds the
+ * substitution to assets of that kind rather than any named asset.
  *
  * Layout follows the composed message's decoded type. Initial (SUBASSET_ISSUANCE / LR_SUBASSET):
  * `[asset_id, quantity, divisible, lock, reset, compacted_length, compacted_name, mime_type,
@@ -258,10 +261,16 @@ function packSubasset(
   // of an OP_RETURN), so it is packed normally and `inscriptionEnvelope.ts` checks the envelope.
   const mimeType = typeof params.mime_type === 'string' ? params.mime_type : '';
 
-  // Irreversible against a substituted id — see the borrow argument above.
-  if (params.lock === true || params.lock === 'true') return null;
-  if (params.reset === true || params.reset === 'true') return null;
-  if (requireString(params, 'transfer_destination')) return null;
+  // A previous revision declined lock, reset and transfer here, reasoning that a substituted
+  // asset id does irreversible harm for those. That was wrong twice over. It did not prevent the
+  // substitution, because the field-comparison fallback cannot see the asset id either — nothing
+  // local can, which is the whole reason the id is borrowed. And it broke the most common
+  // issuance on the chain: declining sent locked subassets to a fallback that compares the
+  // request's longname against the message's numeric asset name and calls the difference a
+  // critical mismatch, so locking a subasset failed outright.
+  //
+  // Byte equality is strictly better here. It proves the quantity, flags, description, MIME type
+  // and the compacted longname, leaving only the id — which no local check could have covered.
 
   const assetId = typeof observed?.assetId === 'bigint' ? observed.assetId : null;
   if (assetId === null || assetId <= 26n ** 12n || assetId >= 1n << 64n) return null;
@@ -289,8 +298,8 @@ function packSubasset(
     assetId,
     quantity,
     params.divisible ? 1n : 0n,
-    0n, // lock — the borrow refuses irreversible operations, so these are always clear
-    0n, // reset
+    params.lock === true || params.lock === 'true' ? 1n : 0n,
+    params.reset === true || params.reset === 'true' ? 1n : 0n,
     BigInt(compacted.length),
     compacted,
     mimeType,

--- a/src/utils/blockchain/counterparty/transactionSafety.ts
+++ b/src/utils/blockchain/counterparty/transactionSafety.ts
@@ -157,6 +157,8 @@ export function analyzeTransactionSafety(
       .map(normalizeAddressForComparison)
   );
   const suspiciousOutputs: Array<{ address: string; value: number }> = [];
+  /** Non-dust outputs whose script could not be resolved to any address. */
+  const unattributableOutputs: Array<{ value: number }> = [];
 
   for (const output of outputs) {
     // Skip OP_RETURN — that's the Counterparty data, no BTC is sent
@@ -171,6 +173,12 @@ export function analyzeTransactionSafety(
     // This is a non-dust output to a different address — suspicious
     if (output.address) {
       suspiciousOutputs.push({ address: output.address, value: output.value });
+    } else {
+      // A script no decoder could attribute. It was previously dropped here, so a non-dust output
+      // to a bare-multisig or P2WSH script raised nothing at all and appeared only as "Unknown
+      // address" in the movement list. Value leaving to a script nobody can name deserves at
+      // least the same warning as value leaving to one that can be.
+      unattributableOutputs.push({ value: output.value });
     }
   }
 
@@ -186,6 +194,22 @@ export function analyzeTransactionSafety(
         `This transaction sends ${btcAmount} BTC to ${addresses.length === 1 ? 'an address' : `${addresses.length} addresses`} ` +
         `that ${addresses.length === 1 ? 'is' : 'are'} not yours: ${addresses.map(a => a.slice(0, 12) + '…').join(', ')}. ` +
         'Normal Counterparty transactions only send BTC back to your own address as change.',
+    });
+  }
+
+  if (unattributableOutputs.length > 0) {
+    const totalSats = unattributableOutputs.reduce((sum, o) => sum + o.value, 0);
+    const btcAmount = (totalSats / 100_000_000).toFixed(8);
+    const count = unattributableOutputs.length;
+
+    warnings.push({
+      severity: 'danger',
+      title: 'BTC Sent to an Unrecognized Script',
+      message:
+        `This transaction sends ${btcAmount} BTC to ${count === 1 ? 'an output' : `${count} outputs`} `
+        + `whose destination could not be determined, so ${count === 1 ? 'it' : 'they'} cannot be `
+        + 'shown as an address or confirmed to be yours. Do not sign unless you know what this '
+        + 'script does.',
     });
   }
 

--- a/src/utils/blockchain/counterparty/unpack/verify.ts
+++ b/src/utils/blockchain/counterparty/unpack/verify.ts
@@ -588,9 +588,16 @@ function verifyIssuance(
   params: Record<string, unknown>,
   result: VerificationResult
 ): void {
-  // Asset - critical
-  if (!valuesEqual(data.asset, params.asset)) {
-    addMismatch(result, 'asset', params.asset, data.asset, 'critical',
+  // Asset - critical.
+  //
+  // A subasset message names its asset twice: `asset` is the numeric name the id resolves to
+  // (A123…), and `subassetLongname` is the PARENT.child the user actually typed. Comparing the
+  // request's longname against the numeric name flags every honest subasset issuance as a
+  // critical mismatch, so the longname is what gets compared when the message carries one.
+  const requested = params.asset;
+  const composed = data.subassetLongname ?? data.asset;
+  if (!valuesEqual(composed, requested)) {
+    addMismatch(result, 'asset', requested, composed, 'critical',
       'Wrong asset name = creating/modifying wrong asset');
   }
 

--- a/src/utils/provider/requestIdentity.ts
+++ b/src/utils/provider/requestIdentity.ts
@@ -27,6 +27,24 @@ interface ProviderPermissionReader {
   hasPairedAddressPermission(origin: string, walletId: string, address: string): Promise<boolean>;
 }
 
+/**
+ * Revalidate that the requesting site is still connected, immediately before signing.
+ *
+ * Identity checks answer "is this still the authorized wallet"; this answers "is this still an
+ * authorized site". They are different questions, and an approval flow lives long enough — up to
+ * ten minutes — for a user to revoke the site in Settings and then approve a request that was
+ * already open. Signing would hand the result to an origin that no longer has permission.
+ */
+export async function getConnectionRevokedError(
+  request: AuthorizedRequest,
+  permissions: Pick<ProviderPermissionReader, 'hasPermission'>,
+): Promise<string | null> {
+  if (!await permissions.hasPermission(request.origin)) {
+    return 'This site is no longer connected. Reconnect it before signing.';
+  }
+  return null;
+}
+
 /** Revalidate provider grants immediately before a stored PSBT request is signed. */
 export async function getPsbtPermissionError(
   request: PsbtAuthorizationRequest,


### PR DESCRIPTION
Items 3e, 3c, 3d and the item 2 leftover from PRIORITIES.md, per the recommendations discussed.

## 3e — recheck the site is still connected before signing (a bug, not a policy)

Identity checks answer *"is this still the authorized wallet"*. They do not answer *"is this still an authorized site"*. An approval flow stays open for up to **ten minutes** — long enough to revoke a site in Settings → Connected Sites and then approve a request already on screen, handing the signature to an origin with no permission.

The PSBT screen has always rechecked via `getPsbtPermissionError`. The raw-transaction screen only checked identity. It now rechecks too, through a shared `getConnectionRevokedError`. No false-positive risk: if the site is still connected the check passes silently.

## 3c — warn earlier, still don't block

`exceedsSaneFeeRate` shared `MAX_SANE_FEE_RATE` (5,000 sat/vB) with the compose path's **blocking** check. That threshold is deliberately far above any legitimate rate, which is right for blocking and useless for warning: a 250-vByte transaction at 4,999 sat/vB burns ~0.0125 BTC while staying under both it and the 0.1 BTC absolute ceiling — **no signal at all**.

The two now have separate thresholds, because they answer different questions:

- `MAX_SANE_FEE_RATE` = 5,000 — unchanged, still blocks on the compose path where the wallet built the transaction.
- `HIGH_FEE_RATE_WARNING` = 500 — new, warns only, roughly 50× a busy-day rate.

**Still warn-not-block on provider paths.** A site-built transaction can be expensive for reasons the wallet cannot see (fee bump, time-sensitive CPFP), and commit `ba3e8d79` already walked this back from blocking once.

## 3d — flag outputs whose destination cannot be determined

The suspicious-output check recorded a finding only `if (output.address)`. So a non-dust output to a bare-multisig or P2WSH script — anything `decodeAddressFromScript` can't attribute — raised **nothing**, appearing only as "Unknown address" in the movement list. Value leaving to a script nobody can name now gets the same `danger` warning as value leaving to one that can be. Dust is still ignored, since Counterparty encodings use it routinely.

Full deny-by-default output accounting is **not** attempted: it works on the compose path because the request names intended destinations, and a site handing over finished bytes states no intent, so every output would be unexplained and everything would block.

## Item 2 leftover — decoded fields on the unbacked screens

The seven types with no local packer showed the response's echo for the fields that identify *what is being done*. Those are stated by the transaction, so they now come from the decoded message:

- **BTCPay** — order match id
- **Dispenser** — asset, mainchain rate, and the escrow/give ratio behind the BTC totals
- **Pool deposit / withdraw** — the asset pair and LP asset

A composer that settled a different order match, or opened a dispenser on a different asset or at a different price, can no longer display the requested one.

**Quantities deliberately still use the response's normalized strings.** Converting decoded base units needs each asset's divisibility, which is a ledger fact rather than part of the transaction — the same reasoning the send screen already documents.

## Tests

- New cases in `transactionSafety.test.ts`: unattributable non-dust output warns at `danger`; dust doesn't; fully-attributable outputs don't.
- `saneFeeRate.test.ts` updated for the split thresholds, including a case at 1,000 sat/vB that previously passed unremarked and now warns.
- Two component tests needed the composer context mocked — the real module reaches for `webext-bridge`.
- `tsc --noEmit` clean; **3702 unit tests pass**. (The Trezor emulator suite fails for want of a device — pre-existing and documented in HANDOFF.md.)
- E2E locally: `provider-transaction-signing` 11/11, `compose/dispenser` + `compose/utxo` 16/16.

https://claude.ai/code/session_01CcjnCrgosSeshymXLBxdGj
