### PR TITLE
Show output addresses in full on the dapp approval screens

### DIFF
--- a/src/pages/requests/psbt/approve.tsx
+++ b/src/pages/requests/psbt/approve.tsx
@@ -377,9 +377,12 @@ export default function ApprovePsbtPage() {
                           </span>
                           <span className="text-gray-900 font-medium">{formatAmount({ value: fromSatoshis(output.value, true), minimumFractionDigits: 8, maximumFractionDigits: 8 })} BTC</span>
                         </div>
+                        {/* Shown in full and allowed to wrap - see the matching note in the
+                            transaction approval screen. Outputs are where a site's transaction
+                            sends money, so the whole address has to be comparable. */}
                         {output.address && (
-                          <div className="text-gray-500 truncate" title={output.address}>
-                            {formatAddress(output.address, true)}
+                          <div className="text-gray-500 break-all font-mono" title={output.address}>
+                            {formatAddress(output.address, false)}
                           </div>
                         )}
                       </div>

--- a/src/pages/requests/transaction/approve.tsx
+++ b/src/pages/requests/transaction/approve.tsx
@@ -418,9 +418,14 @@ export default function ApproveTransactionPage() {
                             </span>
                             <span className="text-gray-900 font-medium">{formatAmount({ value: fromSatoshis(output.value, true), minimumFractionDigits: 8, maximumFractionDigits: 8 })} BTC</span>
                           </div>
+                          {/* Shown in full and allowed to wrap. This is where the user checks
+                              where a site's transaction sends money, and 6 leading + 6 trailing
+                              characters is grindable for a lookalike - the prefix of a bech32
+                              address is fixed, so only a handful of characters are actually
+                              being compared. */}
                           {output.address && (
-                            <div className="text-gray-500 truncate" title={output.address}>
-                              {formatAddress(output.address, true)}
+                            <div className="text-gray-500 break-all font-mono" title={output.address}>
+                              {formatAddress(output.address, false)}
                             </div>
                           )}
                         </div>


### PR DESCRIPTION
Found while reviewing the highest-fanout files — `utils/format.ts` has 74 importers, and tracing `formatAddress` into the approval screens surfaced this.

## The problem

`transaction/approve.tsx` and `psbt/approve.tsx` rendered each **output** address as `formatAddress(address, true)` → 6 leading + 6 trailing characters, with the full value only in a `title` tooltip that never appears on touch.

That's the screen where a user checks where a **site-supplied** transaction sends money. Six-and-six is a weak comparison: a bech32 address has a fixed `bc1q` prefix, so matching the visible characters means grinding roughly 2 free prefix chars + 6 suffix chars ≈ 32⁸ — ordinary vanity-address work, not an exotic attack.

The wallet already knows this matters. `review-screen.tsx:148` passes `shorten: false` with the comment *"show full address"* for its own compose flow. This just extends the same treatment to the path where the transaction comes from an untrusted site instead of from us.

## Scope

**Changed — outputs only** (2 sites): `transaction/approve.tsx:428`, `psbt/approve.tsx:385`.

**Left truncated — inputs** (`transaction:386`, `psbt:345`, `psbt:285`). They spend the user's own UTXOs, and the wallet only signs inputs it can derive keys for, so a lookalike input address gains an attacker nothing. Truncating those stays a reasonable use of space.

## One detail worth noting

The containers carried Tailwind's `truncate` (`overflow-hidden` + `text-overflow: ellipsis` + `nowrap`). Passing the full address without touching the CSS would have clipped it right back to an ellipsis and quietly achieved nothing — so they move to `break-all` and wrap. `font-mono` is added because character-by-character comparison is the whole point.

## Verification

- `tsc --noEmit` clean
- `biome check src` clean (675 files)
- `wxt build` succeeds
- `playwright test e2e/pages/requests/transaction/approve.spec.ts` — 10 passed
- `playwright test e2e/pages/requests/psbt/approve.spec.ts` — 3 passed

https://claude.ai/code/session_01CcjnCrgosSeshymXLBxdGj
