### PR TITLE
Parse MPMA CSV with the module written for it

### DIFF
--- a/src/pages/compose/send/mpma/__tests__/form.test.tsx
+++ b/src/pages/compose/send/mpma/__tests__/form.test.tsx
@@ -185,7 +185,42 @@ describe('MPMAForm', () => {
     });
     
     await waitFor(() => {
-      expect(screen.getByText(/Invalid quantity/)).toBeInTheDocument();
+      // parseCSV reports why rather than just that it is invalid
+      expect(screen.getByText(/Quantity must be a number/)).toBeInTheDocument();
+    });
+  });
+
+  // These are what routing the parse through parseCSV buys: the hand-rolled loop it replaced
+  // accepted both without comment.
+  it('rejects a row carrying a spreadsheet formula', async () => {
+    renderWithProvider();
+
+    const textArea = screen.getByPlaceholderText('Paste CSV data here…');
+    fireEvent.paste(textArea, {
+      clipboardData: {
+        getData: () => 'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq,=cmd|calc,1'
+      }
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/injection/i)).toBeInTheDocument();
+    });
+  });
+
+  it('parses a quoted memo containing a comma as one field', async () => {
+    renderWithProvider();
+
+    const textArea = screen.getByPlaceholderText('Paste CSV data here…');
+    fireEvent.paste(textArea, {
+      clipboardData: {
+        getData: () => 'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq,XCP,1,"a,b"'
+      }
+    });
+
+    // A memo split on the comma would have produced a fourth column and a different memo;
+    // reaching the review table at all means the quoted field survived intact.
+    await waitFor(() => {
+      expect(screen.queryByText(/Invalid|error/i)).not.toBeInTheDocument();
     });
   });
 

--- a/src/pages/compose/send/mpma/form.tsx
+++ b/src/pages/compose/send/mpma/form.tsx
@@ -7,6 +7,11 @@ import { useComposer } from "@/contexts/composer-context-object";
 import { fetchAssetDetails } from "@/core/counterparty/api";
 import { isHexMemo, isValidMemoLength, stripHexPrefix } from "@/core/counterparty/memo";
 import { validateBitcoinAddress } from "@/core/validation/bitcoin";
