### PR TITLE
Add the bare multisig actions, rebased onto the current tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xcp-wallet",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xcp-wallet",
-      "version": "0.6.2",
+      "version": "0.7.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/src/components/domain/address/destinations-input.tsx
+++ b/src/components/domain/address/destinations-input.tsx
@@ -2,7 +2,7 @@ import { Description, Field, Input, Label } from "@headlessui/react";
 import { type ReactElement, useEffect, useRef, useState } from "react";
 import { FiMinus, FiPlus } from "@/components/icons";
 import { lookupAssetOwner, shouldTriggerAssetLookup } from "@/core/validation/assetOwner";
-import { validateBitcoinAddress } from "@/core/validation/bitcoin";
+import { isMultisigAddress, validateBitcoinAddress } from "@/core/validation/bitcoin";
 import { type Destination, isMPMASupported, parseMultiLineDestinations, validateDestinations } from "@/core/validation/destinations";
 import { useMultiAssetOwnerLookup } from "@/hooks/useAssetOwnerLookup";
 
@@ -146,7 +146,8 @@ export function DestinationsInput({
     }
   };
 
-  const showAddButton = isMPMASupported(asset) && enableMPMA && destinations.length < 1000;
+  const hasMultisig = destinations.some(d => d.address && isMultisigAddress(d.address));
+  const showAddButton = isMPMASupported(asset) && enableMPMA && destinations.length < 1000 && !hasMultisig;
   const canRemove = destinations.length > 1;
 
   return (

--- a/src/core/bitcoin/__tests__/multisigSignatures.test.ts
+++ b/src/core/bitcoin/__tests__/multisigSignatures.test.ts
@@ -1,0 +1,113 @@
+import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
+import * as secp from '@noble/secp256k1';
+import { SigHash, Transaction } from '@scure/btc-signer';
+import { describe, expect, it } from 'vitest';
+import {
+  buildBareMultisigScript,
+  legacySighashForTest,
+  verifyMultisigSignatures,
+} from '@/core/bitcoin/multisigSignatures';
+
+/**
+ * Signatures are produced here rather than pasted as fixtures, so the test proves the verifier
+ * agrees with a real signing operation instead of agreeing with a blob someone recorded.
+ */
+const KEY_A = hexToBytes('1'.repeat(64));
+const KEY_B = hexToBytes('2'.repeat(64));
+const PUB_A = secp.getPublicKey(KEY_A, true);
+const PUB_B = secp.getPublicKey(KEY_B, true);
+const SCRIPT = buildBareMultisigScript([PUB_A, PUB_B], 2);
+const PREV_TXID = 'ab'.repeat(32);
+
+/** Re-encode a compact (r||s) signature as DER, which is what a scriptSig carries. */
+function toDer(compact: Uint8Array): Uint8Array {
+  const trim = (v: Uint8Array) => {
+    let i = 0;
+    while (i < v.length - 1 && v[i] === 0) i += 1;
+    const t = v.slice(i);
+    return t[0]! & 0x80 ? new Uint8Array([0, ...t]) : t;
+  };
+  const r = trim(compact.slice(0, 32));
+  const s = trim(compact.slice(32, 64));
+  return new Uint8Array([0x30, 4 + r.length + s.length, 0x02, r.length, ...r, 0x02, s.length, ...s]);
+}
+
+/** An unsigned transaction spending one bare multisig input. */
+function unsignedTx(outputAmount: bigint): string {
+  const tx = new Transaction({
+    allowUnknownInputs: true,
+    allowUnknownOutputs: true,
+    disableScriptCheck: true,
+    allowLegacyWitnessUtxo: true,
+  });
+  tx.addInput({ txid: hexToBytes(PREV_TXID), index: 0, sequence: 0xffffffff });
+  tx.addOutput({
+    script: hexToBytes('76a914' + '11'.repeat(20) + '88ac'),
+    amount: outputAmount,
+  });
+  return bytesToHex(tx.toBytes(true, false));
+}
+
+/** Sign an input the way a counterparty would, returning DER plus the sighash byte. */
+function sign(rawTxHex: string, key: Uint8Array, index = 0): Uint8Array {
+  const tx = Transaction.fromRaw(hexToBytes(rawTxHex), {
+    allowUnknownInputs: true,
+    allowUnknownOutputs: true,
+    disableScriptCheck: true,
+    allowLegacyWitnessUtxo: true,
+  });
+  const sighash = legacySighashForTest(tx, index, SCRIPT, SigHash.ALL);
+  const compact = secp.sign(sighash, key);
+  return new Uint8Array([...toDer(compact), SigHash.ALL]);
+}
+
+describe('verifying bare multisig signatures before combining', () => {
+  const raw = unsignedTx(100000n);
+
+  it('accepts signatures genuinely made for this transaction', () => {
+    const result = verifyMultisigSignatures(raw, 0, [PUB_A, PUB_B], [sign(raw, KEY_A), sign(raw, KEY_B)], 2);
+    expect(result.error).toBeUndefined();
+    expect(result.ok).toBe(true);
+  });
+
+  // The check that matters: a signature over a different transaction must not pass, or the
+  // feature would be certifying an authorship claim it never verified.
+  it('rejects a signature made for a different transaction', () => {
+    const other = unsignedTx(999999n);
+    const result = verifyMultisigSignatures(raw, 0, [PUB_A, PUB_B], [sign(raw, KEY_A), sign(other, KEY_B)], 2);
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/Signature 2/);
+  });
+
+  it('rejects a signature from the wrong key', () => {
+    const stranger = hexToBytes('3'.repeat(64));
+    const result = verifyMultisigSignatures(raw, 0, [PUB_A, PUB_B], [sign(raw, KEY_A), sign(raw, stranger)], 2);
+    expect(result.ok).toBe(false);
+  });
+
+  // A bare multisig scriptSig must present signatures in pubkey order; swapping them produces a
+  // script the network rejects, so it is caught here rather than after broadcast.
+  it('rejects signatures paired with the wrong keys', () => {
+    const result = verifyMultisigSignatures(raw, 0, [PUB_A, PUB_B], [sign(raw, KEY_B), sign(raw, KEY_A)], 2);
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects a sighash type other than ALL', () => {
+    const sig = sign(raw, KEY_A);
+    sig[sig.length - 1] = SigHash.SINGLE;
+    const result = verifyMultisigSignatures(raw, 0, [PUB_A, PUB_B], [sig, sign(raw, KEY_B)], 2);
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/SIGHASH_ALL/);
+  });
+
+  it('rejects a truncated signature rather than reading past it', () => {
+    const result = verifyMultisigSignatures(raw, 0, [PUB_A, PUB_B], [new Uint8Array([1, 2, 3]), sign(raw, KEY_B)], 2);
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects an input index the transaction does not have', () => {
+    const result = verifyMultisigSignatures(raw, 5, [PUB_A, PUB_B], [sign(raw, KEY_A), sign(raw, KEY_B)], 2);
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/does not exist/);
+  });
+});

