### PR TITLE
Reject a non-canonical compacted subasset longname, as core does

### DIFF
--- a/src/core/counterparty/pack/messages.ts
+++ b/src/core/counterparty/pack/messages.ts
@@ -214,7 +214,7 @@ const SUBASSET_DIGITS = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ012
  *
  * Returns null for a character outside the charset, which core refuses to compose.
  */
-function compactSubassetLongname(longname: string): Uint8Array | null {
+export function compactSubassetLongname(longname: string): Uint8Array | null {
   let integer = 0n;
   for (const char of longname) {
     const digit = SUBASSET_DIGITS.indexOf(char) + 1;

--- a/src/core/counterparty/unpack/__tests__/coreWireFidelity.test.ts
+++ b/src/core/counterparty/unpack/__tests__/coreWireFidelity.test.ts
@@ -9,6 +9,8 @@
 import { describe, expect, it } from 'vitest';
 import { unpackAddress, unpackAddressLegacy } from '@/core/counterparty/unpack/address';
 import { unpackBroadcast } from '@/core/counterparty/unpack/messages/broadcast';
+import { encodeCbor } from '@/core/counterparty/pack/cbor';
+import { compactSubassetLongname } from '@/core/counterparty/pack/messages';
 import { unpackIssuance } from '@/core/counterparty/unpack/messages/issuance';
 
 /** ">IdI" header: timestamp, value (float64 BE), fee_fraction_int. */
@@ -22,6 +24,15 @@ function broadcastHeader(timestamp = 1735689600, value = 0, feeFractionInt = 0):
 }
 
 const ascii = (s: string): number[] => Array.from(new TextEncoder().encode(s));
+
+
+/** CBOR subasset issuance: [asset_id, quantity, divisible, lock, reset, len, name, mime, desc]. */
+function cborSubasset(compactedName: Uint8Array): Uint8Array {
+  return encodeCbor([
+    95428956661682177n, 1000n, true, false, false,
+    BigInt(compactedName.length), compactedName, '', new TextEncoder().encode('d'),
+  ]);
+}
 
 describe('broadcast text — core takes the tail', () => {
   it('reads a well-formed varint-prefixed text', () => {
@@ -135,5 +146,22 @@ describe('mpma address table — core decodes it with legacy rules only', () => 
   it('decodes a 0x80-marked segwit entry as bech32, as core does', () => {
     const program = new Uint8Array(20).fill(0x22);
     expect(unpackAddressLegacy(new Uint8Array([0x80, ...program])).startsWith('bc1q')).toBe(true);
+  });
+});
+
+describe('subasset longname — canonical compaction only', () => {
+  it('refuses a zero-padded compaction that expands to the same name', () => {
+    // Distinct byte strings expand to the same longname, so without re-compacting and comparing,
+    // a familiar name renders here for bytes core refuses to unpack. Core raises deliberately
+    // outside its own legacy fallback so the rejection cannot be swallowed.
+    const canonical = compactSubassetLongname('sub')!;
+    const padded = new Uint8Array([0x00, ...canonical]);
+
+    // Both expand to the same string...
+    expect(padded.length).toBeGreaterThan(canonical.length);
+
+    // ...but only the minimal encoding is accepted.
+    expect(() => unpackIssuance(cborSubasset(canonical), 21)).not.toThrow();
+    expect(() => unpackIssuance(cborSubasset(padded), 21)).toThrow(/non-canonical/i);
   });
 });

--- a/src/core/counterparty/unpack/messages/issuance.ts
+++ b/src/core/counterparty/unpack/messages/issuance.ts
@@ -24,6 +24,7 @@
  *              compacted_length, compacted_name, mime_type, description]
  */
 
+import { compactSubassetLongname } from '@/core/counterparty/pack/messages';
 import { assetIdToName } from '@/core/counterparty/unpack/assetId';
 import { BinaryReader, bytesToTextOrHex } from '@/core/counterparty/unpack/binary';
 import { type CborValue, tryDecodeCborArray } from '@/core/counterparty/unpack/cbor';
@@ -147,7 +148,23 @@ function tryCborDecode(payload: Uint8Array, messageTypeId: number): IssuanceData
   if (isSubasset) {
     const compactedName = decoded[6];
     if (compactedName instanceof Uint8Array) {
-      result.subassetLongname = decodeCompactedSubasset(compactedName);
+      const longname = decodeCompactedSubasset(compactedName);
+
+      // Canonical-form guard, matching core. Distinct byte strings expand to the same longname —
+      // a leading zero pad, or the phantom '!' digit when an intermediate integer is divisible by
+      // 68 — so without re-compacting and comparing, a name renders here for bytes core refuses to
+      // unpack. Core runs this check deliberately outside its own legacy fallback so the rejection
+      // cannot be swallowed; it is likewise fatal here rather than a silent difference.
+      const recompacted = compactSubassetLongname(longname);
+      if (
+        !recompacted ||
+        recompacted.length !== compactedName.length ||
+        !recompacted.every((byte, i) => byte === compactedName[i])
+      ) {
+        throw new Error('Non-canonical compacted subasset longname');
+      }
+
+      result.subassetLongname = longname;
     }
     result.description = cborDescription(decoded[8] ?? null);
   } else {


### PR DESCRIPTION
Distinct compacted byte strings expand to the **same** subasset longname — a leading zero pad, or the phantom `!` digit when an intermediate integer is divisible by 68. Core re-compacts the expanded name and raises `UnpackError` on any difference, deliberately *outside* its own legacy fallback so the rejection cannot be swallowed:

> Without canonicalization an attacker mints subassets under a rendering they didn't honestly compose.
> — `messages/issuance.py`

Nothing here did that. A familiar-looking subasset name rendered on the approval screen for bytes core refuses to unpack — the user reads a name they recognise and signs an issuance the chain marks invalid.

The forward compaction already existed in the packer for composing subassets, so it is exported and reused rather than transcribed a second time.

Found while re-auditing what the previous pass left open, rather than reported by a user.

https://claude.ai/code/session_01H6NZ7JtqTVvsVGkYf6hE6s