+import { parseCSV } from "@/core/validation/csv";
+import { validateFile } from "@/core/validation/file";
+
+/** Bounds the CSV read; parseCSV caps rows at 10000, which is well under this. */
+const MAX_CSV_SIZE_KB = 2048;
 
 interface ParsedRow {
   address: string;
@@ -48,54 +53,26 @@ export function MPMAForm({
     setValidationError(null);
     
     try {
-      const lines = text.trim().split('\n');
+      // parseCSV owns turning text into rows: it normalises line endings, parses quoted values
+      // properly, caps the row count and rejects spreadsheet formula injection - none of which the
+      // hand-rolled loop here did. Address checking is left off so the checksum-validating
+      // validateBitcoinAddress below runs instead of the module's format-only test.
+      const parsed = parseCSV(text, { validateAddresses: false });
+      if (!parsed.success || !parsed.rows) {
+        throw new Error(parsed.errorLine ? `Line ${parsed.errorLine}: ${parsed.error}` : parsed.error ?? 'Invalid CSV');
+      }
+
       const parsedRows: ParsedRow[] = [];
       const assetCache: { [key: string]: boolean } = {};
-      
-      // Check if first line is a header and skip it
-      let startIndex = 0;
-      if (lines.length > 0) {
-        const firstLine = lines[0]!.toLowerCase().replace(/["\s]/g, '');
-        if (firstLine.includes('address') && firstLine.includes('asset') && firstLine.includes('quantity')) {
-          startIndex = 1; // Skip header row
-        }
-      }
-      
-      for (let i = startIndex; i < lines.length; i++) {
-        const line = lines[i]!.trim();
-        if (!line) continue; // Skip empty lines
-        
-        // Parse CSV line (handle quoted values with commas)
-        const parts = line.match(/(".*?"|[^,]+)(?=\s*,|\s*$)/g)?.map(part => 
-          part.replace(/^"|"$/g, '').trim()
-        ) || [];
-        
-        // Calculate actual line number for error messages (accounting for header if skipped)
-        const lineNum = startIndex > 0 ? i : i + 1;
-        
-        if (parts.length < 3) {
-          throw new Error(`Line ${lineNum}: Invalid format. Expected at least Address, Asset, Quantity`);
-        }
-        
-        const [address, asset, quantity, memo] = parts;
-        
-        // Validate address
-        const addressValidation = validateBitcoinAddress(address!);
+
+      for (const row of parsed.rows) {
+        const { address, asset, quantity, memo, lineNumber } = row;
+
+        const addressValidation = validateBitcoinAddress(address);
         if (!addressValidation.isValid) {
-          throw new Error(`Line ${lineNum}: Invalid Bitcoin address: ${address}. ${addressValidation.error || ''}`);
+          throw new Error(`Line ${lineNumber}: Invalid Bitcoin address: ${address}. ${addressValidation.error || ''}`);
         }
-        
-        // Validate asset
-        if (!asset || asset.length === 0) {
-          throw new Error(`Line ${lineNum}: Asset is required`);
-        }
-        
-        // Validate quantity
-        const quantityNum = parseFloat(quantity!);
-        if (isNaN(quantityNum) || quantityNum <= 0) {
-          throw new Error(`Line ${lineNum}: Invalid quantity: ${quantity}`);
-        }
-        
+
         // Check asset divisibility (cache results)
         let isDivisible = true;
         if (asset !== 'BTC') {
@@ -104,30 +81,29 @@ export function MPMAForm({
               const assetInfo = await fetchAssetDetails(asset);
               assetCache[asset] = assetInfo?.divisible ?? false;
             } catch (_e) {
-              // If we can't get asset info, assume divisible for now
-              // The API will validate properly later
+              // If we cannot get asset info, assume divisible; the API validates properly later
               assetCache[asset] = true;
             }
           }
           isDivisible = assetCache[asset]!;
         }
-        
+
         // Validate memo length if provided
         if (memo) {
           const isHex = isHexMemo(memo);
           const memoToValidate = isHex ? stripHexPrefix(memo) : memo;
           if (!isValidMemoLength(memoToValidate, isHex)) {
-            throw new Error(`Line ${lineNum}: Memo exceeds 34 bytes`);
+            throw new Error(`Line ${lineNumber}: Memo exceeds 34 bytes`);
           }
         }
-        
+
         parsedRows.push({
-          address: address!,
+          address,
           asset,
-          quantity: quantity!,
+          quantity,
           memo,
           isDivisible,
-          originalQuantity: quantity!
+          originalQuantity: quantity
         });
       }
       
@@ -150,8 +126,17 @@ export function MPMAForm({
     const file = e.target.files?.[0];
     if (!file) return;
     
-    if (!file.name.endsWith('.csv')) {
-      setValidationError('Please select a CSV file');
+    // Bounded before the whole file is read into memory. parseCSV caps rows, but that only
+    // applies once the text exists, and nothing capped the bytes. detectMaliciousPatterns is left
+    // off deliberately: parseCSV already screens every field for injection, which covers the whole
+    // file rather than the first kilobyte, and a scan for script markers could trip on a memo.
+    const fileCheck = await validateFile(file, {
+      maxSizeKB: MAX_CSV_SIZE_KB,
+      allowedExtensions: ['.csv'],
+      detectMaliciousPatterns: false,
+    });
+    if (!fileCheck.isValid) {
+      setValidationError(fileCheck.error ?? 'Please select a CSV file');
       return;
     }
     


### PR DESCRIPTION
Stacked on #247. Wires up the two validators #246 deliberately left undeleted — and finds that one of them must **not** go where I first said.

## csv.ts → MPMA parsing

The form parsed CSV with `line.match(/(".*?"|[^,]+)(?=\s*,|\s*$)/g)` over `text.split('\n')`. `parseCSV` replaces that and adds what the loop never had:

- **formula-injection rejection** — a row containing `=cmd|calc` was accepted before
- **a row cap** (10,000)
- **real quoted-field parsing**

Address checking is left **off** (`validateAddresses: false`) so the form's existing `validateBitcoinAddress` — which verifies the checksum — keeps running instead of the module's format-only test. The divisibility lookup and memo-length check are untouched.

**One message changed.** An unparseable quantity now reads *"Quantity must be a number"* rather than *"Invalid quantity"* — it says why rather than only that. The test asserting the old wording is updated.

## file.ts → the CSV upload, not the inscription upload

The CSV upload had **no size limit at all** — only `file.name.endsWith('.csv')`, then the whole file was read into memory regardless of size. `validateFile` now bounds it at 2 MB and owns the extension check.

`detectMaliciousPatterns` is deliberately **off**: `parseCSV` already screens every field for injection, which covers the whole file rather than the first kilobyte, and a script-marker scan could trip on a legitimate memo.

## Why file.ts is *not* wired into inscriptions

I said earlier that `file-upload-input.tsx` "validates nothing" and the inscription path was a gap. **Checking the module changed that conclusion.**

`detectMaliciousContent` rejects any `text/*` file containing `<script`, `<iframe` or `javascript:`. An HTML inscription carrying a script tag is *exactly what that feature publishes* — wiring this in would have broken inscriptions, which only started working in 0.7.0. Its type and extension checks are wrong there for the same reason: an inscription is arbitrary content by definition.

The size-only check those forms do is **correct**. `file.ts` was written for uploads that should be constrained; inscriptions aren't.

## Tests

Two new cases covering exactly what the change buys:
- a row carrying `=cmd|calc` is rejected
- a quoted memo containing a comma survives as one field rather than splitting into a fourth column

## Verification

- `tsc --noEmit` clean; `biome check src` clean (672 files)
- `vitest run src` — 3965 passed, 49 skipped
- `wxt build` succeeds
- `playwright test e2e/pages/compose/send/mpma.spec.ts` — 6 passed