### PR TITLE
Reject malformed hex instead of decoding it to a different byte

### DIFF
--- a/src/utils/blockchain/counterparty/unpack/__tests__/binary.test.ts
+++ b/src/utils/blockchain/counterparty/unpack/__tests__/binary.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { BinaryReadError, bytesToHex, hexToBytes } from '@/utils/blockchain/counterparty/unpack/binary';
+
+describe('hexToBytes', () => {
+  it('decodes a well-formed string', () => {
+    expect(bytesToHex(hexToBytes('4a6f686e'))).toBe('4a6f686e');
+  });
+
+  it('accepts either case and an optional 0x prefix', () => {
+    expect(bytesToHex(hexToBytes('0xDEADbeef'))).toBe('deadbeef');
+  });
+
+  it('decodes an empty string to no bytes', () => {
+    expect(hexToBytes('')).toHaveLength(0);
+  });
+
+  it('rejects an odd-length string', () => {
+    expect(() => hexToBytes('abc')).toThrow(BinaryReadError);
+  });
+
+  // `parseInt('9z', 16)` returns 9 rather than NaN, so a per-pair isNaN check passes and the
+  // pair decodes to 0x09. These strings used to come back as bytes with no error at all, which
+  // matters because unpackCounterpartyMessage hands this untrusted API hex directly.
+  it.each([
+    ['9z', 'bad trailing nibble'],
+    ['0g', 'bad trailing nibble, zero leading'],
+    ['a!', 'punctuation'],
+    ['7-', 'hyphen'],
+    ['ff 0a', 'embedded space'],
+  ])('rejects %s (%s) instead of decoding it', (bad) => {
+    expect(() => hexToBytes(bad)).toThrow(BinaryReadError);
+  });
+
+  it('rejects a bad nibble in the middle of an otherwise valid string', () => {
+    expect(() => hexToBytes('4a6f686e6e9z')).toThrow(BinaryReadError);
+  });
+
+  it('reports the position of the offending character', () => {
+    expect(() => hexToBytes('4a6fzz')).toThrow(/position 4/);
+  });
+});

--- a/src/utils/blockchain/counterparty/unpack/binary.ts
+++ b/src/utils/blockchain/counterparty/unpack/binary.ts
@@ -178,13 +178,17 @@ export function hexToBytes(hex: string): Uint8Array {
     throw new BinaryReadError('Invalid hex string: odd length');
   }
 
+  // Checked up front rather than per byte. `parseInt('9z', 16)` returns 9 instead of NaN —
+  // it stops at the first character it cannot read — so a per-pair isNaN check only catches a
+  // bad *leading* nibble and silently decodes the rest to a different byte.
+  const invalid = cleanHex.search(/[^0-9a-fA-F]/);
+  if (invalid !== -1) {
+    throw new BinaryReadError(`Invalid hex character at position ${invalid}`);
+  }
+
   const bytes = new Uint8Array(cleanHex.length / 2);
   for (let i = 0; i < bytes.length; i++) {
-    const byte = parseInt(cleanHex.slice(i * 2, i * 2 + 2), 16);
-    if (isNaN(byte)) {
-      throw new BinaryReadError(`Invalid hex character at position ${i * 2}`);
-    }
-    bytes[i] = byte;
+    bytes[i] = parseInt(cleanHex.slice(i * 2, i * 2 + 2), 16);
   }
   return bytes;
 }


### PR DESCRIPTION
Found while reviewing the highest-fanout files. `unpack/binary.ts` has 18 importers and sits on the ADR-019 verification path.

## The bug

`hexToBytes` validated each byte with `isNaN(parseInt(pair, 16))`. But `parseInt` stops at the first character it can't read instead of rejecting the string, so only a bad **leading** nibble was caught:

```js
parseInt('9z', 16) === 9      parseInt('0g', 16) === 0
parseInt('a!', 16) === 10     parseInt('zz', 16)  // NaN — the only case that threw
```

End to end:

```js
hexToBytes('4a6f686e6e9z')  // -> 4a6f686e6e09, no error
```

Same length, plausible bytes, silently different from the input.

## Why it matters

`unpackCounterpartyMessage` passes untrusted API hex straight into this function (`unpack/index.ts:121`). ADR-019's fourth layer has the approval screen describe the transaction's *own decoded bytes* — so a malformed payload has to fail loudly, not decode into something else. This was the one path where it could quietly not.

## The fix

Validate the whole string once with `search(/[^0-9a-fA-F]/)` before decoding, and report the offending position. That's also cheaper than the per-pair `isNaN` it replaces.

## Tests

New `binary.test.ts` — 11 cases. Confirmed the 5 malformed-input cases **fail against the old implementation** and pass with the fix; the other 6 (well-formed, case-insensitivity, `0x` prefix, empty, odd-length) pass either way.

## Deliberately not included

`BinaryReader.readBytes` and `skip` still accept a negative length — `remaining < -5` is false, so no throw, then `position += -5` walks the cursor backwards. No caller can currently reach it, so it's left for its own change rather than widening this one.

## Verification

- `tsc --noEmit` clean
- `biome check src` clean (676 files)
- `vitest run src/utils/blockchain/counterparty` — 684 passed, 35 skipped, 33 files

https://claude.ai/code/session_01CcjnCrgosSeshymXLBxdGj