--- a/src/core/bitcoin/bip322.ts
+++ b/src/core/bitcoin/bip322.ts
@@ -775,7 +775,8 @@ export async function verifyBIP322Signature(
 /**
  * Parse DER-encoded signature
  */
-function parseDERSignature(der: Uint8Array): Uint8Array | null {
+/** Exported for the multisig combine path, which receives DER signatures from a counterparty. */
+export function parseDERSignature(der: Uint8Array): Uint8Array | null {
   try {
     // Basic DER structure validation
     if (der[0] !== 0x30) return null;

--- a/src/core/bitcoin/buildBareMultisigFunding.ts
+++ b/src/core/bitcoin/buildBareMultisigFunding.ts
@@ -1,0 +1,197 @@
+/**
+ * Builds an unsigned raw transaction that funds a bare multisig (P2MS) output.
+ *
+ * The signed result comes from walletService.signTransaction() which already
+ * handles bare multisig outputs via signWithBareMultisigOutputs().
+ */
+
+import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
+import { Address, NETWORK, OutScript, RawTx } from '@scure/btc-signer';
+import { getInputSizeForAddress } from '@/core/bitcoin/feeEstimation';
+import { selectUtxosForTransaction } from '@/core/counterparty/utxoSelection';
+
+export interface BuildBareMultisigFundingParams {
+  pubkeys: Uint8Array[];
+  m: number;
+  amountSats: number;
+  feeRate: number;
+  sourceAddress: string;
+}
+
+export interface BuildBareMultisigFundingResult {
+  unsignedTxHex: string;
+  multisigScriptHex: string;
+  fee: number;
+  changeAmount: number;
+}
+
+const DUST_LIMIT = 546;
+
+/**
+ * Validates a hex-encoded public key string and returns the byte array.
+ * Accepts compressed (33 bytes, prefix 02/03) or uncompressed (65 bytes, prefix 04).
+ */
+export function validatePubkey(hex: string): Uint8Array {
+  const clean = hex.startsWith('0x') ? hex.slice(2) : hex;
+
+  if (!/^[0-9a-fA-F]+$/.test(clean)) {
+    throw new Error(`Invalid hex characters in pubkey: ${hex}`);
+  }
+
+  if (clean.length !== 66 && clean.length !== 130) {
+    throw new Error(
+      `Invalid pubkey length: expected 66 (compressed) or 130 (uncompressed) hex chars, got ${clean.length}`
+    );
+  }
+
+  const prefix = clean.slice(0, 2).toLowerCase();
+  if (clean.length === 66 && prefix !== '02' && prefix !== '03') {
+    throw new Error(`Invalid compressed pubkey prefix: expected 02 or 03, got ${prefix}`);
+  }
+  if (clean.length === 130 && prefix !== '04') {
+    throw new Error(`Invalid uncompressed pubkey prefix: expected 04, got ${prefix}`);
+  }
+
+  return hexToBytes(clean);
+}
+
+/**
+ * Returns the change output size in bytes based on address type.
+ */
+function getChangeOutputSize(address: string): number {
+  if (address.startsWith('bc1p') || address.startsWith('tb1p')) return 43; // P2TR
+  if (address.startsWith('bc1q') || address.startsWith('tb1q')) return 31; // P2WPKH
+  if (address.startsWith('3') || address.startsWith('2')) return 32;      // P2SH
+  return 34; // P2PKH
+}
+
+/**
+ * Builds an unsigned transaction that creates a bare multisig (P2MS) output.
+ */
+export async function buildBareMultisigFunding(
+  params: BuildBareMultisigFundingParams
+): Promise<BuildBareMultisigFundingResult> {
+  const { pubkeys, m, amountSats, feeRate, sourceAddress } = params;
+
+  if (pubkeys.length < 2 || pubkeys.length > 3) {
+    throw new Error('Bare multisig requires 2 or 3 public keys');
+  }
+  if (m < 1 || m > pubkeys.length) {
+    throw new Error(`m must be between 1 and ${pubkeys.length}`);
+  }
+  if (amountSats <= 0) {
+    throw new Error('Amount must be positive');
+  }
+  if (feeRate <= 0) {
+    throw new Error('Fee rate must be positive');
+  }
+
+  // Build P2MS output script
+  const multisigScript = OutScript.encode({ type: 'ms', pubkeys, m });
+
+  // Build change script from source address
+  // Address().decode widened to include an undefined branch in newer @scure/btc-signer, so an
+  // undecodable source is rejected here rather than passed into OutScript.encode.
+  const decoded = Address(NETWORK).decode(sourceAddress);
+  if (!decoded) {
+    throw new Error(`Could not decode source address: ${sourceAddress}`);
+  }
+  const changeScript = OutScript.encode(decoded);
+
+  // Fetch UTXOs
+  const { utxos } = await selectUtxosForTransaction(sourceAddress, {
+    allowUnconfirmed: true,
+  });
+
+  if (utxos.length === 0) {
+    throw new Error('No UTXOs available');
+  }
+
+  // utxos are already sorted highest-first by selectUtxosForTransaction
+  const inputSize = getInputSizeForAddress(sourceAddress);
+  const multisigOutputSize = 8 + 1 + multisigScript.length;
+  const changeOutputSize = getChangeOutputSize(sourceAddress);
+  const overhead = 10;
+
+  // Coin selection: accumulate inputs until we cover amount + fee
+  const selectedUtxos: typeof utxos = [];
+  let totalInput = 0;
+
+  for (const utxo of utxos) {
+    selectedUtxos.push(utxo);
+    totalInput += utxo.value;
+
+    const vsizeWithChange = overhead
+      + selectedUtxos.length * inputSize
+      + multisigOutputSize
+      + changeOutputSize;
+    const feeWithChange = Math.ceil(vsizeWithChange * feeRate);
+
+    if (totalInput >= amountSats + feeWithChange) {
+      break;
+    }
+  }
+
+  // Determine outputs, fee, and change
+  const vsizeWithChange = overhead
+    + selectedUtxos.length * inputSize
+    + multisigOutputSize
+    + changeOutputSize;
+  const feeWithChange = Math.ceil(vsizeWithChange * feeRate);
+
+  let fee: number;
+  let changeAmount: number;
+  const outputs: { amount: bigint; script: Uint8Array }[] = [
+    { amount: BigInt(amountSats), script: multisigScript },
+  ];
+
+  if (totalInput < amountSats + feeWithChange) {
+    // Can't afford a change output — check if we can cover without one
+    const vsizeNoChange = overhead
+      + selectedUtxos.length * inputSize
+      + multisigOutputSize;
+    const feeNoChange = Math.ceil(vsizeNoChange * feeRate);
+
+    if (totalInput < amountSats + feeNoChange) {
+      throw new Error(
+        `Insufficient funds: have ${totalInput} sats, need ${amountSats + feeNoChange} sats (including fee)`
+      );
+    }
+
+    fee = totalInput - amountSats;
+    changeAmount = 0;
+  } else {
+    const change = totalInput - amountSats - feeWithChange;
+
+    if (change < DUST_LIMIT) {
+      // Dust change — fold into fee
+      fee = totalInput - amountSats;
+      changeAmount = 0;
+    } else {
+      outputs.push({ amount: BigInt(change), script: changeScript });
+      fee = feeWithChange;
+      changeAmount = change;
+    }
+  }
+
+  const encoded = RawTx.encode({
+    version: 2,
+    segwitFlag: false,
+    inputs: selectedUtxos.map(utxo => ({
+      txid: hexToBytes(utxo.txid),
+      index: utxo.vout,
+      finalScriptSig: new Uint8Array(0),
+      sequence: 0xfffffffd,
+    })),
+    outputs,
+    witnesses: [],
+    lockTime: 0,
+  });
+
+  return {
+    unsignedTxHex: bytesToHex(encoded),
+    multisigScriptHex: bytesToHex(multisigScript),
+    fee,
+    changeAmount,
+  };
+}

--- a/src/core/bitcoin/multisigSignatures.ts
+++ b/src/core/bitcoin/multisigSignatures.ts
@@ -1,0 +1,195 @@
+import { sha256 } from '@noble/hashes/sha2.js';
+import { hexToBytes } from '@noble/hashes/utils.js';
+import * as secp from '@noble/secp256k1';
+import { OutScript, SigHash, Transaction } from '@scure/btc-signer';
+import { parseDERSignature } from '@/core/bitcoin/bip322';
+
+/**
+ * Check that a signature was really produced for this transaction by this key.
+ *
+ * Combining signatures is the one place the wallet is handed material it did not create: the
+ * counterparty's signature arrives as a hex blob, out of band, from someone the wallet cannot
+ * ask. Pasting it into a scriptSig and broadcasting means trusting that blob.
+ *
+ * It does not have to. A bare multisig signature commits to the legacy sighash of a specific
+ * input of a specific transaction, so the same signature cannot be valid for different outputs.
+ * Recomputing that sighash and verifying against the claimed public key turns "this looks like a
+ * signature" into "this key signed exactly this transaction" — which is the claim the feature
+ * exists to make. A signature that does not verify is refused rather than broadcast to fail on
+ * the network, where the reason would be far less legible.
+ */
+
+export interface SignatureCheck {
+  ok: boolean;
+  error?: string;
+}
+
+/** DER signature followed by the one-byte sighash flag, as it appears in a scriptSig. */
+function splitDerAndSighashType(signature: Uint8Array): { der: Uint8Array; hashType: number } | null {
+  if (signature.length < 9) return null;
+  return {
+    der: signature.slice(0, -1),
+    hashType: signature[signature.length - 1]!,
+  };
+}
+
+/**
+ * Rebuild the m-of-n script the signatures commit to. The prevout is not in the unsigned
+ * transaction, but a bare multisig script is exactly its pubkeys and threshold, both of which the
+ * caller supplies — so it can be reconstructed rather than trusted.
+ */
+export function buildBareMultisigScript(pubkeys: Uint8Array[], m: number): Uint8Array {
+  return OutScript.encode({ type: 'ms', m, pubkeys });
+}
+
+/**
+ * The legacy (pre-segwit) signature hash, which is what a bare multisig input is signed with.
+ *
+ * Built from the public serialisation rather than @scure's preimageLegacy, which is private in
+ * its types: depending on an unexported method would put a signing-path check one minor version
+ * away from breaking. The algorithm is small and fixed - every input's scriptSig is cleared, the
+ * one being signed carries the script instead, and the four-byte hash type is appended before a
+ * double SHA-256.
+ */
+function legacySighash(
+  source: Transaction,
+  inputIndex: number,
+  script: Uint8Array,
+  hashType: number
+): Uint8Array {
+  const copy = new Transaction({
+    version: source.version,
+    lockTime: source.lockTime,
+    allowUnknownInputs: true,
+    allowUnknownOutputs: true,
+    allowLegacyWitnessUtxo: true,
+    disableScriptCheck: true,
+    allowUnknown: true,
+  });
+
+  // Outputs first: setting a scriptSig below marks the transaction as signed, after which
+  // @scure refuses to accept new outputs.
+  for (let i = 0; i < source.outputsLength; i += 1) {
+    const output = source.getOutput(i);
+    copy.addOutput({ script: output.script!, amount: output.amount! });
+  }
+  for (let i = 0; i < source.inputsLength; i += 1) {
+    const input = source.getInput(i);
+    copy.addInput({
+      txid: input.txid!,
+      index: input.index!,
+      sequence: input.sequence ?? 0xffffffff,
+      // Only the input being signed carries a script; the rest are emptied.
+      ...(i === inputIndex ? { finalScriptSig: script } : {}),
+    });
+  }
+
+  const serialized = copy.toBytes(true, false);
+  const withHashType = new Uint8Array(serialized.length + 4);
+  withHashType.set(serialized);
+  new DataView(withHashType.buffer).setUint32(serialized.length, hashType, true);
+  return sha256(sha256(withHashType));
+}
+
+/**
+ * Verify one signature against the transaction's own sighash for the given input.
+ *
+ * @param rawTxHex   the transaction the signature is claimed to be for
+ * @param inputIndex which input the multisig script secures
+ * @param script     the bare multisig script, from buildBareMultisigScript
+ * @param signature  DER signature with its trailing sighash byte
+ * @param pubkey     the key the signature is claimed to come from
+ */
+export function verifyMultisigSignature(
+  rawTxHex: string,
+  inputIndex: number,
+  script: Uint8Array,
+  signature: Uint8Array,
+  pubkey: Uint8Array
+): SignatureCheck {
+  const split = splitDerAndSighashType(signature);
+  if (!split) {
+    return { ok: false, error: 'Signature is too short to be a DER signature with a sighash byte.' };
+  }
+  if (split.hashType !== SigHash.ALL) {
+    // Anything else commits to a subset of the transaction, so combining it would let the parts
+    // not covered be changed after signing.
+    return { ok: false, error: `Signature uses sighash 0x${split.hashType.toString(16)}; only SIGHASH_ALL is accepted here.` };
+  }
+
+  let tx: Transaction;
+  try {
+    tx = Transaction.fromRaw(hexToBytes(rawTxHex.replace(/^0x/, '')), {
+      allowUnknownInputs: true,
+      allowUnknownOutputs: true,
+      allowLegacyWitnessUtxo: true,
+      disableScriptCheck: true,
+    });
+  } catch {
+    return { ok: false, error: 'The transaction could not be read.' };
+  }
+
+  if (inputIndex < 0 || inputIndex >= tx.inputsLength) {
+    return { ok: false, error: `Input ${inputIndex} does not exist in this transaction.` };
+  }
+
+  let sighash: Uint8Array;
+  try {
+    sighash = legacySighash(tx, inputIndex, script, split.hashType);
+  } catch {
+    return { ok: false, error: 'The signature hash for this input could not be computed.' };
+  }
+
+  // @noble/secp256k1 v3 verifies compact signatures only, so the DER the wire carries is
+  // converted with the parser the BIP-322 path already uses.
+  const compact = parseDERSignature(split.der);
+  if (!compact) {
+    return { ok: false, error: 'Signature is not valid DER.' };
+  }
+
+  try {
+    if (!secp.verify(compact, sighash, pubkey)) {
+      return { ok: false, error: 'Signature does not match this public key for this transaction.' };
+    }
+  } catch {
+    return { ok: false, error: 'Signature could not be checked; it may be malformed.' };
+  }
+
+  return { ok: true };
+}
+
+/**
+ * Verify every signature, each against the key it is paired with.
+ *
+ * Order matters beyond correctness: a bare multisig scriptSig must present signatures in the same
+ * order as the pubkeys in the script, so pairing them here is also what makes the resulting
+ * scriptSig valid.
+ */
+export function verifyMultisigSignatures(
+  rawTxHex: string,
+  inputIndex: number,
+  pubkeys: Uint8Array[],
+  signatures: Uint8Array[],
+  m: number
+): SignatureCheck {
+  if (signatures.length !== pubkeys.length) {
+    return { ok: false, error: 'Each signature must be paired with the public key that produced it.' };
+  }
+
+  let script: Uint8Array;
+  try {
+    script = buildBareMultisigScript(pubkeys, m);
+  } catch {
+    return { ok: false, error: 'A multisig script could not be built from these public keys.' };
+  }
+
+  for (let i = 0; i < signatures.length; i += 1) {
+    const result = verifyMultisigSignature(rawTxHex, inputIndex, script, signatures[i]!, pubkeys[i]!);
+    if (!result.ok) {
+      return { ok: false, error: `Signature ${i + 1}: ${result.error}` };
+    }
+  }
+
+  return { ok: true };
+}
+export { legacySighash as legacySighashForTest };

--- a/src/core/counterparty/compose.ts
+++ b/src/core/counterparty/compose.ts
@@ -3,6 +3,7 @@ import { requireCounterpartyFeature } from '@/core/counterparty/capabilities';
 import { selectUtxosForTransaction } from '@/core/counterparty/utxoSelection';
 import { CounterpartyApiError } from '@/core/errors';
 import { getActiveSettings, LEGACY_MAX_ORDER_EXPIRATION, MAX_ORDER_EXPIRATION } from '@/core/settings';
+import { isMultisigAddress } from '@/core/validation/bitcoin';
 
 /**
  * Type guard to check if an error has a response with data
@@ -450,6 +451,37 @@ async function executeWithUtxoFallback(
 // ============================================================================
 
 /**
+ * Adjust compose params when a destination is a multisig address.
+ * Only checks destination-related fields (not memos or other values).
+ *
+ * - 'send': falls back to legacy send and strips memo (enhanced send
+ *   can't pack multisig destinations; legacy sends don't support memos)
+ * - 'sweep': rejects (sweep packs destination in the protocol message)
+ */
+function adjustParamsForMultisig(
+  params: Record<string, unknown>,
+  endpoint: string
+): Record<string, unknown> {
+  const dest = params.destination ?? params.transfer_destination;
+  if (typeof dest !== 'string' || !isMultisigAddress(dest)) {
+    return params;
+  }
+
+  if (endpoint === 'send') {
+    const { memo, memo_is_hex, ...rest } = params;
+    return { ...rest, use_enhanced_send: 'false' };
+  }
+  if (endpoint === 'sweep') {
+    throw new CounterpartyApiError(
+      'Sweep does not support multisig destinations',
+      endpoint,
+      {}
+    );
+  }
+  return params;
+}
+
+/**
  * Compose a transaction via the Counterparty API.
  */
 export async function composeTransaction<T extends Record<string, unknown>>(
@@ -463,9 +495,11 @@ export async function composeTransaction<T extends Record<string, unknown>>(
   const apiUrl = `${base}/v2/addresses/${sourceAddress}/compose/${endpoint}`;
   const settings = getActiveSettings();
 
+  const finalParams = adjustParamsForMultisig(paramsObj, endpoint);
+
   const makeRequest = async ({ inputsSet, allowUnconfirmed }: ComposeRequestOptions): Promise<ApiResponse> => {
     const params = new URLSearchParams(toStringParams({
-      ...paramsObj,
+      ...finalParams,
       sat_per_vbyte: sat_per_vbyte.toString(),
       exclude_utxos_with_balances: 'true',
       allow_unconfirmed_inputs: allowUnconfirmed.toString(),

--- a/src/core/validation/bitcoin.ts
+++ b/src/core/validation/bitcoin.ts
@@ -163,6 +163,53 @@ function validateBech32Address(address: string): AddressValidationResult {
 }
 
 /**
+ * Validate a Counterparty bare multisig address (M_addr1_addr2[_addr3]_N)
+ * See: counterparty-core/counterpartycore/lib/utils/multisig.py
+ */
+function validateMultisigAddress(address: string): AddressValidationResult {
+  const parts = address.split('_');
+
+  // Minimum: M_addr1_addr2_N = 4 parts, Maximum: M_addr1_addr2_addr3_N = 5 parts
+  if (parts.length < 4 || parts.length > 5) {
+    return { isValid: false, error: 'Invalid multisig address format' };
+  }
+
+  const signaturesRequired = parseInt(parts[0]!, 10);
+  const signaturesPossible = parseInt(parts[parts.length - 1]!, 10);
+  const addresses = parts.slice(1, -1);
+
+  if (isNaN(signaturesRequired) || signaturesRequired < 1 || signaturesRequired > 3) {
+    return { isValid: false, error: 'Invalid signatures required (must be 1-3)' };
+  }
+
+  if (isNaN(signaturesPossible) || signaturesPossible < 2 || signaturesPossible > 3) {
+    return { isValid: false, error: 'Invalid signatures possible (must be 2-3)' };
+  }
+
+  if (signaturesRequired > signaturesPossible) {
+    return { isValid: false, error: 'Signatures required cannot exceed signatures possible' };
+  }
+
+  if (addresses.length !== signaturesPossible) {
+    return { isValid: false, error: `Expected ${signaturesPossible} addresses, got ${addresses.length}` };
+  }
+
+  // Validate each individual address and determine network from first
+  let network: 'mainnet' | 'testnet' | 'regtest' | undefined;
+  for (const addr of addresses) {
+    const result = validateBitcoinAddress(addr);
+    if (!result.isValid) {
+      return { isValid: false, error: `Invalid address in multisig: ${result.error}` };
+    }
+    if (!network && result.network) {
+      network = result.network;
+    }
+  }
+
+  return { isValid: true, addressFormat: 'Multisig', network: network ?? 'mainnet' };
+}
+
+/**
  * Validate a Bitcoin address with full checksum verification
  */
 export function validateBitcoinAddress(address: string): AddressValidationResult {
@@ -172,7 +219,7 @@ export function validateBitcoinAddress(address: string): AddressValidationResult
 
   // Remove whitespace
   const cleaned = address.trim();
-  
+
   if (cleaned.length === 0) {
     return { isValid: false, error: 'Address is empty' };
   }
@@ -182,16 +229,21 @@ export function validateBitcoinAddress(address: string): AddressValidationResult
     return { isValid: false, error: 'Invalid characters in address' };
   }
 
+  // Check if it's a Counterparty multisig address (M_addr1_addr2_N format)
+  if (cleaned.includes('_')) {
+    return validateMultisigAddress(cleaned);
+  }
+
   // Check if it's a bech32 address (starts with bc, tb, or bcrt)
   if (/^(bc|tb|bcrt)1[a-z0-9]+$/i.test(cleaned)) {
     return validateBech32Address(cleaned);
   }
-  
+
   // Otherwise try base58 (legacy/p2sh)
   if (/^[1-9A-HJ-NP-Za-km-z]+$/.test(cleaned)) {
     return validateBase58Address(cleaned);
   }
-  
+
   return { isValid: false, error: 'Invalid Bitcoin address format' };
 }
 
@@ -201,4 +253,13 @@ export function validateBitcoinAddress(address: string): AddressValidationResult
  */
 export function isValidBitcoinAddress(address: string): boolean {
   return validateBitcoinAddress(address).isValid;
+}
+
+/**
+ * Check if an address is a Counterparty multisig address (M_addr1_addr2[_addr3]_N)
+ */
+export function isMultisigAddress(address: string): boolean {
+  if (!address || typeof address !== 'string') return false;
+  const result = validateBitcoinAddress(address.trim());
+  return result.isValid && result.addressFormat === 'Multisig';
 }

--- a/src/entrypoints/popup/app.tsx
+++ b/src/entrypoints/popup/app.tsx
@@ -9,11 +9,15 @@ import { KeychainOpenOrNew } from '@/components/router/keychain-open-or-new';
 import { NoKeychainOnly } from '@/components/router/no-keychain-only';
 import { useWallet } from '@/contexts/wallet-context';
 import ActionsPage from '@/pages/actions';
+import BroadcastTransactionPage from '@/pages/actions/broadcast-transaction';
+import CombineSignaturesPage from '@/pages/actions/combine-signatures';
 // Actions
 import ConsolidatePage from '@/pages/actions/consolidate';
 import ConsolidateStatusPage from '@/pages/actions/consolidate/status';
 import ConsolidateSuccessPage from '@/pages/actions/consolidate/success';
+import FundBareMultisigPage from '@/pages/actions/fund-bare-multisig';
 import SignMessagePage from '@/pages/actions/sign-message';
+import SignTransactionPage from '@/pages/actions/sign-transaction';
 import VerifyMessagePage from '@/pages/actions/verify-message';
 // Viewing
 import AddressesPage from '@/pages/addresses';
@@ -173,6 +177,10 @@ export default function App() {
             <Route path="/actions/consolidate/status" element={<ConsolidateStatusPage />} />
             <Route path="/actions/consolidate/success" element={<ConsolidateSuccessPage />} />
             <Route path="/actions/sign-message" element={<SignMessagePage />} />
+            <Route path="/actions/sign-transaction" element={<SignTransactionPage />} />
+            <Route path="/actions/combine-signatures" element={<CombineSignaturesPage />} />
+            <Route path="/actions/broadcast-transaction" element={<BroadcastTransactionPage />} />
+            <Route path="/actions/fund-bare-multisig" element={<FundBareMultisigPage />} />
             <Route path="/actions/verify-message" element={<VerifyMessagePage />} />
 
             <Route path="/settings/address-types" element={<AddressTypesPage />} />

--- a/src/pages/actions/broadcast-transaction.tsx
+++ b/src/pages/actions/broadcast-transaction.tsx
@@ -1,0 +1,187 @@
+import type { ReactElement } from "react";
+import { useCallback, useEffect, useState } from "react";
+import { useNavigate } from "react-router";
+import { FaCheck, FaCheckCircle, FaCopy, FiExternalLink, FiRefreshCw } from "@/components/icons";
+import { Button } from "@/components/ui/button";
+import { ErrorAlert } from "@/components/ui/error-alert";
+import { TextAreaInput } from "@/components/ui/inputs/textarea-input";
+import { useHeader } from "@/contexts/header-context";
+import { broadcastTransaction } from "@/core/bitcoin/transactionBroadcaster";
+
+type CopiedField = "txid" | null;
+
+export default function BroadcastTransactionPage(): ReactElement {
+  const navigate = useNavigate();
+  const { setHeaderProps } = useHeader();
+
+  const [signedTxHex, setSignedTxHex] = useState("");
+  const [isBroadcasting, setIsBroadcasting] = useState(false);
+  const [txid, setTxid] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [copiedField, setCopiedField] = useState<CopiedField>(null);
+
+  const handleReset = useCallback(() => {
+    setSignedTxHex("");
+    setTxid("");
+    setError(null);
+  }, []);
+
+  useEffect(() => {
+    const hasContent = Boolean(signedTxHex || txid || error);
+    setHeaderProps({
+      title: "Broadcast Transaction",
+      onBack: () => navigate(-1),
+      rightButton: {
+        ariaLabel: "Reset form",
+        icon: <FiRefreshCw className="size-4" aria-hidden="true" />,
+        onClick: handleReset,
+        disabled: !hasContent,
+      },
+    });
+    return () => setHeaderProps(null);
+  }, [setHeaderProps, navigate, handleReset, signedTxHex, txid, error]);
+
+  const handleBroadcast = async () => {
+    setError(null);
+    setTxid("");
+
+    const trimmed = signedTxHex.trim();
+    if (!trimmed) {
+      setError("Please enter a signed transaction hex");
+      return;
+    }
+
+    if (!/^[0-9a-fA-F]+$/.test(trimmed)) {
+      setError("Invalid hex string");
+      return;
+    }
+
+    setIsBroadcasting(true);
+
+    try {
+      const result = await broadcastTransaction(trimmed);
+      setTxid(result.txid);
+    } catch (err) {
+      console.error("Failed to broadcast transaction:", err);
+      setError(
+        err instanceof Error ? err.message : "Failed to broadcast transaction"
+      );
+    } finally {
+      setIsBroadcasting(false);
+    }
+  };
+
+  const handleCopy = async (text: string, field: CopiedField) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopiedField(field);
+      setTimeout(() => setCopiedField(null), 1500);
+    } catch {
+      setError("Failed to copy to clipboard");
+    }
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <div className="bg-white rounded-lg shadow-sm p-3 sm:p-4 space-y-4">
+        {/* Input */}
+        <TextAreaInput
+          value={signedTxHex}
+          onChange={(value) => {
+            setSignedTxHex(value);
+            if (txid) setTxid("");
+          }}
+          label="Signed Transaction Hex"
+          placeholder="Paste signed transaction hex here…"
+          rows={4}
+          required={false}
+          showCharCount={false}
+          disabled={isBroadcasting}
+        />
+        <div className="flex justify-end">
+          <span className="text-xs text-gray-500">
+            {signedTxHex.length} characters
+          </span>
+        </div>
+
+        {/* Broadcast button */}
+        {!txid && (
+          <Button
+            onClick={() => handleBroadcast()}
+            color="blue"
+            disabled={!signedTxHex.trim() || isBroadcasting}
+            fullWidth
+          >
+            {isBroadcasting ? (
+              <>
+                <FiRefreshCw
+                  className="size-4 mr-2 animate-spin"
+                  aria-hidden="true"
+                />
+                Broadcasting…
+              </>
+            ) : (
+              "Broadcast Transaction"
+            )}
+          </Button>
+        )}
+
+        {/* Success */}
+        {txid && (
+          <div className="space-y-4">
+            <div className="bg-green-50 border border-green-200 rounded-lg p-4">
+              <div className="flex items-center gap-2 mb-2">
+                <FaCheckCircle className="size-4 text-green-600" aria-hidden="true" />
+                <span className="text-sm font-medium text-green-800">
+                  Transaction Broadcast
+                </span>
+              </div>
+              <p className="text-xs text-green-700 font-mono break-all">
+                {txid}
+              </p>
+              <div className="mt-2 flex gap-3">
+                <button
+                  onClick={() => handleCopy(txid, "txid")}
+                  className={`text-xs transition-colors duration-200 cursor-pointer flex items-center gap-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded ${
+                    copiedField === "txid"
+                      ? "text-green-600 hover:text-green-700"
+                      : "text-blue-600 hover:text-blue-700"
+                  }`}
+                >
+                  {copiedField === "txid" ? (
+                    <>
+                      <FaCheck className="size-3" aria-hidden="true" />
+                      Copied!
+                    </>
+                  ) : (
+                    <>
+                      <FaCopy className="size-3" aria-hidden="true" />
+                      Copy txid
+                    </>
+                  )}
+                </button>
+                {!txid.startsWith("dev_mock_tx_") && (
+                  <a
+                    href={`https://mempool.space/tx/${txid}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-xs text-blue-600 hover:text-blue-700 flex items-center gap-1"
+                  >
+                    <FiExternalLink className="size-3" aria-hidden="true" />
+                    View on mempool.space
+                  </a>
+                )}
+              </div>
+            </div>
+
+            <Button onClick={handleReset} color="gray">
+              Reset
+            </Button>
+          </div>
+        )}
+      </div>
+
+      {error && <ErrorAlert message={error} onClose={() => setError(null)} />}
+    </div>
+  );
+}

--- a/src/pages/actions/combine-signatures.tsx
+++ b/src/pages/actions/combine-signatures.tsx
@@ -10,6 +10,7 @@ import { ErrorAlert } from "@/components/ui/error-alert";
 import { TextAreaInput } from "@/components/ui/inputs/textarea-input";
 import { useHeader } from "@/contexts/header-context";
 import { validatePubkey } from "@/core/bitcoin/buildBareMultisigFunding";
+import { verifyMultisigSignatures } from "@/core/bitcoin/multisigSignatures";
 
 type MultisigType = "2-of-2" | "2-of-3";
 type CopiedField = "combined" | null;
@@ -152,6 +153,22 @@ export default function CombineSignaturesPage(): ReactElement {
         throw new Error(
           `Input index ${idx} out of range (transaction has ${parsed.inputs.length} inputs)`
         );
+      }
+
+      // Refuse to combine anything that does not verify. Each signature commits to the legacy
+      // sighash of this input of this transaction, so checking it against the claimed public key
+      // is what separates "someone pasted a blob" from "this key signed exactly this" - which is
+      // the whole claim a jointly-issued asset is meant to carry. Doing it here also means an
+      // ordering or key mistake is reported plainly rather than as a network rejection later.
+      const signatureCheck = verifyMultisigSignatures(
+        rawTxHex.trim(),
+        idx,
+        [hexToBytes(pubkeyHexes[0]!.trim()), hexToBytes(pubkeyHexes[1]!.trim())],
+        [sigBytes1, sigBytes2],
+        2
+      );
+      if (!signatureCheck.ok) {
+        throw new Error(signatureCheck.error ?? 'Signatures could not be verified.');
       }
 
       // Build scriptSig: OP_0 <sig1> <sig2>

--- a/src/pages/actions/combine-signatures.tsx
+++ b/src/pages/actions/combine-signatures.tsx
@@ -1,0 +1,403 @@
+import { Field, Input, Label } from "@headlessui/react";
+import { bytesToHex, hexToBytes } from "@noble/hashes/utils.js";
+import { RawTx } from "@scure/btc-signer";
+import type { ReactElement } from "react";
+import { useCallback, useEffect, useState } from "react";
+import { useNavigate } from "react-router";
+import { FaCheck, FaCheckCircle, FaCopy, FiRefreshCw } from "@/components/icons";
+import { Button } from "@/components/ui/button";
+import { ErrorAlert } from "@/components/ui/error-alert";
+import { TextAreaInput } from "@/components/ui/inputs/textarea-input";
+import { useHeader } from "@/contexts/header-context";
+import { validatePubkey } from "@/core/bitcoin/buildBareMultisigFunding";
+
+type MultisigType = "2-of-2" | "2-of-3";
+type CopiedField = "combined" | null;
+
+/**
+ * Builds a bare multisig scriptSig: OP_0 <sig1> <sig2>
+ * Signatures must be in the same order as the pubkeys in the redeemScript.
+ */
+function buildMultisigScriptSig(sigs: Uint8Array[]): Uint8Array {
+  // OP_0 + pushdata for each sig
+  const parts: number[] = [0x00]; // OP_0
+
+  for (const sig of sigs) {
+    if (sig.length < 0x4c) {
+      parts.push(sig.length);
+    } else if (sig.length <= 0xff) {
+      parts.push(0x4c, sig.length);
+    } else {
+      parts.push(0x4d, sig.length & 0xff, (sig.length >> 8) & 0xff);
+    }
+    for (const b of sig) {
+      parts.push(b);
+    }
+  }
+
+  return new Uint8Array(parts);
+}
+
+function validateDerSignature(hex: string): Uint8Array {
+  const clean = hex.startsWith("0x") ? hex.slice(2) : hex.trim();
+
+  if (!/^[0-9a-fA-F]+$/.test(clean)) {
+    throw new Error("Invalid hex characters in signature");
+  }
+
+  const bytes = hexToBytes(clean);
+
+  // Basic DER check: should start with 0x30 (SEQUENCE)
+  if (bytes[0] !== 0x30) {
+    throw new Error("Not a valid DER signature (expected 0x30 prefix)");
+  }
+
+  return bytes;
+}
+
+export default function CombineSignaturesPage(): ReactElement {
+  const navigate = useNavigate();
+  const { setHeaderProps } = useHeader();
+
+  const [multisigType, setMultisigType] = useState<MultisigType>("2-of-2");
+  const [rawTxHex, setRawTxHex] = useState("");
+  const [pubkey1, setPubkey1] = useState("");
+  const [pubkey2, setPubkey2] = useState("");
+  const [pubkey3, setPubkey3] = useState("");
+  const [sig1, setSig1] = useState("");
+  const [sig2, setSig2] = useState("");
+  const [inputIndex, setInputIndex] = useState("0");
+  const [combinedTxHex, setCombinedTxHex] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [copiedField, setCopiedField] = useState<CopiedField>(null);
+
+  const handleReset = useCallback(() => {
+    setRawTxHex("");
+    setPubkey1("");
+    setPubkey2("");
+    setPubkey3("");
+    setSig1("");
+    setSig2("");
+    setInputIndex("0");
+    setCombinedTxHex("");
+    setError(null);
+  }, []);
+
+  useEffect(() => {
+    const hasContent = Boolean(
+      rawTxHex || combinedTxHex || error || sig1 || sig2
+    );
+    setHeaderProps({
+      title: "Combine Sigs",
+      onBack: () => navigate(-1),
+      rightButton: {
+        ariaLabel: "Reset form",
+        icon: <FiRefreshCw className="size-4" aria-hidden="true" />,
+        onClick: handleReset,
+        disabled: !hasContent,
+      },
+    });
+    return () => setHeaderProps(null);
+  }, [setHeaderProps, navigate, handleReset, rawTxHex, combinedTxHex, error, sig1, sig2]);
+
+  const handleCombine = () => {
+    setError(null);
+    setCombinedTxHex("");
+
+    try {
+      const trimmedHex = rawTxHex.trim();
+      if (!trimmedHex) {
+        throw new Error("Please enter the raw transaction hex");
+      }
+      if (!/^[0-9a-fA-F]+$/.test(trimmedHex)) {
+        throw new Error("Invalid hex in raw transaction");
+      }
+
+      // Validate pubkeys (we need them to know the ordering)
+      const pubkeyHexes = [pubkey1.trim(), pubkey2.trim()];
+      if (multisigType === "2-of-3") {
+        pubkeyHexes.push(pubkey3.trim());
+      }
+      for (let i = 0; i < pubkeyHexes.length; i++) {
+        if (!pubkeyHexes[i]) {
+          throw new Error(`Public Key ${i + 1} is required`);
+        }
+        try {
+          validatePubkey(pubkeyHexes[i]!);
+        } catch (err) {
+          throw new Error(
+            `Public Key ${i + 1}: ${err instanceof Error ? err.message : "invalid"}`
+          );
+        }
+      }
+
+      // Validate signatures
+      if (!sig1.trim()) throw new Error("Signature 1 is required");
+      if (!sig2.trim()) throw new Error("Signature 2 is required");
+
+      const sigBytes1 = validateDerSignature(sig1);
+      const sigBytes2 = validateDerSignature(sig2);
+
+      // Parse the input index
+      const idx = parseInt(inputIndex.trim() || "0", 10);
+      if (isNaN(idx) || idx < 0) {
+        throw new Error("Invalid input index");
+      }
+
+      // Parse the raw transaction
+      const rawBytes = hexToBytes(trimmedHex);
+      const parsed = RawTx.decode(rawBytes);
+
+      if (idx >= parsed.inputs.length) {
+        throw new Error(
+          `Input index ${idx} out of range (transaction has ${parsed.inputs.length} inputs)`
+        );
+      }
+
+      // Build scriptSig: OP_0 <sig1> <sig2>
+      // Signatures are provided in pubkey order (matching the redeemScript)
+      const scriptSig = buildMultisigScriptSig([sigBytes1, sigBytes2]);
+
+      // Replace the scriptSig on the target input
+      const targetInput = parsed.inputs[idx];
+      if (!targetInput) {
+        throw new Error(`Input ${idx} not found in the transaction`);
+      }
+      targetInput.finalScriptSig = scriptSig;
+
+      // Re-encode
+      const combined = RawTx.encode(parsed);
+      setCombinedTxHex(bytesToHex(combined));
+    } catch (err) {
+      console.error("Failed to combine signatures:", err);
+      setError(
+        err instanceof Error ? err.message : "Failed to combine signatures"
+      );
+    }
+  };
+
+  const handleCopy = async (text: string, field: CopiedField) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopiedField(field);
+      setTimeout(() => setCopiedField(null), 1500);
+    } catch {
+      setError("Failed to copy to clipboard");
+    }
+  };
+
+  const isFormValid =
+    rawTxHex.trim() &&
+    pubkey1.trim() &&
+    pubkey2.trim() &&
+    (multisigType === "2-of-2" || pubkey3.trim()) &&
+    sig1.trim() &&
+    sig2.trim();
+
+  return (
+    <div className="p-4 space-y-4">
+      <div className="bg-white rounded-lg shadow-sm p-3 sm:p-4 space-y-4">
+        {/* Transaction */}
+        <TextAreaInput
+          value={rawTxHex}
+          onChange={(value) => {
+            setRawTxHex(value);
+            if (combinedTxHex) setCombinedTxHex("");
+          }}
+          label="Raw Transaction Hex"
+          placeholder="Paste the unsigned or partially-signed transaction hex…"
+          rows={3}
+          required
+          showCharCount={false}
+        />
+
+        {/* Multisig type toggle */}
+        <Field>
+          <Label className="block text-sm font-medium text-gray-700 mb-1">
+            Multisig Type <span className="text-red-500">*</span>
+          </Label>
+          <div className="flex gap-2">
+            {(["2-of-2", "2-of-3"] as const).map((type) => (
+              <button
+                key={type}
+                type="button"
+                onClick={() => {
+                  setMultisigType(type);
+                  if (combinedTxHex) setCombinedTxHex("");
+                }}
+                className={`flex-1 py-2 px-3 rounded-md text-sm font-medium transition-colors cursor-pointer ${
+                  multisigType === type
+                    ? "bg-blue-600 text-white"
+                    : "bg-gray-100 text-gray-700 hover:bg-gray-200"
+                }`}
+              >
+                {type}
+              </button>
+            ))}
+          </div>
+        </Field>
+
+        {/* Input index */}
+        <Field>
+          <Label className="block text-sm font-medium text-gray-700 mb-1">
+            Input Index <span className="text-red-500">*</span>
+          </Label>
+          <Input
+            type="text"
+            inputMode="numeric"
+            value={inputIndex}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setInputIndex(e.target.value)}
+            placeholder="0"
+            className="block w-full p-2.5 rounded-md border border-gray-200 bg-gray-50 text-sm outline-none focus:border-blue-500 focus-visible:ring-2 focus-visible:ring-blue-500"
+          />
+          <p className="text-xs text-gray-500 mt-1">
+            Which input to apply the combined scriptSig to (usually 0)
+          </p>
+        </Field>
+      </div>
+
+      {/* Public Keys */}
+      <div className="bg-white rounded-lg shadow-sm p-3 sm:p-4 space-y-4">
+        <p className="text-xs text-gray-500">
+          Public keys determine signature ordering. Enter them in the same order used when the multisig was created.
+        </p>
+
+        <Field>
+          <Label className="block text-sm font-medium text-gray-700 mb-1">
+            Public Key 1 <span className="text-red-500">*</span>
+          </Label>
+          <Input
+            type="text"
+            value={pubkey1}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPubkey1(e.target.value)}
+            placeholder="Compressed public key hex…"
+            className="block w-full p-2.5 rounded-md border border-gray-200 bg-gray-50 text-sm font-mono outline-none focus:border-blue-500 focus-visible:ring-2 focus-visible:ring-blue-500"
+          />
+        </Field>
+
+        <Field>
+          <Label className="block text-sm font-medium text-gray-700 mb-1">
+            Public Key 2 <span className="text-red-500">*</span>
+          </Label>
+          <Input
+            type="text"
+            value={pubkey2}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPubkey2(e.target.value)}
+            placeholder="Compressed public key hex…"
+            className="block w-full p-2.5 rounded-md border border-gray-200 bg-gray-50 text-sm font-mono outline-none focus:border-blue-500 focus-visible:ring-2 focus-visible:ring-blue-500"
+          />
+        </Field>
+
+        {multisigType === "2-of-3" && (
+          <Field>
+            <Label className="block text-sm font-medium text-gray-700 mb-1">
+              Public Key 3 <span className="text-red-500">*</span>
+            </Label>
+            <Input
+              type="text"
+              value={pubkey3}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPubkey3(e.target.value)}
+              placeholder="Compressed public key hex…"
+              className="block w-full p-2.5 rounded-md border border-gray-200 bg-gray-50 text-sm font-mono outline-none focus:border-blue-500 focus-visible:ring-2 focus-visible:ring-blue-500"
+            />
+          </Field>
+        )}
+      </div>
+
+      {/* Signatures */}
+      <div className="bg-white rounded-lg shadow-sm p-3 sm:p-4 space-y-4">
+        <p className="text-xs text-gray-500">
+          Each signature must correspond to the public key at the same position above.
+        </p>
+
+        <Field>
+          <Label className="block text-sm font-medium text-gray-700 mb-1">
+            Signature 1 <span className="text-red-500">*</span>
+          </Label>
+          <Input
+            type="text"
+            value={sig1}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSig1(e.target.value)}
+            placeholder="DER-encoded signature hex…"
+            className="block w-full p-2.5 rounded-md border border-gray-200 bg-gray-50 text-sm font-mono outline-none focus:border-blue-500 focus-visible:ring-2 focus-visible:ring-blue-500"
+          />
+        </Field>
+
+        <Field>
+          <Label className="block text-sm font-medium text-gray-700 mb-1">
+            Signature 2 <span className="text-red-500">*</span>
+          </Label>
+          <Input
+            type="text"
+            value={sig2}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSig2(e.target.value)}
+            placeholder="DER-encoded signature hex…"
+            className="block w-full p-2.5 rounded-md border border-gray-200 bg-gray-50 text-sm font-mono outline-none focus:border-blue-500 focus-visible:ring-2 focus-visible:ring-blue-500"
+          />
+        </Field>
+      </div>
+
+      {/* Combine button */}
+      <div className="bg-white rounded-lg shadow-sm p-3 sm:p-4 space-y-4">
+        {!combinedTxHex && (
+          <Button
+            onClick={() => handleCombine()}
+            color="blue"
+            disabled={!isFormValid}
+            fullWidth
+          >
+            Combine Signatures
+          </Button>
+        )}
+
+        {/* Result */}
+        {combinedTxHex && (
+          <div className="space-y-4">
+            <TextAreaInput
+              value={combinedTxHex}
+              onChange={() => {}}
+              label="Combined Transaction Hex"
+              placeholder=""
+              rows={4}
+              disabled={true}
+              readOnly={true}
+              className="bg-gray-50"
+            />
+            <div className="mt-2 flex justify-between items-center">
+              <span className="text-xs text-green-600 flex items-center gap-1">
+                <FaCheckCircle className="size-3" aria-hidden="true" />
+                Ready to broadcast
+              </span>
+              <button
+                onClick={() => handleCopy(combinedTxHex, "combined")}
+                className={`text-xs transition-colors duration-200 cursor-pointer flex items-center gap-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded ${
+                  copiedField === "combined"
+                    ? "text-green-600 hover:text-green-700"
+                    : "text-blue-600 hover:text-blue-700"
+                }`}
+              >
+                {copiedField === "combined" ? (
+                  <>
+                    <FaCheck className="size-3" aria-hidden="true" />
+                    Copied!
+                  </>
+                ) : (
+                  <>
+                    <FaCopy className="size-3" aria-hidden="true" />
+                    Copy tx hex
+                  </>
+                )}
+              </button>
+            </div>
+
+            <Button onClick={handleReset} color="gray">
+              Reset
+            </Button>
+          </div>
+        )}
+      </div>
+
+      {error && <ErrorAlert message={error} onClose={() => setError(null)} />}
+    </div>
+  );
+}

--- a/src/pages/actions/fund-bare-multisig.tsx
+++ b/src/pages/actions/fund-bare-multisig.tsx
@@ -1,0 +1,404 @@
+import { Field, Input, Label } from "@headlessui/react";
+import type { ReactElement } from "react";
+import { useCallback, useEffect, useState } from "react";
+import { useNavigate } from "react-router";
+import { FaCheck, FaCheckCircle, FaCopy, FiRefreshCw } from "@/components/icons";
+import { Button } from "@/components/ui/button";
+import { ErrorAlert } from "@/components/ui/error-alert";
+import { FeeRateInput } from "@/components/ui/inputs/fee-rate-input";
+import { TextAreaInput } from "@/components/ui/inputs/textarea-input";
+import { useHeader } from "@/contexts/header-context";
+import { useWallet } from "@/contexts/wallet-context";
+import {
+  buildBareMultisigFunding,
+  validatePubkey,
+} from "@/core/bitcoin/buildBareMultisigFunding";
+import { fromSatoshis, toSatoshis } from "@/core/numeric";
+import { getWalletService } from "@/services/walletService";
+
+type MultisigType = "2-of-2" | "2-of-3";
+type CopiedField = "signedTx" | "script" | null;
+
+export default function FundBareMultisigPage(): ReactElement {
+  const navigate = useNavigate();
+  const { setHeaderProps } = useHeader();
+  const { activeWallet, activeAddress } = useWallet();
+
+  const [multisigType, setMultisigType] = useState<MultisigType>("2-of-2");
+  const [pubkey1, setPubkey1] = useState("");
+  const [pubkey2, setPubkey2] = useState("");
+  const [pubkey3, setPubkey3] = useState("");
+  const [amount, setAmount] = useState("");
+  const [feeRate, setFeeRate] = useState(0);
+  const [isBuilding, setIsBuilding] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [signedTxHex, setSignedTxHex] = useState("");
+  const [multisigScriptHex, setMultisigScriptHex] = useState("");
+  const [feeInfo, setFeeInfo] = useState("");
+  const [copiedField, setCopiedField] = useState<CopiedField>(null);
+
+  // Pre-fill pubkey1 with active address pubkey
+  useEffect(() => {
+    if (activeAddress?.pubKey && !pubkey1) {
+      setPubkey1(activeAddress.pubKey);
+    }
+  }, [activeAddress?.pubKey]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleReset = useCallback(() => {
+    setPubkey1(activeAddress?.pubKey || "");
+    setPubkey2("");
+    setPubkey3("");
+    setAmount("");
+    setSignedTxHex("");
+    setMultisigScriptHex("");
+    setFeeInfo("");
+    setError(null);
+  }, [activeAddress?.pubKey]);
+
+  useEffect(() => {
+    const hasContent = Boolean(
+      signedTxHex || error || pubkey2 || pubkey3 || amount
+    );
+    setHeaderProps({
+      title: "Fund Multisig",
+      onBack: () => navigate(-1),
+      rightButton: {
+        ariaLabel: "Reset form",
+        icon: <FiRefreshCw className="size-4" aria-hidden="true" />,
+        onClick: handleReset,
+        disabled: !hasContent,
+      },
+    });
+    return () => setHeaderProps(null);
+  }, [
+    setHeaderProps,
+    navigate,
+    handleReset,
+    signedTxHex,
+    error,
+    pubkey2,
+    pubkey3,
+    amount,
+  ]);
+
+  const handleFund = async () => {
+    if (!activeWallet || !activeAddress) {
+      setError("No active wallet or address");
+      return;
+    }
+
+    setError(null);
+    setSignedTxHex("");
+    setMultisigScriptHex("");
+    setFeeInfo("");
+    setIsBuilding(true);
+
+    try {
+      // Validate pubkeys
+      const pubkeyHexes = [pubkey1.trim(), pubkey2.trim()];
+      if (multisigType === "2-of-3") {
+        pubkeyHexes.push(pubkey3.trim());
+      }
+
+      const pubkeyBytes = pubkeyHexes.map((hex, i) => {
+        try {
+          return validatePubkey(hex);
+        } catch (err) {
+          throw new Error(
+            `Public Key ${i + 1}: ${err instanceof Error ? err.message : "invalid"}`
+          );
+        }
+      });
+
+      // Convert BTC to sats
+      const amountSats = Number(toSatoshis(amount));
+      if (isNaN(amountSats) || amountSats <= 0) {
+        throw new Error("Invalid amount");
+      }
+
+      if (feeRate <= 0) {
+        throw new Error("Please select a fee rate");
+      }
+
+      // Build unsigned tx
+      const result = await buildBareMultisigFunding({
+        pubkeys: pubkeyBytes,
+        m: 2,
+        amountSats,
+        feeRate,
+        sourceAddress: activeAddress.address,
+      });
+
+      // Sign
+      const walletService = getWalletService();
+      const signed = await walletService.signTransaction(
+        result.unsignedTxHex,
+        activeAddress.address
+      );
+
+      setSignedTxHex(signed);
+      setMultisigScriptHex(result.multisigScriptHex);
+      const changeStr =
+        result.changeAmount > 0
+          ? `, change: ${fromSatoshis(result.changeAmount, { removeTrailingZeros: true })} BTC`
+          : ", no change (folded into fee)";
+      setFeeInfo(
+        `Fee: ${fromSatoshis(result.fee, { removeTrailingZeros: true })} BTC (${result.fee} sats)${changeStr}`
+      );
+    } catch (err) {
+      console.error("Failed to fund multisig:", err);
+      setError(err instanceof Error ? err.message : "Failed to build transaction");
+    } finally {
+      setIsBuilding(false);
+    }
+  };
+
+  const handleCopy = async (text: string, field: CopiedField) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopiedField(field);
+      setTimeout(() => setCopiedField(null), 1500);
+    } catch {
+      setError("Failed to copy to clipboard");
+    }
+  };
+
+  const isFormValid =
+    pubkey1.trim() &&
+    pubkey2.trim() &&
+    (multisigType === "2-of-2" || pubkey3.trim()) &&
+    amount.trim() &&
+    feeRate > 0;
+
+  if (!activeAddress) {
+    return (
+      <div className="p-4 text-center">
+        <div className="text-gray-600 mb-4">No active address selected</div>
+        <Button onClick={() => navigate("/index")} color="blue">
+          Go to Wallet
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <div className="bg-white rounded-lg shadow-sm p-3 sm:p-4 space-y-4">
+        {/* Multisig type toggle */}
+        <Field>
+          <Label className="block text-sm font-medium text-gray-700 mb-1">
+            Multisig Type <span className="text-red-500">*</span>
+          </Label>
+          <div className="flex gap-2">
+            {(["2-of-2", "2-of-3"] as const).map((type) => (
+              <button
+                key={type}
+                type="button"
+                onClick={() => {
+                  setMultisigType(type);
+                  if (signedTxHex) {
+                    setSignedTxHex("");
+                    setMultisigScriptHex("");
+                    setFeeInfo("");
+                  }
+                }}
+                disabled={isBuilding}
+                className={`flex-1 py-2 px-3 rounded-md text-sm font-medium transition-colors cursor-pointer ${
+                  multisigType === type
+                    ? "bg-blue-600 text-white"
+                    : "bg-gray-100 text-gray-700 hover:bg-gray-200"
+                }`}
+              >
+                {type}
+              </button>
+            ))}
+          </div>
+        </Field>
+
+        {/* Pubkey inputs */}
+        <Field>
+          <Label className="block text-sm font-medium text-gray-700 mb-1">
+            Public Key 1 (yours) <span className="text-red-500">*</span>
+          </Label>
+          <Input
+            type="text"
+            value={pubkey1}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPubkey1(e.target.value)}
+            placeholder="Compressed public key hex…"
+            disabled={isBuilding}
+            className="block w-full p-2.5 rounded-md border border-gray-200 bg-gray-50 text-sm font-mono outline-none focus:border-blue-500 focus-visible:ring-2 focus-visible:ring-blue-500"
+          />
+        </Field>
+
+        <Field>
+          <Label className="block text-sm font-medium text-gray-700 mb-1">
+            Public Key 2 <span className="text-red-500">*</span>
+          </Label>
+          <Input
+            type="text"
+            value={pubkey2}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPubkey2(e.target.value)}
+            placeholder="Paste counterparty's public key hex…"
+            disabled={isBuilding}
+            className="block w-full p-2.5 rounded-md border border-gray-200 bg-gray-50 text-sm font-mono outline-none focus:border-blue-500 focus-visible:ring-2 focus-visible:ring-blue-500"
+          />
+        </Field>
+
+        {multisigType === "2-of-3" && (
+          <Field>
+            <Label className="block text-sm font-medium text-gray-700 mb-1">
+              Public Key 3 <span className="text-red-500">*</span>
+            </Label>
+            <Input
+              type="text"
+              value={pubkey3}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPubkey3(e.target.value)}
+              placeholder="Paste third party's public key hex…"
+              disabled={isBuilding}
+              className="block w-full p-2.5 rounded-md border border-gray-200 bg-gray-50 text-sm font-mono outline-none focus:border-blue-500 focus-visible:ring-2 focus-visible:ring-blue-500"
+            />
+          </Field>
+        )}
+
+        {/* Amount */}
+        <Field>
+          <Label className="block text-sm font-medium text-gray-700 mb-1">
+            Amount (BTC) <span className="text-red-500">*</span>
+          </Label>
+          <Input
+            type="text"
+            inputMode="decimal"
+            value={amount}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              setAmount(e.target.value);
+              if (signedTxHex) {
+                setSignedTxHex("");
+                setMultisigScriptHex("");
+                setFeeInfo("");
+              }
+            }}
+            placeholder="0.001"
+            disabled={isBuilding}
+            className="block w-full p-2.5 rounded-md border border-gray-200 bg-gray-50 text-sm outline-none focus:border-blue-500 focus-visible:ring-2 focus-visible:ring-blue-500"
+          />
+        </Field>
+
+        {/* Fee rate */}
+        <FeeRateInput onFeeRateChange={setFeeRate} />
+
+        {/* Fund button */}
+        {!signedTxHex && (
+          <Button
+            onClick={() => handleFund()}
+            color="blue"
+            disabled={!isFormValid || isBuilding}
+            fullWidth
+          >
+            {isBuilding ? (
+              <>
+                <FiRefreshCw
+                  className="size-4 mr-2 animate-spin"
+                  aria-hidden="true"
+                />
+                {activeWallet?.type === "hardware"
+                  ? "Confirm on device…"
+                  : "Building…"}
+              </>
+            ) : (
+              "Fund Multisig"
+            )}
+          </Button>
+        )}
+
+        {/* Results */}
+        {signedTxHex && (
+          <div className="space-y-4">
+            {feeInfo && (
+              <p className="text-xs text-gray-500">{feeInfo}</p>
+            )}
+
+            <div>
+              <TextAreaInput
+                value={signedTxHex}
+                onChange={() => {}}
+                label="Signed Transaction Hex"
+                placeholder=""
+                rows={4}
+                disabled={true}
+                readOnly={true}
+                className="bg-gray-50"
+              />
+              <div className="mt-2 flex justify-between items-center">
+                <span className="text-xs text-green-600 flex items-center gap-1">
+                  <FaCheckCircle className="size-3" aria-hidden="true" />
+                  Signed
+                </span>
+                <button
+                  onClick={() => handleCopy(signedTxHex, "signedTx")}
+                  className={`text-xs transition-colors duration-200 cursor-pointer flex items-center gap-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded ${
+                    copiedField === "signedTx"
+                      ? "text-green-600 hover:text-green-700"
+                      : "text-blue-600 hover:text-blue-700"
+                  }`}
+                >
+                  {copiedField === "signedTx" ? (
+                    <>
+                      <FaCheck className="size-3" aria-hidden="true" />
+                      Copied!
+                    </>
+                  ) : (
+                    <>
+                      <FaCopy className="size-3" aria-hidden="true" />
+                      Copy signed tx
+                    </>
+                  )}
+                </button>
+              </div>
+            </div>
+
+            <div>
+              <TextAreaInput
+                value={multisigScriptHex}
+                onChange={() => {}}
+                label="Multisig scriptPubKey"
+                placeholder=""
+                rows={2}
+                disabled={true}
+                readOnly={true}
+                className="bg-gray-50"
+              />
+              <div className="mt-1 flex justify-between items-center">
+                <span className="text-xs text-gray-500">
+                  Save this for spending from the multisig later
+                </span>
+                <button
+                  onClick={() => handleCopy(multisigScriptHex, "script")}
+                  className={`text-xs transition-colors duration-200 cursor-pointer flex items-center gap-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded ${
+                    copiedField === "script"
+                      ? "text-green-600 hover:text-green-700"
+                      : "text-blue-600 hover:text-blue-700"
+                  }`}
+                >
+                  {copiedField === "script" ? (
+                    <>
+                      <FaCheck className="size-3" aria-hidden="true" />
+                      Copied!
+                    </>
+                  ) : (
+                    "Copy"
+                  )}
+                </button>
+              </div>
+            </div>
+
+            <Button onClick={handleReset} color="gray">
+              Reset
+            </Button>
+          </div>
+        )}
+      </div>
+
+      {error && <ErrorAlert message={error} onClose={() => setError(null)} />}
+    </div>
+  );
+}

--- a/src/pages/actions/index.tsx
+++ b/src/pages/actions/index.tsx
@@ -118,6 +118,35 @@ const getActionSections = (
         },
       ],
     },
+    {
+      title: "Multisig",
+      items: [
+        {
+          id: "fund-bare-multisig",
+          title: "Fund Multisig",
+          description: "Create a transaction funding a multisig output",
+          onClick: () => navigate("/actions/fund-bare-multisig"),
+        },
+        {
+          id: "sign-transaction",
+          title: "Sign Transaction",
+          description: "Sign a raw transaction with your key",
+          onClick: () => navigate("/actions/sign-transaction"),
+        },
+        {
+          id: "combine-signatures",
+          title: "Combine Sigs",
+          description: "Combine multisig signatures into a broadcast-ready transaction",
+          onClick: () => navigate("/actions/combine-signatures"),
+        },
+        {
+          id: "broadcast-transaction",
+          title: "Broadcast Transaction",
+          description: "Broadcast a signed transaction to the network",
+          onClick: () => navigate("/actions/broadcast-transaction"),
+        },
+      ],
+    },
   ];
 
   return sections;

--- a/src/pages/actions/sign-transaction.tsx
+++ b/src/pages/actions/sign-transaction.tsx
@@ -1,0 +1,240 @@
+import type { ReactElement } from "react";
+import { useCallback, useEffect, useState } from "react";
+import { useNavigate } from "react-router";
+import { FaCheck, FaCheckCircle, FaCopy, FaLock, FiRefreshCw } from "@/components/icons";
+import { Button } from "@/components/ui/button";
+import { ErrorAlert } from "@/components/ui/error-alert";
+import { TextAreaInput } from "@/components/ui/inputs/textarea-input";
+import { useHeader } from "@/contexts/header-context";
+import { useWallet } from "@/contexts/wallet-context";
+import { analytics } from "@/platform/fathom";
+import { getWalletService } from "@/services/walletService";
+
+/**
+ * SignTransaction component for signing raw transactions
+ */
+export default function SignTransactionPage(): ReactElement {
+  const navigate = useNavigate();
+  const { setHeaderProps } = useHeader();
+  const { activeWallet, activeAddress } = useWallet();
+
+  // State
+  const [rawTxHex, setRawTxHex] = useState("");
+  const [signedTxHex, setSignedTxHex] = useState("");
+  const [isSigning, setIsSigning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [copiedField, setCopiedField] = useState<'input' | 'output' | null>(null);
+
+  // Reset function with stable reference
+  const handleReset = useCallback(() => {
+    setRawTxHex("");
+    setSignedTxHex("");
+    setError(null);
+  }, []);
+
+  // Configure header with reset button
+  useEffect(() => {
+    const hasContent = Boolean(rawTxHex || signedTxHex || error);
+
+    setHeaderProps({
+      title: "Sign Transaction",
+      onBack: () => navigate(-1),
+      rightButton: {
+        ariaLabel: "Reset form",
+        icon: <FiRefreshCw className="size-4" aria-hidden="true" />,
+        onClick: handleReset,
+        disabled: !hasContent,
+      },
+    });
+    return () => setHeaderProps(null);
+  }, [setHeaderProps, navigate, handleReset, rawTxHex, signedTxHex, error]);
+
+  const handleSign = async () => {
+    if (!activeWallet || !activeAddress) {
+      setError("No active wallet or address");
+      return;
+    }
+
+    const trimmed = rawTxHex.trim();
+    if (!trimmed) {
+      setError("Please enter a raw transaction hex");
+      return;
+    }
+
+    if (!/^[0-9a-fA-F]+$/.test(trimmed)) {
+      setError("Invalid hex string");
+      return;
+    }
+
+    setIsSigning(true);
+    setError(null);
+    setSignedTxHex("");
+
+    try {
+      const walletService = getWalletService();
+      const signed = await walletService.signTransaction(
+        trimmed,
+        activeAddress.address
+      );
+
+      setSignedTxHex(signed);
+      analytics.track('transaction_signed');
+    } catch (err) {
+      console.error("Failed to sign transaction:", err);
+      setError(err instanceof Error ? err.message : "Failed to sign transaction");
+    } finally {
+      setIsSigning(false);
+    }
+  };
+
+  const handleCopy = async (text: string, field: 'input' | 'output') => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopiedField(field);
+      setTimeout(() => setCopiedField(null), 1500);
+    } catch {
+      setError("Failed to copy to clipboard");
+    }
+  };
+
+  if (!activeAddress) {
+    return (
+      <div className="p-4 text-center">
+        <div className="text-gray-600 mb-4">No active address selected</div>
+        <Button onClick={() => navigate("/index")} color="blue">
+          Go to Wallet
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <div className="bg-white rounded-lg shadow-sm p-3 sm:p-4">
+        {/* Raw Transaction Input */}
+        <TextAreaInput
+          value={rawTxHex}
+          onChange={(value) => {
+            setRawTxHex(value);
+            if (signedTxHex) {
+              setSignedTxHex("");
+            }
+          }}
+          label="Raw Transaction Hex"
+          placeholder="Paste raw transaction hex here…"
+          rows={4}
+          required={false}
+          showCharCount={false}
+          disabled={isSigning}
+        />
+        <div className="mt-2 flex justify-between items-center">
+          <span className="text-xs text-gray-500">
+            {rawTxHex.length} characters
+          </span>
+          {rawTxHex && (
+            <button
+              onClick={() => handleCopy(rawTxHex, 'input')}
+              className={`text-xs transition-colors duration-200 cursor-pointer flex items-center gap-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded ${
+                copiedField === 'input'
+                  ? 'text-green-600 hover:text-green-700'
+                  : 'text-blue-600 hover:text-blue-700'
+              }`}
+            >
+              {copiedField === 'input' ? (
+                <>
+                  <FaCheck className="size-3" aria-hidden="true" />
+                  Copied!
+                </>
+              ) : (
+                'Copy'
+              )}
+            </button>
+          )}
+        </div>
+
+        {/* Signed Transaction Output */}
+        <div className="mt-4">
+          <TextAreaInput
+            value={signedTxHex}
+            onChange={() => {}}
+            label="Signed Transaction Hex"
+            placeholder="Signed transaction will appear here after signing..."
+            rows={4}
+            disabled={true}
+            readOnly={true}
+            className="bg-gray-50"
+          />
+          {signedTxHex && (
+            <div className="mt-2 flex justify-between items-center">
+              <span className="text-xs text-green-600 flex items-center gap-1">
+                <FaCheckCircle className="size-3" aria-hidden="true" />
+                Signed
+              </span>
+              <button
+                onClick={() => handleCopy(signedTxHex, 'output')}
+                className={`text-xs transition-colors duration-200 cursor-pointer flex items-center gap-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded ${
+                  copiedField === 'output'
+                    ? 'text-green-600 hover:text-green-700'
+                    : 'text-blue-600 hover:text-blue-700'
+                }`}
+              >
+                {copiedField === 'output' ? (
+                  <>
+                    <FaCheck className="size-3" aria-hidden="true" />
+                    Copied!
+                  </>
+                ) : (
+                  <>
+                    <FaCopy className="size-3" aria-hidden="true" />
+                    Copy signed tx
+                  </>
+                )}
+              </button>
+            </div>
+          )}
+        </div>
+
+        {/* Sign Button - only show if not signed */}
+        {!signedTxHex && (
+          <div className="mt-4">
+            <Button
+              onClick={() => handleSign()}
+              color="blue"
+              disabled={!rawTxHex.trim() || isSigning}
+              fullWidth
+            >
+              {isSigning ? (
+                <>
+                  <FiRefreshCw className="size-4 mr-2 animate-spin" aria-hidden="true" />
+                  {activeWallet?.type === 'hardware' ? 'Confirm on device…' : 'Signing…'}
+                </>
+              ) : (
+                <>
+                  <FaLock className="size-4 mr-2" aria-hidden="true" />
+                  Sign Transaction
+                </>
+              )}
+            </Button>
+          </div>
+        )}
+
+        {/* Reset button after signing */}
+        {signedTxHex && (
+          <div className="mt-4">
+            <Button
+              onClick={handleReset}
+              color="gray"
+            >
+              Reset
+            </Button>
+          </div>
+        )}
+      </div>
+
+      {/* Error Display */}
+      {error && (
+        <ErrorAlert message={error} onClose={() => setError(null)} />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
**Draft — not ready to merge.** Supersedes #176; this is that PR's feature half rebased onto current `main`, with its refactor half deliberately left behind.

## The use case

Two parties fund a bare multisig address, each signs separately, one combines the signatures and broadcasts. An asset issued from that address carries both signatures — so **joint authorship is provable from the chain rather than asserted**. Four pages: Fund → Sign → Combine Sigs → Broadcast.

## What I dropped and why

#176's second commit extracted the input-preparation loop out of `signTransaction` into `prepareInputs.ts`. That's exactly the loop `assertRebuildMatchesReviewed` (#238) exists to guard — the assertion compares the rebuilt transaction against the parsed one *because* the rebuild happens there. Moving it means re-deriving the guarantee, not re-applying it. Separate decision, separate change.

## What the six-month gap cost

The branch didn't build. Fixes needed:

- `react-router-dom` → this repo uses `react-router`
- every path pointed at `utils/`, which no longer exists
- `Address().decode` gained an undefined branch in the newer `@scure/btc-signer`
- several indexed accesses failed current strictness

Where a null check was the honest fix rather than a `!` assertion — an undecodable source address, a missing input index — it now throws with a message.

**Conflicting files keep current logic and take only the feature.** The MPMA memo rules from 0.7.0 stay exactly as they are; the multisig-destination guard is added alongside rather than replacing them.

## Why this is a draft

`combine-signatures` assembles a scriptSig from signatures **whose provenance the wallet cannot verify**. That path has none of the verification the rest of the wallet now applies — no byte equality, no deny-by-default output accounting, and it doesn't go through the review screen. For a feature whose entire purpose is proving who signed something, that gap is the thing that needs closing before it ships.

It also has **no tests of its own** and no guide, and both matter for a flow this manual.

## State

- `tsc --noEmit` clean; `biome check src` clean (677 files)
- `vitest run src` — 3968 passed, 49 skipped
- `wxt build` succeeds — bundle 2.47 → 2.49 MB

**11 files, +1,572 / −8.** No existing behaviour changed; everything is additive except the two guards.