### PR TITLE
Pin the two advisory scenarios as regression tests

### DIFF
--- a/src/core/bitcoin/__tests__/committedOutputs.advisory.test.ts
+++ b/src/core/bitcoin/__tests__/committedOutputs.advisory.test.ts
@@ -1,0 +1,65 @@
+import { SigHash } from '@scure/btc-signer';
+import { describe, expect, it } from 'vitest';
+import { committedOutputIndices } from '@/core/bitcoin/psbt';
+
+/**
+ * The scenario from GHSA-xchm-466g-93cw, kept as a regression test.
+ *
+ * The reported bypass was that any SIGHASH_ALL input made the function return null — "every output
+ * is committed" — which absorbed a SINGLE|ANYONECANPAY input signed in the same PSBT and put the
+ * at-risk figure back to zero.
+ *
+ * The argument that makes it a real bypass, and the one the current implementation encodes: a
+ * signature only binds transactions containing its own input. ANYONECANPAY exists so that its input
+ * can be lifted into a different transaction. Whoever holds the PSBT drops the ALL-signed input
+ * along with its signature and rebuilds around the detachable one, so the ALL signature never has
+ * to be satisfied — the transaction no longer contains the input it belongs to.
+ */
+describe('GHSA-xchm-466g-93cw — an ALL input must not absorb a detachable one', () => {
+  // input 0: victim, SIGHASH_ALL, present only to poison the verdict
+  // input 1: victim, SINGLE|ANYONECANPAY, the one that can be lifted out
+  // outputs: 0 change, 1 the dust the SINGLE input commits to, 2 the ~1 BTC presented as change
+  const reported = [
+    { index: 0, sighashType: SigHash.ALL },
+    { index: 1, sighashType: SigHash.SINGLE_ANYONECANPAY },
+  ];
+
+  it('does not report every output as committed', () => {
+    // null would mean "nothing is at risk", which is the bypass.
+    expect(committedOutputIndices(reported, 3)).not.toBeNull();
+  });
+
+  it('commits only to the output the detachable input covers on its own', () => {
+    const committed = committedOutputIndices(reported, 3);
+    expect([...committed!]).toEqual([1]);
+  });
+
+  it('leaves the large output outside the committed set, so it counts as at risk', () => {
+    const committed = committedOutputIndices(reported, 3);
+    expect(committed!.has(2)).toBe(false);
+  });
+
+  // The advisory notes 0x81 masks to 0x01 under & 0x1f, so it took the same early return.
+  it('treats ALL|ANYONECANPAY as detachable rather than as a plain ALL', () => {
+    const committed = committedOutputIndices(
+      [
+        { index: 0, sighashType: SigHash.ALL_ANYONECANPAY },
+        { index: 1, sighashType: SigHash.SINGLE_ANYONECANPAY },
+      ],
+      3
+    );
+    // ALL|ANYONECANPAY covers every output, so it constrains nothing; only the SINGLE one does.
+    expect([...committed!]).toEqual([1]);
+  });
+
+  // The cases that must keep returning null, so the fix cannot have been a blanket change.
+  it('still reports everything committed when nothing is detachable', () => {
+    expect(committedOutputIndices([{ index: 0, sighashType: SigHash.ALL }], 3)).toBeNull();
+  });
+
+  it('still reports everything committed when every detachable input covers all outputs', () => {
+    expect(
+      committedOutputIndices([{ index: 0, sighashType: SigHash.ALL_ANYONECANPAY }], 3)
+    ).toBeNull();
+  });
+});

