### PR TITLE
Clear the header caches when the keychain locks

### DIFF
--- a/src/contexts/__tests__/clear-caches-on-lock.test.tsx
+++ b/src/contexts/__tests__/clear-caches-on-lock.test.tsx
@@ -1,0 +1,85 @@
+import { act, render } from '@testing-library/react';
+import { useEffect, useState } from 'react';
+import { describe, expect, it } from 'vitest';
+import { HeaderProvider, useHeader } from '@/contexts/header-context';
+
+/**
+ * The wiring lives in app-providers so header-context stays free of wallet-context (which imports
+ * webext-bridge and cannot load under jsdom). That means the effect is reproduced here rather than
+ * imported: this pins the behaviour — a lock empties the caches — not the import graph.
+ */
+function ClearOnLock({ locked }: { locked: boolean }) {
+  const { clearAllCaches } = useHeader();
+  useEffect(() => {
+    if (locked) clearAllCaches();
+  }, [locked, clearAllCaches]);
+  return null;
+}
+
+const BALANCE = {
+  asset: 'XCP',
+  quantity: 100,
+  quantity_normalized: '1.00000000',
+  asset_info: { asset_longname: null, description: '', issuer: '', divisible: true, locked: false },
+} as any;
+
+function Harness({ onCaches }: { onCaches: (n: number) => void }) {
+  const { cacheBalances, subheadings } = useHeader();
+  const [locked, setLocked] = useState(false);
+
+  useEffect(() => { cacheBalances([BALANCE]); }, [cacheBalances]);
+  useEffect(() => { onCaches(Object.keys(subheadings.balances).length); }, [subheadings, onCaches]);
+
+  return (
+    <>
+      <ClearOnLock locked={locked} />
+      <button type="button" onClick={() => setLocked(true)}>lock</button>
+    </>
+  );
+}
+
+describe('locking the keychain', () => {
+  it('empties the header caches', async () => {
+    const counts: number[] = [];
+    const { getByText } = render(
+      <HeaderProvider>
+        <Harness onCaches={(n) => counts.push(n)} />
+      </HeaderProvider>
+    );
+
+    // Balances are cached while unlocked.
+    expect(counts.at(-1)).toBe(1);
+
+    await act(async () => { getByText('lock').click(); });
+
+    // ...and gone once locked. Holdings must not survive an explicit lock in memory.
+    expect(counts.at(-1)).toBe(0);
+  });
+
+  it('clearAllCaches empties every cache, not just balances', () => {
+    let api: ReturnType<typeof useHeader> | undefined;
+    function Probe() {
+      api = useHeader();
+      return null;
+    }
+    render(<HeaderProvider><Probe /></HeaderProvider>);
+
+    act(() => {
+      api!.cacheBalances([BALANCE]);
+      api!.setAddressHeader('bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4', 'Wallet 1');
+      api!.cacheOwnedAssets([{
+        asset: 'MYTOKEN', asset_longname: null, supply_normalized: '1', description: '', locked: false,
+      }]);
+    });
+
+    expect(Object.keys(api!.subheadings.balances)).toHaveLength(1);
+    expect(Object.keys(api!.subheadings.addresses)).toHaveLength(1);
+    expect(Object.keys(api!.subheadings.ownedAssets)).toHaveLength(1);
+
+    act(() => { api!.clearAllCaches(); });
+
+    expect(Object.keys(api!.subheadings.balances)).toHaveLength(0);
+    expect(Object.keys(api!.subheadings.addresses)).toHaveLength(0);
+    expect(Object.keys(api!.subheadings.ownedAssets)).toHaveLength(0);
+  });
+});

--- a/src/contexts/app-providers.tsx
+++ b/src/contexts/app-providers.tsx
@@ -1,7 +1,7 @@
 import { type ReactElement, type ReactNode, useCallback, useEffect, useRef } from 'react';
 import { ErrorBoundary } from '@/components/layout/error-boundary';
 import { ApiStatusProvider } from '@/contexts/api-status-context';
-import { HeaderProvider } from '@/contexts/header-context';
+import { HeaderProvider, useHeader } from '@/contexts/header-context';
 import { SettingsProvider, useSettings } from '@/contexts/settings-context';
 import { useWallet, WalletProvider } from '@/contexts/wallet-context';
 import { useIdleTimer } from '@/hooks/useIdleTimer';
