### PR TITLE
Fix dApp approval headlines rendering "undefined"

### DIFF
--- a/src/core/counterparty/__tests__/transaction.test.ts
+++ b/src/core/counterparty/__tests__/transaction.test.ts
@@ -129,6 +129,14 @@ describe('describeCounterpartyMessage', () => {
     expect(desc).toContain('BTC');
   });
 
+  it('describes dispense without inventing a dispenser field', () => {
+    // core's dispense.unpack returns only { data } — the marker byte. Reading a
+    // `dispenser` key rendered "Dispense from undefined" on every dispense.
+    const desc = describeCounterpartyMessage('dispense', { data: '0d' });
+    expect(desc).not.toContain('undefined');
+    expect(desc.toLowerCase()).toContain('dispenser');
+  });
+
   it('describes dispenser', () => {
     const desc = describeCounterpartyMessage('dispenser', {
       give_quantity: 1000,

--- a/src/core/counterparty/__tests__/transaction.test.ts
+++ b/src/core/counterparty/__tests__/transaction.test.ts
@@ -75,14 +75,36 @@ describe('hasCounterpartyPrefix', () => {
 
 describe('describeCounterpartyMessage', () => {
   it('describes enhanced_send', () => {
+    // `/v2/transactions/unpack` names this field `address`, not `destination`.
+    // The fixture used to disagree with production, so this test passed while
+    // the approval headline rendered "to undefined".
     const desc = describeCounterpartyMessage('enhanced_send', {
       quantity: 100000000,
       asset: 'XCP',
-      destination: 'bc1qtest',
+      address: 'bc1qtest',
     });
     expect(desc).toContain('Send');
     expect(desc).toContain('XCP');
     expect(desc).toContain('bc1qtest');
+    expect(desc).not.toContain('undefined');
+  });
+
+  it('describes a send that supplies destination instead of address', () => {
+    const desc = describeCounterpartyMessage('send', {
+      quantity: 100000000,
+      asset: 'XCP',
+      destination: 'bc1qlegacy',
+    });
+    expect(desc).toContain('bc1qlegacy');
+    expect(desc).not.toContain('undefined');
+  });
+
+  it('never renders undefined when neither recipient key is present', () => {
+    const desc = describeCounterpartyMessage('enhanced_send', {
+      quantity: 100000000,
+      asset: 'XCP',
+    });
+    expect(desc).not.toContain('undefined');
   });
 
   it('describes send (legacy)', () => {

--- a/src/core/counterparty/transaction.ts
+++ b/src/core/counterparty/transaction.ts
@@ -230,10 +230,19 @@ export function describeCounterpartyMessage(
     return BigInt(String(raw)).toLocaleString();
   };
 
+  /**
+   * The recipient of a send. `/v2/transactions/unpack` names this field
+   * `address` for both send variants, while sweep and utxo_move use
+   * `destination` — so both keys are read rather than assuming one shape.
+   * Reading only `destination` rendered every send headline as "to undefined".
+   */
+  const recipient = (): string =>
+    String(messageData.address ?? messageData.destination ?? 'unknown address');
+
   switch (messageType) {
     case 'enhanced_send':
     case 'send':
-      return `Send ${q('quantity', 'asset')} ${displayName('asset')} to ${messageData.destination}`;
+      return `Send ${q('quantity', 'asset')} ${displayName('asset')} to ${recipient()}`;
     case 'order':
       return `DEX Order: Give ${q('give_quantity', 'give_asset')} ${displayName('give_asset')} for ${q('get_quantity', 'get_asset')} ${displayName('get_asset')}`;
     case 'dispenser':

--- a/src/core/counterparty/transaction.ts
+++ b/src/core/counterparty/transaction.ts
@@ -248,7 +248,11 @@ export function describeCounterpartyMessage(
     case 'dispenser':
       return `Create Dispenser: ${q('give_quantity', 'asset')} ${displayName('asset')} per ${messageData.mainchainrate} sats`;
     case 'dispense':
-      return `Dispense from ${messageData.dispenser}`;
+      // The dispense payload is a marker byte — core's unpack returns only
+      // `data`. Which dispenser is triggered is decided by the BTC output, not
+      // the payload, so naming one here rendered "Dispense from undefined".
+      // The outputs are listed on the approval screen itself.
+      return 'Trigger a dispenser';
     case 'issuance':
       return `Issue Asset: ${displayName('asset')}${messageData.quantity ? ` (${q('quantity', 'asset')} units)` : ''}`;
     case 'dividend':


### PR DESCRIPTION
Two dApp approval headlines currently render `undefined`. Both come from `describeCounterpartyMessage` reading keys the unpack API doesn't return.

## 1. Sends: "Send 1.00000000 XCP to undefined"

`/v2/transactions/unpack` names the send recipient `address`; the code read `destination`. Verified against mainnet tx `ba71100e7d13…`:
```
unpack message_type: enhanced_send
unpack keys: ['address', 'asset', 'memo', 'quantity']
destination: None | address: 13Hnmhs5gy2yXKVBx4wSM5HCBdKnaSBZJH
```
**Not a blanket mismatch, so both keys are read rather than swapped**: `sweep` genuinely returns `destination` (verified against a real sweep), and so does `utxo_move` (core's `messages/utxo.py`). Legacy `send1` also uses `destination`, and it shares this code arm — another reason to accept both.

`providerVerify.ts:123` already handled both shapes via `getApiValue(api, 'destination', 'address')` — the codebase knew the API varies here; only the display assumed. This aligns display with verification.

## 2. Dispenses: "Dispense from undefined"

core's `dispense.unpack` returns only `{ data }` — the payload is a marker byte. Confirmed on mainnet: `message_data keys: ['data']`. Which dispenser is triggered is decided by the BTC output, not the payload, and the outputs are already listed on the screen — so the headline no longer claims to name one.

## Audit

Rather than fix the reported key and stop, every arm of `describeCounterpartyMessage` was checked against core's unpack return shapes and a 500-transaction live sample. `order`, `dispenser`, `issuance`, `dividend`, `cancel`, `sweep`, `broadcast`, `fairminter`, `fairmint`, `pooldeposit`, `poolwithdraw`, `attach`, `detach`, `utxo_move` and `destroy` all read keys that exist. Sends and dispenses were the only two wrong.

## Why they survived

The send fixture supplied `destination`, so the unit test passed while production printed `undefined`. The fixture now matches production, and four tests assert the headline never contains `undefined` — API shape, legacy shape, neither-key-present, and dispense.

695 tests pass; typecheck and build clean.

The send bug was reported by an external reviewer reading v0.7.0; independently verified against the live API and counterparty-core, and the dispense bug found while auditing the rest.

https://claude.ai/code/session_01H6NZ7JtqTVvsVGkYf6hE6s