### PR TITLE
Only claim a cross-check when a payload field was compared

### DIFF
--- a/src/components/domain/tx/verification-status.test.tsx
+++ b/src/components/domain/tx/verification-status.test.tsx
@@ -18,7 +18,7 @@ describe('VerificationStatus', () => {
     render(<VerificationStatus passed comparedAgainstApi={false} />);
 
     expect(screen.queryByText(/no tampering detected/i)).not.toBeInTheDocument();
-    expect(screen.getByText(/no second source/i)).toBeInTheDocument();
+    expect(screen.getByText(/nothing to compare/i)).toBeInTheDocument();
   });
 
   it('renders nothing when verification was not attempted', () => {

--- a/src/components/domain/tx/verification-status.tsx
+++ b/src/components/domain/tx/verification-status.tsx
@@ -36,7 +36,7 @@ export interface VerificationStatusProps {
  * Displays verification status with appropriate styling.
  *
  * - Green: cross-checked and agreed
- * - Neutral: decoded locally, but no second source to compare against
+ * - Neutral: decoded locally, but no payload field was compared
  * - Orange: Verification failed (non-strict mode, warning only)
  * - Red: Verification failed (strict mode, signing blocked)
  */
@@ -52,12 +52,14 @@ export function VerificationStatus({
     return null;
   }
 
-  // Decoded, but nothing to compare it against. Neither an error nor a clean bill of health.
+  // Decoded, but no payload field was actually compared — either no second
+  // source was available, or this message type carries nothing comparable.
+  // Neither an error nor a clean bill of health.
   if (passed === true && !comparedAgainstApi) {
     return (
       <div className="flex items-center justify-center gap-1.5 text-xs font-medium text-gray-600">
         <FiInfo className="size-4 flex-shrink-0" aria-hidden="true" />
-        Decoded locally — no second source to check it against
+        Decoded locally — nothing to compare it against
       </div>
     );
   }

--- a/src/core/counterparty/unpack/__tests__/providerVerify.test.ts
+++ b/src/core/counterparty/unpack/__tests__/providerVerify.test.ts
@@ -918,6 +918,36 @@ describe('verifyProviderTransaction', () => {
       expect(result.passed).toBe(true);
     });
 
+    it('reports dispense as not compared — its payload has no fields', () => {
+      const data = buildMessage(MessageTypeId.DISPENSE, '00');
+      const api: ApiCounterpartyMessage = {
+        messageType: 'dispense',
+        messageTypeId: MessageTypeId.DISPENSE,
+        messageData: {},
+        description: '',
+      };
+      const result = verifyProviderTransaction(data, api);
+      // Passing is fine; claiming it was cross-checked is not.
+      expect(result.passed).toBe(true);
+      expect(result.comparedAgainstApi).toBe(false);
+    });
+
+    it('catches a detach destination the API disagrees with', () => {
+      const destBytes = new TextEncoder().encode('mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc');
+      const destHex = Array.from(destBytes).map(b => b.toString(16).padStart(2, '0')).join('');
+      const data = buildMessage(MessageTypeId.UTXO_DETACH, destHex);
+      const api: ApiCounterpartyMessage = {
+        messageType: 'detach',
+        messageTypeId: MessageTypeId.UTXO_DETACH,
+        messageData: { destination: 'mzKp5S4TFqvcNwLcv2S3xUgnrqzhoTGusL' },
+        description: '',
+      };
+      const result = verifyProviderTransaction(data, api);
+      expect(result.passed).toBe(false);
+      expect(result.comparedAgainstApi).toBe(true);
+      expect(result.mismatches.join(' ')).toMatch(/Destination/i);
+    });
+
     it('detach passes with matching type (minimal verification)', () => {
       // Detach payload is a destination address string
       const destBytes = new TextEncoder().encode('mn6q3dS2EnDUx3bmyWc6D4szJNVGtaR7zc');

--- a/src/core/counterparty/unpack/providerVerify.ts
+++ b/src/core/counterparty/unpack/providerVerify.ts
@@ -8,7 +8,7 @@
 
 import { addressesEqual } from '@/core/counterparty/unpack/address';
 import { isCounterpartyData, type UnpackResult, unpackCounterpartyMessage } from '@/core/counterparty/unpack/index';
-import type { AttachData, } from '@/core/counterparty/unpack/messages/attach';
+import type { AttachData, DetachData } from '@/core/counterparty/unpack/messages/attach';
 import type { BroadcastData } from '@/core/counterparty/unpack/messages/broadcast';
 import type { BTCPayData } from '@/core/counterparty/unpack/messages/btcpay';
 import type { CancelData } from '@/core/counterparty/unpack/messages/cancel';
@@ -255,6 +255,27 @@ function verifyDestroy(
 /**
  * Verify a sweep message
  */
+/**
+ * Detach carries a single field — where the assets leave the UTXO to. A wrong
+ * destination sends them to an address the signer does not control, so this is
+ * exactly the comparison worth making, not one to skip.
+ */
+function verifyDetach(
+  local: DetachData,
+  api: Record<string, unknown>
+): string[] {
+  const mismatches: string[] = [];
+
+  const apiDest = getApiValue(api, 'destination', 'address') as string | undefined;
+  // "0" is the protocol's stand-in for "back to the sender", which the API
+  // renders as the resolved address — not a mismatch.
+  if (apiDest && local.destination !== '0' && !addressesEqual(local.destination, apiDest)) {
+    mismatches.push(`Destination: local="${local.destination}", API="${apiDest}"`);
+  }
+
+  return mismatches;
+}
+
 function verifySweep(
   local: SweepData,
   api: Record<string, unknown>
@@ -646,7 +667,14 @@ export function verifyProviderTransaction(
     );
   }
 
-  // Verify specific fields based on message type
+  // Verify specific fields based on message type.
+  //
+  // Whether any payload field was actually compared, as opposed to the type and
+  // type ID matching and the switch falling through. Reporting a pass as
+  // "compared against the API" when no comparator ran overstates the check
+  // precisely where the least of it happened, which is what this flag exists to
+  // prevent.
+  let payloadCompared = true;
   const apiData = apiMessage.messageData;
 
   switch (localUnpack.messageType) {
@@ -722,16 +750,20 @@ export function verifyProviderTransaction(
       break;
 
     case 'detach':
-      // Detach payload is just a destination address — minimal verification
+      mismatches.push(...verifyDetach(localUnpack.data as DetachData, apiData));
       break;
 
     case 'dispense':
-      // Dispense has minimal payload - just a marker byte
-      // Verification is at the transaction level (destination/amount)
+      // A dispense payload is a marker byte: core's unpack returns only { data },
+      // so there is no field to compare. Which dispenser is triggered lives in
+      // the outputs, which the approval screen shows directly.
+      payloadCompared = false;
       break;
 
     default:
-      // Unknown message type - type match check is done above
+      // No comparator for this type in this build. The type and type ID above
+      // still matched, but no payload field was checked.
+      payloadCompared = false;
       break;
   }
 
@@ -739,7 +771,7 @@ export function verifyProviderTransaction(
 
   return {
     passed,
-    comparedAgainstApi: true,
+    comparedAgainstApi: payloadCompared,
     warning: passed ? undefined : `Verification failed: ${mismatches.join('; ')}`,
     mismatches,
     localUnpack,


### PR DESCRIPTION
`verifyProviderTransaction` returned `comparedAgainstApi: true` unconditionally at the end of the switch, so message types with no comparator still rendered the green **"Verified locally — no tampering detected"** badge.

That overstates the check precisely where the least of it happened — which is the situation this flag was introduced (#222) to prevent. #222 covered *no API decode available*; this is *a decode was available, but this build has no comparator for that type*.

## Changes

- **`payloadCompared` tracks whether a comparator actually ran.** `dispense` (payload is a marker byte — core's unpack returns only `{ data }`, so there is genuinely nothing to compare) and unrecognized types now report `false` and render the neutral *"Decoded locally — nothing to compare it against"* state. The type and type-ID checks still run and still fail loudly on mismatch.
- **`detach` gains a real comparator.** Its payload is a single field: the destination the assets leave the UTXO to. A wrong one moves them somewhere the signer does not control, so it is exactly the field worth comparing. `"0"` (the protocol's "back to sender") is not treated as a mismatch against the API's resolved address.
- **Neutral-state wording generalized** from *"no second source to check it against"* to *"nothing to compare it against"*, which is accurate for both causes.

## Tests

- dispense passes but reports `comparedAgainstApi: false`
- a detach whose API destination disagrees now fails with a `Destination` mismatch and `comparedAgainstApi: true`

3,216 tests pass; typecheck and build clean. (The Trezor emulator suite needs a running emulator and is unrelated.)

Reported by an external reviewer against v0.7.0, who also noted the missing comparator already existed on the compose path (`verify.ts`'s `verifyMove`).

https://claude.ai/code/session_01H6NZ7JtqTVvsVGkYf6hE6s