### PR TITLE
Release 0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "xcp-wallet",
   "description": "Counterparty Web3 Wallet",
   "private": true,
-  "version": "0.6.2",
+  "version": "0.7.0",
   "license": "MIT",
   "type": "module",
   "engines": {


### PR DESCRIPTION
Version bump for the 0.7.0 release. Draft release notes and package are staged at the releases page.

wxt reads the version from package.json, so this also names the built zip and the manifest.