### PR TITLE
Harden four things found reviewing the most-imported files

### DIFF
--- a/src/contexts/wallet-context.tsx
+++ b/src/contexts/wallet-context.tsx
@@ -260,7 +260,15 @@ export function WalletProvider({ children }: { children: ReactNode }): ReactElem
   const walletStateRef = useRef(walletState);
   walletStateRef.current = walletState;
 
-  // Track lock state version to prevent stale updates from overriding lock events
+  // Track lock state version to prevent stale updates from overriding lock events.
+  //
+  // This looks redundant and is not. `refreshWalletState` and the lock handler both take the
+  // 'wallet-refresh' lock, so they cannot normally interleave — but `stateLockManager` force-
+  // releases a lock after 30s while its holder is still running. A refresh that decrypts a wallet
+  // and derives addresses can reach that, and then a lock event runs *concurrently* with a refresh
+  // that is about to write an unlocked state. The version check below is what discards it.
+  //
+  // Removing either this or the force-release without the other reintroduces that fail-open.
   const lockStateVersionRef = useRef(0);
 
   const refreshWalletState = useCallback(async () => {

--- a/src/utils/blockchain/bitcoin/__tests__/address.test.ts
+++ b/src/utils/blockchain/bitcoin/__tests__/address.test.ts
@@ -266,6 +266,27 @@ describe('Bitcoin Address Utilities', () => {
       expect(address?.length).toBe(62); // bech32m P2TR is 62 chars
     });
 
+    // A script with a valid prefix and length but a non-hex hash used to decode to zero bytes,
+    // because parseInt returns NaN for a bad pair and Uint8Array stores NaN as 0. That handed back
+    // a real, wrong address instead of null - and output accounting reads null as "cannot be
+    // attributed", so a wrong address is worse there than no address.
+    it.each([
+      ['0014' + 'z'.repeat(40), 'P2WPKH with a non-hex hash'],
+      ['76a914' + 'z'.repeat(40) + '88ac', 'P2PKH with a non-hex hash'],
+      ['a914' + 'z'.repeat(40) + '87', 'P2SH with a non-hex hash'],
+      ['5120' + 'z'.repeat(64), 'P2TR with a non-hex key'],
+    ])('returns null for %s (%s)', (script) => {
+      expect(decodeAddressFromScript(script)).toBeNull();
+    });
+
+    it('does not decode a malformed hash to the all-zeros address', () => {
+      const zeros = decodeAddressFromScript('0014' + '0'.repeat(40));
+      const garbage = decodeAddressFromScript('0014' + 'z'.repeat(40));
+      expect(zeros).not.toBeNull();
+      expect(garbage).toBeNull();
+      expect(garbage).not.toBe(zeros);
+    });
+
     it('should return null for OP_RETURN script', () => {
       // OP_RETURN script: 6a<data>
       const script = '6a0f68656c6c6f20776f726c64';

--- a/src/utils/blockchain/bitcoin/address.ts
+++ b/src/utils/blockchain/bitcoin/address.ts
@@ -144,9 +144,18 @@ export function decodeAddressFromScript(scriptHex: string): string | null {
 }
 
 /**
- * Convert hex string to Uint8Array
+ * Convert hex string to Uint8Array.
+ *
+ * Throws on anything that is not clean hex rather than decoding it. `parseInt` returns NaN for a
+ * bad pair and Uint8Array stores NaN as 0, so without this a garbage hash decodes to zero bytes
+ * and `decodeAddressFromScript` hands back a valid-looking address instead of null. Output
+ * accounting treats null as the signal that a script cannot be attributed, so a wrong address is
+ * worse there than no address.
  */
 function hexToUint8Array(hex: string): Uint8Array {
+  if (hex.length % 2 !== 0 || /[^0-9a-fA-F]/.test(hex)) {
+    throw new Error('Invalid hex string');
+  }
   const bytes = new Uint8Array(hex.length / 2);
   for (let i = 0; i < hex.length; i += 2) {
     bytes[i / 2] = parseInt(hex.slice(i, i + 2), 16);

--- a/src/utils/blockchain/counterparty/__tests__/api.test.ts
+++ b/src/utils/blockchain/counterparty/__tests__/api.test.ts
@@ -123,6 +123,38 @@ describe('counterparty/api.ts', () => {
     mockedGetSettings.mockReturnValue(mockSettings as any);
   });
 
+  describe('response cache', () => {
+    const ok = (data: unknown) => ({
+      data, status: 200, statusText: 'OK', headers: {}, config: {},
+    }) as any;
+
+    // Keys used to be built as `${k}=${v}` joined by '&', so a value containing '&' or '=' could
+    // forge a separator: { cursor: '1&limit=2' } and { cursor: '1', limit: '2' } collided, and
+    // whichever ran first had its response served to the other. Cursors come from the API.
+    it('does not let a param value forge a separator', async () => {
+      // Params are sorted then joined as `k=v` with '&'. Unencoded, a sort value carrying
+      // '&type=' produces the exact key that a separate `type` param would, so the two requests
+      // collide and the first one's response is served to the second.
+      mockedApiClient.get.mockResolvedValue(ok({ result: [mockTokenBalance] }));
+      await fetchTokenBalances(mockAddress, { sort: 'x&type=y' });
+
+      mockedApiClient.get.mockResolvedValue(ok({ result: [] }));
+      const second = await fetchTokenBalances(mockAddress, { sort: 'x', type: 'y' as any });
+
+      expect(second).toEqual([]);
+      expect(mockedApiClient.get).toHaveBeenCalledTimes(2);
+    });
+
+    it('still serves a genuine repeat from cache', async () => {
+      mockedApiClient.get.mockResolvedValue(ok({ result: [mockTokenBalance] }));
+      const first = await fetchTokenBalances(mockAddress, { cursor: 'abc' } as any);
+      const second = await fetchTokenBalances(mockAddress, { cursor: 'abc' } as any);
+
+      expect(second).toEqual(first);
+      expect(mockedApiClient.get).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('fetchTokenBalances', () => {
     it('should return token balances array on valid response', async () => {
       const mockData = {

--- a/src/utils/blockchain/counterparty/api.ts
+++ b/src/utils/blockchain/counterparty/api.ts
@@ -35,9 +35,13 @@ const cache = new Map<string, CacheEntry<unknown>>();
  */
 function getCacheKey(url: string, params?: Record<string, string | number | boolean>): string {
   if (!params || Object.keys(params).length === 0) return url;
+  // Values are encoded so a value containing & or = cannot forge a separator. Without it
+  // { cursor: '1&limit=2' } and { cursor: '1', limit: '2' } produce the same key, and whichever
+  // ran first has its response served to the other. Cursors come from the API, so their contents
+  // are not ours to assume.
   const sortedParams = Object.entries(params)
     .sort(([a], [b]) => a.localeCompare(b))
-    .map(([k, v]) => `${k}=${v}`)
+    .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(String(v))}`)
     .join('&');
   return `${url}?${sortedParams}`;
 }
@@ -56,9 +60,23 @@ function getFromCache<T>(key: string): T | null {
 }
 
 /**
+ * Largest number of entries kept. Expired entries are only dropped when their key is read again,
+ * so without a bound anything fetched once and never revisited stays for the life of the context.
+ */
+const MAX_CACHE_ENTRIES = 500;
+
+/**
  * Store data in cache.
  */
 function setInCache<T>(key: string, data: T): void {
+  // Re-setting an existing key must not count as growth, so delete first: Map preserves insertion
+  // order, and deleting then setting also moves the entry to the newest position.
+  cache.delete(key);
+  if (cache.size >= MAX_CACHE_ENTRIES) {
+    // Map iterates in insertion order, so the first key is the oldest.
+    const oldest = cache.keys().next();
+    if (!oldest.done) cache.delete(oldest.value);
+  }
   cache.set(key, { data, timestamp: Date.now() });
 }
 

--- a/src/utils/blockchain/counterparty/compose.ts
+++ b/src/utils/blockchain/counterparty/compose.ts
@@ -72,7 +72,7 @@ export interface ComposeParams {
   address?: string;
   dispenser?: string;
   asset: string;
-  quantity: number;
+  quantity: string | number;
   memo: string | null;
   memo_is_hex: boolean;
   use_enhanced_send: boolean;
@@ -142,7 +142,7 @@ export interface BTCPayOptions extends BaseComposeOptions {
 }
 
 export interface BurnOptions extends BaseComposeOptions {
-  quantity: number;
+  quantity: string | number;
   overburn?: boolean;
 }
 
@@ -152,15 +152,15 @@ export interface CancelOptions extends BaseComposeOptions {
 
 export interface DestroyOptions extends BaseComposeOptions {
   asset: string;
-  quantity: number;
+  quantity: string | number;
   tag?: string;
 }
 
 export interface DispenserOptions extends BaseComposeOptions {
   asset: string;
-  give_quantity: number;
-  escrow_quantity: number;
-  mainchainrate: number;
+  give_quantity: string | number;
+  escrow_quantity: string | number;
+  mainchainrate: string | number;
   status?: string;
   open_address?: string;
   oracle_address?: string;
@@ -168,19 +168,19 @@ export interface DispenserOptions extends BaseComposeOptions {
 
 export interface DispenseOptions extends BaseComposeOptions {
   dispenser: string;
-  quantity: number;
+  quantity: string | number;
   pubkeys?: string;
 }
 
 export interface DividendOptions extends BaseComposeOptions {
   asset: string;
   dividend_asset: string;
-  quantity_per_unit: number;
+  quantity_per_unit: string | number;
 }
 
 export interface IssuanceOptions extends BaseComposeOptions {
   asset: string;
-  quantity: number;
+  quantity: string | number;
   divisible?: boolean;
   lock: boolean;
   reset: boolean;
@@ -206,9 +206,9 @@ export interface MPMAOptions extends BaseComposeOptions {
 
 export interface OrderOptions extends BaseComposeOptions {
   give_asset: string;
-  give_quantity: number;
+  give_quantity: string | number;
   get_asset: string;
-  get_quantity: number;
+  get_quantity: string | number;
   expiration: number;
   fee_required?: number;
 }
@@ -216,7 +216,7 @@ export interface OrderOptions extends BaseComposeOptions {
 export interface SendOptions extends BaseComposeOptions {
   destination: string;
   asset: string;
-  quantity: number;
+  quantity: string | number;
   memo?: string;
   memo_is_hex?: boolean;
   no_dispense?: boolean;
@@ -231,14 +231,14 @@ export interface SweepOptions extends BaseComposeOptions {
 export interface FairminterOptions extends BaseComposeOptions {
   asset: string;
   lot_price?: number;
-  lot_size?: number;
-  max_mint_per_tx?: number;
-  max_mint_per_address?: number;
-  hard_cap?: number;
-  premint_quantity?: number;
+  lot_size?: string | number;
+  max_mint_per_tx?: string | number;
+  max_mint_per_address?: string | number;
+  hard_cap?: string | number;
+  premint_quantity?: string | number;
   start_block?: number;
   end_block?: number;
-  soft_cap?: number;
+  soft_cap?: string | number;
   soft_cap_deadline_block?: number;
   minted_asset_commission?: number;
   burn_payment?: boolean;
@@ -255,7 +255,7 @@ export interface FairminterOptions extends BaseComposeOptions {
 
 export interface FairmintOptions extends BaseComposeOptions {
   asset: string;
-  quantity?: number;
+  quantity?: string | number;
 }
 
 export interface PoolDepositOptions extends BaseComposeOptions {
@@ -278,7 +278,7 @@ export interface PoolWithdrawOptions extends BaseComposeOptions {
 
 export interface AttachOptions extends BaseComposeOptions {
   asset: string;
-  quantity: number;
+  quantity: string | number;
   utxo_value?: number; // Optional value for the new UTXO (disabled after block 871900)
   destination_vout?: number; // Optional output to attach to
 }


### PR DESCRIPTION
Bundles the small findings from reviewing the highest-fanout files (`numeric.ts`, `binary.ts`, `format.ts`, `compose.ts`, `api.ts`, `address.ts`, `wallet-context.tsx`). The two sharp ones already went out as #234 and #235.

**None of these are reachable today.** They're the cases where a layer other code trusts could fail *quietly* rather than loudly.

## 1. `hexToUint8Array` had no validation — `address.ts`

`parseInt` returns `NaN` for a bad pair and `Uint8Array` stores `NaN` as `0`. So `0014` + 40 non-hex chars passed the prefix and length checks, decoded to twenty zero bytes, and `decodeAddressFromScript` returned a **valid bech32 address** instead of `null`.

Every current caller passes `bytesToHex(...)` output, so it can't be reached. It matters anyway because `null` is the failure signal the output-accounting layer is built on — `outputPolicy.ts:134` ("a script we cannot attribute might pay anyone, so it cannot be explained") and `localTransactionParse.ts` ("never guessed"). Deny-by-default holds only while a returned address is *correct*; a plausible wrong one defeats it silently. Same class as #234's `hexToBytes`, now consistent with it.

**Tests:** 5 new cases, all confirmed failing against the old implementation.

## 2. `getCacheKey` let a param value forge a separator — `api.ts`

Params were joined as `k=v` with `&` and nothing encoded, so:

```
sort: 'x&type=y'        -> limit=100&offset=0&sort=x&type=y&verbose=true
sort: 'x', type: 'y'    -> limit=100&offset=0&sort=x&type=y&verbose=true   // same key
```

Whichever ran first had its response served to the other. Values include API-supplied strings.

**Test:** confirmed failing against the old implementation.

## 3. The response cache had no bound — `api.ts`

Entries are dropped only when their key is read again after expiry, so anything fetched once and never revisited stayed for the life of the context. Capped at 500 with oldest-first eviction (delete-then-set so a refresh doesn't count as growth and moves the entry to newest).

## 4. Quantity fields were typed `number` but carry strings — `compose.ts`

`normalize.ts` converts every quantity with `toSatoshis()` / `toBigNumber().integerValue().toString()` before it reaches compose, so the runtime value is a BigNumber-derived string. The annotation said `number` — and these are 64-bit values while a JS number is exact only to 2⁵³, about **90.07M units of a divisible asset**, well inside real supplies.

Widened to `string | number`, matching `quantity_a`/`quantity_b` which already said so. **Nothing needed changing to accept it**, which is the evidence that no caller was doing arithmetic on them — the runtime was already correct, only the type lied.

## Plus: a comment that stops a real fail-open being "simplified" away

`lockStateVersionRef` in `wallet-context.tsx` reads as redundant — `refreshWalletState` and the lock handler both take the `'wallet-refresh'` lock, so they can't interleave. It isn't redundant: `stateLockManager` **force-releases after 30s while the holder is still running** (`stateLockManager.ts:42`), and a refresh that decrypts a wallet and derives addresses can reach that. The version check is what discards the unlocked state a concurrent refresh would then write. Removing either it or the force-release without the other reintroduces the fail-open.

## Verification

- `tsc --noEmit` clean
- `biome check src` clean (675 files)
- `vitest run src/utils/blockchain src/contexts` — 1410 passed, 35 skipped, 66 files
- `wxt build` succeeds
- `playwright test e2e/pages/compose/broadcast/index.spec.ts` — 10 passed

https://claude.ai/code/session_01CcjnCrgosSeshymXLBxdGj