--- a/src/core/counterparty/__tests__/transactionSafety.unclassified.test.ts
+++ b/src/core/counterparty/__tests__/transactionSafety.unclassified.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { analyzeTransactionSafety } from '@/core/counterparty/transactionSafety';
+
+/**
+ * The second root cause named in GHSA-hghm-pm6h-67gp, kept as a regression test.
+ *
+ * Every classification in analyzeTransactionSafety hangs off `if (messageType)`. In 0.6.0 an
+ * undefined type skipped all of it — including the "unknown type" warning that would have been the
+ * natural fallback — so a transaction the wallet could not read rendered exactly like one it had
+ * read and found safe. Combined with the payload extractor only inspecting OP_RETURN, a sweep in
+ * another encoding reached the approval screen with no block and no warning at all.
+ *
+ * The extractor now covers bare multisig too, so such a sweep classifies and the block fires. This
+ * pins the other half: when a payload genuinely cannot be read, the screen must say so rather than
+ * present the transaction as ordinary.
+ */
+const payment = { index: 1, value: 30000, type: 'p2pkh' as const, address: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa' };
+
+describe('a transaction whose payload could not be classified', () => {
+  // Each of these is a shape a data-carrying output takes across the PSBT decoder's vocabulary and
+  // the node's scriptPubKey types.
+  it.each([
+    ['op_return', 'an OP_RETURN that did not decrypt to a Counterparty message'],
+    ['unknown', 'bare multisig, as the PSBT decoder reports it'],
+    ['multisig', 'bare multisig, as a node reports it'],
+    ['nonstandard', 'a script the node could not categorise'],
+  ])('warns when the outputs include a %s output (%s)', (type) => {
+    const safety = analyzeTransactionSafety(
+      undefined,
+      [{ index: 0, value: 546, type }, payment] as never,
+      []
+    );
+
+    expect(safety.warnings.map((w) => w.title)).toContain('Unrecognized Transaction');
+  });
+
+  it('does not warn about an ordinary transfer that carries no data outputs', () => {
+    const safety = analyzeTransactionSafety(undefined, [payment] as never, []);
+
+    expect(safety.warnings.map((w) => w.title)).not.toContain('Unrecognized Transaction');
+  });
+
+  // The warning is the fallback, not a replacement: a payload that does classify as a sweep must
+  // still be blocked outright rather than merely flagged.
+  it('still blocks a sweep once the payload is classified', () => {
+    const safety = analyzeTransactionSafety('sweep', [payment] as never, []);
+
+    expect(safety.blocked).toBe(true);
+    expect(safety.warnings.map((w) => w.severity)).toContain('block');
+  });
+});


### PR DESCRIPTION
Both open advisories report **0.6.0 behaviour that 0.7.0 already fixed** — but neither fix has a test naming the scenario it closed, so nothing would go red if either regressed.

## GHSA-xchm-466g-93cw — at-risk gate bypass

One `SIGHASH_ALL` input made `committedOutputIndices` return `null` (*every output committed, nothing at risk*), absorbing a `SINGLE|ANYONECANPAY` input signed in the same PSBT.

The function has since been rewritten around **detachability** — which is the reporter's own argument: a signature only binds transactions containing its own input, so an `ALL`-signed input that can simply be dropped constrains nothing. On the reported PSBT it now returns `{1}`, only the dust output the detachable input covers, leaving the ~1 BTC output at risk.

**I confirmed the v0.6.0 implementation returns `null` on the same input**, so these tests would have caught the original bug rather than passing vacuously.

Two cases assert the verdicts that must **not** change — nothing detachable, and every detachable input covering all outputs — so the fix can't be mistaken for a blanket "never return null".

## GHSA-hghm-pm6h-67gp — sweep block bypassable by encoding

The advisory named two causes:

1. **Payload extraction gated on OP_RETURN** — now fixed; `extractPayloadFromOutputs` falls through to `extractMultisigPayload`, and `multisig-encoding.test.ts` already covers it
2. **The classifier no-ops on an undefined type** — **had no test.** Every classification hangs off `if (messageType)`, and in 0.6.0 an undefined type skipped all of it, including the unknown-type warning, so an unreadable transaction rendered like a safe one

These cases pin the fallback across each data-carrying output shape (`op_return`, `unknown`, `multisig`, `nonstandard`), assert an ordinary transfer doesn't trigger it, and assert it stays a *fallback* — a payload that does classify as a sweep is still **blocked**, not merely flagged.

## Note on the pubkeyhash claim

The sweep advisory lists `pubkeyhash` among the encodings a sweep could hide in. Checking counterparty-core's `determine_encoding` (`lib/api/composer.py`), that encoding **doesn't exist**:

```python
if encoding not in ("multisig", "opreturn", "taproot"):
    raise exceptions.ComposeError(f"Not supported encoding: {encoding}")
```

Core rejects it outright. `taproot` is real but requires a segwit source and **no destinations**, so a sweep can't use it either. The two encodings a sweep can actually take are `opreturn` and `multisig` — both now covered.

The extension's own `BaseComposeOptions.encoding` union still lists `'pubkeyhash'`, which is what the advisory quoted. **Worth trimming separately** — it's the artifact that will mislead the next reader.

## Verification

- `tsc --noEmit` clean; `biome check src` clean (674 files)
- `vitest run src/core` — 2116 passed, 46 skipped
- 12 new tests across the two suites

Tests only. No production code changed.