### PR TITLE
Pool swap experience, unified pool pages, and market/compose UX polish

### DIFF
--- a/e2e/pages/addresses/index.spec.ts
+++ b/e2e/pages/addresses/index.spec.ts
@@ -207,15 +207,19 @@ walletTest.describe('Select Address Page (/addresses)', () => {
     }
   });
 
-  walletTest('header has Add button for quick add', async ({ page }) => {
+  walletTest('header has Address Type settings button', async ({ page }) => {
     await page.goto(page.url().replace(/\/index.*/, '/addresses'));
     await page.waitForLoadState('networkidle');
 
     walletTest.skip(!page.url().includes('addresses'), 'Redirected - non-mnemonic wallet');
 
-    // Header should have Add Address button (icon only, in header section)
-    const headerAddButton = selectAddress.headerAddButton(page);
-    await expect(headerAddButton).toBeVisible({ timeout: 5000 });
+    // The header cog opens the address type page; adding addresses lives in the
+    // bottom button only
+    const headerButton = selectAddress.headerAddressTypeButton(page);
+    await expect(headerButton).toBeVisible({ timeout: 5000 });
+    await headerButton.click();
+
+    await expect(page).toHaveURL(/settings\/address-types/, { timeout: 5000 });
   });
 
   walletTest('shows address previews in list', async ({ page }) => {

--- a/e2e/pages/assets/[asset]/balance.spec.ts
+++ b/e2e/pages/assets/[asset]/balance.spec.ts
@@ -39,10 +39,10 @@ walletTest.describe('View Balance Page (/assets/:asset/balance)', () => {
     await expect(swapAction).toBeVisible({ timeout: 10000 });
   });
 
-  walletTest('does not show Sell action for XCP', async ({ page }) => {
+  walletTest('shows Sell action for XCP', async ({ page }) => {
     await navigateToBalance(page, 'XCP');
 
-    await expect(page.locator('text="Sell"').first()).not.toBeVisible();
+    await expect(page.locator('text="Sell"').first()).toBeVisible({ timeout: 10000 });
   });
 
   walletTest('does not show Attach action for XCP', async ({ page }) => {

--- a/e2e/pages/market/xcp-price.spec.ts
+++ b/e2e/pages/market/xcp-price.spec.ts
@@ -34,8 +34,11 @@ const PRICE_HISTORY = {
   },
 };
 
-/** Serve the two explorer endpoints the page reads. Registered most-specific-last so it wins. */
-async function stubPriceApi(page: Page, overrides: { tickerStatus?: number } = {}) {
+/** Serve the endpoints the page reads. Registered most-specific-last so it wins. */
+async function stubPriceApi(
+  page: Page,
+  overrides: { tickerStatus?: number; dispensers?: object[] } = {},
+) {
   await page.route('**/v2/price', (route) =>
     route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(PRICE_HISTORY) }),
   );
@@ -44,6 +47,16 @@ async function stubPriceApi(page: Page, overrides: { tickerStatus?: number } = {
       status: overrides.tickerStatus ?? 200,
       contentType: 'application/json',
       body: JSON.stringify(overrides.tickerStatus ? { error: 'unavailable' } : TICKER),
+    }),
+  );
+  // Open XCP dispensers feed the floor-price row; with none open the page
+  // falls back to the explorer's DEX rate.
+  const dispensers = overrides.dispensers ?? [];
+  await page.route('**/v2/assets/XCP/dispensers*', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ result: dispensers, result_count: dispensers.length }),
     }),
   );
 }
@@ -63,7 +76,7 @@ walletTest.describe('XCP Price Page (/market/xcp)', () => {
     await expect(page.getByText(/Counterparty \(USD\)/i)).toBeVisible();
   });
 
-  walletTest('reports the DEX rate and all-time high', async ({ page }) => {
+  walletTest('falls back to the DEX rate when no dispensers are open', async ({ page }) => {
     await stubPriceApi(page);
     await gotoXcpPrice(page);
 
@@ -72,6 +85,19 @@ walletTest.describe('XCP Price Page (/market/xcp)', () => {
     await expect(page.getByText(/2,200 sats/)).toBeVisible();
     await expect(market.allTimeHigh(page)).toBeVisible();
     await expect(page.getByText(/\$88\.93/)).toBeVisible();
+  });
+
+  walletTest('reports the floor price from the cheapest open dispenser', async ({ page }) => {
+    await stubPriceApi(page, {
+      dispensers: [
+        { source: 'bc1qcheapest', satoshirate: 2400, give_quantity_normalized: '1' },
+        { source: 'bc1qpricier', satoshirate: 5000, give_quantity_normalized: '1' },
+      ],
+    });
+    await gotoXcpPrice(page);
+
+    await expect(market.floorPrice(page)).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText(/2,400 sats/)).toBeVisible();
   });
 
   walletTest('draws the price chart', async ({ page }) => {

--- a/e2e/selectors.ts
+++ b/e2e/selectors.ts
@@ -403,7 +403,7 @@ export const selectAddress = {
   // Use aria-label for stability, filter to the visible full-width one
   addAddressButton: (page: Page) => page.locator('button[aria-label="Add Address"]').filter({ hasText: 'Add Address' }),
   // Header Add button (icon only, no text)
-  headerAddButton: (page: Page) => page.locator('header button[aria-label="Add Address"]'),
+  headerAddressTypeButton: (page: Page) => page.locator('header button[aria-label="Change Address Type"]'),
   chevronButton: (page: Page) => page.locator('[aria-label="Select another address"]'),
   addressLabel: (page: Page, num: number) => page.locator(`text=Address ${num}`),
   copyButton: (page: Page) => page.locator('[title*="Copy"], [aria-label*="Copy"]').first(),
@@ -448,6 +448,7 @@ export const market = {
   xcpRange30d: (page: Page) => page.getByRole('button', { name: '30D' }),
   xcpRangeAll: (page: Page) => page.getByRole('button', { name: 'All' }),
   dexRate: (page: Page) => page.getByText(/DEX Rate/i),
+  floorPrice: (page: Page) => page.getByText(/Floor Price/i),
   allTimeHigh: (page: Page) => page.getByText(/All-Time High/i),
 
   // Asset dispensers/orders pages - main heading

--- a/src/components/domain/asset/asset-select-input.tsx
+++ b/src/components/domain/asset/asset-select-input.tsx
@@ -137,8 +137,7 @@ export function AssetSelectInput({
       <Combobox value={selectedAsset} onChange={handleAssetChange}>
         <div className="relative">
           <label className="block text-sm font-medium text-gray-700">
-            {label}
-            {required && <span className="text-red-500">*</span>}
+            {label} {required && <span className="text-red-500">*</span>}
           </label>
           <div className="relative mt-1">
             <div className="relative w-full cursor-default overflow-hidden rounded-md bg-gray-50 text-left focus:outline-none sm:text-sm">

--- a/src/components/domain/asset/fairminter-select-input.tsx
+++ b/src/components/domain/asset/fairminter-select-input.tsx
@@ -162,8 +162,7 @@ export function FairminterSelectInput({
       <Combobox value={selectedAsset} onChange={handleAssetChange}>
         <div className="relative">
           <label className="block text-sm font-medium text-gray-700">
-            {label}
-            {required && <span className="text-red-500">*</span>}
+            {label} {required && <span className="text-red-500">*</span>}
           </label>
           <div className="relative mt-1">
             <div className="relative w-full cursor-default overflow-hidden rounded-md bg-gray-50 text-left focus:outline-none sm:text-sm">

--- a/src/components/icons/index.tsx
+++ b/src/components/icons/index.tsx
@@ -155,6 +155,18 @@ export const FiRefreshCw = (props: IconProps): ReactElement => (
   </FeatherIcon>
 );
 
+// Lucide (Feather's maintained successor, same stroke style): vertical swap arrows
+export const LuArrowDownUp = (props: IconProps): ReactElement => (
+  <FeatherIcon {...props}>
+    <>
+      <path d="m3 16 4 4 4-4" />
+      <path d="M7 20V4" />
+      <path d="m21 8-4-4-4 4" />
+      <path d="M17 4v16" />
+    </>
+  </FeatherIcon>
+);
+
 export const FiRotateCcw = (props: IconProps): ReactElement => (
   <FeatherIcon {...props}>
     <>

--- a/src/components/ui/cards/pool-card.tsx
+++ b/src/components/ui/cards/pool-card.tsx
@@ -51,11 +51,14 @@ export function PoolCard({
       tabIndex={0}
     >
       <div className="flex items-center gap-3">
-        <div className="relative h-8 w-12 flex-shrink-0">
-          <div className="absolute left-0 top-0">
+        {/* Overlapping pair icons: solid white backing keeps transparent icon art
+            from bleeding through, hairline ring keeps each circle crisp, and the
+            front icon carries a white halo to separate it from the back one. */}
+        <div className="relative h-8 w-[52px] flex-shrink-0">
+          <div className="absolute left-0 top-0 rounded-full bg-white ring-1 ring-gray-200 overflow-hidden">
             <AssetIcon asset={assetA} size="md" />
           </div>
-          <div className="absolute left-4 top-0 rounded-full ring-2 ring-white">
+          <div className="absolute left-5 top-0 rounded-full bg-white ring-1 ring-gray-200 overflow-hidden shadow-[0_0_0_2px_white]">
             <AssetIcon asset={assetB} size="md" />
           </div>
         </div>
@@ -65,9 +68,18 @@ export function PoolCard({
           </div>
           <div className="flex justify-between text-xs text-gray-500">
             <span className="truncate">
-              {formatAmount({ value: reserveA, maximumFractionDigits: 2 })} {assetA}
-              {" / "}
-              {formatAmount({ value: reserveB, maximumFractionDigits: 2 })} {assetB}
+              {reserveA > 0 && reserveB > 0 ? (
+                <>
+                  1 {assetB} ={" "}
+                  {formatAmount({
+                    value: reserveA / reserveB,
+                    maximumFractionDigits: reserveA / reserveB >= 1 ? 2 : 8,
+                  })}{" "}
+                  {assetA}
+                </>
+              ) : (
+                "No liquidity"
+              )}
             </span>
             {quantity !== null && (
               <span className="flex-shrink-0 ml-2">

--- a/src/components/ui/headers/pool-header.tsx
+++ b/src/components/ui/headers/pool-header.tsx
@@ -27,7 +27,7 @@ export function PoolHeader({ pool, className = "" }: PoolHeaderProps): ReactElem
       <div className="min-w-0">
         <h2 className="text-xl font-bold break-words">{pair}</h2>
         <p className="text-sm text-gray-600">
-          {balance ? `Balance: ${balance}` : `LP Asset: ${pool.lp_asset}`}
+          {balance ? `Balance: ${balance}` : `LP: ${pool.lp_asset}`}
         </p>
       </div>
     </div>

--- a/src/core/bitcoin/address.ts
+++ b/src/core/bitcoin/address.ts
@@ -44,6 +44,33 @@ export function normalizeAddressForComparison(address: string): string {
 }
 
 /**
+ * Human-readable label for an address format, shown wherever the UI names a
+ * wallet's address type (settings, address list).
+ */
+export function getAddressFormatLabel(format: AddressFormat): string {
+  switch (format) {
+    case AddressFormat.P2PKH:
+      return 'Legacy (P2PKH)';
+    case AddressFormat.P2WPKH:
+      return 'Native SegWit (P2WPKH)';
+    case AddressFormat.P2SH_P2WPKH:
+      return 'Nested SegWit (P2SH-P2WPKH)';
+    case AddressFormat.P2TR:
+      return 'Taproot (P2TR)';
+    case AddressFormat.Counterwallet:
+      return 'CounterWallet (P2PKH)';
+    case AddressFormat.CounterwalletSegwit:
+      return 'CounterWallet SegWit (P2WPKH)';
+    case AddressFormat.FreewalletBIP39:
+      return 'FreeWallet (P2PKH)';
+    case AddressFormat.FreewalletBIP39Segwit:
+      return 'FreeWallet SegWit (P2WPKH)';
+    default:
+      return format;
+  }
+}
+
+/**
  * Check if an address format is a SegWit format (P2WPKH, P2SH-P2WPKH, CounterwalletSegwit, or P2TR).
  */
 export function isSegwitFormat(format: AddressFormat): boolean {

--- a/src/core/counterparty/__tests__/pool.test.ts
+++ b/src/core/counterparty/__tests__/pool.test.ts
@@ -5,6 +5,7 @@ import {
   calculateLimitingLpEstimate,
   getCanonicalPoolAssets,
   getCanonicalPoolPair,
+  normalizePoolPosition,
 } from "../pool";
 
 describe("counterparty pool utilities", () => {
@@ -29,5 +30,30 @@ describe("counterparty pool utilities", () => {
     expect(calculateLimitingLpEstimate("1000", "500", "250")).toBe("500");
     expect(calculateLimitingLpEstimate("1000", "500", "500")).toBe("1000");
     expect(calculateLimitingLpEstimate("1000", null, "250")).toBe("1000");
+  });
+
+  describe("normalizePoolPosition", () => {
+    const position = {
+      asset_a: "PEPECASH",
+      asset_b: "XCP",
+      reserve_a: 75000000000000,
+      reserve_b: 300000000000,
+      lp_asset: "A6900000000000001774",
+      quantity: 4743416490252,
+    };
+
+    it("derives quantity_normalized when the endpoint omits it", () => {
+      expect(normalizePoolPosition(position).quantity_normalized).toBe("47434.16490252");
+    });
+
+    it("does not divide when lp_asset_info marks the LP asset indivisible", () => {
+      const indivisible = { ...position, quantity: 42, lp_asset_info: { divisible: false } };
+      expect(normalizePoolPosition(indivisible).quantity_normalized).toBe("42");
+    });
+
+    it("keeps quantity_normalized from the API when present", () => {
+      const alreadyNormalized = { ...position, quantity_normalized: "47434.1649" };
+      expect(normalizePoolPosition(alreadyNormalized).quantity_normalized).toBe("47434.1649");
+    });
   });
 });

--- a/src/core/counterparty/pool.ts
+++ b/src/core/counterparty/pool.ts
@@ -1,4 +1,25 @@
-import { BigNumber, toBigNumber } from "@/core/numeric";
+import type { PoolPosition } from "@/core/counterparty/api";
+import { BigNumber, fromSatoshis, toBigNumber } from "@/core/numeric";
+
+/**
+ * verbose=true does not normalize the LP `quantity` on the address pools
+ * endpoint: core's get_pool_positions_by_address selects no `asset` column, so
+ * verbose.py never resolves the asset_info it needs to inject
+ * quantity_normalized (reserves do normalize, via asset_a/asset_b). Derive it
+ * from lp_asset_info.divisible — always true today, per core's own comment in
+ * verbose.py — so raw satoshis never reach the UI pretending to be normalized.
+ */
+export function normalizePoolPosition(position: PoolPosition): PoolPosition {
+  if (position.quantity_normalized != null || position.quantity == null) {
+    return position;
+  }
+  const lpAssetInfo = position.lp_asset_info as { divisible?: boolean } | undefined;
+  const divisible = lpAssetInfo?.divisible ?? true;
+  return {
+    ...position,
+    quantity_normalized: divisible ? fromSatoshis(position.quantity) : String(position.quantity),
+  };
+}
 
 export function getCanonicalPoolAssets(assetA: string, assetB: string): [string, string] {
   return assetA <= assetB ? [assetA, assetB] : [assetB, assetA];

--- a/src/entrypoints/popup/app.tsx
+++ b/src/entrypoints/popup/app.tsx
@@ -48,6 +48,7 @@ import ComposePoolWithdrawPage from '@/pages/compose/pool/withdraw';
 // Compose
 import ComposeSendPage from '@/pages/compose/send';
 import ComposeMpmaPage from '@/pages/compose/send/mpma';
+import ComposeSwapPage from '@/pages/compose/swap';
 import ComposeSweepPage from '@/pages/compose/sweep';
 import ComposeUtxoAttachPage from '@/pages/compose/utxo/attach';
 import ComposeUtxoDetachPage from '@/pages/compose/utxo/detach';
@@ -210,6 +211,7 @@ export default function App() {
             <Route path="/compose/order/btcpay" element={<ComposeOrderBtcPayPage />} />
             <Route path="/compose/order/cancel/:hash?" element={<ComposeOrderCancelPage />} />
             <Route path="/compose/order/:asset?" element={<ComposeOrderPage />} />
+            <Route path="/compose/swap/:giveAsset?/:getAsset?" element={<ComposeSwapPage />} />
             <Route path="/compose/issuance/issue-supply/:asset" element={<ComposeIssueSupplyPage />} />
             <Route path="/compose/issuance/lock-supply/:asset" element={<ComposeLockSupplyPage />} />
             <Route path="/compose/issuance/reset-supply/:asset" element={<ComposeResetSupplyPage />} />

--- a/src/hooks/useLpAssetPool.ts
+++ b/src/hooks/useLpAssetPool.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useWallet } from "@/contexts/wallet-context";
 import { fetchAddressPoolByLpAsset, type PoolPosition } from "@/core/counterparty/api";
+import { normalizePoolPosition } from "@/core/counterparty/pool";
 
 interface LpAssetPoolState {
   data: PoolPosition | null;
@@ -24,7 +25,7 @@ export function useLpAssetPool(asset: string | undefined): LpAssetPoolState {
     fetchAddressPoolByLpAsset(activeAddress.address, asset, { limit: 100 })
       .then((response) => {
         if (cancelled) return;
-        setState({ data: response, isLoading: false, error: null });
+        setState({ data: response ? normalizePoolPosition(response) : null, isLoading: false, error: null });
       })
       .catch((err) => {
         if (!cancelled) {

--- a/src/hooks/usePoolQuotes.ts
+++ b/src/hooks/usePoolQuotes.ts
@@ -1,8 +1,10 @@
 import { useEffect, useState } from "react";
 import {
   fetchPoolDepositQuote,
+  fetchPoolQuote,
   fetchPoolWithdrawQuote,
   type PoolDepositQuote,
+  type PoolQuote,
   type PoolWithdrawQuote,
 } from "@/core/counterparty/api";
 import { roundDown, toSatoshis } from "@/core/numeric";
@@ -66,6 +68,68 @@ export function usePoolDepositQuote({
       clearTimeout(timer);
     };
   }, [assetA, assetB, enabled, isAssetADivisible, quantityA]);
+
+  return state;
+}
+
+/**
+ * Debounced swap quote: how much of getAsset you would receive right now for
+ * selling `quantity` of giveAsset, routed across the AMM pool and the resting
+ * order book (core's /v2/pools/<give>/<get>/quote endpoint).
+ */
+export function usePoolSwapQuote({
+  giveAsset,
+  getAsset,
+  quantity,
+  isGiveDivisible,
+  enabled,
+}: {
+  giveAsset: string;
+  getAsset: string;
+  quantity: string;
+  isGiveDivisible: boolean;
+  enabled: boolean;
+}): PoolQuoteState<PoolQuote> {
+  const [state, setState] = useState<PoolQuoteState<PoolQuote>>({
+    data: null,
+    isLoading: false,
+    error: null,
+  });
+
+  useEffect(() => {
+    if (!enabled) {
+      setState({ data: null, isLoading: false, error: null });
+      return;
+    }
+
+    let cancelled = false;
+    setState({ data: null, isLoading: true, error: null });
+
+    const timer = setTimeout(() => {
+      fetchPoolQuote(
+        giveAsset,
+        getAsset,
+        isGiveDivisible ? toSatoshis(quantity) : roundDown(quantity).toString()
+      )
+        .then((data) => {
+          if (!cancelled) setState({ data, isLoading: false, error: null });
+        })
+        .catch((err) => {
+          if (!cancelled) {
+            setState({
+              data: null,
+              isLoading: false,
+              error: err instanceof Error ? err.message : "Unable to load swap quote.",
+            });
+          }
+        });
+    }, 300);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [giveAsset, getAsset, quantity, isGiveDivisible, enabled]);
 
   return state;
 }

--- a/src/pages/actions/consolidate/form.tsx
+++ b/src/pages/actions/consolidate/form.tsx
@@ -3,7 +3,6 @@ import { AddressHeader } from "@/components/domain/address/address-header";
 import { Button } from "@/components/ui/button";
 import { DestinationInput } from "@/components/ui/inputs/destination-input";
 import { FeeRateInput } from "@/components/ui/inputs/fee-rate-input";
-import { useSettings } from "@/contexts/settings-context";
 import { useWallet } from "@/contexts/wallet-context";
 import {
   type ConsolidationData,
@@ -30,17 +29,16 @@ const DEFAULT_FORM_DATA: ConsolidationFormData = {
 
 interface ConsolidationFormProps {
   onSubmit: (data: ConsolidationFormData) => void;
+  showHelpText?: boolean;
 }
 
-export function ConsolidationForm({ onSubmit }: ConsolidationFormProps) {
+export function ConsolidationForm({ onSubmit, showHelpText }: ConsolidationFormProps) {
   const { activeAddress, activeWallet } = useWallet();
   const [formData, setFormData] =
     useState<ConsolidationFormData>(DEFAULT_FORM_DATA);
   const [isLoading, setIsLoading] = useState(false);
   const [isInitialLoad, setIsInitialLoad] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const { settings } = useSettings();
-  const shouldShowHelpText = settings?.showHelpText;
 
   // Fetch recovery data for the active address.
   useEffect(() => {
@@ -133,7 +131,7 @@ export function ConsolidationForm({ onSubmit }: ConsolidationFormProps) {
         <AddressHeader
           address={activeAddress.address}
           walletName={activeWallet?.name}
-          className="mb-6"
+          className="mt-1 mb-5"
         />
       )}
       <form
@@ -266,13 +264,13 @@ export function ConsolidationForm({ onSubmit }: ConsolidationFormProps) {
           label="Destination Address (Optional)"
           placeholder="Leave empty to consolidate to source address"
           required={false}
-          showHelpText={shouldShowHelpText}
+          showHelpText={showHelpText}
           helpText="If left empty, UTXOs will be consolidated to your source address."
         />
 
         <FeeRateInput
           onFeeRateChange={handleFeeRateChange}
-          showHelpText={shouldShowHelpText}
+          showHelpText={showHelpText}
         />
 
         <Button

--- a/src/pages/actions/consolidate/index.tsx
+++ b/src/pages/actions/consolidate/index.tsx
@@ -22,9 +22,13 @@ function ConsolidatePage() {
   const { setHeaderProps } = useHeader();
   const { settings, updateSettings } = useSettings();
 
+  // Local, non-persisting help toggle (same behavior as compose forms):
+  // seeded from the global setting, but never written back to it.
+  const [localShowHelpText, setLocalShowHelpText] = useState<boolean | null>(null);
+  const showHelpText = localShowHelpText ?? settings?.showHelpText ?? false;
   const toggleHelp = useCallback(() => {
-    updateSettings({ showHelpText: !settings?.showHelpText });
-  }, [settings?.showHelpText, updateSettings]);
+    setLocalShowHelpText(prev => prev === null ? !settings?.showHelpText : !prev);
+  }, [settings?.showHelpText]);
 
   // Mark the recover bitcoin page as visited
   useEffect(() => {
@@ -51,7 +55,7 @@ function ConsolidatePage() {
       });
     }
     return () => setHeaderProps(null);
-  }, [step, setHeaderProps, navigate]);
+  }, [step, setHeaderProps, navigate, toggleHelp]);
 
   if (!activeAddress || !activeWallet) return null;
 
@@ -110,7 +114,7 @@ function ConsolidatePage() {
 
       {step === "form" && (
         <>
-          <ConsolidationForm onSubmit={handleFormSubmit} />
+          <ConsolidationForm onSubmit={handleFormSubmit} showHelpText={showHelpText} />
           <ConsolidationHistory address={activeAddress.address} />
         </>
       )}

--- a/src/pages/actions/index.tsx
+++ b/src/pages/actions/index.tsx
@@ -105,6 +105,12 @@ const getActionSections = (
           onClick: () => navigate("/compose/order/cancel"),
         },
         {
+          id: "create-dispenser",
+          title: "Create Dispenser",
+          description: "Sell an asset at a fixed BTC price",
+          onClick: () => navigate("/compose/dispenser"),
+        },
+        {
           id: "close-dispenser",
           title: "Close Dispenser", 
           description: "Close an existing dispenser",

--- a/src/pages/addresses/index.tsx
+++ b/src/pages/addresses/index.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from "react";
 import { useCallback, useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router";
-import { FaPlus } from "@/components/icons";
+import { FaCog, FaPlus } from "@/components/icons";
 import { Button } from "@/components/ui/button";
 import { ErrorAlert } from "@/components/ui/error-alert";
 import { AddressList } from "@/components/ui/lists/address-list";
@@ -91,15 +91,15 @@ export default function AddressesPage(): ReactElement {
       title: "Addresses",
       onBack: () => navigate(returnTo, { replace: true }),
       rightButton:
-        activeWallet?.type === "mnemonic" && !isAddingAddress
+        activeWallet?.type === "mnemonic"
           ? {
-              icon: <FaPlus aria-hidden="true" />,
-              onClick: handleAddAddress,
-              ariaLabel: "Add Address",
+              icon: <FaCog aria-hidden="true" />,
+              onClick: () => navigate("/settings/address-types", { state: { returnTo: PATHS.SELECT } }),
+              ariaLabel: "Change Address Type",
             }
           : undefined,
     });
-  }, [setHeaderProps, navigate, returnTo, activeWallet?.type, handleAddAddress, isAddingAddress]);
+  }, [setHeaderProps, navigate, returnTo, activeWallet?.type]);
 
   if (!activeWallet) return <div className="p-4">No active wallet found</div>;
 

--- a/src/pages/assets/[asset]/balance.tsx
+++ b/src/pages/assets/[asset]/balance.tsx
@@ -7,6 +7,8 @@ import { ActionList } from "@/components/ui/lists/action-list";
 import { Spinner } from "@/components/ui/spinner";
 import { useHeader } from "@/contexts/header-context";
 import type { TokenBalance } from "@/core/counterparty/api";
+import { getCanonicalPoolPair } from "@/core/counterparty/pool";
+import { divide, formatDecimal, isGreaterThan, multiply, toBigNumber } from "@/core/numeric";
 import { useAssetDetails } from "@/hooks/useAssetDetails";
 import { useLpAssetPool } from "@/hooks/useLpAssetPool";
 
@@ -94,6 +96,7 @@ export default function AssetBalancePage(): ReactElement {
       title: "Destroy",
       description: "Permanently burn this asset",
       onClick: () => navigate(`${PATHS.COMPOSE}/issuance/destroy/${encodedAsset}`),
+      className: "!border !border-red-500",
     };
 
     const items = isBTC
@@ -115,12 +118,11 @@ export default function AssetBalancePage(): ReactElement {
           },
         ]
       : isXCP
-      ? [sendAction, swapAction, mintAction, destroyAction]
+      ? [sendAction, sellAction, swapAction, mintAction, destroyAction]
       : [sendAction, sellAction, swapAction, destroyAction];
     if (lpPool) {
       return [
         {
-          title: "Liquidity Pool",
           items: [
             {
               id: "manage-pool",
@@ -128,9 +130,9 @@ export default function AssetBalancePage(): ReactElement {
               description: `${lpPool.asset_a} / ${lpPool.asset_b}`,
               onClick: () => navigate(`/pools/${encodeURIComponent(lpPool.lp_asset)}`),
             },
+            ...items,
           ],
         },
-        { items },
       ];
     }
     return [{ items }];
@@ -176,11 +178,60 @@ export default function AssetBalancePage(): ReactElement {
     return <div className="p-4 text-center text-gray-600">Failed to load balance information</div>;
   }
 
+  // Pool position details for LP asset balances, in the UTXO-details card style.
+  const poolDetails = (() => {
+    if (!lpPool) return null;
+    const lpBalance = toBigNumber(lpPool.quantity_normalized ?? 0);
+    const lpSupply = toBigNumber(assetDetails?.assetInfo?.supply_normalized);
+    const poolShare = isGreaterThan(lpSupply, 0) && isGreaterThan(lpBalance, 0)
+      ? divide(lpBalance, lpSupply)
+      : null;
+    return {
+      pair: getCanonicalPoolPair(lpPool.asset_a, lpPool.asset_b),
+      sharePercent: poolShare ? formatDecimal(multiply(poolShare, 100), 4) : null,
+      underlying: poolShare
+        ? [
+            { asset: lpPool.asset_a, amount: formatDecimal(multiply(poolShare, toBigNumber(lpPool.reserve_a_normalized ?? lpPool.reserve_a))) },
+            { asset: lpPool.asset_b, amount: formatDecimal(multiply(poolShare, toBigNumber(lpPool.reserve_b_normalized ?? lpPool.reserve_b))) },
+          ]
+        : null,
+    };
+  })();
+
   return (
     <div className="p-4 space-y-6" role="main" aria-labelledby="balance-title">
-      <div className="space-y-4">
-        <BalanceHeader balance={balanceData} className="mt-1 mb-5" />
-      </div>
+      <BalanceHeader balance={balanceData} className="mt-1 mb-5" />
+      {poolDetails && (
+        <div className="bg-white rounded-lg p-4 shadow-sm">
+          <h2 className="text-sm font-medium text-gray-900">Pool Position</h2>
+          <div className="mt-2 space-y-2">
+            <div className="flex justify-between">
+              <span className="text-sm text-gray-500">Pool</span>
+              <span className="text-sm text-gray-900">{poolDetails.pair}</span>
+            </div>
+            {poolDetails.sharePercent && (
+              <div className="flex justify-between">
+                <span className="text-sm text-gray-500">Pool Share</span>
+                <span className="text-sm text-gray-900">{poolDetails.sharePercent}%</span>
+              </div>
+            )}
+          </div>
+          {poolDetails.underlying && (
+            <>
+              <hr className="my-4 border-gray-200" />
+              <h2 className="text-sm font-medium text-gray-900">Underlying</h2>
+              <div className="mt-2 space-y-2">
+                {poolDetails.underlying.map(({ asset: underlyingAsset, amount }) => (
+                  <div key={underlyingAsset} className="flex justify-between">
+                    <span className="text-sm text-gray-500">{underlyingAsset}</span>
+                    <span className="text-sm text-gray-900">{amount}</span>
+                  </div>
+                ))}
+              </div>
+            </>
+          )}
+        </div>
+      )}
       <ActionList sections={getActionSections()} />
     </div>
   );

--- a/src/pages/assets/[asset]/index.tsx
+++ b/src/pages/assets/[asset]/index.tsx
@@ -251,12 +251,10 @@ export default function AssetPage(): ReactElement {
 
   return (
     <div className="p-4 space-y-6" role="main" aria-labelledby="asset-title">
-      <div className="space-y-4">
-        <AssetHeader
-          className="mt-1 mb-5"
-          assetInfo={headerAssetInfo}
-        />
-      </div>
+      <AssetHeader
+        className="mt-1 mb-5"
+        assetInfo={headerAssetInfo}
+      />
       {/* Actions require full data for ownership checks */}
       <ActionList sections={getActionSections()} />
       <div className="bg-white rounded-lg p-4 shadow-sm space-y-3">

--- a/src/pages/compose/order/form.tsx
+++ b/src/pages/compose/order/form.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from "react";
 import { useEffect, useState } from "react";
+import { useNavigate } from "react-router";
 import { ComposerForm } from "@/components/composer/composer-form";
 import { AddressHeader } from "@/components/domain/address/address-header";
 import { AssetSelectInput } from "@/components/domain/asset/asset-select-input";
@@ -14,6 +15,7 @@ import { formatAmount } from "@/core/format";
 import { toBigNumber } from "@/core/numeric";
 import { DEFAULT_ORDER_EXPIRATION } from "@/core/settings";
 import { useAssetDetails } from "@/hooks/useAssetDetails";
+import { usePool } from "@/hooks/usePool";
 import { useTradingPair } from "@/hooks/useTradingPair";
 import { OrderSettings } from "@/pages/settings/order-settings";
 
@@ -57,6 +59,7 @@ export function OrderForm({
 }: OrderFormProps): ReactElement {
   // Context hooks
   const { activeAddress, activeWallet, settings, showHelpText, feeRate } = useComposer();
+  const navigate = useNavigate();
 
   const initialBaseAsset = giveAsset || (
     initialFormData?.type === "buy"
@@ -75,6 +78,13 @@ export function OrderForm({
   const { data: giveAssetDetails } = useAssetDetails(baseAsset);
   const { data: quoteAssetDetails } = useAssetDetails(quoteAsset);
   const { data: getAssetDetails } = useAssetDetails(baseAsset);
+
+  // A pool for this pair unlocks the Swap tab (BTC pairs never have pools)
+  const hasBtcInPair = baseAsset === "BTC" || quoteAsset === "BTC";
+  const { data: pairPool } = usePool(
+    !hasBtcInPair && baseAsset ? baseAsset : undefined,
+    !hasBtcInPair && baseAsset ? quoteAsset : undefined,
+  );
   
   // Local error state management for form-specific errors
   const [validationError, setValidationError] = useState<string | null>(null);
@@ -233,6 +243,15 @@ export function OrderForm({
           >
             Sell
           </button>
+          {pairPool && (
+            <button
+              type="button"
+              className="text-lg font-semibold bg-transparent p-0 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 rounded"
+              onClick={() => navigate(`/compose/swap/${encodeURIComponent(baseAsset)}/${encodeURIComponent(quoteAsset)}`)}
+            >
+              Swap
+            </button>
+          )}
         </div>
         <button
           type="button"

--- a/src/pages/compose/pool/deposit/form.tsx
+++ b/src/pages/compose/pool/deposit/form.tsx
@@ -1,6 +1,7 @@
 import { Description, Field } from "@headlessui/react";
 import { type ReactElement, useMemo, useState } from "react";
 import { useFormStatus } from "react-dom";
+import { useNavigate } from "react-router";
 import { ComposerForm } from "@/components/composer/composer-form";
 import { AssetNameInput } from "@/components/domain/asset/asset-name-input";
 import { AssetSelectInput } from "@/components/domain/asset/asset-select-input";
@@ -48,6 +49,7 @@ export function PoolDepositForm({
 }: PoolDepositFormProps): ReactElement {
   const { activeAddress, showHelpText, feeRate, settings } = useComposer<PoolDepositOptions>();
   const { pending } = useFormStatus();
+  const navigate = useNavigate();
   const [assetA, setAssetA] = useState(initialFormData?.asset_a || initialAssetA || "XCP");
   const [assetB, setAssetB] = useState(initialFormData?.asset_b || initialAssetB || "");
   const [quantityA, setQuantityA] = useState(initialFormData?.quantity_a?.toString() || "");
@@ -153,176 +155,194 @@ export function PoolDepositForm({
     formAction(formData);
   };
 
-  if (showSettings) {
-    return (
-      <PoolSlippageSettings
-        value={slippage}
-        onChange={setSlippage}
-        onBack={() => setShowSettings(false)}
-        showHelpText={showHelpText}
-      />
-    );
-  }
-
   return (
-    <ComposerForm
-      formAction={handleFormAction}
-      header={
-        <div className="flex items-start justify-between gap-2">
-          <div className="min-w-0 flex-1">
-            {pool ? (
-              <PoolHeader pool={pool} className="mt-1 mb-5" />
-            ) : assetABalanceHeader ? (
-              <BalanceHeader balance={assetABalanceHeader} className="mt-1 mb-5" />
-            ) : null}
-          </div>
+    <div className="space-y-4">
+      {pool ? (
+        <PoolHeader pool={pool} className="mt-1 mb-5" />
+      ) : assetABalanceHeader ? (
+        <BalanceHeader balance={assetABalanceHeader} className="mt-1 mb-5" />
+      ) : null}
+      {/* Deposit/Withdraw tabs with the settings cog, mirroring the DEX order form */}
+      <div className="flex justify-between items-center mb-2">
+        <div className="flex space-x-4">
           <button
             type="button"
-            onClick={() => setShowSettings(true)}
-            aria-label="Pool settings"
-            className="mt-1 shrink-0 p-2 rounded-full hover:bg-gray-100 transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+            className="text-lg font-semibold bg-transparent p-0 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 rounded underline"
+            onClick={() => setShowSettings(false)}
           >
-            <FaCog className="size-4 text-gray-600" aria-hidden="true" />
+            Deposit
+          </button>
+          <button
+            type="button"
+            disabled={!pool?.lp_asset}
+            onClick={() => pool?.lp_asset && navigate(`/compose/pool/withdraw/${encodeURIComponent(pool.lp_asset)}`)}
+            className={`text-lg font-semibold bg-transparent p-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 rounded ${
+              pool?.lp_asset ? "cursor-pointer" : "text-gray-400 cursor-not-allowed"
+            }`}
+          >
+            Withdraw
           </button>
         </div>
-      }
-      submitText="Review Deposit"
-      submitDisabled={pending || submitDisabled}
-    >
-      {localError && <ErrorAlert message={localError} onClose={() => setLocalError(null)} />}
+        <button
+          type="button"
+          onClick={() => setShowSettings(!showSettings)}
+          aria-label="Pool Settings"
+          className={`p-2 hover:bg-gray-100 rounded-full transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
+            showSettings ? "bg-gray-100" : ""
+          }`}
+        >
+          <FaCog className="size-4 text-gray-600" aria-hidden="true" />
+        </button>
+      </div>
+      {showSettings ? (
+        <PoolSlippageSettings
+          value={slippage}
+          onChange={setSlippage}
+          onBack={() => setShowSettings(false)}
+          showHelpText={showHelpText}
+        />
+      ) : (
+        <ComposerForm
+          formAction={handleFormAction}
+          submitText="Review Deposit"
+          submitDisabled={pending || submitDisabled}
+        >
+          {localError && <ErrorAlert message={localError} onClose={() => setLocalError(null)} />}
 
-      <AssetSelectInput
-        selectedAsset={assetA}
-        onChange={setAssetA}
-        label="Asset A"
-        required
-        showHelpText={showHelpText}
-      />
-
-      <AmountWithMaxInput
-        asset={assetA}
-        availableBalance={assetADetails?.availableBalance || "0"}
-        value={quantityA}
-        onChange={setQuantityA}
-        feeRate={feeRate}
-        setError={setLocalError}
-        showHelpText={showHelpText}
-        sourceAddress={activeAddress}
-        maxAmount={assetADetails?.availableBalance || "0"}
-        label="Amount"
-        name="quantity_a_display"
-        disabled={pending || !assetA}
-        isDivisible={isAssetADivisible}
-      />
-
-      <AssetSelectInput
-        selectedAsset={assetB}
-        onChange={setAssetB}
-        label="Asset B"
-        required
-        showHelpText={showHelpText}
-      />
-
-      <AmountWithMaxInput
-        asset={assetB}
-        availableBalance={assetBDetails?.availableBalance || "0"}
-        value={quantityB}
-        onChange={setQuantityB}
-        feeRate={feeRate}
-        setError={setLocalError}
-        showHelpText={showHelpText}
-        sourceAddress={activeAddress}
-        maxAmount={assetBDetails?.availableBalance || "0"}
-        label="Amount"
-        name="quantity_b_display"
-        disabled={pending || !assetB}
-        isDivisible={isAssetBDivisible}
-        labelRight={
-          partnerQuantity && !isFirstDeposit ? (
-            <button
-              type="button"
-              className="text-xs text-blue-600 hover:text-blue-800"
-              onClick={() => setQuantityB(partnerQuantity.toString())}
-            >
-              Use quote
-            </button>
-          ) : null
-        }
-      />
-
-      {isLoadingQuote && (
-        <p className="text-sm text-gray-500">Loading pool quote...</p>
-      )}
-
-      {quoteError && (
-        <ErrorAlert message={quoteError} />
-      )}
-
-      {quote?.message && (
-        <div className="rounded border border-gray-200 bg-gray-50 p-3 text-sm text-gray-600">
-          {quote.message}
-        </div>
-      )}
-
-      {partnerQuantity && !isFirstDeposit && (
-        <div className="rounded border border-gray-200 bg-gray-50 p-3 text-sm text-gray-600">
-          Quoted partner amount: {partnerQuantity.toString()} {assetB}
-        </div>
-      )}
-
-      {partnerQuantity && !isFirstDeposit && !partnerQuantityMatches && (
-        <div className="rounded border border-yellow-200 bg-yellow-50 p-3 text-sm text-yellow-800">
-          {partnerQuantityIsHigh
-            ? "Only the pool-ratio amount will be deposited; extra is left unused."
-            : partnerQuantityIsLow
-              ? "This deposits less than the quoted ratio allows."
-              : "Pool deposits use the current pool ratio."}
-        </div>
-      )}
-
-      {isZeroSupplyRestart && (
-        <div className="rounded border border-yellow-200 bg-yellow-50 p-3 text-sm text-yellow-800">
-          LP supply is zero. This deposit restarts the pool and may claim existing reserves.
-        </div>
-      )}
-
-      {hasLpMinimum && (
-        <div className="rounded border border-gray-200 bg-gray-50 p-3 text-sm text-gray-600">
-          Minimum LP tokens:{" "}
-          <span className="font-medium text-gray-900">
-            {fromSatoshis(minLpQuantity, { removeTrailingZeros: true })}
-          </span>{" "}
-          after {slippage || "0"}% slippage.
-        </div>
-      )}
-
-      {isNewPool && (
-        <Field>
-          <AssetNameInput
-            value={lpAsset}
-            onChange={setLpAsset}
-            onValidationChange={setIsLpAssetValid}
-            label="LP Asset"
-            required={false}
-            showRandomNumeric
+          <AssetSelectInput
+            selectedAsset={assetA}
+            onChange={setAssetA}
+            label="Asset A"
+            required
             showHelpText={showHelpText}
-            helpText="Optional. Leave blank to auto-generate the LP asset."
           />
-          {showHelpText && (
-            <Description className="mt-2 text-sm text-gray-500">
-              The LP asset represents your share of the pool.
-            </Description>
-          )}
-        </Field>
-      )}
 
-      <input type="hidden" name="asset_a" value={assetA} />
-      <input type="hidden" name="asset_b" value={assetB} />
-      <input type="hidden" name="quantity_a" value={quantityA} />
-      <input type="hidden" name="quantity_b" value={quantityB} />
-      <input type="hidden" name="min_lp_quantity" value={minLpQuantity} />
-      <input type="hidden" name="slippage" value={slippage} />
-      {lpAsset && <input type="hidden" name="lp_asset" value={lpAsset} />}
-    </ComposerForm>
+          <AmountWithMaxInput
+            asset={assetA}
+            availableBalance={assetADetails?.availableBalance || "0"}
+            value={quantityA}
+            onChange={setQuantityA}
+            feeRate={feeRate}
+            setError={setLocalError}
+            showHelpText={showHelpText}
+            sourceAddress={activeAddress}
+            maxAmount={assetADetails?.availableBalance || "0"}
+            label="Amount"
+            name="quantity_a_display"
+            disabled={pending || !assetA}
+            isDivisible={isAssetADivisible}
+          />
+
+          <AssetSelectInput
+            selectedAsset={assetB}
+            onChange={setAssetB}
+            label="Asset B"
+            required
+            showHelpText={showHelpText}
+          />
+
+          <AmountWithMaxInput
+            asset={assetB}
+            availableBalance={assetBDetails?.availableBalance || "0"}
+            value={quantityB}
+            onChange={setQuantityB}
+            feeRate={feeRate}
+            setError={setLocalError}
+            showHelpText={showHelpText}
+            sourceAddress={activeAddress}
+            maxAmount={assetBDetails?.availableBalance || "0"}
+            label="Amount"
+            name="quantity_b_display"
+            disabled={pending || !assetB}
+            isDivisible={isAssetBDivisible}
+            labelRight={
+              partnerQuantity && !isFirstDeposit ? (
+                <button
+                  type="button"
+                  className="text-xs text-blue-600 hover:text-blue-800"
+                  onClick={() => setQuantityB(partnerQuantity.toString())}
+                >
+                  Use quote
+                </button>
+              ) : null
+            }
+          />
+
+          {isLoadingQuote && (
+            <p className="text-sm text-gray-500">Loading pool quote...</p>
+          )}
+
+          {quoteError && (
+            <ErrorAlert message={quoteError} />
+          )}
+
+          {quote?.message && (
+            <div className="rounded border border-gray-200 bg-gray-50 p-3 text-sm text-gray-600">
+              {quote.message}
+            </div>
+          )}
+
+          {partnerQuantity && !isFirstDeposit && (
+            <div className="rounded border border-gray-200 bg-gray-50 p-3 text-sm text-gray-600">
+              Quoted partner amount: {partnerQuantity.toString()} {assetB}
+            </div>
+          )}
+
+          {partnerQuantity && !isFirstDeposit && !partnerQuantityMatches && (
+            <div className="rounded border border-yellow-200 bg-yellow-50 p-3 text-sm text-yellow-800">
+              {partnerQuantityIsHigh
+                ? "Only the pool-ratio amount will be deposited; extra is left unused."
+                : partnerQuantityIsLow
+                  ? "This deposits less than the quoted ratio allows."
+                  : "Pool deposits use the current pool ratio."}
+            </div>
+          )}
+
+          {isZeroSupplyRestart && (
+            <div className="rounded border border-yellow-200 bg-yellow-50 p-3 text-sm text-yellow-800">
+              LP supply is zero. This deposit restarts the pool and may claim existing reserves.
+            </div>
+          )}
+
+          {hasLpMinimum && (
+            <div className="rounded border border-gray-200 bg-gray-50 p-3 text-sm text-gray-600">
+              Minimum LP tokens:{" "}
+              <span className="font-medium text-gray-900">
+                {fromSatoshis(minLpQuantity, { removeTrailingZeros: true })}
+              </span>{" "}
+              after {slippage || "0"}% slippage.
+            </div>
+          )}
+
+          {isNewPool && (
+            <Field>
+              <AssetNameInput
+                value={lpAsset}
+                onChange={setLpAsset}
+                onValidationChange={setIsLpAssetValid}
+                label="LP Asset"
+                required={false}
+                showRandomNumeric
+                showHelpText={showHelpText}
+                helpText="Optional. Leave blank to auto-generate the LP asset."
+              />
+              {showHelpText && (
+                <Description className="mt-2 text-sm text-gray-500">
+                  The LP asset represents your share of the pool.
+                </Description>
+              )}
+            </Field>
+          )}
+
+          <input type="hidden" name="asset_a" value={assetA} />
+          <input type="hidden" name="asset_b" value={assetB} />
+          <input type="hidden" name="quantity_a" value={quantityA} />
+          <input type="hidden" name="quantity_b" value={quantityB} />
+          <input type="hidden" name="min_lp_quantity" value={minLpQuantity} />
+          <input type="hidden" name="slippage" value={slippage} />
+          {lpAsset && <input type="hidden" name="lp_asset" value={lpAsset} />}
+        </ComposerForm>
+      )}
+    </div>
   );
 }

--- a/src/pages/compose/pool/deposit/index.tsx
+++ b/src/pages/compose/pool/deposit/index.tsx
@@ -12,7 +12,7 @@ export default function ComposePoolDepositPage() {
       <Composer<PoolDepositOptions>
         composeType="pooldeposit"
         composeApiMethod={composePoolDeposit}
-        initialTitle="Pool Deposit"
+        initialTitle="Pool"
         FormComponent={(props) => (
           <PoolDepositForm
             {...props}

--- a/src/pages/compose/pool/withdraw/form.tsx
+++ b/src/pages/compose/pool/withdraw/form.tsx
@@ -1,5 +1,6 @@
 import { type ReactElement, useMemo, useState } from "react";
 import { useFormStatus } from "react-dom";
+import { useNavigate } from "react-router";
 import { ComposerForm } from "@/components/composer/composer-form";
 import { AmountWithMaxInput } from "@/components/domain/balance/amount-with-max-input";
 import { FaCog } from "@/components/icons";
@@ -29,6 +30,7 @@ export function PoolWithdrawForm({
 }: PoolWithdrawFormProps): ReactElement {
   const { activeAddress, showHelpText, feeRate, settings } = useComposer<PoolWithdrawOptions>();
   const { pending } = useFormStatus();
+  const navigate = useNavigate();
   const { data: pool, isLoading, error: poolError } = useLpAssetPool(lpAsset);
   const { data: assetADetails } = useAssetDetails(pool?.asset_a || "");
   const { data: assetBDetails } = useAssetDetails(pool?.asset_b || "");
@@ -93,101 +95,116 @@ export function PoolWithdrawForm({
     return <div className="p-4 text-center text-gray-600">Pool position not found</div>;
   }
 
-  if (showSettings) {
-    return (
-      <PoolSlippageSettings
-        value={slippage}
-        onChange={setSlippage}
-        onBack={() => setShowSettings(false)}
-        showHelpText={showHelpText}
-      />
-    );
-  }
-
   return (
-    <ComposerForm
-      formAction={handleFormAction}
-      header={
-        <div className="flex items-start justify-between gap-2">
-          <div className="min-w-0 flex-1">
-            <PoolHeader pool={pool} className="mt-1 mb-5" />
-          </div>
+    <div className="space-y-4">
+      <PoolHeader pool={pool} className="mt-1 mb-5" />
+      {/* Deposit/Withdraw tabs with the settings cog, mirroring the DEX order form */}
+      <div className="flex justify-between items-center mb-2">
+        <div className="flex space-x-4">
           <button
             type="button"
-            onClick={() => setShowSettings(true)}
-            aria-label="Pool settings"
-            className="mt-1 shrink-0 p-2 rounded-full hover:bg-gray-100 transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+            onClick={() => navigate(`/compose/pool/deposit/${encodeURIComponent(pool.asset_a)}/${encodeURIComponent(pool.asset_b)}`)}
+            className="text-lg font-semibold bg-transparent p-0 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 rounded"
           >
-            <FaCog className="size-4 text-gray-600" aria-hidden="true" />
+            Deposit
+          </button>
+          <button
+            type="button"
+            className="text-lg font-semibold bg-transparent p-0 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 rounded underline"
+            onClick={() => setShowSettings(false)}
+          >
+            Withdraw
           </button>
         </div>
-      }
-      submitText="Review Withdrawal"
-      submitDisabled={pending || submitDisabled}
-    >
-      {localError && <ErrorAlert message={localError} onClose={() => setLocalError(null)} />}
+        <button
+          type="button"
+          onClick={() => setShowSettings(!showSettings)}
+          aria-label="Pool Settings"
+          className={`p-2 hover:bg-gray-100 rounded-full transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
+            showSettings ? "bg-gray-100" : ""
+          }`}
+        >
+          <FaCog className="size-4 text-gray-600" aria-hidden="true" />
+        </button>
+      </div>
+      {showSettings ? (
+        <PoolSlippageSettings
+          value={slippage}
+          onChange={setSlippage}
+          onBack={() => setShowSettings(false)}
+          showHelpText={showHelpText}
+        />
+      ) : (
+        <ComposerForm
+          formAction={handleFormAction}
+          submitText="Review Withdrawal"
+          submitDisabled={pending || submitDisabled}
+        >
+          {localError && <ErrorAlert message={localError} onClose={() => setLocalError(null)} />}
 
-      <AmountWithMaxInput
-        asset={pool.lp_asset}
-        availableBalance={pool.quantity_normalized ?? pool.quantity.toString()}
-        value={quantity}
-        onChange={setQuantity}
-        feeRate={feeRate}
-        setError={setLocalError}
-        showHelpText={showHelpText}
-        sourceAddress={activeAddress}
-        maxAmount={pool.quantity_normalized ?? pool.quantity.toString()}
-        label="LP Tokens to Withdraw"
-        name="quantity_display"
-        disabled={pending}
-        isDivisible
-      />
+          <AmountWithMaxInput
+            asset={pool.lp_asset}
+            availableBalance={pool.quantity_normalized ?? pool.quantity.toString()}
+            value={quantity}
+            onChange={setQuantity}
+            feeRate={feeRate}
+            setError={setLocalError}
+            showHelpText={showHelpText}
+            sourceAddress={activeAddress}
+            maxAmount={pool.quantity_normalized ?? pool.quantity.toString()}
+            label="LP Tokens to Withdraw"
+            name="quantity_display"
+            disabled={pending}
+            isDivisible
+          />
 
-      {isLoadingQuote && (
-        <p className="text-sm text-gray-500">Loading withdrawal quote...</p>
+          {isLoadingQuote && (
+            <p className="text-sm text-gray-500">Loading withdrawal quote...</p>
+          )}
+
+          {quoteError && (
+            <ErrorAlert message={quoteError} />
+          )}
+
+          {quote?.pool_exists && (
+            <div className="rounded border border-gray-200 bg-gray-50 p-3 text-sm text-gray-600">
+              Estimated receive:
+              <div className="mt-1 font-medium text-gray-900">
+                {formatReceived(quote.quantity_a_estimate, isAssetADivisible)} {pool.asset_a}
+              </div>
+              <div className="font-medium text-gray-900">
+                {formatReceived(quote.quantity_b_estimate, isAssetBDivisible)} {pool.asset_b}
+              </div>
+            </div>
+          )}
+
+          {quote?.pool_exists && hasMinimums && (
+            <div className="rounded border border-gray-200 bg-gray-50 p-3 text-sm text-gray-600">
+              Minimum received after {slippage || "0"}% slippage:
+              <div className="mt-1 font-medium text-gray-900">
+                {formatReceived(minQuantityA, isAssetADivisible)} {pool.asset_a}
+              </div>
+              <div className="font-medium text-gray-900">
+                {formatReceived(minQuantityB, isAssetBDivisible)} {pool.asset_b}
+              </div>
+            </div>
+          )}
+
+          {quote?.message && (
+            <div className="rounded border border-gray-200 bg-gray-50 p-3 text-sm text-gray-600">
+              {quote.message}
+            </div>
+          )}
+
+          <input type="hidden" name="lp_asset" value={pool.lp_asset} />
+          <input type="hidden" name="asset_a" value={pool.asset_a} />
+          <input type="hidden" name="asset_b" value={pool.asset_b} />
+          <input type="hidden" name="quantity" value={quantity} />
+          <input type="hidden" name="min_quantity_a" value={minQuantityA} />
+          <input type="hidden" name="min_quantity_b" value={minQuantityB} />
+          <input type="hidden" name="slippage" value={slippage} />
+        </ComposerForm>
       )}
-
-      {quoteError && (
-        <ErrorAlert message={quoteError} />
-      )}
-
-      {quote?.pool_exists && (
-        <div className="rounded border border-gray-200 bg-gray-50 p-3 text-sm text-gray-600">
-          Estimated receive:
-          <div className="mt-1 font-medium text-gray-900">
-            {formatReceived(quote.quantity_a_estimate, isAssetADivisible)} {pool.asset_a}
-          </div>
-          <div className="font-medium text-gray-900">
-            {formatReceived(quote.quantity_b_estimate, isAssetBDivisible)} {pool.asset_b}
-          </div>
-        </div>
-      )}
-
-      {quote?.pool_exists && hasMinimums && (
-        <div className="rounded border border-gray-200 bg-gray-50 p-3 text-sm text-gray-600">
-          Minimum received after {slippage || "0"}% slippage:
-          <div className="mt-1 font-medium text-gray-900">
-            {formatReceived(minQuantityA, isAssetADivisible)} {pool.asset_a}
-          </div>
-          <div className="font-medium text-gray-900">
-            {formatReceived(minQuantityB, isAssetBDivisible)} {pool.asset_b}
-          </div>
-        </div>
-      )}
-
-      {quote?.message && (
-        <div className="rounded border border-gray-200 bg-gray-50 p-3 text-sm text-gray-600">
-          {quote.message}
-        </div>
-      )}
-
-      <input type="hidden" name="lp_asset" value={pool.lp_asset} />
-      <input type="hidden" name="asset_a" value={pool.asset_a} />
-      <input type="hidden" name="asset_b" value={pool.asset_b} />
-      <input type="hidden" name="quantity" value={quantity} />
-      <input type="hidden" name="min_quantity_a" value={minQuantityA} />
-      <input type="hidden" name="min_quantity_b" value={minQuantityB} />
-      <input type="hidden" name="slippage" value={slippage} />
-    </ComposerForm>
+    </div>
   );
 }

--- a/src/pages/compose/pool/withdraw/index.tsx
+++ b/src/pages/compose/pool/withdraw/index.tsx
@@ -13,7 +13,7 @@ export default function ComposePoolWithdrawPage() {
       <Composer<PoolWithdrawOptions>
         composeType="poolwithdraw"
         composeApiMethod={composePoolWithdraw}
-        initialTitle="Pool Withdraw"
+        initialTitle="Pool"
         FormComponent={(props) => <PoolWithdrawForm {...props} lpAsset={asset} />}
         ReviewComponent={ReviewPoolWithdraw}
       />

--- a/src/pages/compose/swap/form.tsx
+++ b/src/pages/compose/swap/form.tsx
@@ -1,0 +1,427 @@
+import { type ReactElement, type ReactNode, useMemo, useState } from "react";
+import { useFormStatus } from "react-dom";
+import { ComposerForm } from "@/components/composer/composer-form";
+import { AddressHeader } from "@/components/domain/address/address-header";
+import { AssetSelectInput } from "@/components/domain/asset/asset-select-input";
+import { AmountWithMaxInput } from "@/components/domain/balance/amount-with-max-input";
+import { FaCog, LuArrowDownUp } from "@/components/icons";
+import { ErrorAlert } from "@/components/ui/error-alert";
+import { FeeRateInput } from "@/components/ui/inputs/fee-rate-input";
+import { useComposer } from "@/contexts/composer-context-object";
+import { useSettings } from "@/contexts/settings-context";
+import type { PoolQuote } from "@/core/counterparty/api";
+import type { OrderOptions } from "@/core/counterparty/compose";
+import { applyPoolSlippage } from "@/core/counterparty/pool";
+import { formatAmount } from "@/core/format";
+import {
+  fromSatoshis,
+  isGreaterThan,
+  isLessThanOrEqualTo,
+  isValidPositiveNumber,
+  toBigNumber,
+} from "@/core/numeric";
+import { DEFAULT_POOL_SLIPPAGE } from "@/core/settings";
+import { useAssetDetails } from "@/hooks/useAssetDetails";
+import { usePool } from "@/hooks/usePool";
+import { usePoolSwapQuote } from "@/hooks/usePoolQuotes";
+import { SlippageInput } from "@/pages/compose/pool/slippage-input";
+
+interface SwapFormProps {
+  formAction: (formData: FormData) => void;
+  initialFormData: OrderOptions | null;
+  initialGiveAsset?: string;
+  initialGetAsset?: string;
+}
+
+/** Everything the UI needs from a usable quote, in display units. */
+interface QuoteView {
+  estimated: string;
+  minReceived: string;
+  price: string | null;
+  impact: number | null;
+  poolFee: { bps: number; amount: string | null } | null;
+  route: string;
+}
+
+const CARD_CLASS = "bg-white rounded-lg shadow-lg p-3 sm:p-4 space-y-4";
+
+/**
+ * Swaps are immediate-or-cancel: the order matches whatever it can (within the
+ * slippage-derived minimum price) as soon as it confirms, and any unfilled
+ * remainder expires one block later and is refunded — it never rests on the
+ * book. Expiration counts from confirmation, so mempool time doesn't eat it.
+ */
+const SWAP_EXPIRATION_BLOCKS = 1;
+
+/** Raw satoshi quantity → display units for the given divisibility. */
+function toDisplayUnits(sats: number | string, divisible: boolean): string {
+  return divisible
+    ? fromSatoshis(sats, { removeTrailingZeros: true })
+    : toBigNumber(sats).toString();
+}
+
+/** "Pool", "3 orders", or "Pool + 3 orders" depending on where the fill comes from. */
+function routeLabel(quote: PoolQuote): string {
+  const orders = quote.book_orders_matched ?? 0;
+  const orderText = `${orders} order${orders === 1 ? "" : "s"}`;
+  if ((quote.book_output ?? 0) <= 0) return "Pool";
+  return quote.pool_exists && (quote.pool_output ?? 0) > 0 ? `Pool + ${orderText}` : orderText;
+}
+
+function DetailRow({
+  label,
+  value,
+  valueClass = "text-gray-900",
+}: {
+  label: ReactNode;
+  value: ReactNode;
+  valueClass?: string;
+}): ReactElement {
+  return (
+    <div className="flex justify-between">
+      <span>{label}</span>
+      <span className={`font-medium ${valueClass}`}>{value}</span>
+    </div>
+  );
+}
+
+/**
+ * Swap form: sell a fixed amount of one asset for a quoted amount of another,
+ * routed by the protocol across the AMM pool and the resting order book.
+ *
+ * Under the hood this composes a regular DEX order whose get_quantity is the
+ * quoted output minus the slippage tolerance — order matching guarantees
+ * best-price execution against pool and book, so the order's implied price
+ * acts as the minimum-received guard.
+ */
+export function SwapForm({
+  formAction,
+  initialFormData,
+  initialGiveAsset,
+  initialGetAsset,
+}: SwapFormProps): ReactElement {
+  const { activeAddress, activeWallet, showHelpText, feeRate, setFeeRate, settings } = useComposer<OrderOptions>();
+  const { updateSettings } = useSettings();
+  const { pending } = useFormStatus();
+
+  // ---- Form state (restored from initialFormData when returning from review) ----
+  const [giveAsset, setGiveAsset] = useState(
+    initialFormData?.give_asset || initialGiveAsset || "",
+  );
+  const [getAsset, setGetAsset] = useState(
+    initialFormData?.get_asset || initialGetAsset || "XCP",
+  );
+  const [amount, setAmount] = useState(initialFormData?.give_quantity?.toString() || "");
+  const [slippage, setSlippage] = useState(
+    (initialFormData as (OrderOptions & { slippage?: string }) | null)?.slippage
+      || settings?.defaultPoolSlippage
+      || DEFAULT_POOL_SLIPPAGE,
+  );
+  const [showDetails, setShowDetails] = useState(false);
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  // ---- Pair and asset data ----
+  const { data: giveDetails } = useAssetDetails(giveAsset);
+  const { data: getDetails } = useAssetDetails(getAsset);
+  const giveDetailsReady = giveDetails?.assetInfo?.asset === giveAsset;
+  const isGiveDivisible = giveDetailsReady && giveDetails ? giveDetails.isDivisible : true;
+  const isGetDivisible = getDetails?.assetInfo?.asset === getAsset ? getDetails.isDivisible : true;
+  const availableBalance = giveDetailsReady && giveDetails ? giveDetails.availableBalance : "";
+
+  const hasBtc = giveAsset === "BTC" || getAsset === "BTC";
+  const pairSelected = Boolean(giveAsset && getAsset && giveAsset !== getAsset);
+  const pairUsable = pairSelected && !hasBtc;
+
+  const { data: pool, isLoading: isPoolLoading } = usePool(
+    pairUsable ? giveAsset : undefined,
+    pairUsable ? getAsset : undefined,
+  );
+  const noPool = pairUsable && !isPoolLoading && pool === null;
+
+  // ---- Quote ----
+  const canQuote = pairUsable && giveDetailsReady && isGreaterThan(amount || 0, 0);
+  const { data: quote, isLoading: isLoadingQuote, error: quoteError } = usePoolSwapQuote({
+    giveAsset,
+    getAsset,
+    quantity: amount,
+    isGiveDivisible,
+    enabled: canQuote,
+  });
+  const unfilled = (quote?.give_remaining ?? 0) > 0;
+
+  // Null until the quote produces actual output; all values in display units.
+  const quoteView = useMemo<QuoteView | null>(() => {
+    const estimatedSats = quote?.estimated_output ?? 0;
+    if (!quote || estimatedSats <= 0) return null;
+
+    const estimated = toDisplayUnits(estimatedSats, isGetDivisible);
+    const priceRatio = isGreaterThan(amount || 0, 0)
+      ? toBigNumber(estimated).dividedBy(toBigNumber(amount))
+      : null;
+    const priceValid = priceRatio?.isFinite() && priceRatio.isGreaterThan(0);
+
+    return {
+      estimated,
+      minReceived: toDisplayUnits(applyPoolSlippage(estimatedSats, slippage), isGetDivisible),
+      // Computed in display units: the API's effective_price is a raw satoshi
+      // ratio, which is wrong across mixed divisibility.
+      price: priceValid && priceRatio
+        ? formatAmount({
+            value: priceRatio.toNumber(),
+            maximumFractionDigits: priceRatio.isGreaterThanOrEqualTo(1) ? 4 : 8,
+          })
+        : null,
+      impact: typeof quote.price_impact === "number" ? quote.price_impact : null,
+      poolFee: quote.pool_exists && typeof quote.fee_bps === "number"
+        ? {
+            bps: quote.fee_bps,
+            amount: quote.fee_amount
+              ? toDisplayUnits(quote.fee_amount, isGiveDivisible)
+              : null,
+          }
+        : null,
+      route: routeLabel(quote),
+    };
+  }, [quote, amount, slippage, isGetDivisible, isGiveDivisible]);
+
+  // ---- Submission ----
+  const isSlippageValid =
+    isValidPositiveNumber(slippage, { allowZero: true, maxDecimals: 2 })
+    && isLessThanOrEqualTo(slippage, 50);
+
+  const submitDisabled =
+    !pairUsable
+    || !isGreaterThan(amount || 0, 0)
+    || isLoadingQuote
+    || !quoteView
+    || unfilled
+    || !isSlippageValid
+    || Boolean(availableBalance && isGreaterThan(amount, availableBalance));
+
+  // ---- Handlers ----
+  const handleFlip = () => {
+    setGiveAsset(getAsset);
+    setGetAsset(giveAsset);
+    setAmount("");
+  };
+
+  // Selecting the counterparty asset on either side swaps the two.
+  const handleGiveAssetChange = (asset: string) => {
+    if (asset === getAsset) setGetAsset(giveAsset);
+    setGiveAsset(asset);
+  };
+  const handleGetAssetChange = (asset: string) => {
+    if (asset === giveAsset) setGiveAsset(getAsset);
+    setGetAsset(asset);
+  };
+
+  // Edits apply to this swap immediately and persist as the user's default,
+  // same as the pool deposit/withdraw settings panel.
+  const handleSlippageChange = (next: string) => {
+    setSlippage(next);
+    void updateSettings({ defaultPoolSlippage: next });
+  };
+
+  const priceRowText = quoteView?.price
+    ? `1 ${giveAsset} ≈ ${quoteView.price} ${getAsset}`
+    : isLoadingQuote
+      ? "Fetching quote…"
+      : `1 ${giveAsset || "—"} = —`;
+
+  // The API reports impact as positive-when-worse; flip the sign so the label
+  // reads like a gain/loss ("Impact: -1.8%" = you receive 1.8% under spot).
+  const signedImpact = quoteView?.impact !== null && quoteView?.impact !== undefined
+    ? -quoteView.impact
+    : null;
+  const impactClass = signedImpact === null
+    ? ""
+    : signedImpact < -5
+      ? "text-red-600"
+      : signedImpact > 0
+        ? "text-green-600"
+        : "text-gray-500";
+
+  return (
+    <ComposerForm
+      formAction={formAction}
+      header={
+        activeAddress && (
+          <AddressHeader
+            address={activeAddress.address}
+            walletName={activeWallet?.name ?? ""}
+            className="mt-1 mb-5"
+          />
+        )
+      }
+      submitText="Review Swap"
+      submitDisabled={pending || submitDisabled}
+      showFeeRate={false}
+      containerClassName=""
+    >
+      {validationError && (
+        <ErrorAlert message={validationError} onClose={() => setValidationError(null)} />
+      )}
+      {hasBtc && (
+        <ErrorAlert message="BTC pairs are not supported for swaps. Use a DEX order instead." />
+      )}
+      {noPool && (
+        <div className="rounded border border-amber-200 bg-amber-50 p-3 text-sm text-amber-700">
+          No liquidity pool exists for {giveAsset}/{getAsset}. Swaps for this
+          pair can only fill from resting DEX orders.
+        </div>
+      )}
+
+      {/* You Send */}
+      <div className={CARD_CLASS}>
+        <AssetSelectInput
+          selectedAsset={giveAsset}
+          onChange={handleGiveAssetChange}
+          label="You Send"
+          description="Asset you are selling."
+          showHelpText={showHelpText}
+          required
+        />
+        <AmountWithMaxInput
+          asset={giveAsset}
+          availableBalance={availableBalance}
+          value={amount}
+          onChange={setAmount}
+          feeRate={feeRate}
+          setError={setValidationError}
+          showHelpText={showHelpText}
+          sourceAddress={activeAddress}
+          maxAmount={availableBalance}
+          label="Amount"
+          name="amount_display"
+          description={`Amount to sell. ${isGiveDivisible ? "Enter up to 8 decimal places." : "Enter whole numbers only."}`}
+          disabled={pending}
+          isDivisible={isGiveDivisible}
+          labelRight={
+            availableBalance ? (
+              <span className="text-xs text-gray-500 font-normal">
+                Balance: {formatAmount({ value: Number(availableBalance), maximumFractionDigits: 8 })}
+              </span>
+            ) : undefined
+          }
+        />
+      </div>
+
+      {/* Flip direction — a bare icon between the two cards */}
+      <div className="flex justify-center">
+        <button
+          type="button"
+          onClick={handleFlip}
+          aria-label="Flip swap direction"
+          className="p-1 rounded text-gray-500 hover:text-gray-700 transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+        >
+          <LuArrowDownUp className="size-4" aria-hidden="true" />
+        </button>
+      </div>
+
+      {/* You Receive */}
+      <div className={CARD_CLASS}>
+        <AssetSelectInput
+          selectedAsset={getAsset}
+          onChange={handleGetAssetChange}
+          label="You Receive"
+          description="Asset you are buying."
+          showHelpText={showHelpText}
+          required
+        />
+        <div>
+          <label htmlFor="swap-receive-estimate" className="text-sm font-medium text-gray-700 flex justify-between items-center">
+            <span>Amount <span className="text-red-500">*</span></span>
+            {signedImpact !== null && (
+              <span className={`text-xs font-normal ${impactClass}`}>
+                Impact: {signedImpact > 0 ? "+" : ""}{formatAmount({ value: signedImpact, maximumFractionDigits: 2 })}%
+              </span>
+            )}
+          </label>
+          <input
+            id="swap-receive-estimate"
+            type="text"
+            value={quoteView?.estimated ?? ""}
+            placeholder={isGetDivisible ? "0.00000000" : "0"}
+            disabled
+            aria-live="polite"
+            aria-label="Estimated amount received"
+            className="mt-1 block w-full p-2.5 rounded-md border border-gray-300 bg-gray-100 text-gray-900 cursor-not-allowed"
+          />
+        </div>
+      </div>
+
+      {quoteError && <ErrorAlert message={quoteError} />}
+      {canQuote && !isLoadingQuote && quote && !quoteView && (
+        <div className="rounded border border-gray-200 bg-gray-50 p-3 text-sm text-gray-600">
+          {quote.message || "No liquidity available for this pair."}
+        </div>
+      )}
+
+      {/* Price summary bar; the gear expands quote details + settings */}
+      {pairUsable && (
+        <div className="rounded-lg bg-white shadow-sm border border-gray-200">
+          <div className="flex items-center justify-between p-3">
+            <span className="text-sm font-medium text-gray-900">{priceRowText}</span>
+            <button
+              type="button"
+              onClick={() => setShowDetails((prev) => !prev)}
+              aria-label={showDetails ? "Hide swap details" : "Show swap details"}
+              aria-expanded={showDetails}
+              className="shrink-0 p-1 rounded-full hover:bg-gray-100 transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+            >
+              <FaCog className="size-4 text-gray-600" aria-hidden="true" />
+            </button>
+          </div>
+          {/* hidden, not unmounted: SlippageInput keeps its custom-entry state while closed */}
+          <div className={showDetails ? "border-t border-gray-200 p-3 space-y-3 text-sm text-gray-600" : "hidden"}>
+            {quoteView && (
+              <>
+                <DetailRow
+                  label="Minimum received"
+                  value={`${formatAmount({ value: Number(quoteView.minReceived), maximumFractionDigits: 8 })} ${getAsset}`}
+                />
+                {quoteView.poolFee && (
+                  <DetailRow
+                    label={`Pool fee (${(quoteView.poolFee.bps / 100).toFixed(2)}%)`}
+                    value={quoteView.poolFee.amount ? `${quoteView.poolFee.amount} ${giveAsset}` : "—"}
+                  />
+                )}
+                <DetailRow label="Route" value={quoteView.route} />
+              </>
+            )}
+            <div className="border-t border-gray-200 pt-3">
+              <SlippageInput
+                value={slippage}
+                onChange={handleSlippageChange}
+                showHelpText={showHelpText}
+              />
+            </div>
+          </div>
+          {/* Fee rate stays visible whether or not the details are expanded */}
+          <div className="border-t border-gray-200 p-3">
+            <FeeRateInput
+              showHelpText={showHelpText}
+              disabled={pending}
+              initialValue={feeRate}
+              onFeeRateChange={setFeeRate}
+            />
+          </div>
+        </div>
+      )}
+
+      {unfilled && (
+        <div className="rounded border border-amber-200 bg-amber-50 p-3 text-sm text-amber-700">
+          Not enough liquidity to fill this amount right now. Try a smaller
+          amount, or place a DEX order to rest on the book.
+        </div>
+      )}
+
+      <input type="hidden" name="give_asset" value={giveAsset} />
+      <input type="hidden" name="get_asset" value={getAsset} />
+      <input type="hidden" name="give_quantity" value={amount} />
+      <input type="hidden" name="get_quantity" value={quoteView?.minReceived ?? ""} />
+      <input type="hidden" name="expiration" value={SWAP_EXPIRATION_BLOCKS} />
+      <input type="hidden" name="slippage" value={slippage} />
+    </ComposerForm>
+  );
+}

--- a/src/pages/compose/swap/index.tsx
+++ b/src/pages/compose/swap/index.tsx
@@ -1,0 +1,34 @@
+import { useParams } from "react-router";
+import { Composer } from "@/components/composer/composer";
+import type { OrderOptions } from "@/core/counterparty/compose";
+import { composeOrder } from "@/core/counterparty/compose";
+import { SwapForm } from "@/pages/compose/swap/form";
+import { ReviewSwap } from "@/pages/compose/swap/review";
+
+/**
+ * Swap composes a regular DEX order priced from the pool/book quote, so it
+ * shares the order compose method and review screen.
+ */
+function ComposeSwapPage() {
+  const { giveAsset, getAsset } = useParams<{ giveAsset?: string; getAsset?: string }>();
+
+  return (
+    <div className="p-4">
+      <Composer<OrderOptions>
+        composeType="order"
+        composeApiMethod={composeOrder}
+        initialTitle="Swap"
+        FormComponent={(props) => (
+          <SwapForm
+            {...props}
+            initialGiveAsset={giveAsset ? decodeURIComponent(giveAsset) : ""}
+            initialGetAsset={getAsset ? decodeURIComponent(getAsset) : "XCP"}
+          />
+        )}
+        ReviewComponent={ReviewSwap}
+      />
+    </div>
+  );
+}
+
+export default ComposeSwapPage;

--- a/src/pages/compose/swap/review.tsx
+++ b/src/pages/compose/swap/review.tsx
@@ -1,0 +1,88 @@
+import { useState } from "react";
+import { FaExchangeAlt } from "@/components/icons";
+import { ReviewScreen } from "@/components/screens/review-screen";
+import { formatPriceRatio } from "@/core/format";
+
+/**
+ * Props for the ReviewSwap component.
+ */
+interface ReviewSwapProps {
+  apiResponse: any; // Same order compose response shape as ReviewOrder
+  onSign: () => void;
+  onBack: () => void;
+  error: string | null;
+  isSigning: boolean; // Passed from useActionState in Composer
+}
+
+/**
+ * Displays a review screen for swap transactions.
+ *
+ * A swap composes a regular DEX order, but the labels reflect swap semantics:
+ * the order's get_quantity is the MINIMUM received (quote minus slippage), not
+ * the expected fill, and the implied ratio is the worst acceptable price.
+ * @param {ReviewSwapProps} props - Component props
+ * @returns {ReactElement} Review UI for swap transaction
+ */
+export function ReviewSwap({
+  apiResponse,
+  onSign,
+  onBack,
+  error,
+  isSigning
+}: ReviewSwapProps) {
+  const { result } = apiResponse;
+  const [isPriceFlipped, setIsPriceFlipped] = useState(false);
+
+  // Use asset_longname if available, otherwise use asset name
+  const giveAssetDisplay = result.params.give_asset_info?.asset_longname || result.params.give_asset;
+  const getAssetDisplay = result.params.get_asset_info?.asset_longname || result.params.get_asset;
+
+  // Use normalized values from verbose API response (already formatted correctly for divisibility)
+  const giveQuantityDisplay = result.params.give_quantity_normalized ?? result.params.give_quantity;
+  const getQuantityDisplay = result.params.get_quantity_normalized ?? result.params.get_quantity;
+
+  const customFields = [
+    {
+      label: "You Send",
+      value: `${giveQuantityDisplay} ${giveAssetDisplay}`,
+    },
+    {
+      label: "Minimum Received",
+      value: `${getQuantityDisplay} ${getAssetDisplay}`,
+    },
+    {
+      label: "Minimum Price",
+      value: formatPriceRatio(
+        giveQuantityDisplay,
+        getQuantityDisplay,
+        giveAssetDisplay,
+        getAssetDisplay,
+        isPriceFlipped
+      ),
+      rightElement: (
+        <button
+          type="button"
+          onClick={() => setIsPriceFlipped(!isPriceFlipped)}
+          className="p-1 hover:bg-gray-100 rounded-full transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+          aria-label="Flip price ratio"
+        >
+          <FaExchangeAlt className="size-4 text-gray-600" aria-hidden="true" />
+        </button>
+      ),
+    },
+    // Swaps compose with expiration 1: fill what the price allows on
+    // confirmation, refund the rest a block later.
+    { label: "Fills", value: "Immediately, or cancels next block" },
+  ];
+
+  return (
+    <ReviewScreen
+      apiResponse={apiResponse}
+      onSign={onSign}
+      onBack={onBack}
+      customFields={customFields}
+      error={error}
+      isSigning={isSigning}
+    />
+  );
+}

--- a/src/pages/market/dispensers/[asset].tsx
+++ b/src/pages/market/dispensers/[asset].tsx
@@ -346,7 +346,7 @@ export default function AssetDispensersPage(): ReactElement {
         <div className="p-4 pb-0 flex-shrink-0">
           {/* Asset Header */}
           {assetInfo && (
-            <AssetHeader assetInfo={assetInfo} showInfoPopover className="mb-4" />
+            <AssetHeader assetInfo={assetInfo} showInfoPopover className="mt-1 mb-5" />
           )}
 
           {/* Stats Card - contextual based on tab */}

--- a/src/pages/market/index.tsx
+++ b/src/pages/market/index.tsx
@@ -24,6 +24,7 @@ import {
   type Pool,
   type PoolPosition,
 } from "@/core/counterparty/api";
+import { normalizePoolPosition } from "@/core/counterparty/pool";
 import { formatAddress } from "@/core/format";
 import { formatPrice } from "@/core/priceFormat";
 import { getTradingPair } from "@/core/tradingPair";
@@ -162,7 +163,7 @@ export default function MarketPage(): ReactElement {
           }
           const response = await fetchAddressPools(activeAddress.address, { limit: POOL_PAGE_SIZE, offset: 0 });
           if (cancelled) return;
-          setUserPools(response.result);
+          setUserPools(response.result.map(normalizePoolPosition));
           setPoolsHasMore(response.result.length === POOL_PAGE_SIZE && response.result.length < response.result_count);
         } else {
           const response = await fetchPools({ limit: POOL_PAGE_SIZE, offset: 0 });
@@ -205,7 +206,7 @@ export default function MarketPage(): ReactElement {
         if (viewMode === "manage") {
           const response = await fetchAddressPools(activeAddress!.address, { limit: POOL_PAGE_SIZE, offset: poolsOffset });
           if (cancelled) return;
-          appendUserPools(response.result);
+          appendUserPools(response.result.map(normalizePoolPosition));
           setPoolsHasMore(response.result.length === POOL_PAGE_SIZE && poolsOffset + response.result.length < response.result_count);
         } else {
           const response = await fetchPools({ limit: POOL_PAGE_SIZE, offset: poolsOffset });

--- a/src/pages/market/orders/[baseAsset]/[quoteAsset].tsx
+++ b/src/pages/market/orders/[baseAsset]/[quoteAsset].tsx
@@ -412,7 +412,7 @@ export default function AssetOrdersPage(): ReactElement {
         <div className="p-4 pb-0 flex-shrink-0">
           {/* Asset Header */}
           {baseAssetInfo && (
-            <AssetHeader assetInfo={baseAssetInfo} showInfoPopover className="mb-4" />
+            <AssetHeader assetInfo={baseAssetInfo} showInfoPopover className="mt-1 mb-5" />
           )}
 
           {/* Stats Card - contextual based on tab */}

--- a/src/pages/market/xcp.tsx
+++ b/src/pages/market/xcp.tsx
@@ -6,6 +6,7 @@ import { PriceChart } from "@/components/ui/charts/price-chart";
 import { Spinner } from "@/components/ui/spinner";
 import { useHeader } from "@/contexts/header-context";
 import type { PricePoint } from "@/core/bitcoin/price";
+import { fetchAssetDispensers } from "@/core/counterparty/api";
 import {
   getXcpPriceHistory,
   getXcpStats,
@@ -27,6 +28,12 @@ const TIME_RANGES: { id: XcpTimeRange; label: string; days: number | null }[] = 
 // Chart dimensions
 const CHART_HEIGHT = 200;
 
+/** The cheapest open XCP dispenser: the price you can actually pay right now. */
+interface DispenserFloor {
+  satsPerXcp: number;
+  source: string;
+}
+
 function filterHistory(history: PricePoint[], range: XcpTimeRange): PricePoint[] {
   const days = TIME_RANGES.find((t) => t.id === range)?.days;
   if (!days) return history;
@@ -45,6 +52,7 @@ export default function XcpPricePage(): ReactElement {
   // Data state
   const [stats, setStats] = useState<XcpStats | null>(null);
   const [historyData, setHistoryData] = useState<XcpPriceHistoryData | null>(null);
+  const [floor, setFloor] = useState<DispenserFloor | null>(null);
   const [loading, setLoading] = useState(true);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [chartError, setChartError] = useState<string | null>(null);
@@ -61,6 +69,28 @@ export default function XcpPricePage(): ReactElement {
       setStats(statsData);
     } else {
       setStatsError("Unable to load price");
+    }
+  }, []);
+
+  // Find the cheapest open XCP dispenser (sats per whole XCP). Checks the first
+  // 100 open dispensers; the true floor could hide beyond that, but in practice
+  // open XCP dispensers number far fewer.
+  const loadFloor = useCallback(async () => {
+    try {
+      const response = await fetchAssetDispensers("XCP", { limit: 100, status: "open" });
+      let best: DispenserFloor | null = null;
+      for (const dispenser of response.result) {
+        const unitsPerDispense = Number(dispenser.give_quantity_normalized);
+        if (unitsPerDispense <= 0) continue;
+        const satsPerXcp = dispenser.satoshirate / unitsPerDispense;
+        if (!best || satsPerXcp < best.satsPerXcp) {
+          best = { satsPerXcp, source: dispenser.source };
+        }
+      }
+      setFloor(best);
+    } catch (err) {
+      console.error("Failed to load XCP dispenser floor:", err);
+      setFloor(null);
     }
   }, []);
 
@@ -82,23 +112,23 @@ export default function XcpPricePage(): ReactElement {
     const loadInitial = async () => {
       setLoading(true);
       try {
-        await Promise.all([loadStats(), loadHistory()]);
+        await Promise.all([loadStats(), loadHistory(), loadFloor()]);
       } finally {
         setLoading(false);
       }
     };
     loadInitial();
-  }, [loadStats, loadHistory]);
+  }, [loadStats, loadHistory, loadFloor]);
 
   // Handle refresh
   const handleRefresh = useCallback(async () => {
     setIsRefreshing(true);
     try {
-      await Promise.all([loadStats(), loadHistory()]);
+      await Promise.all([loadStats(), loadHistory(), loadFloor()]);
     } finally {
       setIsRefreshing(false);
     }
-  }, [loadStats, loadHistory]);
+  }, [loadStats, loadHistory, loadFloor]);
 
   // Configure header
   useEffect(() => {
@@ -219,7 +249,7 @@ export default function XcpPricePage(): ReactElement {
             <PriceChart
               data={chartData}
               height={CHART_HEIGHT}
-              lineColor="#e11d48"
+              lineColor="#0ea5e9"
               className="w-full"
               currencySymbol="$"
               priceDecimals={2}
@@ -229,18 +259,29 @@ export default function XcpPricePage(): ReactElement {
         </div>
 
         {/* Market Stats */}
-        {historyData && (historyData.satsPerXcp || historyData.ath) && (
+        {(floor || historyData?.satsPerXcp || historyData?.ath) && (
           <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-3 mt-4">
-            {historyData.satsPerXcp && (
+            {floor ? (
+              <div className={`flex items-center justify-between ${historyData?.ath ? "pb-2 border-b border-gray-100" : ""}`}>
+                <span className="text-sm text-gray-600">Floor Price</span>
+                <button
+                  onClick={() => navigate(`/compose/dispenser/dispense?address=${floor.source}&asset=XCP`)}
+                  className="text-sm font-medium text-blue-600 hover:text-blue-800 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
+                  aria-label="Buy from the cheapest open XCP dispenser"
+                >
+                  1 XCP = {formatAmount({ value: floor.satsPerXcp, maximumFractionDigits: 0 })} sats
+                </button>
+              </div>
+            ) : historyData?.satsPerXcp ? (
               <div className={`flex items-center justify-between ${historyData.ath ? "pb-2 border-b border-gray-100" : ""}`}>
                 <span className="text-sm text-gray-600">DEX Rate</span>
                 <span className="text-sm font-medium text-gray-900">
                   1 XCP = {formatAmount({ value: historyData.satsPerXcp, maximumFractionDigits: 0 })} sats
                 </span>
               </div>
-            )}
-            {historyData.ath && (
-              <div className={`flex items-center justify-between ${historyData.satsPerXcp ? "pt-2" : ""}`}>
+            ) : null}
+            {historyData?.ath && (
+              <div className={`flex items-center justify-between ${(floor || historyData.satsPerXcp) ? "pt-2" : ""}`}>
                 <span className="text-sm text-gray-600">All-Time High</span>
                 <span className="text-sm font-medium text-gray-900">
                   {formatPrice(historyData.ath.usd)}

--- a/src/pages/pools/[assetA]/[assetB].tsx
+++ b/src/pages/pools/[assetA]/[assetB].tsx
@@ -3,12 +3,12 @@ import { useEffect } from "react";
 import { useNavigate, useParams } from "react-router";
 import { Button } from "@/components/ui/button";
 import { ErrorAlert } from "@/components/ui/error-alert";
-import { PoolHeader } from "@/components/ui/headers/pool-header";
-import { ActionList } from "@/components/ui/lists/action-list";
 import { Spinner } from "@/components/ui/spinner";
 import { useHeader } from "@/contexts/header-context";
-import { getCanonicalPoolAssets, getCanonicalPoolPair } from "@/core/counterparty/pool";
+import { getCanonicalPoolPair } from "@/core/counterparty/pool";
+import { useLpAssetPool } from "@/hooks/useLpAssetPool";
 import { usePool } from "@/hooks/usePool";
+import { PoolOverview } from "@/pages/pools/pool-overview";
 
 export default function PoolPage(): ReactElement {
   const { assetA, assetB } = useParams<{ assetA: string; assetB: string }>();
@@ -17,6 +17,9 @@ export default function PoolPage(): ReactElement {
   const decodedAssetA = assetA ? decodeURIComponent(assetA) : undefined;
   const decodedAssetB = assetB ? decodeURIComponent(assetB) : undefined;
   const { data: pool, isLoading, error } = usePool(decodedAssetA, decodedAssetB);
+  // The viewer's LP position, if they hold this pool's LP asset — shows
+  // pool share, underlying, and Withdraw on the shared overview.
+  const { data: position } = useLpAssetPool(pool?.lp_asset);
   const pair = decodedAssetA && decodedAssetB
     ? getCanonicalPoolPair(decodedAssetA, decodedAssetB)
     : "Pool";
@@ -67,66 +70,5 @@ export default function PoolPage(): ReactElement {
     );
   }
 
-  const [firstReserveAsset, secondReserveAsset] = getCanonicalPoolAssets(pool.asset_a, pool.asset_b);
-  const reserveByAsset = {
-    [pool.asset_a]: pool.reserve_a_normalized ?? pool.reserve_a,
-    [pool.asset_b]: pool.reserve_b_normalized ?? pool.reserve_b,
-  };
-
-  return (
-    <div className="p-4 space-y-6" role="main" aria-label={pair}>
-      <section className="space-y-5">
-        <PoolHeader pool={pool} className="mt-1 mb-5" />
-
-        <div className="rounded border border-gray-200 bg-white">
-          <div className="border-b border-gray-200 p-4">
-            <div className="text-xs font-medium uppercase text-gray-500">LP Asset</div>
-            <div className="mt-1 break-all text-sm font-semibold text-gray-900">{pool.lp_asset}</div>
-          </div>
-          <div className="grid grid-cols-2 divide-x divide-gray-200">
-            <div className="p-4">
-              <div className="text-xs font-medium uppercase text-gray-500">Reserve {firstReserveAsset}</div>
-              <div className="mt-1 text-sm font-semibold text-gray-900">
-                {reserveByAsset[firstReserveAsset]}
-              </div>
-            </div>
-            <div className="p-4">
-              <div className="text-xs font-medium uppercase text-gray-500">Reserve {secondReserveAsset}</div>
-              <div className="mt-1 text-sm font-semibold text-gray-900">
-                {reserveByAsset[secondReserveAsset]}
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <Button
-          fullWidth
-          onClick={() => navigate(`/compose/pool/deposit/${encodeURIComponent(pool.asset_a)}/${encodeURIComponent(pool.asset_b)}`)}
-        >
-          Deposit
-        </Button>
-      </section>
-
-      <ActionList
-        sections={[
-          {
-            items: [
-              {
-                id: "trade-a",
-                title: `Trade ${pool.asset_a}`,
-                description: `Open DEX order flow for ${pool.asset_a}`,
-                onClick: () => navigate(`/compose/order/${encodeURIComponent(pool.asset_a)}`),
-              },
-              {
-                id: "trade-b",
-                title: `Trade ${pool.asset_b}`,
-                description: `Open DEX order flow for ${pool.asset_b}`,
-                onClick: () => navigate(`/compose/order/${encodeURIComponent(pool.asset_b)}`),
-              },
-            ],
-          },
-        ]}
-      />
-    </div>
-  );
+  return <PoolOverview pool={pool} position={position} />;
 }

--- a/src/pages/pools/[lpAsset].tsx
+++ b/src/pages/pools/[lpAsset].tsx
@@ -1,16 +1,11 @@
 import type { ReactElement } from "react";
 import { useEffect } from "react";
 import { useNavigate, useParams } from "react-router";
-import { Button } from "@/components/ui/button";
 import { ErrorAlert } from "@/components/ui/error-alert";
-import { PoolHeader } from "@/components/ui/headers/pool-header";
-import { ActionList } from "@/components/ui/lists/action-list";
 import { Spinner } from "@/components/ui/spinner";
 import { useHeader } from "@/contexts/header-context";
-import { getCanonicalPoolAssets, getCanonicalPoolPair } from "@/core/counterparty/pool";
-import { divide, formatDecimal, isGreaterThan, multiply, toBigNumber } from "@/core/numeric";
-import { useAssetInfo } from "@/hooks/useAssetInfo";
 import { useLpAssetPool } from "@/hooks/useLpAssetPool";
+import { PoolOverview } from "@/pages/pools/pool-overview";
 
 export default function PoolPositionPage(): ReactElement {
   const { lpAsset } = useParams<{ lpAsset: string }>();
@@ -18,7 +13,6 @@ export default function PoolPositionPage(): ReactElement {
   const { setHeaderProps } = useHeader();
   const asset = lpAsset ? decodeURIComponent(lpAsset) : undefined;
   const { data: pool, isLoading, error } = useLpAssetPool(asset);
-  const { data: lpAssetInfo } = useAssetInfo(pool?.lp_asset || "");
 
   useEffect(() => {
     setHeaderProps({
@@ -43,104 +37,5 @@ export default function PoolPositionPage(): ReactElement {
     return <div className="p-4 text-center text-gray-600">Pool position not found</div>;
   }
 
-  const pair = getCanonicalPoolPair(pool.asset_a, pool.asset_b);
-  const [firstReserveAsset, secondReserveAsset] = getCanonicalPoolAssets(pool.asset_a, pool.asset_b);
-  const reserveByAsset = {
-    [pool.asset_a]: pool.reserve_a_normalized ?? pool.reserve_a,
-    [pool.asset_b]: pool.reserve_b_normalized ?? pool.reserve_b,
-  };
-  const lpBalanceValue = toBigNumber(pool.quantity_normalized ?? pool.quantity);
-  const lpSupply = toBigNumber(lpAssetInfo?.supply_normalized);
-  const poolShare = isGreaterThan(lpSupply, 0) ? divide(lpBalanceValue, lpSupply) : null;
-  const poolSharePercent = poolShare ? formatDecimal(multiply(poolShare, 100), 4) : null;
-  const underlyingA = poolShare
-    ? formatDecimal(multiply(poolShare, pool.reserve_a_normalized ?? pool.reserve_a))
-    : null;
-  const underlyingB = poolShare
-    ? formatDecimal(multiply(poolShare, pool.reserve_b_normalized ?? pool.reserve_b))
-    : null;
-
-  return (
-    <div className="p-4 space-y-6" role="main" aria-label={pair}>
-      <section className="space-y-5">
-        <div>
-          <PoolHeader pool={pool} className="mt-1 mb-5" />
-        </div>
-
-        <div className="rounded border border-gray-200 bg-white">
-          <div className="border-b border-gray-200 p-4">
-            <div className="text-xs font-medium uppercase text-gray-500">LP Asset</div>
-            <div className="mt-1 break-all text-sm font-semibold text-gray-900">{pool.lp_asset}</div>
-          </div>
-          <div className="grid grid-cols-2 divide-x divide-gray-200 border-b border-gray-200">
-            <div className="p-4">
-              <div className="text-xs font-medium uppercase text-gray-500">Reserve {firstReserveAsset}</div>
-              <div className="mt-1 text-sm font-semibold text-gray-900">
-                {reserveByAsset[firstReserveAsset]}
-              </div>
-            </div>
-            <div className="p-4">
-              <div className="text-xs font-medium uppercase text-gray-500">Reserve {secondReserveAsset}</div>
-              <div className="mt-1 text-sm font-semibold text-gray-900">
-                {reserveByAsset[secondReserveAsset]}
-              </div>
-            </div>
-          </div>
-          {poolSharePercent && underlyingA && underlyingB && (
-            <div className="grid grid-cols-2 divide-x divide-gray-200 border-t border-gray-200">
-              <div className="p-4">
-                <div className="text-xs font-medium uppercase text-gray-500">Pool share</div>
-                <div className="mt-1 text-sm font-semibold text-gray-900">{poolSharePercent}%</div>
-              </div>
-              <div className="p-4">
-                <div className="text-xs font-medium uppercase text-gray-500">Underlying</div>
-                <div className="mt-1 text-sm font-semibold text-gray-900">
-                  {underlyingA} {pool.asset_a}
-                </div>
-                <div className="text-sm font-semibold text-gray-900">
-                  {underlyingB} {pool.asset_b}
-                </div>
-              </div>
-            </div>
-          )}
-        </div>
-
-        <div className="grid grid-cols-2 gap-3">
-          <Button
-            fullWidth
-            onClick={() => navigate(`/compose/pool/deposit/${encodeURIComponent(pool.asset_a)}/${encodeURIComponent(pool.asset_b)}`)}
-          >
-            Deposit
-          </Button>
-          <Button
-            fullWidth
-            onClick={() => navigate(`/compose/pool/withdraw/${encodeURIComponent(pool.lp_asset)}`)}
-          >
-            Withdraw
-          </Button>
-        </div>
-      </section>
-
-      <ActionList
-        sections={[
-          {
-            items: [
-              {
-                id: "trade-a",
-                title: `Trade ${pool.asset_a}`,
-                description: `Open DEX order flow for ${pool.asset_a}`,
-                onClick: () => navigate(`/compose/order/${encodeURIComponent(pool.asset_a)}`),
-              },
-              {
-                id: "trade-b",
-                title: `Trade ${pool.asset_b}`,
-                description: `Open DEX order flow for ${pool.asset_b}`,
-                onClick: () => navigate(`/compose/order/${encodeURIComponent(pool.asset_b)}`),
-              },
-            ],
-          },
-        ]}
-      />
-    </div>
-  );
+  return <PoolOverview pool={pool} position={pool} />;
 }

--- a/src/pages/pools/pool-overview.tsx
+++ b/src/pages/pools/pool-overview.tsx
@@ -1,0 +1,147 @@
+import type { ReactElement } from "react";
+import { useNavigate } from "react-router";
+import { Button } from "@/components/ui/button";
+import { PoolHeader } from "@/components/ui/headers/pool-header";
+import { ActionList } from "@/components/ui/lists/action-list";
+import type { Pool, PoolPosition } from "@/core/counterparty/api";
+import { getCanonicalPoolAssets, getCanonicalPoolPair } from "@/core/counterparty/pool";
+import { divide, formatDecimal, isGreaterThan, multiply, toBigNumber } from "@/core/numeric";
+import { useAssetInfo } from "@/hooks/useAssetInfo";
+
+interface PoolOverviewProps {
+  pool: Pool;
+  /** The viewer's LP position in this pool, when they hold the LP asset */
+  position?: PoolPosition | null;
+}
+
+/**
+ * Shared pool page body: pair header, reserves, implied price, and — when the
+ * viewer holds the LP asset — their pool share, underlying value, and Withdraw.
+ * Rendered by both the LP-asset route (from a balance) and the pair route
+ * (from the market), so the two entry points show one consistent page.
+ */
+export function PoolOverview({ pool, position }: PoolOverviewProps): ReactElement {
+  const navigate = useNavigate();
+  const pair = getCanonicalPoolPair(pool.asset_a, pool.asset_b);
+  const [firstReserveAsset, secondReserveAsset] = getCanonicalPoolAssets(pool.asset_a, pool.asset_b);
+  const { data: lpAssetInfo } = useAssetInfo(position ? pool.lp_asset : "");
+
+  const reserveByAsset = {
+    [pool.asset_a]: pool.reserve_a_normalized ?? pool.reserve_a,
+    [pool.asset_b]: pool.reserve_b_normalized ?? pool.reserve_b,
+  };
+  const firstReserve = toBigNumber(reserveByAsset[firstReserveAsset]);
+  const secondReserve = toBigNumber(reserveByAsset[secondReserveAsset]);
+  const hasLiquidity = isGreaterThan(firstReserve, 0) && isGreaterThan(secondReserve, 0);
+  const priceOfFirst = hasLiquidity ? formatDecimal(divide(secondReserve, firstReserve)) : null;
+  const priceOfSecond = hasLiquidity ? formatDecimal(divide(firstReserve, secondReserve)) : null;
+
+  const lpBalanceValue = position ? toBigNumber(position.quantity_normalized ?? position.quantity) : null;
+  const lpSupply = toBigNumber(lpAssetInfo?.supply_normalized);
+  const poolShare = lpBalanceValue && isGreaterThan(lpSupply, 0) ? divide(lpBalanceValue, lpSupply) : null;
+  const poolSharePercent = poolShare ? formatDecimal(multiply(poolShare, 100), 4) : null;
+  const underlyingA = poolShare
+    ? formatDecimal(multiply(poolShare, toBigNumber(reserveByAsset[pool.asset_a])))
+    : null;
+  const underlyingB = poolShare
+    ? formatDecimal(multiply(poolShare, toBigNumber(reserveByAsset[pool.asset_b])))
+    : null;
+
+  return (
+    <div className="p-4 space-y-6" role="main" aria-label={pair}>
+      <section className="space-y-5">
+        <PoolHeader pool={pool} className="mt-1 mb-5" />
+
+        <div className="rounded border border-gray-200 bg-white">
+          {priceOfFirst && priceOfSecond && (
+            <div className="border-b border-gray-200 p-4">
+              <div className="text-xs font-medium uppercase text-gray-500">Price</div>
+              <div className="mt-1 text-sm font-semibold text-gray-900">
+                1 {firstReserveAsset} = {priceOfFirst} {secondReserveAsset}
+              </div>
+              <div className="text-sm font-semibold text-gray-900">
+                1 {secondReserveAsset} = {priceOfSecond} {firstReserveAsset}
+              </div>
+            </div>
+          )}
+          <div className="grid grid-cols-2 divide-x divide-gray-200">
+            <div className="p-4">
+              <div className="text-xs font-medium uppercase text-gray-500">Reserve {firstReserveAsset}</div>
+              <div className="mt-1 text-sm font-semibold text-gray-900">
+                {reserveByAsset[firstReserveAsset]}
+              </div>
+            </div>
+            <div className="p-4">
+              <div className="text-xs font-medium uppercase text-gray-500">Reserve {secondReserveAsset}</div>
+              <div className="mt-1 text-sm font-semibold text-gray-900">
+                {reserveByAsset[secondReserveAsset]}
+              </div>
+            </div>
+          </div>
+          {poolSharePercent && underlyingA && underlyingB && (
+            <div className="grid grid-cols-2 divide-x divide-gray-200 border-t border-gray-200">
+              <div className="p-4">
+                <div className="text-xs font-medium uppercase text-gray-500">Pool share</div>
+                <div className="mt-1 text-sm font-semibold text-gray-900">{poolSharePercent}%</div>
+              </div>
+              <div className="p-4">
+                <div className="text-xs font-medium uppercase text-gray-500">Underlying</div>
+                <div className="mt-1 text-sm font-semibold text-gray-900">
+                  {underlyingA} {pool.asset_a}
+                </div>
+                <div className="text-sm font-semibold text-gray-900">
+                  {underlyingB} {pool.asset_b}
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {position ? (
+          <div className="grid grid-cols-2 gap-3">
+            <Button
+              fullWidth
+              onClick={() => navigate(`/compose/pool/deposit/${encodeURIComponent(pool.asset_a)}/${encodeURIComponent(pool.asset_b)}`)}
+            >
+              Deposit
+            </Button>
+            <Button
+              fullWidth
+              onClick={() => navigate(`/compose/pool/withdraw/${encodeURIComponent(pool.lp_asset)}`)}
+            >
+              Withdraw
+            </Button>
+          </div>
+        ) : (
+          <Button
+            fullWidth
+            onClick={() => navigate(`/compose/pool/deposit/${encodeURIComponent(pool.asset_a)}/${encodeURIComponent(pool.asset_b)}`)}
+          >
+            Deposit
+          </Button>
+        )}
+      </section>
+
+      <ActionList
+        sections={[
+          {
+            items: [
+              {
+                id: "pool-swap",
+                title: "Pool Swap",
+                description: "Swap instantly at the quoted price",
+                onClick: () => navigate(`/compose/swap/${encodeURIComponent(pool.asset_a)}/${encodeURIComponent(pool.asset_b)}`),
+              },
+              {
+                id: "dex-order",
+                title: "DEX Order",
+                description: "Set your own price on the order book",
+                onClick: () => navigate(`/compose/order/${encodeURIComponent(pool.asset_a)}`),
+              },
+            ],
+          },
+        ]}
+      />
+    </div>
+  );
+}

--- a/src/pages/settings/address-types.tsx
+++ b/src/pages/settings/address-types.tsx
@@ -1,14 +1,14 @@
 import { RadioGroup } from "@headlessui/react";
 import type { ReactElement } from "react";
 import { useEffect, useRef, useState } from "react";
-import { useNavigate } from "react-router";
+import { useLocation, useNavigate } from "react-router";
 import { FiHelpCircle } from "@/components/icons";
 import { SelectionCard, SelectionCardGroup } from "@/components/ui/cards/selection-card";
 import { ErrorAlert } from "@/components/ui/error-alert";
 import { Spinner } from "@/components/ui/spinner";
 import { useHeader } from "@/contexts/header-context";
 import { useWallet } from "@/contexts/wallet-context";
-import { AddressFormat, isCounterwalletFormat, isFreewalletBIP39Format } from '@/core/bitcoin/address';
+import { AddressFormat, getAddressFormatLabel, isCounterwalletFormat, isFreewalletBIP39Format } from '@/core/bitcoin/address';
 import { formatAddress } from "@/core/format";
 
 /**
@@ -35,7 +35,9 @@ const AVAILABLE_ADDRESS_TYPES = Object.values(AddressFormat);
  */
 export default function AddressTypesPage(): ReactElement {
   const navigate = useNavigate();
+  const location = useLocation();
   const { setHeaderProps } = useHeader();
+  const returnTo = (location.state as { returnTo?: string } | null)?.returnTo;
   const { activeWallet, updateWalletAddressFormat, getPreviewAddressForFormat } = useWallet();
   const [addresses, setAddresses] = useState<{ [key: string]: string }>({});
   const [isInitialLoading, setIsInitialLoading] = useState(true);
@@ -48,8 +50,11 @@ export default function AddressTypesPage(): ReactElement {
   // Configure header with dynamic back navigation and help button
   useEffect(() => {
     const handleBack = () => {
-      // If address type was changed, go to index
-      if (hasChangedType.current) {
+      // Return to the page that linked here (e.g. the address list)
+      if (returnTo) {
+        navigate(returnTo);
+      } else if (hasChangedType.current) {
+        // If address type was changed, go to index
         navigate("/index");
       } else {
         // Otherwise go back to settings
@@ -66,7 +71,7 @@ export default function AddressTypesPage(): ReactElement {
         ariaLabel: "Help",
       },
     });
-  }, [setHeaderProps, navigate]);
+  }, [setHeaderProps, navigate, returnTo]);
 
 
   // Load preview addresses
@@ -140,35 +145,6 @@ export default function AddressTypesPage(): ReactElement {
     }
   };
 
-  /**
-   * Gets a human-readable description for an address type.
-   * @param type - The address type.
-   * @returns {string} The description of the address type.
-   */
-  const getAddressFormatDescription = (type: AddressFormat): string => {
-    switch (type) {
-      case AddressFormat.P2PKH:
-        return "Legacy (P2PKH)";
-      case AddressFormat.P2WPKH:
-        return "Native SegWit (P2WPKH)";
-      case AddressFormat.P2SH_P2WPKH:
-        return "Nested SegWit (P2SH-P2WPKH)";
-      case AddressFormat.P2TR:
-        return "Taproot (P2TR)";
-      case AddressFormat.Counterwallet:
-          return "CounterWallet (P2PKH)";
-      case AddressFormat.CounterwalletSegwit:
-          return "CounterWallet SegWit (P2WPKH)";
-      case AddressFormat.FreewalletBIP39:
-          return "FreeWallet (P2PKH)";
-      case AddressFormat.FreewalletBIP39Segwit:
-          return "FreeWallet SegWit (P2WPKH)";
-      default:
-        return type;
-    }
-  };
-
-
   if (isInitialLoading) {
     return (
       <div className="flex items-center justify-center h-full">
@@ -225,7 +201,7 @@ export default function AddressTypesPage(): ReactElement {
 
             return true;
           }).map((type) => {
-            const typeLabel = getAddressFormatDescription(type);
+            const typeLabel = getAddressFormatLabel(type);
             // Use loaded address preview
             const address = addresses[type] || "";
             const addressPreview = address ? formatAddress(address) : "";

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -7,7 +7,7 @@ import type { ActionSection } from "@/components/ui/lists/action-list";
 import { ActionList } from "@/components/ui/lists/action-list";
 import { useHeader } from "@/contexts/header-context";
 import { useWallet } from "@/contexts/wallet-context";
-import { AddressFormat } from '@/core/bitcoin/address';
+import { getAddressFormatLabel } from '@/core/bitcoin/address';
 import packageJson from "../../../package.json";
 
 
@@ -70,26 +70,7 @@ export default function SettingsPage(): ReactElement {
    */
   const getAddressTypeDescription = (): string => {
     if (!activeWallet) return "";
-    switch (activeWallet.addressFormat) {
-      case AddressFormat.P2PKH:
-        return "Legacy (P2PKH)";
-      case AddressFormat.P2SH_P2WPKH:
-        return "Nested SegWit (P2SH-P2WPKH)";
-      case AddressFormat.P2WPKH:
-        return "Native SegWit (P2WPKH)";
-      case AddressFormat.P2TR:
-        return "Taproot (P2TR)";
-      case AddressFormat.Counterwallet:
-        return "CounterWallet (P2PKH)";
-      case AddressFormat.CounterwalletSegwit:
-        return "CounterWallet SegWit (P2WPKH)";
-      case AddressFormat.FreewalletBIP39:
-        return "FreeWallet (P2PKH)";
-      case AddressFormat.FreewalletBIP39Segwit:
-        return "FreeWallet SegWit (P2WPKH)";
-      default:
-        return "";
-    }
+    return getAddressFormatLabel(activeWallet.addressFormat);
   };
 
   const settingSections: ActionSection[] = [

--- a/src/platform/__tests__/fathom.test.ts
+++ b/src/platform/__tests__/fathom.test.ts
@@ -203,6 +203,15 @@ describe('fathom sanitizePath', () => {
       expect(sanitizePath('/compose/dividend/XCP')).toBe('/compose/dividend');
     });
 
+    it('strips the pair from /compose/swap/:giveAsset/:getAsset', () => {
+      expect(sanitizePath('/compose/swap/PEPECASH/XCP')).toBe('/compose/swap');
+      expect(sanitizePath('/compose/swap/XCP')).toBe('/compose/swap');
+    });
+
+    it('preserves /compose/swap (no pair)', () => {
+      expect(sanitizePath('/compose/swap')).toBe('/compose/swap');
+    });
+
     it('preserves static compose paths', () => {
       expect(sanitizePath('/compose/broadcast')).toBe('/compose/broadcast');
       expect(sanitizePath('/compose/broadcast/address-options')).toBe('/compose/broadcast/address-options');

--- a/src/platform/fathom.ts
+++ b/src/platform/fathom.ts
@@ -121,6 +121,7 @@ const SENSITIVE_PATH_PATTERNS: Array<{ prefix: string; sanitized: string }> = [
   { prefix: '/compose/order/btcpay', sanitized: '/compose/order/btcpay' }, // static
   { prefix: '/compose/order/cancel/', sanitized: '/compose/order/cancel' },
   { prefix: '/compose/order/', sanitized: '/compose/order' },
+  { prefix: '/compose/swap/', sanitized: '/compose/swap' },
   { prefix: '/compose/pool/deposit/', sanitized: '/compose/pool/deposit' },
   { prefix: '/compose/pool/deposit', sanitized: '/compose/pool/deposit' },
   { prefix: '/compose/pool/withdraw/', sanitized: '/compose/pool/withdraw' },


### PR DESCRIPTION
One big UX/UI improvement pass across the market, pool, and compose surfaces, plus the bug fixes uncovered along the way.

## Fixes

- **LP quantities were raw satoshis pretending to be normalized.** `verbose=true` on `/v2/addresses/:address/pools` never injects `quantity_normalized` (core's query selects no `asset` column for `verbose.py` to resolve), which inflated pool share to 10,000,000,000% and withdraw amounts by 1e8. `normalizePoolPosition` now derives it from `lp_asset_info.divisible` in the domain layer. Verified against the production API and core master source.
- **Recovery Tool help toggle could only turn on** (stale closure in the header effect). Now a local, non-persisting toggle like the compose forms.
- **Two select inputs rendered `Label*`** because JSX collapses newline-only whitespace; every input now renders `Label *`.

## Features

- **Swap** (`/compose/swap/:give?/:get?`): sell a fixed amount, receive a quoted amount routed across the AMM pool and resting order book (`/v2/pools/:give/:get/quote`). Composes a regular DEX order — quoted output minus slippage as the minimum received, expiration hardcoded to 1 block for immediate-or-cancel fills — so compose, review, and local message verification reuse the proven order paths. Two-card send/receive layout with live impact on the receive field, a price bar whose gear expands details + slippage, and always-visible fee rate. Reachable from pool pages ("Pool Swap") and a Swap tab on the DEX order form whenever the pair has a pool.
- **One pool page**: the LP-asset and pair routes render a shared overview — implied price first, reserves, then share/underlying/Withdraw only when you hold the LP asset.
- **Pool deposit/withdraw as tabs** under one "Pool" title, mirroring the DEX order form's Buy/Sell + settings-cog structure.
- **XCP price page shows the real floor**: cheapest open dispenser (linked to its dispense flow) instead of the explorer's thin-trade DEX rate that ran ~2.4x above reality; DEX rate remains as the no-dispenser fallback. Chart recolored rose→sky (red reads as losses).

## Polish

- Sub-headers (asset/balance/address/pool) sit at consistent 20px offsets on every page instead of varying 16–24px.
- Pool cards: implied price + solid-backed icon circles (no more transparent-art bleed).
- Balance page: UTXO-style "Pool Position" card for LP assets, Sell action for XCP, red outline on Destroy.
- Actions page: Create Dispenser entry; Addresses page: header cog opens the address-type switcher (which now returns to the address list).

## Testing

- 495 unit tests pass; typecheck and biome clean.
- e2e specs updated for the new UI (floor price with stubbed dispensers, header cog, XCP Sell); `xcp-price.spec.ts` run locally 10/10 — full suite via CI on this branch.
- Key flows verified in the running extension against mainnet (PEPECASH/XCP pool quotes, floor price, pool pages).

https://claude.ai/code/session_01H6NZ7JtqTVvsVGkYf6hE6s