@@ -12,6 +12,29 @@ import { getAutoLockTimeoutMs } from '@/utils/settings';
  */
 interface AppProvidersProps {
   children: ReactNode;
+}
+
+/**
+ * Drops the header caches when the keychain locks.
+ *
+ * They hold balances, owned assets and the addresses holding them. Locking is meant to drop that —
+ * wallet-context nulls activeWallet and activeAddress on the same event — but HeaderProvider sits
+ * above the routes and does not unmount when the UI returns to the unlock screen, so the holdings
+ * would otherwise stay in memory across an explicit lock.
+ *
+ * This lives here rather than inside HeaderProvider so that header-context stays independent of
+ * wallet-context: the wallet imports webext-bridge, which opens a runtime port at module load and
+ * cannot be imported under jsdom.
+ */
+function ClearHeaderCachesOnLock(): null {
+  const { keychainLocked } = useWallet();
+  const { clearAllCaches } = useHeader();
+
+  useEffect(() => {
+    if (keychainLocked) clearAllCaches();
+  }, [keychainLocked, clearAllCaches]);
+
+  return null;
 }
 
 /**
@@ -128,6 +151,7 @@ export function AppProviders({ children }: AppProvidersProps): ReactElement {
                 <IdleTimerWrapper>
                   <ApiStatusProvider>
                     <HeaderProvider>
+                      <ClearHeaderCachesOnLock />
                       {children}
                     </HeaderProvider>
                   </ApiStatusProvider>

--- a/src/pages/compose/send/review.tsx
+++ b/src/pages/compose/send/review.tsx
@@ -78,7 +78,11 @@ export function ReviewSend({
               <div className="font-medium">
                 {tx.quantity} {tx.asset}
               </div>
-              <div className="text-gray-600 truncate" title={tx.destination}>
+              {/* Wrapped rather than truncated. These recipients are read from the transaction's
+                  own bytes above so a substituted one cannot hide behind the echo — clipping the
+                  address to a prefix would give that back, since the start of a bech32 address is
+                  the part that does not vary. */}
+              <div className="text-gray-600 break-all font-mono" title={tx.destination}>
                 → {tx.destination}
               </div>
               {tx.memo && (

--- a/src/utils/__tests__/fathom-routes.test.ts
+++ b/src/utils/__tests__/fathom-routes.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizePath } from '@/utils/fathom';
+
+/**
+ * Every dynamic route in src/pages, with a realistic value in the parameter slot.
+ * The point is coverage of the route table rather than of the sanitizer's branches: a new
+ * dynamic route added without a SENSITIVE_PATH_PATTERNS entry should still be caught by the
+ * DYNAMIC_SEGMENT_PATTERNS backstop, and this is what proves that stays true.
+ */
+const TX_HASH = 'a'.repeat(64);
+const BECH32 = 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4';
+const TAPROOT = 'bc1p5d7rjq7g6rdk2yhzks9smlaqtedr4dekq08ge8ztwac72sfr9rusxg3297';
+const BASE58 = '1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH';
+
+const ROUTES: Array<[string, string]> = [
+  ['/assets/utxos/' + TX_HASH, 'utxo tx hash'],
+  ['/assets/XCP', 'asset name'],
+  ['/assets/RARE.PEPE', 'subasset longname'],
+  ['/assets/A95428956661682177', 'numeric asset'],
+  ['/market/dispensers/PEPECASH', 'dispenser asset'],
+  ['/market/orders/XCP', 'order base asset'],
+  ['/market/orders/XCP/PEPECASH', 'order pair'],
+  ['/pools/XCP', 'pool asset a'],
+  ['/pools/XCP/PEPECASH', 'pool pair'],
+  ['/pools/A123456789012345678', 'lp asset'],
+  ['/transactions/' + TX_HASH, 'transaction hash'],
+  ['/compose/sweep/' + BECH32, 'bech32 address'],
+  ['/compose/sweep/' + TAPROOT, 'taproot address'],
+  ['/compose/sweep/' + BASE58, 'base58 address'],
+];
+
+/** Anything that could identify the user or their holdings must not survive sanitisation. */
+function leaks(sanitized: string, original: string): string[] {
+  const found: string[] = [];
+  for (const value of [TX_HASH, BECH32, TAPROOT, BASE58, 'XCP', 'PEPECASH', 'RARE.PEPE',
+    'A95428956661682177', 'A123456789012345678']) {
+    if (original.includes(value) && sanitized.includes(value)) found.push(value);
+  }
+  return found;
+}
+
+describe('sanitizePath covers every dynamic route', () => {
+  it.each(ROUTES)('%s (%s)', (path) => {
+    const sanitized = sanitizePath(path);
+    expect(leaks(sanitized, path), `"${sanitized}" still carries data from "${path}"`).toEqual([]);
+  });
+
+  it('leaves a fully static path alone', () => {
+    expect(sanitizePath('/settings/advanced')).toBe('/settings/advanced');
+    expect(sanitizePath('/index')).toBe('/index');
+  });
+
+  // The backstop is what makes an unlisted dynamic route safe by default.
+  it('truncates an unlisted route carrying an address', () => {
+    expect(sanitizePath(`/some/new/route/${BECH32}`)).toBe('/some/new/route');
+  });
+});

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -160,6 +160,21 @@ export function setSettingsProvider(provider: () => AppSettings): void {
   settingsProvider = provider;
 }
 
+/**
+ * Note what the fallback means for anything read here while the keychain is locked.
+ *
+ * Settings live inside the encrypted keychain, so they cannot be read without the key —
+ * `walletManager.getSettings()` returns DEFAULT_SETTINGS when no keychain is loaded, and so does
+ * this when no provider is registered yet. For the security flags that fails safe:
+ * `strictTransactionVerification` defaults to true and `trezorEmulatorMode` to undefined.
+ *
+ * `counterpartyApiBase` is the exception. It falls back to the public node, so a user who pointed
+ * the wallet at their own node has any request issued before unlock go somewhere they did not
+ * choose. `IdleTimerWrapper` re-reads settings once the keychain is confirmed loaded, which closes
+ * the window after unlock but not before it. Closing it entirely means storing the API base
+ * outside the encrypted keychain — a deliberate trade, since it then becomes readable without the
+ * password, rather than something to change quietly here.
+ */
 export function getActiveSettings(): AppSettings {
   return settingsProvider ? settingsProvider() : DEFAULT_SETTINGS;
 }


### PR DESCRIPTION
The three items left open after reviewing all 20 most-imported files, plus the analytics route test.

## 1. Header caches survived the lock

They hold balances, owned assets, and the addresses holding them. `clearAllCaches` existed for exactly this purpose and **was never called from anywhere** — only `clearBalances` was, by `composer-context.tsx:623` after a broadcast.

`wallet-context.tsx:421` already nulls `activeWallet`/`activeAddress` on the lock event, so the intent is established; `HeaderProvider` just wasn't included. It sits above the routes and doesn't unmount when the UI returns to the unlock screen, so holdings stayed in memory across an explicit lock. Nothing renders from them, so this is defence in depth rather than exposure.

**Where the wiring lives, and why:** I first put it inside `HeaderProvider` consuming `useWallet()`. That broke `header-context.test.tsx` outright — the wallet imports `webext-bridge`, which calls `chrome.runtime.connect` at module load and fails under jsdom. It's the same coupling the `composer-context-object` split was made to avoid. So it's a small component between the two providers in `app-providers.tsx`, and `header-context` stays independent.

## 2. MPMA recipients were CSS-truncated

`send/review.tsx:81` used `truncate` in the list whose comment three lines above says it reads from `decodedSends` "so a substituted recipient cannot hide behind a correct-looking echo." Clipping the address back to a prefix gives that up — the start of a bech32 address is the part that doesn't vary. Now `break-all` + `font-mono`, same reasoning as #235.

## 3. Settings fallback — documented, not changed

Settings live **inside the encrypted keychain**, so they can't be read while locked and `walletManager.getSettings()` returns defaults. The security flags fail safe (`strictTransactionVerification: true`, `trezorEmulatorMode` undefined). `counterpartyApiBase` doesn't — it falls back to the public node, so a user who pointed the wallet at their own node has pre-unlock requests go elsewhere.

I didn't "fix" this. `IdleTimerWrapper` already re-reads settings once the keychain is confirmed loaded, closing the window *after* unlock but not before. Closing it entirely means storing the API base outside the encrypted keychain, where it becomes readable without the password — a trade to make deliberately, not quietly in a hardening PR. The comment records the constraint and the existing mitigation.

## 4. Analytics route coverage

`fathom.ts` is careful work and I couldn't break it: all 14 real dynamic routes sanitise correctly, and the three wallet-ID routes are covered by the explicit prefix list. But the `DYNAMIC_SEGMENT_PATTERNS` backstop matches 32+ hex, bech32, base58, uppercase/dotted asset names and bare numbers — **it cannot match a lowercase wallet ID**. So asset and address routes genuinely fail closed; wallet-ID routes depend entirely on the prefix list staying in sync. This test is what notices if that stops being true.

## Verification

- `tsc --noEmit` clean
- `biome check src` clean (677 files)
- `vitest run src/contexts src/utils src/components` — 3626 passed, 49 skipped, 181 files. The one failing suite is `trezorAdapter.emulator.test.ts`, which needs an emulator on `localhost:9001` and fails the same way on `main`.
- `wxt build` succeeds
- `playwright test e2e/pages/compose/send` — 26 passed (covers the MPMA review change)

https://claude.ai/code/session_01CcjnCrgosSeshymXLBxdGj
