### PR TITLE
Stop an unreadable quantity from certifying a message as verified

### DIFF
--- a/src/utils/blockchain/counterparty/unpack/__tests__/verifyTypes.test.ts
+++ b/src/utils/blockchain/counterparty/unpack/__tests__/verifyTypes.test.ts
@@ -53,6 +53,35 @@ describe('verifyTransaction activation per type', () => {
     });
   });
 
+  describe('unreadable quantities', () => {
+    const message = PREFIX + '6e' + u64(1n) + u64(100000000n); // destroy, XCP, 1 XCP
+
+    // toBigInt used to answer 0n for anything BigInt() could not parse, which conflated
+    // "could not read this" with "this is zero" and broke the comparison in both directions.
+
+    // The half that costs security: two unreadable values compared equal and certified each
+    // other, so a tampered message passed as verified.
+    it('does not let an unreadable request certify a message', () => {
+      const r = verifyTransaction(message, 'destroy', { asset: 'XCP', quantity: 'not-a-number' });
+      expect(r.valid).toBe(false);
+      expect(r.criticalMismatches.some((m) => m.field === 'quantity')).toBe(true);
+    });
+
+    it('does not treat an unreadable value as zero', () => {
+      // Against a message carrying zero, the old sentinel made these compare equal.
+      const zeroMessage = PREFIX + '6e' + u64(1n) + u64(0n);
+      const r = verifyTransaction(zeroMessage, 'destroy', { asset: 'XCP', quantity: '1.5' });
+      expect(r.valid).toBe(false);
+    });
+
+    // The other half: a readable request must still verify normally, in either spelling.
+    it('still accepts a quantity given as a numeric string', () => {
+      const r = verifyTransaction(message, 'destroy', { asset: 'XCP', quantity: '100000000' });
+      expect(r.errors).toHaveLength(0);
+      expect(r.valid).toBe(true);
+    });
+  });
+
   describe('dispenser', () => {
     // type 12: asset, give_quantity, escrow_quantity, mainchainrate, status
     const message = PREFIX + '0c' + u64(1n) + u64(100n) + u64(1000n) + u64(1000000n) + '00';

--- a/src/utils/blockchain/counterparty/unpack/verify.ts
+++ b/src/utils/blockchain/counterparty/unpack/verify.ts
@@ -184,15 +184,21 @@ export interface VerificationResult {
 /**
  * Normalize quantity to bigint for comparison
  */
-function toBigInt(value: number | string | bigint | boolean | undefined | null): bigint {
+function toBigInt(value: number | string | bigint | boolean | undefined | null): bigint | null {
   if (value === undefined || value === null) return 0n;
   if (typeof value === 'boolean') return value ? 1n : 0n;
   if (typeof value === 'bigint') return value;
-  if (typeof value === 'number') return BigInt(Math.floor(value));
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? BigInt(Math.floor(value)) : null;
+  }
   try {
     return BigInt(value);
   } catch {
-    return 0n;
+    // null, not 0n. Returning zero here conflated "could not read this" with "this is zero", and
+    // that broke the comparison in both directions: one unreadable side produced a spurious
+    // critical mismatch against a real quantity, and two unreadable sides compared equal and
+    // certified each other as verified. A value we cannot read must never stand in for one we can.
+    return null;
   }
 }
 
@@ -237,7 +243,11 @@ function valuesEqual(a: unknown, b: unknown): boolean {
   // Handle numbers/bigints/strings that represent quantities
   if (typeof a === 'bigint' || typeof b === 'bigint' ||
       typeof a === 'number' || typeof b === 'number') {
-    return toBigInt(a as string | number | bigint) === toBigInt(b as string | number | bigint);
+    // Same shape as the boolean branch above: an unreadable value is never equal to anything,
+    // including another unreadable one, so it is reported as a mismatch rather than a match.
+    const numA = toBigInt(a as string | number | bigint);
+    const numB = toBigInt(b as string | number | bigint);
+    return numA !== null && numB !== null && numA === numB;
   }
 
   // Handle strings (addresses, assets, etc.)


### PR DESCRIPTION
Found auditing `verify.ts` for over-blocking. The audit's conclusion was that the file is already unusually careful — `verifyOptional` explicitly declines to compare fields the server fills in, and `valuesEqual` normalises absence, boolean spellings and bigint/number/string. But every quantity comparison funnels through one primitive, and that primitive had the wrong failure value.

## The bug

```js
try { return BigInt(value); } catch { return 0n; }
```

`0n` conflates *"could not read this"* with *"this is zero"*, and that breaks the comparison in **both** directions.

**Costs security.** A request whose quantity doesn't parse became `0n`. Against a message carrying zero, the two compared **equal** — so the message passed as verified with nothing actually checked. Two unreadable values certified each other.

**Costs usability.** Against a non-zero message, the same `0n` produced a **critical** mismatch and refused to sign a transaction that may have been perfectly fine.

## The fix

`toBigInt` returns `null` when it can't read a value, and `valuesEqual` treats `null` as never equal to anything — including another `null`. That mirrors the boolean branch immediately above it, which already refused to coerce unrecognised spellings:

```js
return boolA !== null && boolB !== null && boolA === boolB;   // existing
return numA  !== null && numB  !== null && numA  === numB;    // now matches
```

Non-finite numbers get the same treatment instead of being pushed through `Math.floor`.

**Absent values are untouched:** `undefined`, `null` and `''` still mean "not provided" and still compare equal to each other, so a blank form field doesn't read as a difference. That was the existing protection against false mismatches and it stays.

## Tests

Three cases, and I'd rather be precise about which were red:

- **`does not treat an unreadable value as zero`** — an unreadable request against a zero-quantity message. **This one fails against the old sentinel.** It's the security half.
- `does not let an unreadable request certify a message` and `still accepts a quantity given as a numeric string` — both passed before and after. They guard the directions that already worked so the fix can't regress them, but they didn't demonstrate the bug.

## Verification

- `tsc --noEmit` clean; `biome check src` clean (675 files)
- `vitest run src/utils/blockchain/counterparty` — 676 passed, 35 skipped, 32 files
- `wxt build` succeeds
- `playwright test e2e/pages/compose/send/index.spec.ts` — 20 passed, including "review page shows correct transaction details"

## Left open from the same audit

`verifyTransaction` has no top-level `try`/`catch`, so any unexpected throw propagates and `composer-context` turns it into a blocked signature. Fail-closed is right for signing, but it means a parsing bug anywhere in this file becomes *"user cannot transact"* rather than *"user sees a warning"*. Not changed here — that's a deliberate policy call rather than a fix.

https://claude.ai/code/session_01CcjnCrgosSeshymXLBxdGj
