### PR TITLE
Make base units and display units different types, and fuzz the decoder against core

### DIFF
--- a/src/components/domain/asset/asset-card.test.tsx
+++ b/src/components/domain/asset/asset-card.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { BrowserRouter } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OwnedAsset } from "@/core/counterparty/api";
+import { asDisplayUnits } from '@/core/numeric';
 import { AssetCard } from "./asset-card";
 
 // Mock the AssetMenu component
@@ -75,7 +76,7 @@ describe("AssetCard", () => {
     asset_longname: "RARE.PEPE.COLLECTION",
     description: "Rare Pepe Collection",
     locked: false,
-    supply_normalized: "1000.00000000",
+    supply_normalized: asDisplayUnits("1000.00000000"),
   };
 
   const mockDivisibleAsset: OwnedAsset = {
@@ -83,7 +84,7 @@ describe("AssetCard", () => {
     asset_longname: null,
     description: "My Custom Token",
     locked: true,
-    supply_normalized: "10000.00000000",
+    supply_normalized: asDisplayUnits("10000.00000000"),
   };
 
   beforeEach(() => {

--- a/src/components/domain/asset/asset-header.test.tsx
+++ b/src/components/domain/asset/asset-header.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import '@testing-library/jest-dom/vitest';
 import type { AssetInfo } from '@/core/counterparty/api';
+import { asBaseUnits, asDisplayUnits } from '@/core/numeric';
 import { AssetHeader } from './asset-header';
 
 // Mock dependencies
@@ -35,6 +36,9 @@ vi.mock('@/core/format', () => ({
 }));
 
 vi.mock('@/core/numeric', () => ({
+  // Brands are compile-time only; at runtime they are identity.
+  asBaseUnits: (v: unknown) => v,
+  asDisplayUnits: (v: unknown) => v,
   fromSatoshis: vi.fn((value, options) => {
     const numValue = typeof value === 'string' ? parseInt(value) : value;
     const result = numValue / 100000000;
@@ -50,8 +54,8 @@ describe('AssetHeader', () => {
     issuer: 'bc1qxyz789',
     divisible: true,
     locked: true,
-    supply: '1000000000000',
-    supply_normalized: '10000.00000000'
+    supply: asBaseUnits('1000000000000'),
+    supply_normalized: asDisplayUnits('10000.00000000')
   };
 
   beforeEach(() => {
@@ -112,7 +116,7 @@ describe('AssetHeader', () => {
     const indivisibleAsset = {
       ...mockAssetInfo,
       divisible: false,
-      supply: '1000'
+      supply: asBaseUnits('1000')
     };
     
     render(<AssetHeader assetInfo={indivisibleAsset} />);
@@ -123,7 +127,7 @@ describe('AssetHeader', () => {
   it('should handle zero supply', () => {
     const zeroSupplyAsset = {
       ...mockAssetInfo,
-      supply: 0
+      supply: asBaseUnits(0)
     };
     
     render(<AssetHeader assetInfo={zeroSupplyAsset} />);
@@ -146,7 +150,7 @@ describe('AssetHeader', () => {
   it('should handle string supply', () => {
     const stringSupplyAsset = {
       ...mockAssetInfo,
-      supply: '5000000'
+      supply: asBaseUnits('5000000')
     };
     
     render(<AssetHeader assetInfo={stringSupplyAsset} />);
@@ -163,7 +167,7 @@ describe('AssetHeader', () => {
     
     const updatedAssetInfo = {
       ...mockAssetInfo,
-      supply: '2000000000000'
+      supply: asBaseUnits('2000000000000')
     };
     
     rerender(<AssetHeader assetInfo={updatedAssetInfo} />);
@@ -174,7 +178,7 @@ describe('AssetHeader', () => {
   it('should use cached data when available', () => {
     const cachedData: AssetInfo = {
       ...mockAssetInfo,
-      supply: '999999999'
+      supply: asBaseUnits('999999999')
     };
     
     mockSubheadings.assets['PEPECASH'] = cachedData;
@@ -239,7 +243,7 @@ describe('AssetHeader', () => {
       asset_longname: null,
       divisible: false,
       locked: false,
-      supply_normalized: '0'
+      supply_normalized: asDisplayUnits('0')
     };
     
     render(<AssetHeader assetInfo={minimalAsset} />);
@@ -257,8 +261,8 @@ describe('AssetHeader', () => {
       issuer: 'bc1qissuer123',
       divisible: true,
       locked: true,
-      supply: 21000000,
-      supply_normalized: '0.21'
+      supply: asBaseUnits(21000000),
+      supply_normalized: asDisplayUnits('0.21')
     };
     
     render(<AssetHeader assetInfo={fullAsset} />);
@@ -279,8 +283,8 @@ describe('AssetHeader', () => {
       asset_longname: null,
       divisible: true,
       locked: true,
-      supply: '2600000000000000',
-      supply_normalized: '26000000'
+      supply: asBaseUnits('2600000000000000'),
+      supply_normalized: asDisplayUnits('26000000')
     };
     
     rerender(<AssetHeader assetInfo={differentAsset} />);
@@ -305,7 +309,7 @@ describe('AssetHeader', () => {
   it('should handle large supply numbers', () => {
     const largeSupplyAsset = {
       ...mockAssetInfo,
-      supply: '9999999999999999999999'
+      supply: asBaseUnits('9999999999999999999999')
     };
     
     render(<AssetHeader assetInfo={largeSupplyAsset} />);
@@ -323,8 +327,8 @@ describe('AssetHeader', () => {
       asset_longname: null,
       divisible: true,
       locked: false,
-      supply: 1000,
-      supply_normalized: '0.00001'
+      supply: asBaseUnits(1000),
+      supply_normalized: asDisplayUnits('0.00001')
     };
     
     mockSubheadings.assets['TEST'] = { ...initialAsset };
@@ -352,8 +356,8 @@ describe('AssetHeader', () => {
       asset_longname: null,
       divisible: false,
       locked: false,
-      supply: 500,
-      supply_normalized: '500'
+      supply: asBaseUnits(500),
+      supply_normalized: asDisplayUnits('500')
     };
     
     render(<AssetHeader assetInfo={newAsset} />);

--- a/src/components/domain/asset/asset-list.test.tsx
+++ b/src/components/domain/asset/asset-list.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 import type { OwnedAsset } from "@/core/counterparty/api";
+import { asDisplayUnits } from '@/core/numeric';
 import { AssetList } from "./asset-list";
 
 // Mock dependencies
@@ -89,14 +90,14 @@ describe("AssetList", () => {
     {
       asset: "PEPECASH",
       asset_longname: null,
-      supply_normalized: "1000000000",
+      supply_normalized: asDisplayUnits("1000000000"),
       description: "Test asset",
       locked: true,
     } as OwnedAsset,
     {
       asset: "RAREPEPE",
       asset_longname: "A.RAREPEPE",
-      supply_normalized: "500000",
+      supply_normalized: asDisplayUnits("500000"),
       description: "Another test asset",
       locked: false,
     } as OwnedAsset,

--- a/src/components/domain/asset/asset-menu.test.tsx
+++ b/src/components/domain/asset/asset-menu.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { asDisplayUnits } from '@/core/numeric';
 import { AssetMenu } from './asset-menu';
 
 const mockNavigate = vi.fn();
@@ -16,7 +17,7 @@ describe('AssetMenu', () => {
   const unlockedAsset = {
     asset: 'TESTASSET',
     asset_longname: null,
-    supply_normalized: '1000000',
+    supply_normalized: asDisplayUnits('1000000'),
     description: 'Test Asset',
     locked: false
   };
@@ -24,7 +25,7 @@ describe('AssetMenu', () => {
   const lockedAsset = {
     asset: 'LOCKEDASSET',
     asset_longname: null,
-    supply_normalized: '1000000',
+    supply_normalized: asDisplayUnits('1000000'),
     description: 'Locked Asset',
     locked: true
   };

--- a/src/components/domain/asset/asset-select-input.test.tsx
+++ b/src/components/domain/asset/asset-select-input.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
+import { asDisplayUnits } from '@/core/numeric';
 import { AssetSelectInput } from "./asset-select-input";
 
 // Mock settings - use vi.hoisted for variables used in vi.mock factory
@@ -43,12 +44,12 @@ describe("AssetSelectInput", () => {
           {
             asset: "XCP",
             description: "Counterparty",
-            supply_normalized: "2600000",
+            supply_normalized: asDisplayUnits("2600000"),
           },
           {
             asset: "PEPECASH",
             description: "Pepe Cash",
-            supply_normalized: "1000000000",
+            supply_normalized: asDisplayUnits("1000000000"),
           },
         ],
       }),

--- a/src/components/domain/balance/amount-with-max-input.test.tsx
+++ b/src/components/domain/balance/amount-with-max-input.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import '@testing-library/jest-dom/vitest';
+import { asDisplayUnits } from '@/core/numeric';
 import { AmountWithMaxInput } from './amount-with-max-input';
 
 // Mock the validation utilities
@@ -13,13 +14,16 @@ vi.mock('@/core/counterparty/utxoSelection', () => ({
 }));
 
 vi.mock('@/core/numeric', () => ({
+  // Brands are compile-time only; at runtime they are identity.
+  asBaseUnits: (v: unknown) => v,
+  asDisplayUnits: (v: unknown) => v,
   fromSatoshis: vi.fn((sats) => (parseInt(sats) / 100000000).toFixed(8)),
 }));
 
 describe('AmountWithMaxInput', () => {
   const defaultProps = {
     asset: 'XCP',
-    availableBalance: '100.00000000',
+    availableBalance: asDisplayUnits('100.00000000'),
     value: '',
     onChange: vi.fn(),
     feeRate: 1,

--- a/src/components/domain/balance/balance-card.test.tsx
+++ b/src/components/domain/balance/balance-card.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { BrowserRouter } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { TokenBalance } from "@/core/counterparty/api";
+import { asBaseUnits, asDisplayUnits } from '@/core/numeric';
 import { BalanceCard } from "./balance-card";
 
 // Mock the BalanceMenu component
@@ -60,9 +61,9 @@ describe("BalanceCard", () => {
       divisible: true,
       issuer: "bc1qissuer",
       locked: false,
-      supply: "1000000",
+      supply: asBaseUnits("1000000"),
     },
-    quantity_normalized: "100.50000000",
+    quantity_normalized: asDisplayUnits("100.50000000"),
   };
 
   const mockIndivisibleToken: TokenBalance = {
@@ -73,9 +74,9 @@ describe("BalanceCard", () => {
       divisible: false,
       issuer: "bc1qissuer",
       locked: false,
-      supply: "1000",
+      supply: asBaseUnits("1000"),
     },
-    quantity_normalized: "5",
+    quantity_normalized: asDisplayUnits("5"),
   };
 
   beforeEach(() => {
@@ -177,7 +178,7 @@ describe("BalanceCard", () => {
   it("handles token without asset_info gracefully", () => {
     const tokenWithoutInfo: TokenBalance = {
       asset: "UNKNOWN",
-      quantity_normalized: "1.00000000",
+      quantity_normalized: asDisplayUnits("1.00000000"),
     };
 
     render(

--- a/src/components/domain/balance/balance-header.test.tsx
+++ b/src/components/domain/balance/balance-header.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import '@testing-library/jest-dom/vitest';
+import { asBaseUnits, asDisplayUnits } from '@/core/numeric';
 import { BalanceHeader } from './balance-header';
 
 // Mock dependencies
@@ -38,9 +39,9 @@ describe('BalanceHeader', () => {
       issuer: 'bc1qxyz789',
       divisible: true,
       locked: true,
-      supply: '1000000000000'
+      supply: asBaseUnits('1000000000000')
     },
-    quantity_normalized: '500000000'
+    quantity_normalized: asDisplayUnits('500000000')
   };
 
   beforeEach(() => {
@@ -102,7 +103,7 @@ describe('BalanceHeader', () => {
         ...mockBalance.asset_info,
         divisible: false
       },
-      quantity_normalized: '1000'
+      quantity_normalized: asDisplayUnits('1000')
     };
     
     render(<BalanceHeader balance={indivisibleBalance} />);
@@ -113,7 +114,7 @@ describe('BalanceHeader', () => {
   it('should handle zero balance', () => {
     const zeroBalance = {
       ...mockBalance,
-      quantity_normalized: '0'
+      quantity_normalized: asDisplayUnits('0')
     };
     
     render(<BalanceHeader balance={zeroBalance} />);
@@ -124,7 +125,7 @@ describe('BalanceHeader', () => {
   it('should handle undefined quantity_normalized', () => {
     const noQuantityBalance = {
       ...mockBalance,
-      quantity_normalized: '0' // Changed from undefined to '0' since TokenBalance requires string
+      quantity_normalized: asDisplayUnits('0') // Changed from undefined to '0' since TokenBalance requires string
     };
     
     render(<BalanceHeader balance={noQuantityBalance} />);
@@ -139,7 +140,7 @@ describe('BalanceHeader', () => {
     
     const updatedBalance = {
       ...mockBalance,
-      quantity_normalized: '600000000'
+      quantity_normalized: asDisplayUnits('600000000')
     };
     
     rerender(<BalanceHeader balance={updatedBalance} />);
@@ -240,7 +241,7 @@ describe('BalanceHeader', () => {
   it('should handle balance without asset_info', () => {
     const minimalBalance = {
       asset: 'BTC',
-      quantity_normalized: '100000000'
+      quantity_normalized: asDisplayUnits('100000000')
     };
     
     render(<BalanceHeader balance={minimalBalance} />);
@@ -261,7 +262,7 @@ describe('BalanceHeader', () => {
         divisible: true,
         locked: false
       },
-      quantity_normalized: '1000'
+      quantity_normalized: asDisplayUnits('1000')
     };
     
     render(<BalanceHeader balance={partialInfoBalance} />);
@@ -284,7 +285,7 @@ describe('BalanceHeader', () => {
         divisible: true,
         locked: true
       },
-      quantity_normalized: '2600000000000000'
+      quantity_normalized: asDisplayUnits('2600000000000000')
     };
     
     rerender(<BalanceHeader balance={differentBalance} />);
@@ -296,7 +297,7 @@ describe('BalanceHeader', () => {
   it('should handle numeric quantity_normalized', () => {
     const numericQuantityBalance = {
       ...mockBalance,
-      quantity_normalized: '123456.789'
+      quantity_normalized: asDisplayUnits('123456.789')
     };
     
     render(<BalanceHeader balance={numericQuantityBalance} />);
@@ -307,7 +308,7 @@ describe('BalanceHeader', () => {
   it('should handle empty strings gracefully', () => {
     const emptyStringBalance = {
       ...mockBalance,
-      quantity_normalized: ''
+      quantity_normalized: asDisplayUnits('')
     };
     
     render(<BalanceHeader balance={emptyStringBalance} />);
@@ -319,7 +320,7 @@ describe('BalanceHeader', () => {
   it('should use props data as source of truth', () => {
     const initialBalance = {
       ...mockBalance,
-      quantity_normalized: '100'
+      quantity_normalized: asDisplayUnits('100')
     };
     
     const { rerender } = render(<BalanceHeader balance={initialBalance} />);
@@ -328,7 +329,7 @@ describe('BalanceHeader', () => {
     
     const updatedBalance = {
       ...mockBalance,
-      quantity_normalized: '200'
+      quantity_normalized: asDisplayUnits('200')
     };
     
     rerender(<BalanceHeader balance={updatedBalance} />);
@@ -409,7 +410,7 @@ describe('BalanceHeader', () => {
     // Re-render with different balance
     const updatedBalance = {
       ...mockBalance,
-      quantity_normalized: '999999'
+      quantity_normalized: asDisplayUnits('999999')
     };
     rerender(<BalanceHeader balance={updatedBalance} />);
     

--- a/src/components/domain/balance/balance-list.test.tsx
+++ b/src/components/domain/balance/balance-list.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 import type { TokenBalance } from "@/core/counterparty/api";
+import { asBaseUnits, asDisplayUnits } from '@/core/numeric';
 import { BalanceList } from "./balance-list";
 
 // Mock dependencies
@@ -131,38 +132,38 @@ describe("BalanceList", () => {
   const mockTokenBalances: TokenBalance[] = [
     {
       asset: "XCP",
-      quantity_normalized: "100.00000000",
+      quantity_normalized: asDisplayUnits("100.00000000"),
       asset_info: {
         asset_longname: null,
         description: "Counterparty Token",
         issuer: "burn",
         divisible: true,
         locked: true,
-        supply: "2600000",
+        supply: asBaseUnits("2600000"),
       },
     },
     {
       asset: "PEPECASH",
-      quantity_normalized: "1000000",
+      quantity_normalized: asDisplayUnits("1000000"),
       asset_info: {
         asset_longname: null,
         description: "Pepe Cash",
         issuer: "bc1qissuer",
         divisible: false,
         locked: true,
-        supply: "1000000000",
+        supply: asBaseUnits("1000000000"),
       },
     },
     {
       asset: "RAREPEPE",
-      quantity_normalized: "500",
+      quantity_normalized: asDisplayUnits("500"),
       asset_info: {
         asset_longname: "A.RAREPEPE",
         description: "Rare Pepe",
         issuer: "bc1qissuer2",
         divisible: false,
         locked: false,
-        supply: "1000",
+        supply: asBaseUnits("1000"),
       },
     },
   ];
@@ -474,7 +475,7 @@ describe("BalanceList", () => {
       .map((_, i) => ({
         ...mockTokenBalances[0],
         asset: `TOKEN${i}`,
-        quantity_normalized: "100.00000000",
+        quantity_normalized: asDisplayUnits("100.00000000"),
       }));
     mockFetchTokenBalances.mockResolvedValue(tenBalances);
 
@@ -521,7 +522,7 @@ describe("BalanceList", () => {
   it("should filter out zero balances for non-special assets", async () => {
     const zeroBalance: TokenBalance = {
       asset: "EMPTYTOKEN",
-      quantity_normalized: "0",
+      quantity_normalized: asDisplayUnits("0"),
       asset_info: {
         asset_longname: null,
         description: "",

--- a/src/components/domain/balance/balance-list.tsx
+++ b/src/components/domain/balance/balance-list.tsx
@@ -9,7 +9,7 @@ import { useWallet } from "@/contexts/wallet-context";
 import { fetchBTCBalance } from "@/core/bitcoin/balance";
 import type { TokenBalance } from "@/core/counterparty/api";
 import { fetchTokenBalance, fetchTokenBalances } from "@/core/counterparty/api";
-import { fromSatoshis } from "@/core/numeric";
+import { asDisplayUnits, fromSatoshis } from '@/core/numeric';
 import { useInView } from "@/hooks/useInView";
 import { useSearchQuery } from "@/hooks/useSearchQuery";
 
@@ -71,7 +71,7 @@ export const BalanceList = (): ReactElement => {
         const balanceSats = await fetchBTCBalance(activeAddress.address);
         const btcBalance: TokenBalance = {
           asset: "BTC",
-          quantity_normalized: fromSatoshis(balanceSats),
+          quantity_normalized: asDisplayUnits(fromSatoshis(balanceSats)),
           asset_info: {
             asset_longname: null,
             description: "Bitcoin",

--- a/src/components/domain/dispenser/dispenser-card.test.tsx
+++ b/src/components/domain/dispenser/dispenser-card.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { asBaseUnits, asDisplayUnits } from '@/core/numeric';
 import { DispenserCard, type DispenserOption } from "./dispenser-card";
 
 // Mock the format and numeric utils
@@ -18,6 +19,8 @@ vi.mock("@/core/format", () => ({
 }));
 
 vi.mock("@/core/numeric", () => ({
+  asBaseUnits: (v: unknown) => v,
+  asDisplayUnits: (v: unknown) => v,
   divide: (a: string, b: string) =>
     parseFloat((parseFloat(a) / parseFloat(b)).toString()),
   roundDown: (value: number) => Math.floor(value),
@@ -31,10 +34,10 @@ describe("DispenserCard", () => {
       tx_hash: "abc123def456",
       source: "bc1qsource123",
       status: 0,
-      give_remaining: 500000000,
-      give_remaining_normalized: "5.00000000",
+      give_remaining: asBaseUnits(500000000),
+      give_remaining_normalized: asDisplayUnits("5.00000000"),
       give_quantity: 100000000,
-      give_quantity_normalized: "1.00000000",
+      give_quantity_normalized: asDisplayUnits("1.00000000"),
       satoshirate: 10000,
       asset_info: {
         asset_longname: "RARE.PEPE.COLLECTION",
@@ -216,8 +219,8 @@ describe("DispenserCard", () => {
       ...mockDispenser,
       dispenser: {
         ...mockDispenser.dispenser,
-        give_remaining_normalized: "10.00000000",
-        give_quantity_normalized: "2.00000000",
+        give_remaining_normalized: asDisplayUnits("10.00000000"),
+        give_quantity_normalized: asDisplayUnits("2.00000000"),
       },
     };
 

--- a/src/components/domain/tx/tx-action-info.test.ts
+++ b/src/components/domain/tx/tx-action-info.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { asBaseUnits } from '@/core/numeric';
 import { getTxActionInfo, isAssetDivisible, normalizeQuantity } from './tx-action-info';
 
 // Minimal localUnpack source both approval screens pass in.
@@ -35,7 +36,7 @@ describe('isAssetDivisible', () => {
 
 describe('getTxActionInfo', () => {
   it('normalizes a send quantity (the drift bug: no raw satoshis)', () => {
-    const info = getTxActionInfo(fromUnpack('send', { quantity: 100000000, asset: 'XCP' }));
+    const info = getTxActionInfo(fromUnpack('send', { quantity: asBaseUnits(100000000), asset: 'XCP' }));
     expect(info).toEqual({ label: 'Send', description: '1.00000000 XCP' });
   });
 
@@ -47,7 +48,7 @@ describe('getTxActionInfo', () => {
   });
 
   it('detach shows quantity when present, else the destination', () => {
-    expect(getTxActionInfo(fromUnpack('detach', { quantity: 100000000, asset: 'XCP' }))?.description).toBe('1.00000000 XCP');
+    expect(getTxActionInfo(fromUnpack('detach', { quantity: asBaseUnits(100000000), asset: 'XCP' }))?.description).toBe('1.00000000 XCP');
     expect(getTxActionInfo(fromUnpack('detach', { destination: 'bc1qexampleaddress0000' }))?.description)
       .toBe('To bc1qexampleaddre…');
     expect(getTxActionInfo(fromUnpack('detach', {}))?.description).toBe('Detach assets from UTXO');

--- a/src/components/domain/utxo/utxo-card.test.tsx
+++ b/src/components/domain/utxo/utxo-card.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { BrowserRouter } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { UtxoBalance } from "@/core/counterparty/api";
+import { asDisplayUnits } from '@/core/numeric';
 import { UtxoCard } from "./utxo-card";
 
 vi.mock("@/components/domain/utxo/utxo-menu", () => ({
@@ -50,7 +51,7 @@ describe("UtxoCard", () => {
       issuer: "bc1qissuer",
       locked: false,
     },
-    quantity_normalized: "100.50000000",
+    quantity_normalized: asDisplayUnits("100.50000000"),
     utxo: "abc123def456789012345678901234567890123456789012345678901234:0",
     utxo_address: "bc1qtest123",
   };
@@ -64,7 +65,7 @@ describe("UtxoCard", () => {
       issuer: "bc1qissuer",
       locked: false,
     },
-    quantity_normalized: "5",
+    quantity_normalized: asDisplayUnits("5"),
     utxo: "def456abc789012345678901234567890123456789012345678901234567:1",
     utxo_address: "bc1qtest123",
   };

--- a/src/components/domain/utxo/utxo-list.test.tsx
+++ b/src/components/domain/utxo/utxo-list.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import '@testing-library/jest-dom/vitest';
 import type { UtxoBalance } from '@/core/counterparty/api';
+import { asDisplayUnits } from '@/core/numeric';
 import { UtxoList } from './utxo-list';
 
 const mockNavigate = vi.fn();
@@ -69,7 +70,7 @@ const mockUtxoBalances: UtxoBalance[] = [
       issuer: 'bc1qissuer',
       locked: false,
     },
-    quantity_normalized: '100.00000000',
+    quantity_normalized: asDisplayUnits('100.00000000'),
     utxo: 'aaa111bbb222ccc333ddd444eee555fff666aaa111bbb222ccc333ddd444eee555:0',
     utxo_address: 'bc1qtest123',
   },
@@ -82,7 +83,7 @@ const mockUtxoBalances: UtxoBalance[] = [
       issuer: 'bc1qissuer',
       locked: false,
     },
-    quantity_normalized: '50',
+    quantity_normalized: asDisplayUnits('50'),
     utxo: 'fff666eee555ddd444ccc333bbb222aaa111fff666eee555ddd444ccc333bbb222:1',
     utxo_address: 'bc1qtest123',
   },

--- a/src/components/ui/lists/dispenser-list.test.tsx
+++ b/src/components/ui/lists/dispenser-list.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { asBaseUnits, asDisplayUnits } from '@/core/numeric';
 import { DispenserList, type DispenserOption } from './dispenser-list';
 
 // Mock the DispenserCard component
@@ -25,10 +26,10 @@ describe('DispenserList', () => {
         tx_hash: 'abc123',
         source: 'bc1qsource1',
         status: 0,
-        give_remaining: 500000000,
-        give_remaining_normalized: '5.00000000',
+        give_remaining: asBaseUnits(500000000),
+        give_remaining_normalized: asDisplayUnits('5.00000000'),
         give_quantity: 100000000,
-        give_quantity_normalized: '1.00000000',
+        give_quantity_normalized: asDisplayUnits('1.00000000'),
         satoshirate: 10000,
         asset_info: {
           asset_longname: 'RARE.PEPE.COLLECTION',
@@ -48,10 +49,10 @@ describe('DispenserList', () => {
         tx_hash: 'def456',
         source: 'bc1qsource2',
         status: 0,
-        give_remaining: 1000000000,
-        give_remaining_normalized: '10.00000000',
+        give_remaining: asBaseUnits(1000000000),
+        give_remaining_normalized: asDisplayUnits('10.00000000'),
         give_quantity: 200000000,
-        give_quantity_normalized: '2.00000000',
+        give_quantity_normalized: asDisplayUnits('2.00000000'),
         satoshirate: 20000,
         asset_info: {
           asset_longname: null,

--- a/src/contexts/__tests__/clear-caches-on-lock.test.tsx
+++ b/src/contexts/__tests__/clear-caches-on-lock.test.tsx
@@ -2,6 +2,7 @@ import { act, render } from '@testing-library/react';
 import { useEffect, useState } from 'react';
 import { describe, expect, it } from 'vitest';
 import { HeaderProvider, useHeader } from '@/contexts/header-context';
+import { asBaseUnits, asDisplayUnits } from '@/core/numeric';
 
 /**
  * The wiring lives in app-providers so header-context stays free of wallet-context (which imports
@@ -18,8 +19,8 @@ function ClearOnLock({ locked }: { locked: boolean }) {
 
 const BALANCE = {
   asset: 'XCP',
-  quantity: 100,
-  quantity_normalized: '1.00000000',
+  quantity: asBaseUnits(100),
+  quantity_normalized: asDisplayUnits('1.00000000'),
   asset_info: { asset_longname: null, description: '', issuer: '', divisible: true, locked: false },
 } as any;
 
@@ -68,7 +69,7 @@ describe('locking the keychain', () => {
       api!.cacheBalances([BALANCE]);
       api!.setAddressHeader('bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4', 'Wallet 1');
       api!.cacheOwnedAssets([{
-        asset: 'MYTOKEN', asset_longname: null, supply_normalized: '1', description: '', locked: false,
+        asset: 'MYTOKEN', asset_longname: null, supply_normalized: asDisplayUnits('1'), description: '', locked: false,
       }]);
     });
 

--- a/src/contexts/__tests__/composer-context.test.tsx
+++ b/src/contexts/__tests__/composer-context.test.tsx
@@ -3,6 +3,7 @@ import { MemoryRouter } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AddressFormat, decodeAddressFromScript } from '@/core/bitcoin/address';
 import type { ApiResponse } from '@/core/counterparty/compose';
+import { asBaseUnits, asDisplayUnits } from '@/core/numeric';
 import { ComposerProvider } from '../composer-context';
 import { useComposer } from '../composer-context-object';
 
@@ -139,7 +140,7 @@ describe('ComposerContext', () => {
             source: 'bc1qsource',
             destination: 'bc1qdest',
             asset: 'XCP',
-            quantity: 1000,
+            quantity: asBaseUnits(1000),
             memo: null,
             memo_is_hex: false,
             use_enhanced_send: false,
@@ -153,7 +154,7 @@ describe('ComposerContext', () => {
               locked: false,
               owner: 'bc1qowner',
             },
-            quantity_normalized: '0.00001000',
+            quantity_normalized: asDisplayUnits('0.00001000'),
           },
           name: 'send',
         },
@@ -346,7 +347,7 @@ describe('ComposerContext', () => {
             source: 'bc1qsource',
             destination: 'bc1qdest',
             asset: 'BTC',
-            quantity: 0,
+            quantity: asBaseUnits(0),
             memo: null,
             memo_is_hex: false,
             use_enhanced_send: false,
@@ -360,7 +361,7 @@ describe('ComposerContext', () => {
               locked: false,
               owner: '',
             },
-            quantity_normalized: '0',
+            quantity_normalized: asDisplayUnits('0'),
           },
           name: 'send',
         },
@@ -461,7 +462,7 @@ describe('ComposerContext', () => {
             source: 'bc1qsource',
             destination: 'bc1qdest',
             asset: 'BTC',
-            quantity: 0,
+            quantity: asBaseUnits(0),
             memo: null,
             memo_is_hex: false,
             use_enhanced_send: false,
@@ -475,7 +476,7 @@ describe('ComposerContext', () => {
               locked: false,
               owner: '',
             },
-            quantity_normalized: '0',
+            quantity_normalized: asDisplayUnits('0'),
           },
           name: 'send',
         },
@@ -546,7 +547,7 @@ describe('ComposerContext', () => {
             source: 'bc1qsource',
             destination: 'bc1qdest',
             asset: 'BTC',
-            quantity: 0,
+            quantity: asBaseUnits(0),
             memo: null,
             memo_is_hex: false,
             use_enhanced_send: false,
@@ -560,7 +561,7 @@ describe('ComposerContext', () => {
               locked: false,
               owner: '',
             },
-            quantity_normalized: '0',
+            quantity_normalized: asDisplayUnits('0'),
           },
           name: 'send',
         },

--- a/src/contexts/__tests__/header-context.test.tsx
+++ b/src/contexts/__tests__/header-context.test.tsx
@@ -1,5 +1,6 @@
 import { act, renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { asBaseUnits, asDisplayUnits } from '@/core/numeric';
 import { HeaderProvider, useHeader } from '../header-context';
 
 describe('HeaderContext', () => {
@@ -370,8 +371,8 @@ describe('HeaderContext', () => {
         divisible: true,
         locked: false,
         issuer: 'test',
-        supply: '1000000',
-        supply_normalized: '1000000',
+        supply: asBaseUnits('1000000'),
+        supply_normalized: asDisplayUnits('1000000'),
       };
 
       act(() => {
@@ -388,7 +389,7 @@ describe('HeaderContext', () => {
 
       const balance = {
         asset: 'XCP',
-        quantity_normalized: '100.5'
+        quantity_normalized: asDisplayUnits('100.5')
       };
 
       act(() => {
@@ -407,11 +408,11 @@ describe('HeaderContext', () => {
       act(() => {
         result.current.setBalanceHeader('XCP', {
           asset: 'XCP',
-          quantity_normalized: '100'
+          quantity_normalized: asDisplayUnits('100')
         });
         result.current.setBalanceHeader('TEST', {
           asset: 'TEST',
-          quantity_normalized: '50'
+          quantity_normalized: asDisplayUnits('50')
         });
       });
 

--- a/src/core/__tests__/replayPrevention.test.ts
+++ b/src/core/__tests__/replayPrevention.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { asBaseUnits } from '@/core/numeric';
 import {
   _testStore, 
   checkReplayAttempt,
@@ -122,7 +123,7 @@ describe('replayPrevention', () => {
     it('should generate consistent keys for same inputs', () => {
       const origin = 'https://test.com';
       const method = 'xcp_composeSend';
-      const params = [{ asset: 'XCP', quantity: 100 }];
+      const params = [{ asset: 'XCP', quantity: asBaseUnits(100) }];
 
       const key1 = generateIdempotencyKey(origin, method, params);
       const key2 = generateIdempotencyKey(origin, method, params);
@@ -135,8 +136,8 @@ describe('replayPrevention', () => {
     it('should generate different keys for different inputs', () => {
       const origin = 'https://test.com';
       const method = 'xcp_composeSend';
-      const params1 = [{ asset: 'XCP', quantity: 100 }];
-      const params2 = [{ asset: 'XCP', quantity: 200 }];
+      const params1 = [{ asset: 'XCP', quantity: asBaseUnits(100) }];
+      const params2 = [{ asset: 'XCP', quantity: asBaseUnits(200) }];
 
       const key1 = generateIdempotencyKey(origin, method, params1);
       const key2 = generateIdempotencyKey(origin, method, params2);
@@ -149,7 +150,7 @@ describe('replayPrevention', () => {
     it('should detect identical recent requests', async () => {
       const origin = 'https://test.com';
       const method = 'xcp_composeSend';
-      const params = [{ asset: 'XCP', quantity: 100 }];
+      const params = [{ asset: 'XCP', quantity: asBaseUnits(100) }];
 
       // Record first request
       recordTransaction('tx1', origin, method, params, { status: 'pending' });
@@ -164,7 +165,7 @@ describe('replayPrevention', () => {
     it('should not flag old requests as replays', async () => {
       const origin = 'https://test.com';
       const method = 'xcp_composeSend';
-      const params = [{ asset: 'XCP', quantity: 100 }];
+      const params = [{ asset: 'XCP', quantity: asBaseUnits(100) }];
 
       // Mock an old transaction (more than 5 minutes ago)
       const oldTimestamp = Date.now() - (6 * 60 * 1000);
@@ -181,7 +182,7 @@ describe('replayPrevention', () => {
     it('should validate nonces when required', async () => {
       const origin = 'https://test.com';
       const method = 'xcp_composeSend';
-      const params = [{ asset: 'XCP', quantity: 100 }];
+      const params = [{ asset: 'XCP', quantity: asBaseUnits(100) }];
       const address = '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa';
 
       // Generate a nonce first
@@ -210,7 +211,7 @@ describe('replayPrevention', () => {
     it('should handle idempotency keys', async () => {
       const origin = 'https://test.com';
       const method = 'xcp_composeSend';
-      const params = [{ asset: 'XCP', quantity: 100 }];
+      const params = [{ asset: 'XCP', quantity: asBaseUnits(100) }];
       const key = generateIdempotencyKey(origin, method, params);
 
       // Record successful response
@@ -289,7 +290,7 @@ describe('replayPrevention', () => {
     it('should execute handler when no replay detected', async () => {
       const origin = 'https://test.com';
       const method = 'xcp_composeSend';
-      const params = [{ asset: 'XCP', quantity: 100 }];
+      const params = [{ asset: 'XCP', quantity: asBaseUnits(100) }];
       const mockResult = { txid: 'tx123' };
 
       const handler = vi.fn().mockResolvedValue(mockResult);
@@ -303,7 +304,7 @@ describe('replayPrevention', () => {
     it('should return cached response for idempotent requests', async () => {
       const origin = 'https://test.com';
       const method = 'xcp_composeSend';
-      const params = [{ asset: 'XCP', quantity: 100 }];
+      const params = [{ asset: 'XCP', quantity: asBaseUnits(100) }];
       const mockResult = { txid: 'tx123' };
 
       const handler = vi.fn().mockResolvedValue(mockResult);
@@ -343,7 +344,7 @@ describe('replayPrevention', () => {
     it('should generate and validate nonces when required', async () => {
       const origin = 'https://test.com';
       const method = 'xcp_composeSend';
-      const params = [{ asset: 'XCP', quantity: 100 }];
+      const params = [{ asset: 'XCP', quantity: asBaseUnits(100) }];
       const address = '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa';
       const mockResult = { txid: 'tx123' };
 
@@ -361,7 +362,7 @@ describe('replayPrevention', () => {
     it('should handle handler errors', async () => {
       const origin = 'https://test.com';
       const method = 'xcp_composeSend';
-      const params = [{ asset: 'XCP', quantity: 100 }];
+      const params = [{ asset: 'XCP', quantity: asBaseUnits(100) }];
       const error = new Error('Handler failed');
 
       const handler = vi.fn().mockRejectedValue(error);

--- a/src/core/__tests__/tradingPair.test.ts
+++ b/src/core/__tests__/tradingPair.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { asDisplayUnits } from '@/core/numeric';
 import {
   getMatchPricePerUnit,
   getOrderBaseAmount,
@@ -110,10 +111,10 @@ describe('trading-pair utilities', () => {
       const order = {
         give_asset: 'RAREPEPE',
         get_asset: 'XCP',
-        give_quantity_normalized: '100',
-        get_quantity_normalized: '50',
-        give_remaining_normalized: '100',
-        get_remaining_normalized: '50',
+        give_quantity_normalized: asDisplayUnits('100'),
+        get_quantity_normalized: asDisplayUnits('50'),
+        give_remaining_normalized: asDisplayUnits('100'),
+        get_remaining_normalized: asDisplayUnits('50'),
       };
       // Selling 100 RAREPEPE for 50 XCP = 0.5 XCP per RAREPEPE
       expect(getOrderPricePerUnit(order, 'RAREPEPE')).toBe(0.5);
@@ -123,10 +124,10 @@ describe('trading-pair utilities', () => {
       const order = {
         give_asset: 'XCP',
         get_asset: 'RAREPEPE',
-        give_quantity_normalized: '50',
-        get_quantity_normalized: '100',
-        give_remaining_normalized: '50',
-        get_remaining_normalized: '100',
+        give_quantity_normalized: asDisplayUnits('50'),
+        get_quantity_normalized: asDisplayUnits('100'),
+        give_remaining_normalized: asDisplayUnits('50'),
+        get_remaining_normalized: asDisplayUnits('100'),
       };
       // Buying 100 RAREPEPE with 50 XCP = 0.5 XCP per RAREPEPE
       expect(getOrderPricePerUnit(order, 'RAREPEPE')).toBe(0.5);
@@ -136,10 +137,10 @@ describe('trading-pair utilities', () => {
       const order = {
         give_asset: 'RAREPEPE',
         get_asset: 'XCP',
-        give_quantity_normalized: '0',
-        get_quantity_normalized: '50',
-        give_remaining_normalized: '0',
-        get_remaining_normalized: '50',
+        give_quantity_normalized: asDisplayUnits('0'),
+        get_quantity_normalized: asDisplayUnits('50'),
+        give_remaining_normalized: asDisplayUnits('0'),
+        get_remaining_normalized: asDisplayUnits('50'),
       };
       expect(getOrderPricePerUnit(order, 'RAREPEPE')).toBe(0);
     });
@@ -150,10 +151,10 @@ describe('trading-pair utilities', () => {
       const order = {
         give_asset: 'RAREPEPE',
         get_asset: 'XCP',
-        give_quantity_normalized: '100',
-        get_quantity_normalized: '50',
-        give_remaining_normalized: '75',
-        get_remaining_normalized: '37.5',
+        give_quantity_normalized: asDisplayUnits('100'),
+        get_quantity_normalized: asDisplayUnits('50'),
+        give_remaining_normalized: asDisplayUnits('75'),
+        get_remaining_normalized: asDisplayUnits('37.5'),
       };
       expect(getOrderBaseAmount(order, 'RAREPEPE')).toBe(75);
     });
@@ -162,10 +163,10 @@ describe('trading-pair utilities', () => {
       const order = {
         give_asset: 'XCP',
         get_asset: 'RAREPEPE',
-        give_quantity_normalized: '50',
-        get_quantity_normalized: '100',
-        give_remaining_normalized: '37.5',
-        get_remaining_normalized: '75',
+        give_quantity_normalized: asDisplayUnits('50'),
+        get_quantity_normalized: asDisplayUnits('100'),
+        give_remaining_normalized: asDisplayUnits('37.5'),
+        get_remaining_normalized: asDisplayUnits('75'),
       };
       expect(getOrderBaseAmount(order, 'RAREPEPE')).toBe(75);
     });
@@ -176,10 +177,10 @@ describe('trading-pair utilities', () => {
       const order = {
         give_asset: 'RAREPEPE',
         get_asset: 'XCP',
-        give_quantity_normalized: '100',
-        get_quantity_normalized: '50',
-        give_remaining_normalized: '75',
-        get_remaining_normalized: '37.5',
+        give_quantity_normalized: asDisplayUnits('100'),
+        get_quantity_normalized: asDisplayUnits('50'),
+        give_remaining_normalized: asDisplayUnits('75'),
+        get_remaining_normalized: asDisplayUnits('37.5'),
       };
       expect(getOrderQuoteAmount(order, 'RAREPEPE')).toBe(37.5);
     });
@@ -188,10 +189,10 @@ describe('trading-pair utilities', () => {
       const order = {
         give_asset: 'XCP',
         get_asset: 'RAREPEPE',
-        give_quantity_normalized: '50',
-        get_quantity_normalized: '100',
-        give_remaining_normalized: '37.5',
-        get_remaining_normalized: '75',
+        give_quantity_normalized: asDisplayUnits('50'),
+        get_quantity_normalized: asDisplayUnits('100'),
+        give_remaining_normalized: asDisplayUnits('37.5'),
+        get_remaining_normalized: asDisplayUnits('75'),
       };
       expect(getOrderQuoteAmount(order, 'RAREPEPE')).toBe(37.5);
     });

--- a/src/core/bitcoin/__tests__/addressTypeDetector.test.ts
+++ b/src/core/bitcoin/__tests__/addressTypeDetector.test.ts
@@ -3,6 +3,7 @@ import * as bitcoinAddress from '@/core/bitcoin/address';
 import { AddressFormat, detectAddressFormat, detectAddressFormatFromPreviews, getPreviewAddresses } from '@/core/bitcoin/address';
 import { hasAddressActivity } from '@/core/bitcoin/balance';
 import { fetchTokenBalances } from '@/core/counterparty/api';
+import { asBaseUnits } from '@/core/numeric';
 
 // Mock the external dependencies
 vi.mock('@/core/counterparty/api');
@@ -78,7 +79,7 @@ describe('Address Type Detector', () => {
     it('should detect based on Counterparty token activity', async () => {
       // P2PKH address has tokens
       vi.mocked(fetchTokenBalances)
-        .mockResolvedValueOnce([{ asset: 'XCP', quantity: '100' }] as any)
+        .mockResolvedValueOnce([{ asset: 'XCP', quantity: asBaseUnits('100') }] as any)
         .mockResolvedValue([]);
       vi.mocked(hasAddressActivity).mockResolvedValue(false);
 
@@ -89,7 +90,7 @@ describe('Address Type Detector', () => {
     it('should prioritize Counterparty activity over Bitcoin activity', async () => {
       // P2PKH has tokens (will be detected first)
       vi.mocked(fetchTokenBalances)
-        .mockResolvedValueOnce([{ asset: 'PEPE', quantity: '1000' }] as any)  // P2PKH has tokens
+        .mockResolvedValueOnce([{ asset: 'PEPE', quantity: asBaseUnits('1000') }] as any)  // P2PKH has tokens
         .mockResolvedValue([]);
       vi.mocked(hasAddressActivity).mockResolvedValue(false);
 

--- a/src/core/counterparty/__tests__/api.test.ts
+++ b/src/core/counterparty/__tests__/api.test.ts
@@ -3,6 +3,7 @@ import { apiClient } from '@/core/api/client';
 import * as bitcoinBalance from '@/core/bitcoin/balance';
 import { CounterpartyApiError } from '@/core/errors';
 import * as formatUtils from '@/core/format';
+import { asBaseUnits, asDisplayUnits } from '@/core/numeric';
 import { getActiveSettings } from '@/core/settings';
 import {
   type AssetInfo,
@@ -64,8 +65,8 @@ const mockSettings = { counterpartyApiBase: mockApiBase };
 
 const mockTokenBalance: TokenBalance = {
   asset: 'XCP',
-  quantity: 100000000,
-  quantity_normalized: '1.00000000',
+  quantity: asBaseUnits(100000000),
+  quantity_normalized: asDisplayUnits('1.00000000'),
   asset_info: {
     asset_longname: null,
     description: 'The Counterparty protocol token',
@@ -84,7 +85,7 @@ const mockAssetInfo: AssetInfo = {
   divisible: true,
   locked: false,
   supply: 2649755.0,
-  supply_normalized: '2649755.00000000',
+  supply_normalized: asDisplayUnits('2649755.00000000'),
 };
 
 const mockOrder: Order = {
@@ -92,10 +93,10 @@ const mockOrder: Order = {
   block_time: 1640995200,
   give_asset: 'XCP',
   get_asset: 'BTC',
-  give_quantity_normalized: '100.00000000',
-  get_quantity_normalized: '0.01000000',
-  give_remaining_normalized: '50.00000000',
-  get_remaining_normalized: '0.00500000',
+  give_quantity_normalized: asDisplayUnits('100.00000000'),
+  get_quantity_normalized: asDisplayUnits('0.01000000'),
+  give_remaining_normalized: asDisplayUnits('50.00000000'),
+  get_remaining_normalized: asDisplayUnits('0.00500000'),
   status: 'open',
   expire_index: 700000,
 };
@@ -108,11 +109,11 @@ const mockTransaction: Transaction = {
   destination: 'bc1qdest456address',
   type: 'send',
   status: 'valid',
-  data: { asset: 'XCP', quantity: 100000000 },
+  data: { asset: 'XCP', quantity: asBaseUnits(100000000) },
   supported: true,
   unpacked_data: {
     message_type: 'send',
-    message_data: { asset: 'XCP', quantity: 100000000 },
+    message_data: { asset: 'XCP', quantity: asBaseUnits(100000000) },
   },
 };
 
@@ -250,9 +251,9 @@ describe('counterparty/api.ts', () => {
 
       expect(balance).toEqual({
         asset: 'XCP',
-        quantity: '100000000',
+        quantity: asBaseUnits('100000000'),
         asset_info: mockTokenBalance.asset_info,
-        quantity_normalized: '1',
+        quantity_normalized: asDisplayUnits('1'),
       });
     });
 
@@ -270,8 +271,8 @@ describe('counterparty/api.ts', () => {
 
       expect(balance).toEqual({
         asset: 'NONEXISTENT',
-        quantity: 0,
-        quantity_normalized: '0',
+        quantity: asBaseUnits(0),
+        quantity_normalized: asDisplayUnits('0'),
         asset_info: {
           asset_longname: null,
           description: '',
@@ -285,8 +286,8 @@ describe('counterparty/api.ts', () => {
     it('should filter out UTXOs when type is address', async () => {
       const mockBalanceWithoutUtxo = {
         ...mockTokenBalance,
-        quantity: 25000000,
-        quantity_normalized: '0.25000000',
+        quantity: asBaseUnits(25000000),
+        quantity_normalized: asDisplayUnits('0.25000000'),
       };
       const mockData = {
         result: [mockBalanceWithoutUtxo]
@@ -308,8 +309,8 @@ describe('counterparty/api.ts', () => {
     });
 
     it('should aggregate multiple balances', async () => {
-      const balance1 = { ...mockTokenBalance, quantity: 50000000, quantity_normalized: '0.5' };
-      const balance2 = { ...mockTokenBalance, quantity: 25000000, quantity_normalized: '0.25' };
+      const balance1 = { ...mockTokenBalance, quantity: asBaseUnits(50000000), quantity_normalized: asDisplayUnits('0.5') };
+      const balance2 = { ...mockTokenBalance, quantity: asBaseUnits(25000000), quantity_normalized: asDisplayUnits('0.25') };
       const mockData = { result: [balance1, balance2] };
       mockedApiClient.get.mockResolvedValue({
         data: mockData,
@@ -330,8 +331,8 @@ describe('counterparty/api.ts', () => {
       // quantities: summing them as doubles drops digits for exactly the large holdings where the
       // total matters most. 99526925811111111 is the real PEPECASH supply.
       return (async () => {
-        const balance1 = { ...mockTokenBalance, quantity: '99526925811111111', quantity_normalized: '995269258.11111111' };
-        const balance2 = { ...mockTokenBalance, quantity: '1', quantity_normalized: '0.00000001' };
+        const balance1 = { ...mockTokenBalance, quantity: asBaseUnits('99526925811111111'), quantity_normalized: asDisplayUnits('995269258.11111111') };
+        const balance2 = { ...mockTokenBalance, quantity: asBaseUnits('1'), quantity_normalized: asDisplayUnits('0.00000001') };
         mockedApiClient.get.mockResolvedValue({
           data: { result: [balance1, balance2] },
           status: 200, statusText: 'OK', headers: {}, config: {},
@@ -366,8 +367,8 @@ describe('counterparty/api.ts', () => {
       // Now returns zero balance instead of null for missing result
       expect(balance).toEqual({
         asset: 'XCP',
-        quantity: 0,
-        quantity_normalized: '0',
+        quantity: asBaseUnits(0),
+        quantity_normalized: asDisplayUnits('0'),
         asset_info: {
           asset_longname: null,
           description: '',
@@ -381,8 +382,8 @@ describe('counterparty/api.ts', () => {
     it('should handle invalid quantity_normalized values without producing NaN', async () => {
       // Test with various invalid quantity_normalized values
       const invalidBalances = [
-        { ...mockTokenBalance, quantity: 100, quantity_normalized: '' },
-        { ...mockTokenBalance, quantity: 200, quantity_normalized: 'invalid' },
+        { ...mockTokenBalance, quantity: asBaseUnits(100), quantity_normalized: asDisplayUnits('') },
+        { ...mockTokenBalance, quantity: asBaseUnits(200), quantity_normalized: asDisplayUnits('invalid') },
       ];
       const mockData = { result: invalidBalances };
       mockedApiClient.get.mockResolvedValue({
@@ -493,7 +494,7 @@ describe('counterparty/api.ts', () => {
     it('should fetch UTXO balances successfully', async () => {
       const mockUtxoBalance = {
         asset: 'XCP',
-        quantity_normalized: '1.00000000',
+        quantity_normalized: asDisplayUnits('1.00000000'),
         utxo: 'abc123:0',
         utxo_address: mockAddress,
       };
@@ -629,8 +630,8 @@ describe('counterparty/api.ts', () => {
       const mockOrderDetails: OrderDetails = {
         ...mockOrder,
         source: mockAddress,
-        give_quantity: 100000000,
-        get_quantity: 1000000,
+        give_quantity: asBaseUnits(100000000),
+        get_quantity: asBaseUnits(1000000),
         fee_required: 0,
         fee_provided: 1000,
         fee_required_remaining: 0,
@@ -825,8 +826,8 @@ describe('counterparty/api.ts', () => {
         source: mockAddress,
         asset: 'XCP',
         status: 0,
-        give_remaining: 1000000,
-        give_remaining_normalized: '10.00000000',
+        give_remaining: asBaseUnits(1000000),
+        give_remaining_normalized: asDisplayUnits('10.00000000'),
         asset_info: {
           asset_longname: null,
           description: 'Test asset',
@@ -901,8 +902,8 @@ describe('counterparty/api.ts', () => {
         source: mockAddress,
         asset: 'XCP',
         status: 0,
-        give_remaining: 1000000,
-        give_remaining_normalized: '10.00000000',
+        give_remaining: asBaseUnits(1000000),
+        give_remaining_normalized: asDisplayUnits('10.00000000'),
       };
       mockedApiClient.get.mockResolvedValue({
         data: { result: mockDispenser },
@@ -1002,7 +1003,7 @@ describe('counterparty/api.ts', () => {
       const mockOwnedAsset: OwnedAsset = {
         asset: 'MYTOKEN',
         asset_longname: null,
-        supply_normalized: '1000000.00000000',
+        supply_normalized: asDisplayUnits('1000000.00000000'),
         description: 'My custom token',
         locked: false,
       };
@@ -1299,17 +1300,17 @@ describe('counterparty/api.ts', () => {
       expect(mockedApiClient.get).toHaveBeenNthCalledWith(
         1,
         `${mockApiBase}/v2/pools/XCP/POOLTEST/quote`,
-        expect.objectContaining({ params: { quantity: '100000000' } })
+        expect.objectContaining({ params: { quantity: asBaseUnits('100000000') } })
       );
       expect(mockedApiClient.get).toHaveBeenNthCalledWith(
         2,
         `${mockApiBase}/v2/pools/XCP/POOLTEST/quote/deposit`,
-        expect.objectContaining({ params: { quantity: '100000000' } })
+        expect.objectContaining({ params: { quantity: asBaseUnits('100000000') } })
       );
       expect(mockedApiClient.get).toHaveBeenNthCalledWith(
         3,
         `${mockApiBase}/v2/pools/XCP/POOLTEST/quote/withdraw`,
-        expect.objectContaining({ params: { quantity: '1000' } })
+        expect.objectContaining({ params: { quantity: asBaseUnits('1000') } })
       );
     });
 

--- a/src/core/counterparty/__tests__/arc4-roundtrip.test.ts
+++ b/src/core/counterparty/__tests__/arc4-roundtrip.test.ts
@@ -9,6 +9,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
+import { asBaseUnits } from '@/core/numeric';
 import { packAddress } from '../unpack/address';
 import { arc4, bytesToHex, hexToBytes } from '../unpack/binary';
 import { isCounterpartyData, unpackCounterpartyMessage } from '../unpack/index';
@@ -314,9 +315,9 @@ describe('real compose API vector', () => {
     // produced it (give 1 XCP, get 0.0005 BTC, expiration 5000).
     const verification = verifyTransaction(REAL_DATA_HEX, 'order', {
       give_asset: 'XCP',
-      give_quantity: 100000000,
+      give_quantity: asBaseUnits(100000000),
       get_asset: 'BTC',
-      get_quantity: 50000,
+      get_quantity: asBaseUnits(50000),
       expiration: 5000,
     });
     expect(verification.errors).toHaveLength(0);
@@ -326,9 +327,9 @@ describe('real compose API vector', () => {
   it('verifyTransaction rejects the real order when the give amount is tampered', () => {
     const verification = verifyTransaction(REAL_DATA_HEX, 'order', {
       give_asset: 'XCP',
-      give_quantity: 999999999, // wrong
+      give_quantity: asBaseUnits(999999999), // wrong
       get_asset: 'BTC',
-      get_quantity: 50000,
+      get_quantity: asBaseUnits(50000),
       expiration: 5000,
     });
     expect(verification.valid).toBe(false);

--- a/src/core/counterparty/__tests__/compose.assets.test.ts
+++ b/src/core/counterparty/__tests__/compose.assets.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as apiClientUtils from '@/core/api/client';
+import { asBaseUnits } from '@/core/numeric';
 import { getActiveSettings } from '@/core/settings';
 import {
   composeBurn, 
@@ -48,7 +49,7 @@ describe('Compose Asset Management Operations', () => {
   describe('composeIssuance', () => {
     const defaultParams = {
       asset: 'NEWASSET',
-      quantity: 1000000000,
+      quantity: asBaseUnits(1000000000),
       divisible: true,
       lock: false,
       reset: false,
@@ -93,7 +94,7 @@ describe('Compose Asset Management Operations', () => {
     it('should handle subasset issuance', async () => {
       const subassetParams = {
         asset: 'PARENTASSET.SUBASSET',
-        quantity: 100000,
+        quantity: asBaseUnits(100000),
         divisible: true,
         lock: false,
         reset: false,
@@ -111,7 +112,7 @@ describe('Compose Asset Management Operations', () => {
     it('should handle numeric asset issuance', async () => {
       const numericParams = {
         asset: testAssets.NUMERIC,
-        quantity: 1000000000,
+        quantity: asBaseUnits(1000000000),
         divisible: true,
         lock: false,
         reset: false,
@@ -129,7 +130,7 @@ describe('Compose Asset Management Operations', () => {
     it('should handle locking an asset', async () => {
       const lockParams = {
         ...defaultParams,
-        quantity: 0, // No new issuance
+        quantity: asBaseUnits(0), // No new issuance
         lock: true,
       };
       
@@ -153,7 +154,7 @@ describe('Compose Asset Management Operations', () => {
     it('should handle transfer of ownership', async () => {
       const transferParams = {
         asset: 'EXISTINGASSET',
-        quantity: 0,
+        quantity: asBaseUnits(0),
         divisible: true,
         lock: false,
         reset: false,
@@ -258,7 +259,7 @@ describe('Compose Asset Management Operations', () => {
     const defaultParams = {
       asset: 'SHARETOKEN',
       dividend_asset: testAssets.XCP,
-      quantity_per_unit: 1000,
+      quantity_per_unit: asBaseUnits(1000),
     };
 
     it('should compose dividend transaction', async () => {
@@ -292,7 +293,7 @@ describe('Compose Asset Management Operations', () => {
       const btcDividendParams = {
         asset: 'SHARETOKEN',
         dividend_asset: testAssets.BTC,
-        quantity_per_unit: 100, // 100 satoshis per unit
+        quantity_per_unit: asBaseUnits(100), // 100 satoshis per unit
       };
 
       await composeDividend({
@@ -326,7 +327,7 @@ describe('Compose Asset Management Operations', () => {
 
   describe('composeBurn', () => {
     const defaultParams = {
-      quantity: 10000000, // 0.1 BTC
+      quantity: asBaseUnits(10000000), // 0.1 BTC
     };
 
     it('should compose burn transaction', async () => {
@@ -376,7 +377,7 @@ describe('Compose Asset Management Operations', () => {
     });
 
     it('should handle minimum burn amount error', async () => {
-      const smallAmount = { quantity: 100 }; // Too small
+      const smallAmount = { quantity: asBaseUnits(100) }; // Too small
 
       mockedApiClient.get.mockRejectedValueOnce(new Error('Burn amount below minimum'));
 

--- a/src/core/counterparty/__tests__/compose.send.test.ts
+++ b/src/core/counterparty/__tests__/compose.send.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as apiClientUtils from '@/core/api/client';
+import { asBaseUnits } from '@/core/numeric';
 import { getActiveSettings } from '@/core/settings';
 import { composeMove, composeSend, composeSendOrMPMA, composeSweep } from '../compose';
 import {
@@ -113,7 +114,7 @@ describe('Compose Send Operations', () => {
       const btcParams = {
         destination: mockDestAddress,
         asset: testAssets.BTC,
-        quantity: 100000000, // 1 BTC in satoshis
+        quantity: asBaseUnits(100000000), // 1 BTC in satoshis
       };
 
       await composeSend({

--- a/src/core/counterparty/__tests__/compose.specialized.test.ts
+++ b/src/core/counterparty/__tests__/compose.specialized.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as apiClientUtils from '@/core/api/client';
+import { asBaseUnits } from '@/core/numeric';
 import { getActiveSettings } from '@/core/settings';
 import {
   composeAttach,
@@ -346,7 +347,7 @@ describe('Compose Specialized Operations', () => {
   describe('composeFairmint', () => {
     const defaultParams = {
       asset: 'FAIRMINTASSET',
-      quantity: 100,
+      quantity: asBaseUnits(100),
     };
 
     it('should compose fairmint transaction', async () => {
@@ -362,7 +363,7 @@ describe('Compose Specialized Operations', () => {
 
     it('should include optional parameters', async () => {
       const optionalParams = {
-        quantity: 200,
+        quantity: asBaseUnits(200),
       };
 
       await composeFairmint({
@@ -442,7 +443,7 @@ describe('Compose Specialized Operations', () => {
     const defaultParams = {
       asset_a: 'XCP',
       asset_b: 'POOLTEST',
-      quantity: '1000000',
+      quantity: asBaseUnits('1000000'),
     };
 
     it('should compose pool withdraw transaction', async () => {
@@ -468,7 +469,7 @@ describe('Compose Specialized Operations', () => {
       const result = await composePoolWithdraw({
         sourceAddress: mockAddress,
         sat_per_vbyte: mockSatPerVbyte,
-        quantity: '1000000',
+        quantity: asBaseUnits('1000000'),
         min_quantity_a: '100',
         min_quantity_b: '200',
         lp_asset: 'A77777777777777777',

--- a/src/core/counterparty/__tests__/compose.trading.test.ts
+++ b/src/core/counterparty/__tests__/compose.trading.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as apiClientUtils from '@/core/api/client';
 import { requireCounterpartyFeature } from '@/core/counterparty/capabilities';
+import { asBaseUnits, asDisplayUnits } from '@/core/numeric';
 import { getActiveSettings } from '@/core/settings';
 import { composeCancel, composeDispense, composeDispenser, composeOrder } from '../compose';
 import {
@@ -53,7 +54,7 @@ describe('Compose Trading Operations', () => {
       give_asset: testAssets.XCP,
       give_quantity: testQuantities.MEDIUM,
       get_asset: testAssets.BTC,
-      get_quantity: 10000000, // 0.1 BTC
+      get_quantity: asBaseUnits(10000000), // 0.1 BTC
       expiration: 100,
       fee_required: 0,
     };
@@ -90,9 +91,9 @@ describe('Compose Trading Operations', () => {
     it('should handle sell orders (give XCP, get BTC)', async () => {
       const sellParams = {
         give_asset: testAssets.XCP,
-        give_quantity: 100000000,
+        give_quantity: asBaseUnits(100000000),
         get_asset: testAssets.BTC,
-        get_quantity: 10000000,
+        get_quantity: asBaseUnits(10000000),
         expiration: 100,
         fee_required: 0,
       };
@@ -108,9 +109,9 @@ describe('Compose Trading Operations', () => {
     it('should handle buy orders (give BTC, get XCP)', async () => {
       const buyParams = {
         give_asset: testAssets.BTC,
-        give_quantity: 10000000,
+        give_quantity: asBaseUnits(10000000),
         get_asset: testAssets.XCP,
-        get_quantity: 100000000,
+        get_quantity: asBaseUnits(100000000),
         expiration: 100,
         fee_required: 0,
       };
@@ -126,9 +127,9 @@ describe('Compose Trading Operations', () => {
     it('should handle asset-to-asset trades', async () => {
       const assetTradeParams = {
         give_asset: testAssets.DIVISIBLE,
-        give_quantity: 50000000,
+        give_quantity: asBaseUnits(50000000),
         get_asset: testAssets.INDIVISIBLE,
-        get_quantity: 10,
+        get_quantity: asBaseUnits(10),
         expiration: 200,
         fee_required: 0,
       };
@@ -265,8 +266,8 @@ describe('Compose Trading Operations', () => {
   describe('composeDispenser', () => {
     const defaultParams = {
       asset: testAssets.XCP,
-      give_quantity: 1000000,
-      escrow_quantity: 100000000,
+      give_quantity: asBaseUnits(1000000),
+      escrow_quantity: asBaseUnits(100000000),
       mainchainrate: 100,
       status: '0', // 0 = open, 10 = close
     };
@@ -356,7 +357,7 @@ describe('Compose Trading Operations', () => {
   describe('composeDispense', () => {
     const defaultParams = {
       dispenser: 'bc1qdispenser123',
-      quantity: 1000000,
+      quantity: asBaseUnits(1000000),
     };
 
     it('should compose dispense transaction', async () => {
@@ -377,7 +378,7 @@ describe('Compose Trading Operations', () => {
           address: mockAddress,
           dispenser: defaultParams.dispenser,
           quantity: defaultParams.quantity,
-          quantity_normalized: '0.01000000',
+          quantity_normalized: asDisplayUnits('0.01000000'),
         } as any,
       });
       mockedApiClient.get.mockResolvedValue(createMockApiResponse({ result: upstream }));

--- a/src/core/counterparty/__tests__/helpers/composeTestHelpers.ts
+++ b/src/core/counterparty/__tests__/helpers/composeTestHelpers.ts
@@ -8,6 +8,7 @@ export const mockAddress = 'bc1qtest123address';
 export const mockDestAddress = 'bc1qdest456address';
 export const mockApiBase = 'https://api.counterparty.io:4000';
 
+import { asBaseUnits, asDisplayUnits } from '@/core/numeric';
 import { DEFAULT_SETTINGS } from '@/core/settings';
 
 export const mockSettings = {
@@ -38,7 +39,7 @@ export const createMockComposeResult = (overrides?: Partial<ComposeResult>): Com
     source: mockAddress,
     destination: mockDestAddress,
     asset: 'XCP',
-    quantity: 100000000,
+    quantity: asBaseUnits(100000000),
     memo: null,
     memo_is_hex: false,
     use_enhanced_send: false,
@@ -52,9 +53,9 @@ export const createMockComposeResult = (overrides?: Partial<ComposeResult>): Com
       locked: false,
       owner: mockAddress,
       supply: '100000000',
-      supply_normalized: '1.00000000',
+      supply_normalized: asDisplayUnits('1.00000000'),
     },
-    quantity_normalized: '1.00000000',
+    quantity_normalized: asDisplayUnits('1.00000000'),
   },
   name: 'send',
   ...overrides,

--- a/src/core/counterparty/__tests__/inputAssets.test.ts
+++ b/src/core/counterparty/__tests__/inputAssets.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchUtxoBalances } from '@/core/counterparty/api';
+import { asDisplayUnits } from '@/core/numeric';
 import {
   classifySignedInputAssets,
   fetchInputsAttachedAssets,
@@ -30,7 +31,7 @@ describe('fetchInputsAttachedAssets', () => {
     mockedFetch.mockImplementation(async (utxo: string) => {
       if (utxo.startsWith('aaaa')) {
         return page([
-          { asset: 'PEPECASH', quantity_normalized: '1000.00000000', asset_info: { asset_longname: null } },
+          { asset: 'PEPECASH', quantity_normalized: asDisplayUnits('1000.00000000'), asset_info: { asset_longname: null } },
         ]);
       }
       return page([]);
@@ -45,14 +46,14 @@ describe('fetchInputsAttachedAssets', () => {
     expect(assets[0]).toMatchObject({
       inputIndex: 0,
       utxo: `${'aaaa'.repeat(16)}:0`,
-      assets: [{ asset: 'PEPECASH', quantity_normalized: '1000.00000000', asset_longname: null }],
+      assets: [{ asset: 'PEPECASH', quantity_normalized: asDisplayUnits('1000.00000000'), asset_longname: null }],
     });
   });
 
   it('prefers the asset longname when present', async () => {
     mockedFetch.mockResolvedValue(
       page([
-        { asset: 'A95428956661682177', quantity_normalized: '1', asset_info: { asset_longname: 'MYPROJECT.RARE' } },
+        { asset: 'A95428956661682177', quantity_normalized: asDisplayUnits('1'), asset_info: { asset_longname: 'MYPROJECT.RARE' } },
       ])
     );
 
@@ -119,7 +120,7 @@ describe('fetchInputsAttachedAssets', () => {
     const assetTxid = 'ab'.repeat(32);
     mockedFetch.mockImplementation(async (utxo: string) =>
       utxo.startsWith(assetTxid)
-        ? page([{ asset: 'RAREPEPE', quantity_normalized: '1.00000000', asset_info: { asset_longname: null } }])
+        ? page([{ asset: 'RAREPEPE', quantity_normalized: asDisplayUnits('1.00000000'), asset_info: { asset_longname: null } }])
         : page([])
     );
 
@@ -158,15 +159,15 @@ describe('fetchInputsAttachedAssets', () => {
   it('drops balance rows missing an asset or quantity', async () => {
     mockedFetch.mockResolvedValue(
       page([
-        { asset: 'XCP', quantity_normalized: '5.00000000' },
-        { asset: '', quantity_normalized: '1' },
-        { asset: 'GHOST', quantity_normalized: '' },
+        { asset: 'XCP', quantity_normalized: asDisplayUnits('5.00000000') },
+        { asset: '', quantity_normalized: asDisplayUnits('1') },
+        { asset: 'GHOST', quantity_normalized: asDisplayUnits('') },
       ])
     );
 
     const assets = await fetchInputsAttachedAssets([input(0)]);
     expect(assets[0]!.assets).toEqual([
-      { asset: 'XCP', quantity_normalized: '5.00000000', asset_longname: null },
+      { asset: 'XCP', quantity_normalized: asDisplayUnits('5.00000000'), asset_longname: null },
     ]);
   });
 });
@@ -175,7 +176,7 @@ describe('classifySignedInputAssets', () => {
   const withAsset = (inputIndex: number): InputAttachedAssets => ({
     inputIndex,
     utxo: `tx:${inputIndex}`,
-    assets: [{ asset: 'XCP', quantity_normalized: '1', asset_longname: null }],
+    assets: [{ asset: 'XCP', quantity_normalized: asDisplayUnits('1'), asset_longname: null }],
   });
   const failed = (inputIndex: number): InputAttachedAssets => ({
     inputIndex,

--- a/src/core/counterparty/__tests__/normalize.test.ts
+++ b/src/core/counterparty/__tests__/normalize.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as numeric from '@/core/numeric';
+import { asBaseUnits, asDisplayUnits } from '@/core/numeric';
 import type { AssetInfo } from '../api';
 import * as api from '../api';
 import { getComposeType, normalizeFormData } from '../normalize';
@@ -47,7 +48,7 @@ describe('normalize.ts', () => {
     });
 
     it('should detect dispenser type from escrow_quantity field', () => {
-      const formData = { escrow_quantity: '1000' };
+      const formData = { escrow_quantity: asBaseUnits('1000') };
       expect(getComposeType(formData)).toBe('dispenser');
     });
 
@@ -72,12 +73,12 @@ describe('normalize.ts', () => {
     });
 
     it('should detect send type from quantity and asset fields', () => {
-      const formData = { quantity: '1.5', asset: 'XCP' };
+      const formData = { quantity: asBaseUnits('1.5'), asset: 'XCP' };
       expect(getComposeType(formData)).toBe('send');
     });
 
     it('should detect issuance type from quantity and asset_name fields', () => {
-      const formData = { quantity: '1000', asset_name: 'MYTOKEN' };
+      const formData = { quantity: asBaseUnits('1000'), asset_name: 'MYTOKEN' };
       expect(getComposeType(formData)).toBe('issuance');
     });
 
@@ -104,7 +105,7 @@ describe('normalize.ts', () => {
     it('should detect pool withdraw type from LP asset withdraw fields', () => {
       const formData = {
         lp_asset: 'A77777777777777777',
-        quantity: '1',
+        quantity: asBaseUnits('1'),
         min_quantity_a: '0',
       };
       expect(getComposeType(formData)).toBe('poolwithdraw');
@@ -193,7 +194,7 @@ describe('normalize.ts', () => {
         asset_longname: null,
         divisible: true,
         locked: false,
-        supply_normalized: '1000000.00000000'
+        supply_normalized: asDisplayUnits('1000000.00000000')
       };
 
       it('should normalize divisible asset amounts using toSatoshis', async () => {
@@ -224,7 +225,7 @@ describe('normalize.ts', () => {
           asset_longname: null,
           divisible: true,
           locked: false,
-          supply_normalized: '500000.00000000'
+          supply_normalized: asDisplayUnits('500000.00000000')
         };
 
         mockFetchAssetDetails
@@ -257,7 +258,7 @@ describe('normalize.ts', () => {
           asset_longname: null,
           divisible: true,
           locked: false,
-          supply_normalized: '1000000.00000000'
+          supply_normalized: asDisplayUnits('1000000.00000000')
         };
 
         mockFetchAssetDetails
@@ -289,7 +290,7 @@ describe('normalize.ts', () => {
           asset_longname: null,
           divisible: true,
           locked: false,
-          supply_normalized: '1000000.00000000'
+          supply_normalized: asDisplayUnits('1000000.00000000')
         };
 
         mockFetchAssetDetails.mockResolvedValue(mockLpAsset);
@@ -310,7 +311,7 @@ describe('normalize.ts', () => {
         asset_longname: null,
         divisible: false,
         locked: false,
-        supply_normalized: '1000'
+        supply_normalized: asDisplayUnits('1000')
       };
 
       it('should not modify indivisible asset amounts', async () => {
@@ -340,7 +341,7 @@ describe('normalize.ts', () => {
           asset_longname: null,
           divisible: true,
           locked: false,
-          supply_normalized: '1000000.00000000'
+          supply_normalized: asDisplayUnits('1000000.00000000')
         };
 
         mockFetchAssetDetails
@@ -364,7 +365,7 @@ describe('normalize.ts', () => {
         asset_longname: null,
         divisible: true,
         locked: false,
-        supply_normalized: '1000000.00000000'
+        supply_normalized: asDisplayUnits('1000000.00000000')
       };
 
       it('should cache asset info and reuse it for subsequent calls', async () => {
@@ -445,7 +446,7 @@ describe('normalize.ts', () => {
           asset_longname: null,
           divisible: true,
           locked: false,
-          supply_normalized: '1000000.00000000'
+          supply_normalized: asDisplayUnits('1000000.00000000')
         };
 
         mockFetchAssetDetails.mockResolvedValue(mockAsset);
@@ -467,7 +468,7 @@ describe('normalize.ts', () => {
           asset_longname: null,
           divisible: true,
           locked: false,
-          supply_normalized: '1000000.00000000'
+          supply_normalized: asDisplayUnits('1000000.00000000')
         };
 
         mockFetchAssetDetails.mockResolvedValue(mockAsset);
@@ -489,7 +490,7 @@ describe('normalize.ts', () => {
           asset_longname: null,
           divisible: true,
           locked: false,
-          supply_normalized: '1000000.00000000'
+          supply_normalized: asDisplayUnits('1000000.00000000')
         };
 
         mockFetchAssetDetails.mockResolvedValue(mockAsset);
@@ -557,7 +558,7 @@ describe('normalize.ts', () => {
           asset_longname: null,
           divisible: false,
           locked: false,
-          supply_normalized: '10000'
+          supply_normalized: asDisplayUnits('10000')
         };
 
         mockFetchAssetDetails.mockResolvedValue(mockAsset);
@@ -608,7 +609,7 @@ describe('normalize.ts', () => {
           asset_longname: null,
           divisible: undefined as any, // Force undefined
           locked: false,
-          supply_normalized: '1000'
+          supply_normalized: asDisplayUnits('1000')
         };
 
         mockFetchAssetDetails.mockResolvedValue(mockAsset);
@@ -628,7 +629,7 @@ describe('normalize.ts', () => {
           asset_longname: null,
           divisible: null as any, // Force null
           locked: false,
-          supply_normalized: '1000'
+          supply_normalized: asDisplayUnits('1000')
         };
 
         mockFetchAssetDetails.mockResolvedValue(mockAsset);
@@ -685,7 +686,7 @@ describe('normalize.ts', () => {
           asset_longname: null,
           divisible: true,
           locked: false,
-          supply_normalized: '1000000.00000000'
+          supply_normalized: asDisplayUnits('1000000.00000000')
         };
 
         mockFetchAssetDetails.mockResolvedValue(mockAsset);
@@ -707,7 +708,7 @@ describe('normalize.ts', () => {
           asset_longname: null,
           divisible: true,
           locked: false,
-          supply_normalized: '1000000.00000000'
+          supply_normalized: asDisplayUnits('1000000.00000000')
         };
 
         mockFetchAssetDetails.mockResolvedValue(mockAsset);
@@ -729,7 +730,7 @@ describe('normalize.ts', () => {
           asset_longname: null,
           divisible: false,
           locked: false,
-          supply_normalized: '18446744073709551615'
+          supply_normalized: asDisplayUnits('18446744073709551615')
         };
 
         mockFetchAssetDetails.mockResolvedValue(mockAsset);
@@ -752,7 +753,7 @@ describe('normalize.ts', () => {
           asset_longname: null,
           divisible: true,
           locked: true,
-          supply_normalized: '2648998.99999999'
+          supply_normalized: asDisplayUnits('2648998.99999999')
         };
 
         mockFetchAssetDetails.mockResolvedValue(mockAsset);
@@ -774,7 +775,7 @@ describe('normalize.ts', () => {
           asset_longname: null,
           divisible: false,
           locked: false,
-          supply_normalized: '1000'
+          supply_normalized: asDisplayUnits('1000')
         };
 
         mockFetchAssetDetails.mockResolvedValue(mockAsset);
@@ -795,7 +796,7 @@ describe('normalize.ts', () => {
           asset_longname: 'VERYLONGASSETNAME.WITH.DOTS',
           divisible: true,
           locked: false,
-          supply_normalized: '1000000.00000000'
+          supply_normalized: asDisplayUnits('1000000.00000000')
         };
 
         mockFetchAssetDetails.mockResolvedValue(mockAsset);
@@ -821,7 +822,7 @@ describe('normalize.ts', () => {
           asset_longname: null,
           divisible: true,
           locked: false,
-          supply_normalized: '1000000.00000000'
+          supply_normalized: asDisplayUnits('1000000.00000000')
         };
 
         // Simulate both calls returning the same asset info

--- a/src/core/counterparty/__tests__/pool.test.ts
+++ b/src/core/counterparty/__tests__/pool.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { asBaseUnits, asDisplayUnits } from '@/core/numeric';
 import {
   applyPoolSlippage,
   calculateInitialLpEstimate,
@@ -39,7 +40,7 @@ describe("counterparty pool utilities", () => {
       reserve_a: 75000000000000,
       reserve_b: 300000000000,
       lp_asset: "A6900000000000001774",
-      quantity: 4743416490252,
+      quantity: asBaseUnits(4743416490252),
     };
 
     it("derives quantity_normalized when the endpoint omits it", () => {
@@ -47,12 +48,12 @@ describe("counterparty pool utilities", () => {
     });
 
     it("does not divide when lp_asset_info marks the LP asset indivisible", () => {
-      const indivisible = { ...position, quantity: 42, lp_asset_info: { divisible: false } };
+      const indivisible = { ...position, quantity: asBaseUnits(42), lp_asset_info: { divisible: false } };
       expect(normalizePoolPosition(indivisible).quantity_normalized).toBe("42");
     });
 
     it("keeps quantity_normalized from the API when present", () => {
-      const alreadyNormalized = { ...position, quantity_normalized: "47434.1649" };
+      const alreadyNormalized = { ...position, quantity_normalized: asDisplayUnits("47434.1649") };
       expect(normalizePoolPosition(alreadyNormalized).quantity_normalized).toBe("47434.1649");
     });
   });

--- a/src/core/counterparty/__tests__/subassetLockRegression.test.ts
+++ b/src/core/counterparty/__tests__/subassetLockRegression.test.ts
@@ -10,6 +10,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
+import { asBaseUnits } from '@/core/numeric';
 import { packComposeMessage } from '../pack/messages';
 import { unpackCounterpartyMessage } from '../unpack';
 import { bytesToHex } from '../unpack/binary';
@@ -26,7 +27,7 @@ const ASSET_ID = 751209043880280215n;
 /** Params as the issuance form submits them for that transaction. */
 const PARAMS = {
   asset: LONGNAME,
-  quantity: 1,
+  quantity: asBaseUnits(1),
   divisible: false,
   lock: true,
   reset: false,

--- a/src/core/counterparty/__tests__/transaction.test.ts
+++ b/src/core/counterparty/__tests__/transaction.test.ts
@@ -1,3 +1,4 @@
+import { asBaseUnits, asDisplayUnits } from '@/core/numeric';
 /**
  * Tests for Counterparty Transaction Decoding Utilities
  *
@@ -80,7 +81,7 @@ describe('describeCounterpartyMessage', () => {
     // The fixture used to disagree with production, so this test passed while
     // the approval headline rendered "to undefined".
     const desc = describeCounterpartyMessage('enhanced_send', {
-      quantity: 100000000,
+      quantity: asBaseUnits(100000000),
       asset: 'XCP',
       address: 'bc1qtest',
     });
@@ -92,7 +93,7 @@ describe('describeCounterpartyMessage', () => {
 
   it('describes a send that supplies destination instead of address', () => {
     const desc = describeCounterpartyMessage('send', {
-      quantity: 100000000,
+      quantity: asBaseUnits(100000000),
       asset: 'XCP',
       destination: 'bc1qlegacy',
     });
@@ -102,7 +103,7 @@ describe('describeCounterpartyMessage', () => {
 
   it('never renders undefined when neither recipient key is present', () => {
     const desc = describeCounterpartyMessage('enhanced_send', {
-      quantity: 100000000,
+      quantity: asBaseUnits(100000000),
       asset: 'XCP',
     });
     expect(desc).not.toContain('undefined');
@@ -110,7 +111,7 @@ describe('describeCounterpartyMessage', () => {
 
   it('describes send (legacy)', () => {
     const desc = describeCounterpartyMessage('send', {
-      quantity: 50000,
+      quantity: asBaseUnits(50000),
       asset: 'PEPECASH',
       destination: '1Abc',
     });
@@ -120,9 +121,9 @@ describe('describeCounterpartyMessage', () => {
 
   it('describes order with give/get assets', () => {
     const desc = describeCounterpartyMessage('order', {
-      give_quantity: 100000000,
+      give_quantity: asBaseUnits(100000000),
       give_asset: 'XCP',
-      get_quantity: 50000,
+      get_quantity: asBaseUnits(50000),
       get_asset: 'BTC',
     });
     expect(desc).toContain('DEX Order');
@@ -140,7 +141,7 @@ describe('describeCounterpartyMessage', () => {
 
   it('describes dispenser', () => {
     const desc = describeCounterpartyMessage('dispenser', {
-      give_quantity: 1000,
+      give_quantity: asBaseUnits(1000),
       asset: 'PEPECASH',
       mainchainrate: 10000,
     });
@@ -151,7 +152,7 @@ describe('describeCounterpartyMessage', () => {
   it('describes issuance', () => {
     const desc = describeCounterpartyMessage('issuance', {
       asset: 'MYTOKEN',
-      quantity: 1000000,
+      quantity: asBaseUnits(1000000),
     });
     expect(desc).toContain('Issue Asset');
     expect(desc).toContain('MYTOKEN');
@@ -159,7 +160,7 @@ describe('describeCounterpartyMessage', () => {
 
   it('describes dividend', () => {
     const desc = describeCounterpartyMessage('dividend', {
-      quantity_per_unit: 100,
+      quantity_per_unit: asBaseUnits(100),
       dividend_asset: 'XCP',
       asset: 'PEPECASH',
     });
@@ -229,7 +230,7 @@ describe('describeCounterpartyMessage', () => {
     const desc = describeCounterpartyMessage('poolwithdraw', {
       asset_a: 'XCP',
       asset_b: 'POOLTEST',
-      quantity: 1000000,
+      quantity: asBaseUnits(1000000),
     });
     expect(desc).toContain('Withdraw liquidity');
     expect(desc).toContain('XCP/POOLTEST');
@@ -237,7 +238,7 @@ describe('describeCounterpartyMessage', () => {
 
   it('describes attach', () => {
     const desc = describeCounterpartyMessage('attach', {
-      quantity: 500,
+      quantity: asBaseUnits(500),
       asset: 'PEPECASH',
     });
     expect(desc).toContain('Attach');
@@ -251,7 +252,7 @@ describe('describeCounterpartyMessage', () => {
 
   it('describes destroy', () => {
     const desc = describeCounterpartyMessage('destroy', {
-      quantity: 100,
+      quantity: asBaseUnits(100),
       asset: 'XCP',
     });
     expect(desc).toContain('Destroy');
@@ -265,7 +266,7 @@ describe('describeCounterpartyMessage', () => {
     const desc = describeCounterpartyMessage('utxo', {
       destination: 'bc1qdest',
       asset: 'XCP',
-      quantity: 100000000,
+      quantity: asBaseUnits(100000000),
       asset_info: { divisible: true },
     });
     expect(desc).toContain('Move');
@@ -282,8 +283,8 @@ describe('describeCounterpartyMessage', () => {
 
   it('uses _normalized quantity when available', () => {
     const desc = describeCounterpartyMessage('enhanced_send', {
-      quantity: 100000000,
-      quantity_normalized: '1.00000000',
+      quantity: asBaseUnits(100000000),
+      quantity_normalized: asDisplayUnits('1.00000000'),
       asset: 'XCP',
       destination: 'bc1q',
     });
@@ -292,7 +293,7 @@ describe('describeCounterpartyMessage', () => {
 
   it('normalizes quantity using asset_info divisibility', () => {
     const desc = describeCounterpartyMessage('enhanced_send', {
-      quantity: 100000000,
+      quantity: asBaseUnits(100000000),
       asset: 'XCP',
       asset_info: { divisible: true },
       destination: 'bc1q',
@@ -524,7 +525,7 @@ describe('decodeCounterpartyMessage', () => {
     message_type_id: 2,
     message_data: {
       asset: 'XCP',
-      quantity: 100000000,
+      quantity: asBaseUnits(100000000),
       destination: 'bc1qtest',
     },
   };
@@ -587,9 +588,9 @@ describe('decodeCounterpartyMessage', () => {
           message_type_id: 10,
           message_data: {
             give_asset: 'XCP',
-            give_quantity: 100000000,
+            give_quantity: asBaseUnits(100000000),
             get_asset: 'BTC',
-            get_quantity: 50000,
+            get_quantity: asBaseUnits(50000),
           },
         },
       },

--- a/src/core/counterparty/__tests__/utxoSelection.test.ts
+++ b/src/core/counterparty/__tests__/utxoSelection.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as bitcoinUtxo from '@/core/bitcoin/utxo';
+import { asDisplayUnits } from '@/core/numeric';
 import * as counterpartyApi from '../api';
 import { selectUtxosForTransaction } from '../utxoSelection';
 
@@ -67,7 +68,7 @@ describe('selectUtxosForTransaction', () => {
 
     mockedFetchUTXOs.mockResolvedValue(mockUtxos);
     mockedFetchTokenBalances.mockResolvedValue([
-      { asset: 'MYASSET', quantity_normalized: '100', utxo: 'tx2:0' },
+      { asset: 'MYASSET', quantity_normalized: asDisplayUnits('100'), utxo: 'tx2:0' },
     ]);
 
     const result = await selectUtxosForTransaction(mockAddress);
@@ -169,7 +170,7 @@ describe('selectUtxosForTransaction', () => {
 
     mockedFetchUTXOs.mockResolvedValue(mockUtxos);
     mockedFetchTokenBalances.mockResolvedValue([
-      { asset: 'MYASSET', quantity_normalized: '100', utxo: 'tx1:0' },
+      { asset: 'MYASSET', quantity_normalized: asDisplayUnits('100'), utxo: 'tx1:0' },
     ]);
 
     await expect(selectUtxosForTransaction(mockAddress)).rejects.toThrow(
@@ -212,8 +213,8 @@ describe('selectUtxosForTransaction', () => {
 
     mockedFetchUTXOs.mockResolvedValue(mockUtxos);
     mockedFetchTokenBalances.mockResolvedValue([
-      { asset: 'ASSET1', quantity_normalized: '100', utxo: 'tx2:0' },
-      { asset: 'ASSET2', quantity_normalized: '50', utxo: 'tx2:0' },
+      { asset: 'ASSET1', quantity_normalized: asDisplayUnits('100'), utxo: 'tx2:0' },
+      { asset: 'ASSET2', quantity_normalized: asDisplayUnits('50'), utxo: 'tx2:0' },
     ]);
 
     const result = await selectUtxosForTransaction(mockAddress);

--- a/src/core/counterparty/__tests__/wireDifferential.fuzz.test.ts
+++ b/src/core/counterparty/__tests__/wireDifferential.fuzz.test.ts
@@ -1,0 +1,177 @@
+// @vitest-environment node
+/**
+ * Differential fuzz: this wallet's decoder against counterparty-core's, over the same bytes.
+ *
+ * Every wire-format defect found in the 2026-08-05 audit — broadcast text taken from the head
+ * where core takes the tail, legacy issuance read in a layout core abandoned at block 753500, an
+ * MPMA address table decoded with modern rules where core uses legacy-only — was a disagreement
+ * about bytes, found by reading. Reading is unreliable at this: it missed these for months and,
+ * in the same session, produced two false findings.
+ *
+ * `/v2/transactions/unpack` IS core's decoder, reachable over HTTP. Running it against the local
+ * unpacker on generated payloads turns "did we read every format correctly" into something the
+ * machine answers. Running core locally would be better still and is not currently possible: WSL's
+ * disk image is missing and Windows Python fails in python-bitcoinlib at `ctypes.LoadLibrary(None)`.
+ *
+ * The comparison engine is `verifyProviderTransaction`, the same code the approval screen uses, so
+ * a run also exercises the comparator rather than a parallel one written for the test.
+ *
+ * Not part of the default suite: it needs network. Run with
+ *   npx vitest run --config vitest.fuzz.config.ts src/core/counterparty/__tests__/wireDifferential.fuzz.test.ts
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+import { packComposeMessage } from '@/core/counterparty/pack/messages';
+import { bytesToHex } from '@/core/counterparty/unpack/binary';
+import { verifyProviderTransaction } from '@/core/counterparty/unpack/providerVerify';
+
+const API = 'https://api.counterparty.io:4000';
+const CASES_PER_TYPE = Number(process.env.FUZZ_CASES ?? 3);
+/** Spacing between calls. The endpoint is shared infrastructure and rate-limits; a fuzz run has
+ *  no claim on it, and a 429 is indistinguishable from a decode failure to the comparator. */
+const REQUEST_SPACING_MS = 400;
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/** Deterministic PRNG so a failure can be reproduced from its seed. */
+function rng(seed: number) {
+  let s = seed >>> 0;
+  return () => {
+    s = (s * 1664525 + 1013904223) >>> 0;
+    return s / 0x100000000;
+  };
+}
+
+const P2PKH = ['1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa', '1CounterpartyXXXXXXXXXXXXXXXUWLpVr'];
+const BECH32 = ['bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4'];
+const ADDRESSES = [...P2PKH, ...BECH32];
+
+/**
+ * Numeric assets only. Core resolves a named asset through a ledger lookup this test cannot
+ * reach, so a named asset would produce a spurious disagreement about the name rather than about
+ * the bytes.
+ */
+function numericAsset(r: () => number): string {
+  const base = 95428956661682177n;
+  return 'A' + (base + BigInt(Math.floor(r() * 1_000_000_000))).toString();
+}
+
+const pick = <T,>(r: () => number, xs: readonly T[]): T => xs[Math.floor(r() * xs.length)]!;
+const qty = (r: () => number): string => String(Math.floor(r() * 1e12) + 1);
+
+/** Compose params per message type, randomized. Only types the local packer can build. */
+const GENERATORS: Record<string, (r: () => number) => Record<string, unknown>> = {
+  send: (r) => ({ destination: pick(r, ADDRESSES), asset: numericAsset(r), quantity: qty(r) }),
+  order: (r) => ({
+    give_asset: numericAsset(r), give_quantity: qty(r),
+    get_asset: numericAsset(r), get_quantity: qty(r),
+    expiration: String(Math.floor(r() * 60000)), fee_required: '0',
+  }),
+  cancel: (r) => ({
+    offer_hash: Array.from({ length: 64 }, () => '0123456789abcdef'[Math.floor(r() * 16)]).join(''),
+  }),
+  destroy: (r) => ({ asset: numericAsset(r), quantity: qty(r), tag: 'tag' }),
+  dividend: (r) => ({
+    asset: numericAsset(r), dividend_asset: numericAsset(r), quantity_per_unit: qty(r),
+  }),
+  sweep: (r) => ({ destination: pick(r, ADDRESSES), flags: String(1 + Math.floor(r() * 3)) }),
+  broadcast: (r) => ({
+    text: 'fuzz ' + Math.floor(r() * 1e6),
+    value: '0', fee_fraction: '0', timestamp: String(1767225600 + Math.floor(r() * 1e6)),
+  }),
+  issuance: (r) => ({
+    asset: numericAsset(r), quantity: qty(r), divisible: r() > 0.5, description: 'fuzz',
+  }),
+  fairmint: (r) => ({ asset: numericAsset(r), quantity: qty(r) }),
+  dispense: () => ({}),
+};
+
+/**
+ * Known, understood divergences. `/v2/transactions/unpack` returns one entry per ASSET for an
+ * mpma_send rather than one per recipient, so a multi-recipient message cannot be compared field
+ * by field — the approval screen reads those recipients from the bytes for exactly this reason.
+ */
+const EXPECTED_DIVERGENCE = new Set<string>(['mpma']);
+
+async function apiUnpack(datahex: string): Promise<{
+  message_type: string; message_type_id: number; message_data: Record<string, unknown>;
+} | null> {
+  await sleep(REQUEST_SPACING_MS);
+  const res = await fetch(`${API}/v2/transactions/unpack?datahex=${datahex}&verbose=true`);
+  // A 429 is the harness's own fault, not a decode disagreement — surface it rather than
+  // silently counting the payload as unbuildable.
+  if (res.status === 429) throw new Error('rate limited by the counterparty API — slow the run down');
+  if (!res.ok) return null;
+  const json = await res.json();
+  return json?.result ?? null;
+}
+
+let reachable = false;
+
+describe('local decoder vs counterparty-core, same bytes', () => {
+  beforeAll(async () => {
+    try {
+      const res = await fetch(`${API}/v2/blocks/last`);
+      reachable = res.ok;
+    } catch {
+      reachable = false;
+    }
+  }, 20000);
+
+  it('agrees with core on every generated payload', async () => {
+    if (!reachable) {
+      console.warn('counterparty API unreachable — differential fuzz skipped');
+      return;
+    }
+
+    const divergences: string[] = [];
+    const compared: string[] = [];
+    const unbuildable: string[] = [];
+
+    for (const [composeType, generate] of Object.entries(GENERATORS)) {
+      if (EXPECTED_DIVERGENCE.has(composeType)) continue;
+
+      for (let i = 0; i < CASES_PER_TYPE; i += 1) {
+        const seed = 0x5eed + i * 7919 + composeType.length * 104729;
+        const params = generate(rng(seed));
+
+        const packed = packComposeMessage(composeType, params as never);
+        if (!packed) {
+          unbuildable.push(`${composeType}[seed ${seed}]`);
+          continue;
+        }
+
+        const payloadHex = bytesToHex(packed.bytes);
+        const api = await apiUnpack(payloadHex);
+        if (!api) {
+          unbuildable.push(`${composeType}[seed ${seed}] api rejected`);
+          continue;
+        }
+
+        // The screen's own comparator, so this exercises it too.
+        const result = verifyProviderTransaction(payloadHex, {
+          messageType: api.message_type,
+          messageTypeId: api.message_type_id,
+          messageData: api.message_data,
+          description: '',
+        });
+
+        compared.push(composeType);
+        if (!result.passed) {
+          divergences.push(
+            `${composeType} [seed ${seed}] ${JSON.stringify(params)}\n    ${result.mismatches.join('\n    ')}`
+          );
+        }
+      }
+    }
+
+    console.log(
+      `compared ${compared.length} payloads across ${new Set(compared).size} message types` +
+      (unbuildable.length ? `; ${unbuildable.length} not built: ${unbuildable.slice(0, 5).join(', ')}` : '')
+    );
+
+    // A divergence here means the approval screen and the chain would describe the same bytes
+    // differently — the defect class this whole harness exists to catch.
+    expect(divergences, `\n${divergences.join('\n')}\n`).toEqual([]);
+    expect(compared.length).toBeGreaterThan(0);
+  }, 300000);
+});

--- a/src/core/counterparty/api.ts
+++ b/src/core/counterparty/api.ts
@@ -9,7 +9,7 @@
 
 import { apiClient } from '@/core/api/client';
 import { CounterpartyApiError } from '@/core/errors';
-import { toBigNumber } from '@/core/numeric';
+import { asBaseUnits, asDisplayUnits, type BaseUnits, type DisplayUnits, toBigNumber } from '@/core/numeric';
 import { getActiveSettings } from '@/core/settings';
 
 // =============================================================================
@@ -127,7 +127,7 @@ export type DispenserStatusType = (typeof DispenserStatus)[keyof typeof Dispense
  * to numeric.ts — toBigNumber and fromSatoshis accept either and are exact with both — rather than
  * doing arithmetic on them directly, where a string would concatenate instead of add.
  */
-export type ApiQuantity = number | string;
+export type ApiQuantity = BaseUnits;
 
 export interface PaginatedResponse<T> {
   result: T[];
@@ -154,7 +154,7 @@ export interface AssetInfo {
   locked: boolean;
   description_locked?: boolean;
   supply?: string | number;
-  supply_normalized: string;
+  supply_normalized: DisplayUnits;
   fair_minting?: boolean;
   first_issuance_block_index?: number;
   last_issuance_block_index?: number;
@@ -173,7 +173,7 @@ export interface TokenBalance {
     supply?: number | string;
   };
   quantity?: ApiQuantity;
-  quantity_normalized: string;
+  quantity_normalized: DisplayUnits;
   address?: string | null;
   utxo?: string | null;
   utxo_address?: string | null;
@@ -187,7 +187,7 @@ export interface UtxoBalance extends TokenBalance {
 export interface OwnedAsset {
   asset: string;
   asset_longname: string | null;
-  supply_normalized: string;
+  supply_normalized: DisplayUnits;
   description: string;
   locked: boolean;
 }
@@ -201,13 +201,13 @@ export interface Order {
   block_time: number;
   give_asset: string;
   get_asset: string;
-  give_quantity_normalized: string;
-  get_quantity_normalized: string;
-  give_remaining_normalized: string;
-  get_remaining_normalized: string;
+  give_quantity_normalized: DisplayUnits;
+  get_quantity_normalized: DisplayUnits;
+  give_remaining_normalized: DisplayUnits;
+  get_remaining_normalized: DisplayUnits;
   status: string;
   expire_index: number;
-  market_price_normalized?: string;
+  market_price_normalized?: DisplayUnits;
 }
 
 export interface OrderDetails extends Order {
@@ -235,12 +235,12 @@ export interface OrderDetails extends Order {
     divisible: boolean;
     locked: boolean;
   };
-  give_price_normalized?: string;
-  get_price_normalized?: string;
-  fee_provided_normalized?: string;
-  fee_required_normalized?: string;
-  fee_required_remaining_normalized?: string;
-  fee_provided_remaining_normalized?: string;
+  give_price_normalized?: DisplayUnits;
+  get_price_normalized?: DisplayUnits;
+  fee_provided_normalized?: DisplayUnits;
+  fee_required_normalized?: DisplayUnits;
+  fee_required_remaining_normalized?: DisplayUnits;
+  fee_provided_remaining_normalized?: DisplayUnits;
 }
 
 export interface OrderMatch {
@@ -253,20 +253,20 @@ export interface OrderMatch {
   tx1_address: string;
   forward_asset: string;
   forward_quantity: number;
-  forward_quantity_normalized: string;
+  forward_quantity_normalized: DisplayUnits;
   backward_asset: string;
   backward_quantity: number;
-  backward_quantity_normalized: string;
+  backward_quantity_normalized: DisplayUnits;
   tx0_block_index: number;
   tx1_block_index: number;
   block_index: number;
   block_time: number;
   match_expire_index: number;
   fee_paid: number;
-  fee_paid_normalized: string;
+  fee_paid_normalized: DisplayUnits;
   status: string;
   confirmed?: boolean;
-  market_price_normalized?: string;
+  market_price_normalized?: DisplayUnits;
 }
 
 // =============================================================================
@@ -285,15 +285,15 @@ export interface Pool {
   reserve_b: number;
   lp_asset: string;
   status?: string;
-  reserve_a_normalized?: string;
-  reserve_b_normalized?: string;
+  reserve_a_normalized?: DisplayUnits;
+  reserve_b_normalized?: DisplayUnits;
   confirmed?: boolean;
   [key: string]: unknown;
 }
 
 export interface PoolPosition extends Pool {
   quantity: ApiQuantity;
-  quantity_normalized?: string;
+  quantity_normalized?: DisplayUnits;
 }
 
 export interface PoolQuote {
@@ -346,7 +346,7 @@ export interface Dispenser {
   asset: string;
   status: number;
   give_remaining: ApiQuantity;
-  give_remaining_normalized: string;
+  give_remaining_normalized: DisplayUnits;
   asset_info?: {
     asset_longname: string | null;
     description: string;
@@ -358,11 +358,11 @@ export interface Dispenser {
 
 export interface DispenserDetails extends Dispenser {
   give_quantity: ApiQuantity;
-  give_quantity_normalized: string;
+  give_quantity_normalized: DisplayUnits;
   satoshirate: ApiQuantity;
-  satoshirate_normalized: string;
+  satoshirate_normalized: DisplayUnits;
   escrow_quantity: ApiQuantity;
-  escrow_quantity_normalized: string;
+  escrow_quantity_normalized: DisplayUnits;
   block_index: number;
   block_time: number;
   confirmed?: boolean;
@@ -379,10 +379,10 @@ export interface Dispense {
   destination: string;
   asset: string;
   dispense_quantity: number;
-  dispense_quantity_normalized: string;
+  dispense_quantity_normalized: DisplayUnits;
   dispenser_tx_hash: string;
   btc_amount: number;
-  btc_amount_normalized: string;
+  btc_amount_normalized: DisplayUnits;
   confirmed?: boolean;
 }
 
@@ -402,7 +402,7 @@ export interface Transaction {
   status?: string;
   transaction_type?: string;
   btc_amount?: number;
-  btc_amount_normalized?: string;
+  btc_amount_normalized?: DisplayUnits;
   fee?: number;
   data: Record<string, any>;
   supported: boolean;
@@ -435,11 +435,11 @@ export interface Dividend {
   asset: string;
   dividend_asset: string;
   quantity_per_unit: ApiQuantity;
-  quantity_per_unit_normalized: string;
+  quantity_per_unit_normalized: DisplayUnits;
   total_distributed: number;
-  total_distributed_normalized: string;
+  total_distributed_normalized: DisplayUnits;
   fee_paid: number;
-  fee_paid_normalized: string;
+  fee_paid_normalized: DisplayUnits;
   status?: string;
   confirmed?: boolean;
 }
@@ -590,8 +590,8 @@ export async function fetchTokenBalance(
 
   const emptyBalance: TokenBalance = {
     asset,
-    quantity: 0,
-    quantity_normalized: '0',
+    quantity: asBaseUnits(0),
+    quantity_normalized: asDisplayUnits('0'),
     asset_info: { asset_longname: null, description: '', issuer: '', divisible: true, locked: false },
   };
 
@@ -604,12 +604,16 @@ export async function fetchTokenBalance(
     asset,
     // Summed as BigNumber and kept as a string: these are 64-bit asset quantities, and adding
     // them as doubles loses digits for exactly the large balances where the total matters most.
-    quantity: balances
-      .reduce((sum, b) => sum.plus(toBigNumber(b.quantity ?? 0)), toBigNumber(0))
-      .toFixed(0),
-    quantity_normalized: balances
-      .reduce((sum, b) => sum.plus(toBigNumber(b.quantity_normalized)), toBigNumber(0))
-      .toString(),
+    quantity: asBaseUnits(
+      balances
+        .reduce((sum, b) => sum.plus(toBigNumber(b.quantity ?? 0)), toBigNumber(0))
+        .toFixed(0)
+    ),
+    quantity_normalized: asDisplayUnits(
+      balances
+        .reduce((sum, b) => sum.plus(toBigNumber(b.quantity_normalized)), toBigNumber(0))
+        .toString()
+    ),
     asset_info: balances[0]!.asset_info,
   };
 }

--- a/src/core/counterparty/pack/__tests__/coreOracle.test.ts
+++ b/src/core/counterparty/pack/__tests__/coreOracle.test.ts
@@ -28,6 +28,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
+import { asBaseUnits } from '@/core/numeric';
 import { unpackCounterpartyMessage } from '../../unpack';
 import { bytesToHex } from '../../unpack/binary';
 import { packComposeMessage } from '../messages';
@@ -74,7 +75,7 @@ const CASES: OracleCase[] = [
     params: {
       asset: 'XCP',
       destination: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa',
-      quantity: 100,
+      quantity: asBaseUnits(100),
       memo: 'thanks',
     },
     query: {
@@ -87,7 +88,7 @@ const CASES: OracleCase[] = [
   {
     label: 'indivisible issuance',
     composeType: 'issuance',
-    params: { asset: 'LANDMARKS', quantity: 21, divisible: false },
+    params: { asset: 'LANDMARKS', quantity: asBaseUnits(21), divisible: false },
     query: { asset: 'LANDMARKS', quantity: '21', divisible: 'false' },
   },
   {
@@ -104,7 +105,7 @@ const CASES: OracleCase[] = [
     label: 'issuance transferring ownership',
     composeType: 'issuance',
     params: {
-      asset: 'LANDMARKS', quantity: 0, divisible: false,
+      asset: 'LANDMARKS', quantity: asBaseUnits(0), divisible: false,
       transfer_destination: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa',
     },
     query: {
@@ -121,7 +122,7 @@ const CASES: OracleCase[] = [
   {
     label: 'destroy with a tag',
     composeType: 'destroy',
-    params: { asset: 'XCP', quantity: 1000, tag: 'burn' },
+    params: { asset: 'XCP', quantity: asBaseUnits(1000), tag: 'burn' },
     query: { asset: 'XCP', quantity: '1000', tag: 'burn' },
   },
   {
@@ -145,7 +146,7 @@ const CASES: OracleCase[] = [
   {
     label: 'initial subasset issuance',
     composeType: 'issuance',
-    params: { asset: 'PEPECASH.oracle-check', quantity: 1000, divisible: false, description: 'a subasset' },
+    params: { asset: 'PEPECASH.oracle-check', quantity: asBaseUnits(1000), divisible: false, description: 'a subasset' },
     query: { asset: 'PEPECASH.oracle-check', quantity: '1000', divisible: 'false', description: 'a subasset' },
     // Core names the subasset by drawing a random numeric asset per compose, so the id differs on
     // every call and can only come from the response.

--- a/src/core/counterparty/pack/__tests__/messages.test.ts
+++ b/src/core/counterparty/pack/__tests__/messages.test.ts
@@ -11,6 +11,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
+import { asBaseUnits } from '@/core/numeric';
 import { unpackCounterpartyMessage } from '../../unpack';
 import { packAddress } from '../../unpack/address';
 import { assetNameToId } from '../../unpack/assetId';
@@ -47,7 +48,7 @@ describe('packing produces the bytes core composes', () => {
 
     const packed = packComposeMessage('issuance', {
       asset: 'LANDMARKS',
-      quantity: 21,
+      quantity: asBaseUnits(21),
       divisible: false,
     });
 
@@ -104,7 +105,7 @@ describe('packing matches bytes generated with cbor2 5.9.0, the version core pin
   it('reproduces an initial subasset issuance, flags as ints and the longname compacted', () => {
     const packed = packComposeMessage(
       'issuance',
-      { asset: 'JPJA.HELLOKITTY', quantity: 1000, divisible: false, description: 'a subasset' },
+      { asset: 'JPJA.HELLOKITTY', quantity: asBaseUnits(1000), divisible: false, description: 'a subasset' },
       { messageTypeId: 23, assetId: 95428956661682177n }
     );
 
@@ -133,7 +134,7 @@ describe('packing matches bytes generated with cbor2 5.9.0, the version core pin
     const packed = packComposeMessage(
       'issuance',
       {
-        asset: 'LANDMARKS', quantity: 0, divisible: false,
+        asset: 'LANDMARKS', quantity: asBaseUnits(0), divisible: false,
         transfer_destination: TAPROOT_DESTINATION,
       }
     );
@@ -231,7 +232,7 @@ describe('packing matches bytes generated with core\'s MPMA encoder', () => {
     const packed = packComposeMessage('send', {
       asset: 'XCP',
       destinations: `${P2PKH_A},${P2WPKH}`,
-      quantity: 1,
+      quantity: asBaseUnits(1),
       memo: 'thanks',
     });
 
@@ -313,7 +314,7 @@ describe('borrowing only what the request cannot determine', () => {
     // back to field comparison for the whole transaction.
     const packed = packComposeMessage(
       'issuance',
-      { asset: 'LANDMARKS', quantity: 0, description: 'updated text' },
+      { asset: 'LANDMARKS', quantity: asBaseUnits(0), description: 'updated text' },
       { divisible: true }
     );
 
@@ -359,7 +360,7 @@ describe('borrowing only what the request cannot determine', () => {
     for (const assetId of [26n ** 12n, 1n << 64n, 1n]) {
       expect(packComposeMessage(
         'issuance',
-        { asset: 'JPJA.HELLOKITTY', quantity: 1000, divisible: false },
+        { asset: 'JPJA.HELLOKITTY', quantity: asBaseUnits(1000), divisible: false },
         { messageTypeId: 23, assetId }
       )).toBeNull();
     }
@@ -370,7 +371,7 @@ describe('borrowing only what the request cannot determine', () => {
     // rewrote the description has to produce different bytes.
     const packed = packComposeMessage(
       'issuance',
-      { asset: 'LANDMARKS', quantity: 0, description: 'what the user wrote' },
+      { asset: 'LANDMARKS', quantity: asBaseUnits(0), description: 'what the user wrote' },
       { divisible: true, description: 'what the API substituted' }
     );
 
@@ -386,16 +387,16 @@ describe('refusing to pack is not the same as agreeing', () => {
   // Each of these must return null so the caller reports "cannot verify by equality" rather than
   // treating an unpackable request as verified.
   it.each([
-    ['an unsupported compose type', 'attach', { asset: 'XCP', quantity: 1 }],
-    ['a multi-destination send', 'send', { asset: 'XCP', destination: 'bc1qa,bc1qb', quantity: 1 }],
+    ['an unsupported compose type', 'attach', { asset: 'XCP', quantity: asBaseUnits(1) }],
+    ['a multi-destination send', 'send', { asset: 'XCP', destination: 'bc1qa,bc1qb', quantity: asBaseUnits(1) }],
     ['a hex memo, which core encodes differently', 'send', {
-      asset: 'XCP', destination: TAPROOT_DESTINATION, quantity: 1, memo: 'ff00', memo_is_hex: true,
+      asset: 'XCP', destination: TAPROOT_DESTINATION, quantity: asBaseUnits(1), memo: 'ff00', memo_is_hex: true,
     }],
     ['a BTC "send", which is not a Counterparty message', 'send', {
-      asset: 'BTC', destination: TAPROOT_DESTINATION, quantity: 1,
+      asset: 'BTC', destination: TAPROOT_DESTINATION, quantity: asBaseUnits(1),
     }],
     ['a subasset issuance with no composed message to borrow the asset id from', 'issuance', {
-      asset: 'PARENT.child', quantity: 1, divisible: false,
+      asset: 'PARENT.child', quantity: asBaseUnits(1), divisible: false,
     }],
     ['a broadcast with no timestamp and no composed message to borrow one from', 'broadcast', {
       text: 'hello', value: 0, fee_fraction: 0,
@@ -458,10 +459,10 @@ describe('refusing to pack is not the same as agreeing', () => {
       quantities: '1,2',
     }],
     ['a reissuance with no observed message to borrow divisibility from', 'issuance', {
-      asset: 'LANDMARKS', quantity: 0, description: 'new text',
+      asset: 'LANDMARKS', quantity: asBaseUnits(0), description: 'new text',
     }],
     ['a quantity that is not whole base units', 'send', {
-      asset: 'XCP', destination: TAPROOT_DESTINATION, quantity: '1.5',
+      asset: 'XCP', destination: TAPROOT_DESTINATION, quantity: asBaseUnits('1.5'),
     }],
   ])('returns null for %s', (_label, composeType, params) => {
     expect(packComposeMessage(composeType, params as Record<string, unknown>)).toBeNull();
@@ -474,7 +475,7 @@ describe('refusing to pack is not the same as agreeing', () => {
     // beyond any local check, and declining never changed that.
     const packed = packComposeMessage(
       'issuance',
-      { asset: 'JPJA.HELLOKITTY', quantity: 1000, divisible: false, lock: true },
+      { asset: 'JPJA.HELLOKITTY', quantity: asBaseUnits(1000), divisible: false, lock: true },
       { messageTypeId: 23, assetId: 95428956661682177n }
     );
 
@@ -492,7 +493,7 @@ describe('subasset reissuance borrows the ledger-resolved asset id', () => {
     // standard layout; the id is borrowed, and every field the user authored is byte-compared.
     const packed = packComposeMessage(
       'issuance',
-      { asset: 'PARENT.child', quantity: 0, description: 'updated text' },
+      { asset: 'PARENT.child', quantity: asBaseUnits(0), description: 'updated text' },
       { messageTypeId: 22, assetId: 95428956661682177n, divisible: true }
     );
 
@@ -507,7 +508,7 @@ describe('subasset reissuance borrows the ledger-resolved asset id', () => {
   it('still compares the description against what the user wrote', () => {
     const packed = packComposeMessage(
       'issuance',
-      { asset: 'PARENT.child', quantity: 0, description: 'what the user wrote' },
+      { asset: 'PARENT.child', quantity: asBaseUnits(0), description: 'what the user wrote' },
       { messageTypeId: 22, assetId: 95428956661682177n, divisible: true, description: 'substituted' }
     );
 

--- a/src/core/counterparty/pool.ts
+++ b/src/core/counterparty/pool.ts
@@ -1,5 +1,5 @@
 import type { PoolPosition } from "@/core/counterparty/api";
-import { BigNumber, fromSatoshis, toBigNumber } from "@/core/numeric";
+import { asDisplayUnits, BigNumber, fromSatoshis, toBigNumber } from '@/core/numeric';
 
 /**
  * verbose=true does not normalize the LP `quantity` on the address pools
@@ -17,7 +17,7 @@ export function normalizePoolPosition(position: PoolPosition): PoolPosition {
   const divisible = lpAssetInfo?.divisible ?? true;
   return {
     ...position,
-    quantity_normalized: divisible ? fromSatoshis(position.quantity) : String(position.quantity),
+    quantity_normalized: asDisplayUnits(divisible ? fromSatoshis(position.quantity) : String(position.quantity)),
   };
 }
 

--- a/src/core/counterparty/unpack/__tests__/cbor-messages.test.ts
+++ b/src/core/counterparty/unpack/__tests__/cbor-messages.test.ts
@@ -13,6 +13,7 @@
 
 import { base58 } from '@scure/base';
 import { describe, expect, it } from 'vitest';
+import { asBaseUnits } from '@/core/numeric';
 import { packAddress, unpackAddress } from '../address';
 import { assetNameToId } from '../assetId';
 import { decodeCbor } from '../cbor';
@@ -276,7 +277,7 @@ describe('verifyTransaction over CBOR messages', () => {
     const result = verifyTransaction(message, 'send', {
       destination: DESTINATION,
       asset: 'XCP',
-      quantity: 50000000000,
+      quantity: asBaseUnits(50000000000),
     });
     expect(result.criticalMismatches).toEqual([]);
     expect(result.errors).toEqual([]);
@@ -291,7 +292,7 @@ describe('verifyTransaction over CBOR messages', () => {
 
     const result = verifyTransaction(message, 'issuance', {
       asset: 'LANDMARKS',
-      quantity: 21,
+      quantity: asBaseUnits(21),
       divisible: false,
     });
     expect(result.criticalMismatches).toEqual([]);
@@ -306,7 +307,7 @@ describe('verifyTransaction over CBOR messages', () => {
     const payload = payloadOf([assetNameToId('LANDMARKS'), 0n, false, true, false, '', null]);
     const message = new Uint8Array([...CNTRPRTY, 22, ...payload]);
 
-    const result = verifyTransaction(message, 'issuance', { asset: 'LANDMARKS', quantity: 0 });
+    const result = verifyTransaction(message, 'issuance', { asset: 'LANDMARKS', quantity: asBaseUnits(0) });
     expect(result.valid).toBe(false);
     expect(result.dangerousMismatches.some((m) => m.field === 'lock')).toBe(true);
   });
@@ -315,7 +316,7 @@ describe('verifyTransaction over CBOR messages', () => {
     const payload = payloadOf([assetNameToId('LANDMARKS'), 0n, false, false, true, '', null]);
     const message = new Uint8Array([...CNTRPRTY, 22, ...payload]);
 
-    const result = verifyTransaction(message, 'issuance', { asset: 'LANDMARKS', quantity: 0 });
+    const result = verifyTransaction(message, 'issuance', { asset: 'LANDMARKS', quantity: asBaseUnits(0) });
     expect(result.valid).toBe(false);
     expect(result.dangerousMismatches.some((m) => m.field === 'reset')).toBe(true);
   });
@@ -329,7 +330,7 @@ describe('verifyTransaction over CBOR messages', () => {
 
     const result = verifyTransaction(message, 'issuance', {
       asset: 'LANDMARKS',
-      quantity: 21,
+      quantity: asBaseUnits(21),
       divisible: 'false',
     });
     expect(result.valid).toBe(false);
@@ -342,7 +343,7 @@ describe('verifyTransaction over CBOR messages', () => {
 
     const result = verifyTransaction(message, 'issuance', {
       asset: 'LANDMARKS',
-      quantity: 21,
+      quantity: asBaseUnits(21),
       divisible: 'true',
     });
     expect(result.valid).toBe(true);
@@ -354,7 +355,7 @@ describe('verifyTransaction over CBOR messages', () => {
     const payload = payloadOf([assetNameToId('LANDMARKS'), 21n, false, false, false, '', null]);
     const message = new Uint8Array([...CNTRPRTY, 22, ...payload]);
 
-    const result = verifyTransaction(message, 'issuance', { asset: 'LANDMARKS', quantity: 21 });
+    const result = verifyTransaction(message, 'issuance', { asset: 'LANDMARKS', quantity: asBaseUnits(21) });
     expect(result.valid).toBe(true);
   });
 
@@ -368,7 +369,7 @@ describe('verifyTransaction over CBOR messages', () => {
     const result = verifyTransaction(message, 'send', {
       destination: DESTINATION,
       asset: 'XCP',
-      quantity: 50000000000,
+      quantity: asBaseUnits(50000000000),
       memo: '',
     });
     expect(result.valid).toBe(true);
@@ -384,7 +385,7 @@ describe('verifyTransaction over CBOR messages', () => {
     const result = verifyTransaction(message, 'send', {
       destination: DESTINATION,
       asset: 'XCP',
-      quantity: 50000000000,
+      quantity: asBaseUnits(50000000000),
       memo: '',
     });
     expect(result.infoMismatches.some((m) => m.field === 'memo')).toBe(true);
@@ -398,7 +399,7 @@ describe('verifyTransaction over CBOR messages', () => {
     const result = verifyTransaction(message, 'send', {
       destination: DESTINATION,
       asset: 'XCP',
-      quantity: 50000000000,
+      quantity: asBaseUnits(50000000000),
     });
     expect(result.valid).toBe(false);
     expect(result.criticalMismatches.some((m) => m.field === 'destination')).toBe(true);

--- a/src/core/counterparty/unpack/__tests__/integration.test.ts
+++ b/src/core/counterparty/unpack/__tests__/integration.test.ts
@@ -1,3 +1,4 @@
+import { asBaseUnits } from '@/core/numeric';
 /**
  * Integration Tests for Counterparty Message Unpacking
  *
@@ -92,7 +93,7 @@ describe.skip('Integration: Counterparty API Compose & Unpack', () => {
         source: TEST_SOURCE,
         destination: TEST_DEST,
         asset: 'XCP',
-        quantity: 100000000, // 1 XCP
+        quantity: asBaseUnits(100000000), // 1 XCP
       });
 
       if (!result) {
@@ -115,7 +116,7 @@ describe.skip('Integration: Counterparty API Compose & Unpack', () => {
         type: 'enhanced_send',
         params: {
           asset: 'XCP',
-          quantity: 100000000,
+          quantity: asBaseUnits(100000000),
           destination: TEST_DEST,
         },
       });
@@ -129,7 +130,7 @@ describe.skip('Integration: Counterparty API Compose & Unpack', () => {
         source: TEST_SOURCE,
         destination: TEST_DEST,
         asset: 'XCP',
-        quantity: 100000000, // 1 XCP
+        quantity: asBaseUnits(100000000), // 1 XCP
       });
 
       if (!result) {
@@ -144,7 +145,7 @@ describe.skip('Integration: Counterparty API Compose & Unpack', () => {
         type: 'enhanced_send',
         params: {
           asset: 'XCP',
-          quantity: 200000000, // WRONG! Should be 100000000
+          quantity: asBaseUnits(200000000), // WRONG! Should be 100000000
           destination: TEST_DEST,
         },
       });
@@ -159,9 +160,9 @@ describe.skip('Integration: Counterparty API Compose & Unpack', () => {
       const result = await composeTransaction('order', {
         source: TEST_SOURCE,
         give_asset: 'XCP',
-        give_quantity: 100000000, // 1 XCP
+        give_quantity: asBaseUnits(100000000), // 1 XCP
         get_asset: 'BTC',
-        get_quantity: 10000000, // 0.1 BTC
+        get_quantity: asBaseUnits(10000000), // 0.1 BTC
         expiration: 100,
       });
 
@@ -188,9 +189,9 @@ describe.skip('Integration: Counterparty API Compose & Unpack', () => {
         type: 'order',
         params: {
           give_asset: 'XCP',
-          give_quantity: 100000000,
+          give_quantity: asBaseUnits(100000000),
           get_asset: 'BTC',
-          get_quantity: 10000000,
+          get_quantity: asBaseUnits(10000000),
           expiration: 100,
         },
       });
@@ -204,8 +205,8 @@ describe.skip('Integration: Counterparty API Compose & Unpack', () => {
       const result = await composeTransaction('dispenser', {
         source: TEST_SOURCE,
         asset: 'XCP',
-        give_quantity: 10000000, // 0.1 XCP per dispense
-        escrow_quantity: 100000000, // 1 XCP total
+        give_quantity: asBaseUnits(10000000), // 0.1 XCP per dispense
+        escrow_quantity: asBaseUnits(100000000), // 1 XCP total
         mainchainrate: 100000, // 100,000 sats per dispense
         status: 0, // Open
       });
@@ -233,8 +234,8 @@ describe.skip('Integration: Counterparty API Compose & Unpack', () => {
         type: 'dispenser',
         params: {
           asset: 'XCP',
-          give_quantity: 10000000,
-          escrow_quantity: 100000000,
+          give_quantity: asBaseUnits(10000000),
+          escrow_quantity: asBaseUnits(100000000),
           mainchainrate: 100000,
           status: 0,
         },
@@ -285,7 +286,7 @@ describe.skip('Integration: Counterparty API Compose & Unpack', () => {
       const result = await composeTransaction('destroy', {
         source: TEST_SOURCE,
         asset: 'XCP',
-        quantity: 10000000, // 0.1 XCP
+        quantity: asBaseUnits(10000000), // 0.1 XCP
         tag: 'test burn',
       });
 
@@ -309,7 +310,7 @@ describe.skip('Integration: Counterparty API Compose & Unpack', () => {
         type: 'destroy',
         params: {
           asset: 'XCP',
-          quantity: 10000000,
+          quantity: asBaseUnits(10000000),
         },
       });
 
@@ -364,7 +365,7 @@ describe.skip('Integration: Counterparty API Compose & Unpack', () => {
       const result = await composeTransaction('issuance', {
         source: TEST_SOURCE,
         asset: assetName,
-        quantity: 1000000000, // 10 units (divisible)
+        quantity: asBaseUnits(1000000000), // 10 units (divisible)
         divisible: true,
         description: 'Test asset',
       });

--- a/src/core/counterparty/unpack/__tests__/optional-field-guards.test.ts
+++ b/src/core/counterparty/unpack/__tests__/optional-field-guards.test.ts
@@ -12,6 +12,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
+import { asBaseUnits } from '@/core/numeric';
 import { packAddress } from '../address';
 import { hexToBytes } from '../binary';
 import { COUNTERPARTY_PREFIX_HEX } from '../messageTypes';
@@ -50,8 +51,8 @@ function dispenserMessage(
 /** What the dispenser form submits: no status, no open address, no oracle. */
 const OPEN_DISPENSER_REQUEST = {
   asset: 'XCP',
-  give_quantity: 1000,
-  escrow_quantity: 10000,
+  give_quantity: asBaseUnits(1000),
+  escrow_quantity: asBaseUnits(10000),
   mainchainrate: 500,
 };
 
@@ -106,8 +107,8 @@ describe('dispenser fields the request leaves out', () => {
     // compares normally rather than against the omitted-field default.
     const result = verifyTransaction(dispenserMessage({ status: 10 }), 'dispenser', {
       ...OPEN_DISPENSER_REQUEST,
-      give_quantity: 0,
-      escrow_quantity: 0,
+      give_quantity: asBaseUnits(0),
+      escrow_quantity: asBaseUnits(0),
       mainchainrate: 0,
       status: '10',
     });

--- a/src/core/counterparty/unpack/__tests__/providerVerify.test.ts
+++ b/src/core/counterparty/unpack/__tests__/providerVerify.test.ts
@@ -1,3 +1,4 @@
+import { asBaseUnits } from '@/core/numeric';
 /**
  * Tests for Provider Transaction Verification
  *
@@ -93,7 +94,7 @@ describe('verifyProviderTransaction', () => {
       const apiMessage: ApiCounterpartyMessage = {
         messageType: 'enhanced_send',
         messageTypeId: MessageTypeId.ENHANCED_SEND,
-        messageData: { asset: 'XCP', quantity: 1000 },
+        messageData: { asset: 'XCP', quantity: asBaseUnits(1000) },
         description: 'send',
       };
 
@@ -142,7 +143,7 @@ describe('verifyProviderTransaction', () => {
         messageType: 'mpma_send',
         messageTypeId: 3,
         messageData: {
-          sends: [{ asset: 'XCP', destination: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa', quantity: 1000 }],
+          sends: [{ asset: 'XCP', destination: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa', quantity: asBaseUnits(1000) }],
         } as unknown as Record<string, unknown>,
         description: 'Counterparty mpma_send transaction',
       });
@@ -163,9 +164,9 @@ describe('verifyProviderTransaction', () => {
         messageTypeId: 3,
         messageData: {
           sends: [
-            { asset: 'XCP', destination: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa', quantity: 1000 },
+            { asset: 'XCP', destination: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa', quantity: asBaseUnits(1000) },
             // Quantity altered: a full-length reply is still checked, so this must be caught.
-            { asset: 'XCP', destination: '1CounterpartyXXXXXXXXXXXXXXXUWLpVr', quantity: 9999 },
+            { asset: 'XCP', destination: '1CounterpartyXXXXXXXXXXXXXXXUWLpVr', quantity: asBaseUnits(9999) },
           ],
         } as unknown as Record<string, unknown>,
         description: 'Counterparty mpma_send transaction',
@@ -185,7 +186,7 @@ describe('verifyProviderTransaction', () => {
       const apiMessage: ApiCounterpartyMessage = {
         messageType: 'order', // wrong type
         messageTypeId: MessageTypeId.ENHANCED_SEND,
-        messageData: { asset: 'XCP', quantity: 1000 },
+        messageData: { asset: 'XCP', quantity: asBaseUnits(1000) },
         description: '',
       };
 
@@ -201,7 +202,7 @@ describe('verifyProviderTransaction', () => {
       const apiMessage: ApiCounterpartyMessage = {
         messageType: 'enhanced_send',
         messageTypeId: 99, // wrong ID
-        messageData: { asset: 'XCP', quantity: 1000 },
+        messageData: { asset: 'XCP', quantity: asBaseUnits(1000) },
         description: '',
       };
 
@@ -225,7 +226,7 @@ describe('verifyProviderTransaction', () => {
         messageTypeId: MessageTypeId.ENHANCED_SEND,
         messageData: {
           asset: 'XCP',
-          quantity: 1000,
+          quantity: asBaseUnits(1000),
           destination: TEST_ADDR,
           ...overrides,
         },
@@ -251,7 +252,7 @@ describe('verifyProviderTransaction', () => {
 
     it('detects quantity mismatch', () => {
       const data = makeEnhancedSend(XCP_ID, 1000n, TEST_HASH);
-      const api = makeApiMessage({ quantity: 9999 });
+      const api = makeApiMessage({ quantity: asBaseUnits(9999) });
       const result = verifyProviderTransaction(data, api);
       expect(result.passed).toBe(false);
       expect(result.mismatches.some(m => m.includes('Quantity'))).toBe(true);
@@ -267,7 +268,7 @@ describe('verifyProviderTransaction', () => {
 
     it('handles quantity as string in API data', () => {
       const data = makeEnhancedSend(XCP_ID, 1000n, TEST_HASH);
-      const api = makeApiMessage({ quantity: '1000' });
+      const api = makeApiMessage({ quantity: asBaseUnits('1000') });
       const result = verifyProviderTransaction(data, api);
       expect(result.passed).toBe(true);
     });
@@ -311,9 +312,9 @@ describe('verifyProviderTransaction', () => {
         messageTypeId: MessageTypeId.ORDER,
         messageData: {
           give_asset: 'XCP',
-          give_quantity: 50000,
+          give_quantity: asBaseUnits(50000),
           get_asset: 'BTC',
-          get_quantity: 100000,
+          get_quantity: asBaseUnits(100000),
           expiration: 100,
           ...overrides,
         },
@@ -339,7 +340,7 @@ describe('verifyProviderTransaction', () => {
 
     it('detects give_quantity mismatch', () => {
       const data = makeOrder(XCP_ID, 50000n, 0n, 100000n, 100);
-      const api = makeOrderApi({ give_quantity: 99999 });
+      const api = makeOrderApi({ give_quantity: asBaseUnits(99999) });
       const result = verifyProviderTransaction(data, api);
       expect(result.passed).toBe(false);
       expect(result.mismatches.some(m => m.includes('Give quantity'))).toBe(true);
@@ -355,7 +356,7 @@ describe('verifyProviderTransaction', () => {
 
     it('detects get_quantity mismatch', () => {
       const data = makeOrder(XCP_ID, 50000n, 0n, 100000n, 100);
-      const api = makeOrderApi({ get_quantity: 1 });
+      const api = makeOrderApi({ get_quantity: asBaseUnits(1) });
       const result = verifyProviderTransaction(data, api);
       expect(result.passed).toBe(false);
       expect(result.mismatches.some(m => m.includes('Get quantity'))).toBe(true);
@@ -460,7 +461,7 @@ describe('verifyProviderTransaction', () => {
       const api: ApiCounterpartyMessage = {
         messageType: 'destroy',
         messageTypeId: MessageTypeId.DESTROY,
-        messageData: { asset: 'XCP', quantity: 5000 },
+        messageData: { asset: 'XCP', quantity: asBaseUnits(5000) },
         description: '',
       };
       const result = verifyProviderTransaction(data, api);
@@ -472,7 +473,7 @@ describe('verifyProviderTransaction', () => {
       const api: ApiCounterpartyMessage = {
         messageType: 'destroy',
         messageTypeId: MessageTypeId.DESTROY,
-        messageData: { asset: 'PEPECASH', quantity: 5000 },
+        messageData: { asset: 'PEPECASH', quantity: asBaseUnits(5000) },
         description: '',
       };
       const result = verifyProviderTransaction(data, api);
@@ -485,7 +486,7 @@ describe('verifyProviderTransaction', () => {
       const api: ApiCounterpartyMessage = {
         messageType: 'destroy',
         messageTypeId: MessageTypeId.DESTROY,
-        messageData: { asset: 'XCP', quantity: 1 },
+        messageData: { asset: 'XCP', quantity: asBaseUnits(1) },
         description: '',
       };
       const result = verifyProviderTransaction(data, api);
@@ -608,8 +609,8 @@ describe('verifyProviderTransaction', () => {
         messageTypeId: MessageTypeId.DISPENSER,
         messageData: {
           asset: 'XCP',
-          give_quantity: 100,
-          escrow_quantity: 1000,
+          give_quantity: asBaseUnits(100),
+          escrow_quantity: asBaseUnits(1000),
           mainchainrate: 50000,
         },
         description: '',
@@ -625,8 +626,8 @@ describe('verifyProviderTransaction', () => {
         messageTypeId: MessageTypeId.DISPENSER,
         messageData: {
           asset: 'XCP',
-          give_quantity: 999,
-          escrow_quantity: 1000,
+          give_quantity: asBaseUnits(999),
+          escrow_quantity: asBaseUnits(1000),
           mainchainrate: 50000,
         },
         description: '',
@@ -643,8 +644,8 @@ describe('verifyProviderTransaction', () => {
         messageTypeId: MessageTypeId.DISPENSER,
         messageData: {
           asset: 'XCP',
-          give_quantity: 100,
-          escrow_quantity: 5555,
+          give_quantity: asBaseUnits(100),
+          escrow_quantity: asBaseUnits(5555),
           mainchainrate: 50000,
         },
         description: '',
@@ -661,8 +662,8 @@ describe('verifyProviderTransaction', () => {
         messageTypeId: MessageTypeId.DISPENSER,
         messageData: {
           asset: 'XCP',
-          give_quantity: 100,
-          escrow_quantity: 1000,
+          give_quantity: asBaseUnits(100),
+          escrow_quantity: asBaseUnits(1000),
           mainchainrate: 1,
         },
         description: '',
@@ -696,7 +697,7 @@ describe('verifyProviderTransaction', () => {
         messageTypeId: MessageTypeId.ISSUANCE,
         messageData: {
           asset: 'XCP',
-          quantity: 100000,
+          quantity: asBaseUnits(100000),
           divisible: true,
         },
         description: '',
@@ -712,7 +713,7 @@ describe('verifyProviderTransaction', () => {
         messageTypeId: MessageTypeId.ISSUANCE,
         messageData: {
           asset: 'XCP',
-          quantity: 999999,
+          quantity: asBaseUnits(999999),
           divisible: true,
         },
         description: '',
@@ -729,7 +730,7 @@ describe('verifyProviderTransaction', () => {
         messageTypeId: MessageTypeId.ISSUANCE,
         messageData: {
           asset: 'XCP',
-          quantity: 100000,
+          quantity: asBaseUnits(100000),
           divisible: true,
         },
         description: '',
@@ -756,7 +757,7 @@ describe('verifyProviderTransaction', () => {
         messageTypeId: MessageTypeId.DIVIDEND,
         messageData: {
           asset: 'XCP',
-          quantity_per_unit: 500,
+          quantity_per_unit: asBaseUnits(500),
           dividend_asset: 'BTC',
         },
         description: '',
@@ -772,7 +773,7 @@ describe('verifyProviderTransaction', () => {
         messageTypeId: MessageTypeId.DIVIDEND,
         messageData: {
           asset: 'XCP',
-          quantity_per_unit: 999,
+          quantity_per_unit: asBaseUnits(999),
           dividend_asset: 'BTC',
         },
         description: '',
@@ -789,7 +790,7 @@ describe('verifyProviderTransaction', () => {
         messageTypeId: MessageTypeId.DIVIDEND,
         messageData: {
           asset: 'XCP',
-          quantity_per_unit: 500,
+          quantity_per_unit: asBaseUnits(500),
           dividend_asset: 'XCP', // wrong, should be BTC
         },
         description: '',
@@ -891,7 +892,7 @@ describe('verifyProviderTransaction', () => {
       const api: ApiCounterpartyMessage = {
         messageType: 'fairmint',
         messageTypeId: MessageTypeId.FAIRMINT,
-        messageData: { asset: 'XCP', quantity: 1000 },
+        messageData: { asset: 'XCP', quantity: asBaseUnits(1000) },
         description: '',
       };
       const result = verifyProviderTransaction(data, api);
@@ -903,7 +904,7 @@ describe('verifyProviderTransaction', () => {
       const api: ApiCounterpartyMessage = {
         messageType: 'fairmint',
         messageTypeId: MessageTypeId.FAIRMINT,
-        messageData: { asset: 'XCP', quantity: 9999 },
+        messageData: { asset: 'XCP', quantity: asBaseUnits(9999) },
         description: '',
       };
       const result = verifyProviderTransaction(data, api);
@@ -927,7 +928,7 @@ describe('verifyProviderTransaction', () => {
       const api: ApiCounterpartyMessage = {
         messageType: 'send',
         messageTypeId: MessageTypeId.SEND,
-        messageData: { asset: 'XCP', quantity: 2000 },
+        messageData: { asset: 'XCP', quantity: asBaseUnits(2000) },
         description: '',
       };
       const result = verifyProviderTransaction(data, api);
@@ -942,7 +943,7 @@ describe('verifyProviderTransaction', () => {
       const api: ApiCounterpartyMessage = {
         messageType: 'send',
         messageTypeId: MessageTypeId.SEND,
-        messageData: { asset: 'PEPECASH', quantity: 2000 },
+        messageData: { asset: 'PEPECASH', quantity: asBaseUnits(2000) },
         description: '',
       };
       const result = verifyProviderTransaction(data, api);
@@ -961,7 +962,7 @@ describe('verifyProviderTransaction', () => {
         messageTypeId: MessageTypeId.ENHANCED_SEND,
         messageData: {
           asset: 'WRONG',
-          quantity: 9999,
+          quantity: asBaseUnits(9999),
           destination: TEST_ADDR2,
         },
         description: '',

--- a/src/core/counterparty/unpack/__tests__/verifyTypes.test.ts
+++ b/src/core/counterparty/unpack/__tests__/verifyTypes.test.ts
@@ -6,6 +6,7 @@
  * API field names that normalizeFormData produces.
  */
 import { describe, expect, it } from 'vitest';
+import { asBaseUnits } from '@/core/numeric';
 import { COUNTERPARTY_PREFIX_HEX } from '../messageTypes';
 import { verifyTransaction } from '../verify';
 
@@ -42,13 +43,13 @@ describe('verifyTransaction activation per type', () => {
     const message = PREFIX + '6e' + u64(1n) + u64(100000000n); // type 110, XCP, 1 XCP
 
     it('accepts the true intent', () => {
-      const r = verifyTransaction(message, 'destroy', { asset: 'XCP', quantity: 100000000 });
+      const r = verifyTransaction(message, 'destroy', { asset: 'XCP', quantity: asBaseUnits(100000000) });
       expect(r.errors).toHaveLength(0);
       expect(r.valid).toBe(true);
     });
 
     it('rejects a tampered quantity', () => {
-      const r = verifyTransaction(message, 'destroy', { asset: 'XCP', quantity: 999 });
+      const r = verifyTransaction(message, 'destroy', { asset: 'XCP', quantity: asBaseUnits(999) });
       expect(r.valid).toBe(false);
     });
   });
@@ -62,7 +63,7 @@ describe('verifyTransaction activation per type', () => {
     // The half that costs security: two unreadable values compared equal and certified each
     // other, so a tampered message passed as verified.
     it('does not let an unreadable request certify a message', () => {
-      const r = verifyTransaction(message, 'destroy', { asset: 'XCP', quantity: 'not-a-number' });
+      const r = verifyTransaction(message, 'destroy', { asset: 'XCP', quantity: asBaseUnits('not-a-number') });
       expect(r.valid).toBe(false);
       expect(r.criticalMismatches.some((m) => m.field === 'quantity')).toBe(true);
     });
@@ -70,13 +71,13 @@ describe('verifyTransaction activation per type', () => {
     it('does not treat an unreadable value as zero', () => {
       // Against a message carrying zero, the old sentinel made these compare equal.
       const zeroMessage = PREFIX + '6e' + u64(1n) + u64(0n);
-      const r = verifyTransaction(zeroMessage, 'destroy', { asset: 'XCP', quantity: '1.5' });
+      const r = verifyTransaction(zeroMessage, 'destroy', { asset: 'XCP', quantity: asBaseUnits('1.5') });
       expect(r.valid).toBe(false);
     });
 
     // The other half: a readable request must still verify normally, in either spelling.
     it('still accepts a quantity given as a numeric string', () => {
-      const r = verifyTransaction(message, 'destroy', { asset: 'XCP', quantity: '100000000' });
+      const r = verifyTransaction(message, 'destroy', { asset: 'XCP', quantity: asBaseUnits('100000000') });
       expect(r.errors).toHaveLength(0);
       expect(r.valid).toBe(true);
     });
@@ -87,8 +88,8 @@ describe('verifyTransaction activation per type', () => {
     const message = PREFIX + '0c' + u64(1n) + u64(100n) + u64(1000n) + u64(1000000n) + '00';
     const intent = {
       asset: 'XCP',
-      give_quantity: 100,
-      escrow_quantity: 1000,
+      give_quantity: asBaseUnits(100),
+      escrow_quantity: asBaseUnits(1000),
       mainchainrate: 1000000,
       status: 0,
     };

--- a/src/core/counterparty/unpack/providerVerify.ts
+++ b/src/core/counterparty/unpack/providerVerify.ts
@@ -97,8 +97,24 @@ function quantitiesEqual(a: unknown, b: unknown): boolean {
  * Compare two asset names (case-insensitive)
  */
 function assetsEqual(a: string | undefined, b: string | undefined): boolean {
-  if (!a || !b) return false;
-  return a.toUpperCase() === b.toUpperCase();
+  if (!a) return false;
+  if (b === undefined || b === null) return false;
+
+  // Core resolves an asset name through a ledger lookup, and `get_asset_name` returns 0 for an
+  // asset the node does not know (ledger/issuances.py). That is an absence of information, not a
+  // disagreement — 0 is not a valid asset name and cannot be what the bytes say. Treating it as a
+  // mismatch blocked signing on the state of a node's index rather than on the transaction: an
+  // order, destroy or dividend naming an asset the queried node had not indexed reported
+  // tampering. Same shape as the rounding-induced false block fixed earlier — an API limitation
+  // rendered as an accusation.
+  //
+  // Checked before the falsy guard and stringified, because the endpoint serializes the marker as
+  // the NUMBER 0: it is falsy, so a guard placed after `!b` never sees it, and this parameter is
+  // typed string but is not always one at runtime. Both facts found by the differential fuzzer.
+  if (String(b) === '0') return true;
+
+  if (!b) return false;
+  return a.toUpperCase() === String(b).toUpperCase();
 }
 
 /**

--- a/src/core/numeric.ts
+++ b/src/core/numeric.ts
@@ -18,6 +18,43 @@ BigNumber.config({
   },
 });
 
+// =============================================================================
+// UNIT BRANDS
+// =============================================================================
+
+declare const BaseUnitsBrand: unique symbol;
+declare const DisplayUnitsBrand: unique symbol;
+
+/**
+ * An integer count of an asset's smallest unit — what the protocol stores and what a signature
+ * commits to. For a divisible asset this is 1e8 times the number a person would say.
+ *
+ * Branded so it cannot be silently swapped with {@link DisplayUnits}. The two are the same
+ * JavaScript values and differ by a factor of 1e8, which made every confusion between them a
+ * plausible-looking wrong number rather than a type error — a fairminter price sold for a
+ * hundred-millionth of its intended value, a pool deposit shown as 150,000,000 XCP instead of 1.5.
+ *
+ * Values above 2^53-1 arrive as strings so no digits are lost (see core/api/losslessJson.ts),
+ * which is why the underlying type is a union rather than number.
+ */
+export type BaseUnits = (string | number) & { readonly [BaseUnitsBrand]: true };
+
+/** A human-facing decimal, already divided by the asset's divisibility. Never arithmetic input. */
+export type DisplayUnits = string & { readonly [DisplayUnitsBrand]: true };
+
+/**
+ * Assert that a value is already in base units.
+ *
+ * The only way to produce a {@link BaseUnits}, so every entry point is greppable. Use it at a
+ * boundary where the protocol defines the unit — an API response field, a decoded payload — never
+ * to quiet a type error on a value whose unit you are unsure of.
+ */
+export const asBaseUnits = (value: string | number | bigint): BaseUnits =>
+  (typeof value === 'bigint' ? value.toString() : value) as BaseUnits;
+
+/** Assert that a value is already in display units. Same discipline as {@link asBaseUnits}. */
+export const asDisplayUnits = (value: string): DisplayUnits => value as DisplayUnits;
+
 /**
  * Creates a BigNumber instance from a value, safely handling string conversion
  * to prevent precision loss.

--- a/src/core/validation/__tests__/assetOwner.test.ts
+++ b/src/core/validation/__tests__/assetOwner.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as counterpartyApi from '@/core/counterparty/api';
+import { asDisplayUnits } from '@/core/numeric';
 import { 
   looksLikeAssetName, 
   lookupAssetOwner, 
@@ -100,7 +101,7 @@ describe('Asset Owner Validation', () => {
         issuer: '19QWXpMXeLkoEKEJv2xo9rn8wkPCyxACSX',
         divisible: true,
         locked: false,
-        supply_normalized: '1000000000'
+        supply_normalized: asDisplayUnits('1000000000')
       };
 
       mockFetchAssetDetails.mockResolvedValue(mockAssetInfo);
@@ -120,7 +121,7 @@ describe('Asset Owner Validation', () => {
         issuer: '19QWXpMXeLkoEKEJv2xo9rn8wkPCyxACSX',
         divisible: true,
         locked: false,
-        supply_normalized: '1000000000'
+        supply_normalized: asDisplayUnits('1000000000')
       };
 
       mockFetchAssetDetails.mockResolvedValue(mockAssetInfo);
@@ -148,7 +149,7 @@ describe('Asset Owner Validation', () => {
         issuer: '',
         divisible: true,
         locked: false,
-        supply_normalized: '0'
+        supply_normalized: asDisplayUnits('0')
       };
 
       mockFetchAssetDetails.mockResolvedValue(mockAssetInfo);

--- a/src/hooks/__tests__/useAssetBalance.test.ts
+++ b/src/hooks/__tests__/useAssetBalance.test.ts
@@ -1,6 +1,7 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchBTCBalance } from '@/core/bitcoin/balance';
+import { asBaseUnits, asDisplayUnits } from '@/core/numeric';
 import { useAssetBalance } from '../useAssetBalance';
 import { fetchAssetDetailsAndBalance } from '../utils/fetchAssetData';
 
@@ -36,8 +37,8 @@ describe('useAssetBalance', () => {
     description: 'Counterparty',
     divisible: true,
     locked: false,
-    supply: '2648755.95200000',
-    supply_normalized: '2648755.95200000',
+    supply: asBaseUnits('2648755.95200000'),
+    supply_normalized: asDisplayUnits('2648755.95200000'),
     issuer: '',
     fair_minting: false,
   };
@@ -66,7 +67,7 @@ describe('useAssetBalance', () => {
 
   it('should fetch Counterparty asset balance successfully', async () => {
     vi.mocked(fetchAssetDetailsAndBalance).mockResolvedValue({
-      availableBalance: '1000.50000000',
+      availableBalance: asDisplayUnits('1000.50000000'),
       isDivisible: true,
       assetInfo: mockXCPAssetInfo
     });

--- a/src/hooks/__tests__/useAssetDetails.test.ts
+++ b/src/hooks/__tests__/useAssetDetails.test.ts
@@ -1,6 +1,7 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { type AssetInfo, fetchTokenUtxos } from '@/core/counterparty/api';
+import { asBaseUnits, asDisplayUnits } from '@/core/numeric';
 import { useAssetDetails } from '../useAssetDetails';
 import { fetchAssetDetailsAndBalance } from '../utils/fetchAssetData';
 
@@ -29,14 +30,14 @@ describe('useAssetDetails', () => {
     description: 'Rare Pepe Cash',
     divisible: true,
     locked: false,
-    supply: '10000000.00000000',
-    supply_normalized: '10000000.00000000'
+    supply: asBaseUnits('10000000.00000000'),
+    supply_normalized: asDisplayUnits('10000000.00000000')
   };
   
   const mockAssetDetails = {
     isDivisible: true,
     assetInfo: mockAssetInfo,
-    availableBalance: '10000000.00000000'
+    availableBalance: asDisplayUnits('10000000.00000000')
   };
 
   beforeEach(() => {
@@ -64,7 +65,7 @@ describe('useAssetDetails', () => {
     expect(fetchAssetDetailsAndBalance).toHaveBeenCalledWith('PEPECASH', 'bc1qtest123');
     expect(result.current.data).toEqual(expect.objectContaining({
       isDivisible: true,
-      availableBalance: '10000000.00000000'
+      availableBalance: asDisplayUnits('10000000.00000000')
     }));
     expect(result.current.error).toBeNull();
   });
@@ -105,12 +106,12 @@ describe('useAssetDetails', () => {
     const asset1 = { 
       isDivisible: true,
       assetInfo: { ...mockAssetInfo, asset: 'ASSET1' },
-      availableBalance: '100' 
+      availableBalance: asDisplayUnits('100') 
     };
     const asset2 = { 
       isDivisible: true,
       assetInfo: { ...mockAssetInfo, asset: 'ASSET2' },
-      availableBalance: '200' 
+      availableBalance: asDisplayUnits('200') 
     };
     
     // Set up mock to return different values for different calls
@@ -161,15 +162,15 @@ describe('useAssetDetails', () => {
 
     expect(result.current.data).toEqual(expect.objectContaining({
       isDivisible: true,
-      availableBalance: '1',
+      availableBalance: asDisplayUnits('1'),
       assetInfo: expect.objectContaining({
         asset: 'BTC',
         asset_longname: null,
         description: 'Bitcoin',
         divisible: true,
         locked: true,
-        supply: '2100000000000000',
-        supply_normalized: '21000000',
+        supply: asBaseUnits('2100000000000000'),
+        supply_normalized: asDisplayUnits('21000000'),
         issuer: '',
         fair_minting: false
       })
@@ -186,7 +187,7 @@ describe('useAssetDetails', () => {
     const assetWithLongname = {
       isDivisible: true,
       assetInfo: longnameAssetInfo,
-      availableBalance: '10000000.00000000'
+      availableBalance: asDisplayUnits('10000000.00000000')
     };
     vi.mocked(fetchAssetDetailsAndBalance).mockResolvedValue(assetWithLongname);
 
@@ -205,13 +206,13 @@ describe('useAssetDetails', () => {
       description: 'Rare Pepe Cash',
       divisible: false,
       locked: false,
-      supply: '1000',
-      supply_normalized: '1000'
+      supply: asBaseUnits('1000'),
+      supply_normalized: asDisplayUnits('1000')
     };
     const indivisibleAsset = {
       isDivisible: false,
       assetInfo: indivisibleAssetInfo,
-      availableBalance: '1000'
+      availableBalance: asDisplayUnits('1000')
     };
     vi.mocked(fetchAssetDetailsAndBalance).mockResolvedValue(indivisibleAsset);
 

--- a/src/hooks/__tests__/useAssetInfo.test.ts
+++ b/src/hooks/__tests__/useAssetInfo.test.ts
@@ -1,5 +1,6 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { asBaseUnits, asDisplayUnits } from '@/core/numeric';
 import { useAssetInfo } from '../useAssetInfo';
 import { fetchAssetDetailsAndBalance } from '../utils/fetchAssetData';
 
@@ -21,8 +22,8 @@ describe('useAssetInfo', () => {
     description: 'Bitcoin',
     divisible: true,
     locked: true,
-    supply: '2100000000000000',
-    supply_normalized: '21000000',
+    supply: asBaseUnits('2100000000000000'),
+    supply_normalized: asDisplayUnits('21000000'),
     issuer: '',
     fair_minting: false,
   };
@@ -33,8 +34,8 @@ describe('useAssetInfo', () => {
     description: 'Counterparty',
     divisible: true,
     locked: false,
-    supply: '2648755.95200000',
-    supply_normalized: '2648755.95200000',
+    supply: asBaseUnits('2648755.95200000'),
+    supply_normalized: asDisplayUnits('2648755.95200000'),
     issuer: 'bc1qissuer123',
     fair_minting: false,
   };
@@ -60,7 +61,7 @@ describe('useAssetInfo', () => {
 
   it('should fetch Counterparty asset info successfully', async () => {
     vi.mocked(fetchAssetDetailsAndBalance).mockResolvedValue({
-      availableBalance: '1000.50000000',
+      availableBalance: asDisplayUnits('1000.50000000'),
       isDivisible: true,
       assetInfo: mockXCPAssetInfo
     });
@@ -130,10 +131,10 @@ describe('useAssetInfo', () => {
 
     vi.mocked(fetchAssetDetailsAndBalance).mockImplementation(async (asset: string) => {
       if (asset === 'ASSET1') {
-        return { availableBalance: '100', isDivisible: true, assetInfo: asset1Info };
+        return { availableBalance: asDisplayUnits('100'), isDivisible: true, assetInfo: asset1Info };
       }
       if (asset === 'ASSET2') {
-        return { availableBalance: '200', isDivisible: true, assetInfo: asset2Info };
+        return { availableBalance: asDisplayUnits('200'), isDivisible: true, assetInfo: asset2Info };
       }
       throw new Error(`Unexpected asset: ${asset}`);
     });
@@ -184,7 +185,7 @@ describe('useAssetInfo', () => {
     };
 
     vi.mocked(fetchAssetDetailsAndBalance).mockResolvedValue({
-      availableBalance: '100.00000000',
+      availableBalance: asDisplayUnits('100.00000000'),
       isDivisible: true,
       assetInfo: longnameAssetInfo
     });
@@ -206,7 +207,7 @@ describe('useAssetInfo', () => {
     };
 
     vi.mocked(fetchAssetDetailsAndBalance).mockResolvedValue({
-      availableBalance: '5',
+      availableBalance: asDisplayUnits('5'),
       isDivisible: false,
       assetInfo: indivisibleAssetInfo
     });

--- a/src/hooks/__tests__/useAssetUtxos.test.ts
+++ b/src/hooks/__tests__/useAssetUtxos.test.ts
@@ -1,6 +1,7 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchTokenUtxos } from '@/core/counterparty/api';
+import { asDisplayUnits } from '@/core/numeric';
 import { useAssetUtxos } from '../useAssetUtxos';
 
 // Mock the blockchain utilities
@@ -18,12 +19,12 @@ describe('useAssetUtxos', () => {
     {
       asset: 'XCP',
       utxo: 'txid1:0',
-      quantity_normalized: '100.50000000'
+      quantity_normalized: asDisplayUnits('100.50000000')
     },
     {
       asset: 'XCP',
       utxo: 'txid2:1',
-      quantity_normalized: '250.25000000'
+      quantity_normalized: asDisplayUnits('250.25000000')
     }
   ];
 

--- a/src/hooks/__tests__/useLpAssetPool.test.ts
+++ b/src/hooks/__tests__/useLpAssetPool.test.ts
@@ -1,6 +1,7 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchAddressPoolByLpAsset } from '@/core/counterparty/api';
+import { asBaseUnits, asDisplayUnits } from '@/core/numeric';
 import { useLpAssetPool } from '../useLpAssetPool';
 
 const mocks = vi.hoisted(() => ({
@@ -25,8 +26,8 @@ const poolA = {
   reserve_a: 100000000,
   reserve_b: 200000000,
   lp_asset: 'A11111111111111111',
-  quantity: 100000000,
-  quantity_normalized: '1',
+  quantity: asBaseUnits(100000000),
+  quantity_normalized: asDisplayUnits('1'),
 };
 
 const poolB = {
@@ -35,8 +36,8 @@ const poolB = {
   reserve_a: 300000000,
   reserve_b: 400000000,
   lp_asset: 'A22222222222222222',
-  quantity: 200000000,
-  quantity_normalized: '2',
+  quantity: asBaseUnits(200000000),
+  quantity_normalized: asDisplayUnits('2'),
 };
 
 function deferred<T>() {

--- a/src/hooks/__tests__/useSearchQuery.test.ts
+++ b/src/hooks/__tests__/useSearchQuery.test.ts
@@ -1,5 +1,6 @@
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { asBaseUnits } from '@/core/numeric';
 import { useSearchQuery } from "../useSearchQuery";
 
 // Mock fetch
@@ -27,8 +28,8 @@ describe("useSearchQuery", () => {
   it("should search when query is set", async () => {
     const mockResults = {
       assets: [
-        { symbol: "XCP", supply: 2600000 },
-        { symbol: "PEPECASH", supply: 700000000 },
+        { symbol: "XCP", supply: asBaseUnits(2600000) },
+        { symbol: "PEPECASH", supply: asBaseUnits(700000000) },
       ],
     };
 
@@ -160,7 +161,7 @@ describe("useSearchQuery", () => {
 
   it("should clear results when query is cleared", async () => {
     const mockResults = {
-      assets: [{ symbol: "XCP", supply: 2600000 }],
+      assets: [{ symbol: "XCP", supply: asBaseUnits(2600000) }],
     };
 
     (global.fetch as any).mockResolvedValue({

--- a/src/hooks/useAssetBalance.ts
+++ b/src/hooks/useAssetBalance.ts
@@ -3,6 +3,7 @@ import { useHeader } from "@/contexts/header-context";
 import { useWallet } from "@/contexts/wallet-context";
 import { fetchBTCBalance } from "@/core/bitcoin/balance";
 import type { AssetInfo } from "@/core/counterparty/api";
+import { asDisplayUnits } from '@/core/numeric';
 import { fetchAssetDetailsAndBalance } from "@/hooks/utils/fetchAssetData";
 
 interface BalanceState {
@@ -20,7 +21,7 @@ const BTC_ASSET_INFO: AssetInfo = {
   divisible: true,
   locked: true,
   supply: '21000000',
-  supply_normalized: '21000000',
+  supply_normalized: asDisplayUnits('21000000'),
   issuer: '',
   fair_minting: false,
 };
@@ -159,7 +160,7 @@ export function useAssetBalance(asset: string) {
         // Update cache in HeaderContext
         setBalanceHeaderRef.current(asset, {
           asset,
-          quantity_normalized: balance,
+          quantity_normalized: asDisplayUnits(balance),
           asset_info: assetInfo ? {
             asset_longname: assetInfo.asset_longname,
             description: assetInfo.description ?? "",

--- a/src/hooks/useAssetDetails.ts
+++ b/src/hooks/useAssetDetails.ts
@@ -1,5 +1,7 @@
 import { useEffect, useMemo, useRef } from "react";
 import type { AssetInfo } from "@/core/counterparty/api";
+import type { DisplayUnits } from '@/core/numeric';
+import { asDisplayUnits } from '@/core/numeric';
 import { useAssetBalance } from "@/hooks/useAssetBalance";
 import { useAssetInfo } from "@/hooks/useAssetInfo";
 import { useAssetUtxos } from "@/hooks/useAssetUtxos";
@@ -10,7 +12,8 @@ import { useAssetUtxos } from "@/hooks/useAssetUtxos";
 export interface AssetDetails {
   isDivisible: boolean;
   assetInfo: AssetInfo | null;
-  availableBalance: string;
+  /** Display units — already divided by divisibility, as the balance hook returns it. */
+  availableBalance: DisplayUnits;
   utxoBalances?: Array<{
     txid: string;
     amount: string;
@@ -74,7 +77,7 @@ export function useAssetDetails(asset: string, options?: UseAssetDetailsOptions)
     return {
       isDivisible: balance.isDivisible,
       assetInfo: assetInfo.data,
-      availableBalance: balance.balance,
+      availableBalance: asDisplayUnits(balance.balance),
       utxoBalances: utxos.utxos || undefined,
     };
   }, [assetInfo.data, balance.balance, balance.isDivisible, utxos.utxos]);

--- a/src/hooks/useAssetInfo.ts
+++ b/src/hooks/useAssetInfo.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useWallet } from "@/contexts/wallet-context";
 import type { AssetInfo } from "@/core/counterparty/api";
+import { asDisplayUnits } from '@/core/numeric';
 import { fetchAssetDetailsAndBalance } from "@/hooks/utils/fetchAssetData";
 
 interface AssetInfoState {
@@ -17,7 +18,7 @@ const BTC_ASSET_INFO: AssetInfo = {
   divisible: true,
   locked: true,
   supply: '2100000000000000',
-  supply_normalized: '21000000',
+  supply_normalized: asDisplayUnits('21000000'),
   issuer: '',
   fair_minting: false,
 };

--- a/src/hooks/utils/fetchAssetData.ts
+++ b/src/hooks/utils/fetchAssetData.ts
@@ -6,7 +6,7 @@
 import { fetchBTCBalance } from '@/core/bitcoin/balance';
 import { type AssetInfo, fetchAssetDetails, fetchTokenBalance } from '@/core/counterparty/api';
 import { formatAmount } from '@/core/format';
-import { fromSatoshis } from '@/core/numeric';
+import { asDisplayUnits, fromSatoshis } from '@/core/numeric';
 
 export async function fetchAssetDetailsAndBalance(
   asset: string,
@@ -22,7 +22,7 @@ export async function fetchAssetDetailsAndBalance(
       divisible: true,
       locked: true,
       supply: '2100000000000000',
-      supply_normalized: '21000000',
+      supply_normalized: asDisplayUnits('21000000'),
     };
 
     const balanceSats = await fetchBTCBalance(address);

--- a/src/pages/assets/[asset]/balance.tsx
+++ b/src/pages/assets/[asset]/balance.tsx
@@ -8,7 +8,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { useHeader } from "@/contexts/header-context";
 import type { TokenBalance } from "@/core/counterparty/api";
 import { getCanonicalPoolPair } from "@/core/counterparty/pool";
-import { divide, formatDecimal, isGreaterThan, multiply, toBigNumber } from "@/core/numeric";
+import { asDisplayUnits, divide, formatDecimal, isGreaterThan, multiply, toBigNumber } from '@/core/numeric';
 import { useAssetDetails } from "@/hooks/useAssetDetails";
 import { useLpAssetPool } from "@/hooks/useLpAssetPool";
 
@@ -153,7 +153,7 @@ export default function AssetBalancePage(): ReactElement {
           locked: info?.locked ?? false,
           supply: info?.supply,
         },
-        quantity_normalized: assetDetails.availableBalance || "0",
+        quantity_normalized: asDisplayUnits(assetDetails.availableBalance || "0"),
       };
     }
     // Fall back to cached data for instant display

--- a/src/pages/assets/[asset]/index.tsx
+++ b/src/pages/assets/[asset]/index.tsx
@@ -10,6 +10,7 @@ import { useHeader } from "@/contexts/header-context";
 import { useWallet } from "@/contexts/wallet-context";
 import { type Dividend, fetchDividendsByAsset, type PaginatedResponse } from "@/core/counterparty/api";
 import { formatAddress, formatAmount, formatTimeAgo } from "@/core/format";
+import { asDisplayUnits } from '@/core/numeric';
 import { useAssetDetails } from "@/hooks/useAssetDetails";
 
 
@@ -215,7 +216,7 @@ export default function AssetPage(): ReactElement {
         divisible: assetDetails.assetInfo.divisible ?? false,
         locked: assetDetails.assetInfo.locked ?? false,
         supply: assetDetails.assetInfo.supply,
-        supply_normalized: assetDetails.assetInfo.supply_normalized || '0'
+        supply_normalized: assetDetails.assetInfo.supply_normalized || asDisplayUnits('0')
       };
     }
     // Fall back to cached data for instant display (partial info)
@@ -227,8 +228,12 @@ export default function AssetPage(): ReactElement {
         issuer: undefined, // Not available in cache
         divisible: false, // Not available in cache, will update when loaded
         locked: cachedAsset.locked,
-        supply: cachedAsset.supply_normalized, // Use normalized since divisibility unknown
-        supply_normalized: cachedAsset.supply_normalized
+        // supply is base units and the cache holds only the normalized figure, so it is omitted
+        // rather than filled with a display value 1e8 away from what the field means. That
+        // substitution was previously masked by the hardcoded `divisible: false` above — nothing
+        // divided it — which made a wrong value look right only while a second wrong value held.
+        supply: undefined,
+        supply_normalized: asDisplayUnits(cachedAsset.supply_normalized)
       };
     }
     return null;

--- a/src/pages/compose/dispenser/__tests__/review.test.tsx
+++ b/src/pages/compose/dispenser/__tests__/review.test.tsx
@@ -1,5 +1,6 @@
 import { cleanup, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { asBaseUnits, asDisplayUnits } from '@/core/numeric';
 import { ReviewDispenser } from '../review';
 
 // Capture the customFields handed to the shared review screen.
@@ -31,10 +32,10 @@ describe('ReviewDispenser', () => {
 
   const baseParams = {
     asset: 'PEPECASH',
-    escrow_quantity_normalized: '5',
-    give_quantity_normalized: '1',
-    escrow_quantity: 5,
-    give_quantity: 1,
+    escrow_quantity_normalized: asDisplayUnits('5'),
+    give_quantity_normalized: asDisplayUnits('1'),
+    escrow_quantity: asBaseUnits(5),
+    give_quantity: asBaseUnits(1),
     mainchainrate: 100000,
   };
 

--- a/src/pages/compose/dispenser/dispense/__tests__/form.test.tsx
+++ b/src/pages/compose/dispenser/dispense/__tests__/form.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ComposerProvider } from '@/contexts/composer-context';
 import * as counterpartyApi from '@/core/counterparty/api';
 import * as utxoSelection from '@/core/counterparty/utxoSelection';
+import { asBaseUnits, asDisplayUnits } from '@/core/numeric';
 import { DispenseForm } from '../form';
 
 // Mock the API modules
@@ -71,18 +72,18 @@ function createMockDispenser(overrides: Partial<counterpartyApi.DispenserDetails
     source: 'bc1qsource',
     tx_hash: 'abc123',
     status: 0,
-    give_remaining: 1000000,
-    give_remaining_normalized: '10',
-    give_quantity: 100000,
-    give_quantity_normalized: '1',
-    satoshirate: 5000,
-    satoshirate_normalized: '0.00005000',
-    escrow_quantity: 10000000,
-    escrow_quantity_normalized: '100',
+    give_remaining: asBaseUnits(1000000),
+    give_remaining_normalized: asDisplayUnits('10'),
+    give_quantity: asBaseUnits(100000),
+    give_quantity_normalized: asDisplayUnits('1'),
+    satoshirate: asBaseUnits(5000),
+    satoshirate_normalized: asDisplayUnits('0.00005000'),
+    escrow_quantity: asBaseUnits(10000000),
+    escrow_quantity_normalized: asDisplayUnits('100'),
     block_index: 800000,
     block_time: 1700000000,
     confirmed: true,
-    price: 5000,
+    price: asBaseUnits(5000),
     satoshi_price: 5000,
     asset_info: {
       asset_longname: null,
@@ -204,12 +205,12 @@ describe('DispenseForm', () => {
       createMockDispenser({
         asset: 'RAREPEPE',
         tx_hash: 'def456',
-        give_remaining: 500000,
-        give_remaining_normalized: '5',
-        give_quantity: 50000,
-        give_quantity_normalized: '0.5',
-        satoshirate: 10000,
-        satoshirate_normalized: '0.00010000',
+        give_remaining: asBaseUnits(500000),
+        give_remaining_normalized: asDisplayUnits('5'),
+        give_quantity: asBaseUnits(50000),
+        give_quantity_normalized: asDisplayUnits('0.5'),
+        satoshirate: asBaseUnits(10000),
+        satoshirate_normalized: asDisplayUnits('0.00010000'),
         asset_info: {
           asset_longname: null,
           description: 'Rare Pepe',
@@ -251,7 +252,7 @@ describe('DispenseForm', () => {
   }, 15000);
 
   it('should handle max dispenses calculation', async () => {
-    const mockDispensers = [createMockDispenser({ satoshirate: 1000, satoshirate_normalized: '0.00001000' })];
+    const mockDispensers = [createMockDispenser({ satoshirate: asBaseUnits(1000), satoshirate_normalized: asDisplayUnits('0.00001000') })];
 
     mockFetchAddressDispensers.mockResolvedValue({
       result: mockDispensers,
@@ -291,8 +292,8 @@ describe('DispenseForm', () => {
   it('should show insufficient balance error', async () => {
     const mockDispensers = [createMockDispenser({
       asset: 'EXPENSIVE',
-      satoshirate: 100000000, // 1 BTC per dispense (more than our 0.1 BTC balance)
-      satoshirate_normalized: '1.00000000',
+      satoshirate: asBaseUnits(100000000), // 1 BTC per dispense (more than our 0.1 BTC balance)
+      satoshirate_normalized: asDisplayUnits('1.00000000'),
       asset_info: {
         asset_longname: null,
         description: 'Expensive Asset',
@@ -341,10 +342,10 @@ describe('DispenseForm', () => {
   it('should handle empty dispenser', async () => {
     const mockDispensers = [createMockDispenser({
       asset: 'EMPTY',
-      give_remaining: 0,
-      give_remaining_normalized: '0',
-      satoshirate: 1000,
-      satoshirate_normalized: '0.00001000',
+      give_remaining: asBaseUnits(0),
+      give_remaining_normalized: asDisplayUnits('0'),
+      satoshirate: asBaseUnits(1000),
+      satoshirate_normalized: asDisplayUnits('0.00001000'),
       asset_info: {
         asset_longname: null,
         description: 'Empty Asset',

--- a/src/pages/compose/dispenser/form.tsx
+++ b/src/pages/compose/dispenser/form.tsx
@@ -10,6 +10,7 @@ import { PriceWithSuggestInput } from "@/components/ui/inputs/price-with-suggest
 import { TextField } from "@/components/ui/inputs/text-field";
 import { useComposer } from "@/contexts/composer-context-object";
 import type { DispenserOptions } from "@/core/counterparty/compose";
+import { asDisplayUnits } from '@/core/numeric';
 import { useAssetDetails } from "@/hooks/useAssetDetails";
 import { useTradingPair } from "@/hooks/useTradingPair";
 
@@ -182,7 +183,7 @@ export const DispenserForm = memo(function DispenserForm({
           <BalanceHeader
             balance={{
               asset: selectedAsset,
-              quantity_normalized: availableBalance,
+              quantity_normalized: asDisplayUnits(availableBalance),
               asset_info: assetDetails.assetInfo ? {
                 asset_longname: assetDetails.assetInfo.asset_longname,
                 description: assetDetails.assetInfo.description || '',

--- a/src/pages/compose/fairminter/fairmint/form.tsx
+++ b/src/pages/compose/fairminter/fairmint/form.tsx
@@ -8,7 +8,7 @@ import { ErrorAlert } from "@/components/ui/error-alert";
 import { useComposer } from "@/contexts/composer-context-object";
 import type { FairmintOptions } from "@/core/counterparty/compose";
 import { formatAmount } from "@/core/format";
-import { divide, multiply, roundDownToMultiple, toBigNumber } from "@/core/numeric";
+import { asDisplayUnits, divide, multiply, roundDownToMultiple, toBigNumber } from '@/core/numeric';
 import { useAssetDetails } from "@/hooks/useAssetDetails";
 
 interface FairmintFormDataInternal {
@@ -219,7 +219,7 @@ export function FairmintForm({
             <BalanceHeader 
               balance={{
                 asset: currencyType,
-                quantity_normalized: currencyDetails.availableBalance || "0",
+                quantity_normalized: asDisplayUnits(currencyDetails.availableBalance || "0"),
                 asset_info: currencyDetails.assetInfo ? {
                   asset_longname: currencyDetails.assetInfo.asset_longname,
                   description: currencyDetails.assetInfo.description || '',

--- a/src/pages/compose/fairminter/form.tsx
+++ b/src/pages/compose/fairminter/form.tsx
@@ -24,6 +24,7 @@ import { TextField } from "@/components/ui/inputs/text-field";
 import { useComposer } from "@/contexts/composer-context-object";
 import { isSegwitFormat } from '@/core/bitcoin/address';
 import type { FairminterOptions } from "@/core/counterparty/compose";
+import { asDisplayUnits } from '@/core/numeric';
 import { useAssetInfo } from "@/hooks/useAssetInfo";
 
 const FAIRMINTER_MODELS = {
@@ -188,7 +189,7 @@ export function FairminterForm({
                 divisible: assetInfo.divisible ?? true,
                 locked: assetInfo.locked ?? false,
                 supply: assetInfo.supply,
-                supply_normalized: assetInfo.supply_normalized || '0'
+                supply_normalized: asDisplayUnits(assetInfo.supply_normalized || '0')
               }}
               className="mt-1 mb-5" 
             />

--- a/src/pages/compose/issuance/destroy-supply/form.tsx
+++ b/src/pages/compose/issuance/destroy-supply/form.tsx
@@ -8,6 +8,7 @@ import { BalanceHeader } from "@/components/domain/balance/balance-header";
 import { MemoInput } from "@/components/ui/inputs/memo-input";
 import { useComposer } from "@/contexts/composer-context-object";
 import type { DestroyOptions } from "@/core/counterparty/compose";
+import { asDisplayUnits } from '@/core/numeric';
 import { validateQuantity } from "@/core/validation/amount";
 import { useAssetDetails } from "@/hooks/useAssetDetails";
 
@@ -112,7 +113,7 @@ export function DestroySupplyForm({
                 locked: assetDetails.assetInfo?.locked ?? false,
                 supply: assetDetails.assetInfo?.supply
               },
-              quantity_normalized: assetDetails.availableBalance
+              quantity_normalized: asDisplayUnits(assetDetails.availableBalance)
             }}
             className="mt-1 mb-5"
           />

--- a/src/pages/compose/issuance/form.tsx
+++ b/src/pages/compose/issuance/form.tsx
@@ -14,7 +14,7 @@ import { useComposer } from "@/contexts/composer-context-object";
 import { isSegwitFormat } from '@/core/bitcoin/address';
 import type { IssuanceOptions } from "@/core/counterparty/compose";
 import { encodeInscriptionContent } from '@/core/counterparty/inscriptionEnvelope';
-import { toBigNumber } from "@/core/numeric";
+import { asDisplayUnits, toBigNumber } from '@/core/numeric';
 import { useAssetDetails } from "@/hooks/useAssetDetails";
 
 /** Maximum file size for inscriptions in KB */
@@ -153,7 +153,7 @@ export function IssuanceForm({
                   divisible: parentAssetDetails.assetInfo.divisible ?? false,
                   locked: parentAssetDetails.assetInfo.locked ?? false,
                   supply: parentAssetDetails.assetInfo.supply,
-                  supply_normalized: parentAssetDetails.assetInfo.supply_normalized || '0'
+                  supply_normalized: asDisplayUnits(parentAssetDetails.assetInfo.supply_normalized || '0')
                 }}
                 className="mt-1 mb-5"
               />

--- a/src/pages/compose/issuance/issue-supply/form.tsx
+++ b/src/pages/compose/issuance/issue-supply/form.tsx
@@ -9,7 +9,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { useComposer } from "@/contexts/composer-context-object";
 import type { IssuanceOptions } from "@/core/counterparty/compose";
 import { formatAmount } from "@/core/format";
-import { toBigNumber } from "@/core/numeric";
+import { asDisplayUnits, toBigNumber } from '@/core/numeric';
 import { useAssetInfo } from "@/hooks/useAssetInfo";
 
 /**
@@ -124,7 +124,7 @@ export function IssueSupplyForm({
             description: assetInfo?.description ?? "",
             issuer: assetInfo?.issuer ?? "",
             supply: assetInfo?.supply ?? "0",
-            supply_normalized: assetInfo?.supply_normalized || '0'
+            supply_normalized: asDisplayUnits(assetInfo?.supply_normalized || '0')
           }}
           className="mt-1 mb-5"
         />

--- a/src/pages/compose/issuance/lock-description/form.tsx
+++ b/src/pages/compose/issuance/lock-description/form.tsx
@@ -8,6 +8,7 @@ import { CheckboxInput } from "@/components/ui/inputs/checkbox-input";
 import { Spinner } from "@/components/ui/spinner";
 import { useComposer } from "@/contexts/composer-context-object";
 import type { IssuanceOptions } from "@/core/counterparty/compose";
+import { asDisplayUnits } from '@/core/numeric';
 import { useAssetInfo } from "@/hooks/useAssetInfo";
 
 /**
@@ -84,7 +85,7 @@ export function LockDescriptionForm({
             divisible: assetInfo?.divisible ?? false,
             locked: assetInfo?.locked ?? false,
             supply: assetInfo?.supply,
-            supply_normalized: assetInfo?.supply_normalized || '0'
+            supply_normalized: asDisplayUnits(assetInfo?.supply_normalized || '0')
           }}
           className="mt-1 mb-5"
         />

--- a/src/pages/compose/issuance/lock-supply/form.tsx
+++ b/src/pages/compose/issuance/lock-supply/form.tsx
@@ -8,6 +8,7 @@ import { CheckboxInput } from "@/components/ui/inputs/checkbox-input";
 import { Spinner } from "@/components/ui/spinner";
 import { useComposer } from "@/contexts/composer-context-object";
 import type { IssuanceOptions } from "@/core/counterparty/compose";
+import { asDisplayUnits } from '@/core/numeric';
 import { useAssetInfo } from "@/hooks/useAssetInfo";
 
 /**
@@ -86,7 +87,7 @@ export function LockSupplyForm({
             description: assetInfo?.description ?? "",
             issuer: assetInfo?.issuer ?? "",
             supply: assetInfo?.supply ?? "0",
-            supply_normalized: assetInfo?.supply_normalized || '0'
+            supply_normalized: asDisplayUnits(assetInfo?.supply_normalized || '0')
           }}
           className="mt-1 mb-5"
         />

--- a/src/pages/compose/issuance/transfer-ownership/form.tsx
+++ b/src/pages/compose/issuance/transfer-ownership/form.tsx
@@ -7,6 +7,7 @@ import { DestinationInput } from "@/components/ui/inputs/destination-input";
 import { Spinner } from "@/components/ui/spinner";
 import { useComposer } from "@/contexts/composer-context-object";
 import type { IssuanceOptions } from "@/core/counterparty/compose";
+import { asDisplayUnits } from '@/core/numeric';
 import { useAssetInfo } from "@/hooks/useAssetInfo";
 
 /**
@@ -66,7 +67,7 @@ export function TransferOwnershipForm({
             description: assetInfo?.description ?? "",
             issuer: assetInfo?.issuer ?? "",
             supply: assetInfo?.supply ?? "0",
-            supply_normalized: assetInfo?.supply_normalized || '0'
+            supply_normalized: asDisplayUnits(assetInfo?.supply_normalized || '0')
           }}
           className="mt-1 mb-5"
         />

--- a/src/pages/compose/issuance/update-description/form.tsx
+++ b/src/pages/compose/issuance/update-description/form.tsx
@@ -10,6 +10,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { useComposer } from "@/contexts/composer-context-object";
 import { isSegwitFormat } from '@/core/bitcoin/address';
 import type { IssuanceOptions } from "@/core/counterparty/compose";
+import { asDisplayUnits } from '@/core/numeric';
 import { useAssetInfo } from "@/hooks/useAssetInfo";
 
 /**
@@ -91,7 +92,7 @@ export function UpdateDescriptionForm({
             divisible: assetInfo?.divisible ?? false,
             locked: assetInfo?.locked ?? false,
             supply: assetInfo?.supply,
-            supply_normalized: assetInfo?.supply_normalized || '0'
+            supply_normalized: asDisplayUnits(assetInfo?.supply_normalized || '0')
           }}
           className="mt-1 mb-5"
         />

--- a/src/pages/compose/order/form.tsx
+++ b/src/pages/compose/order/form.tsx
@@ -12,7 +12,7 @@ import { PriceWithSuggestInput } from "@/components/ui/inputs/price-with-suggest
 import { useComposer } from "@/contexts/composer-context-object";
 import type { OrderOptions } from "@/core/counterparty/compose";
 import { formatAmount } from "@/core/format";
-import { toBigNumber } from "@/core/numeric";
+import { asDisplayUnits, toBigNumber } from '@/core/numeric';
 import { DEFAULT_ORDER_EXPIRATION } from "@/core/settings";
 import { useAssetDetails } from "@/hooks/useAssetDetails";
 import { usePool } from "@/hooks/usePool";
@@ -202,7 +202,7 @@ export function OrderForm({
         <BalanceHeader
           balance={{
             asset: baseAsset,
-            quantity_normalized: giveAssetDetails.availableBalance,
+            quantity_normalized: asDisplayUnits(giveAssetDetails.availableBalance),
             asset_info: giveAssetDetails.assetInfo ? {
               asset_longname: giveAssetDetails.assetInfo.asset_longname,
               description: giveAssetDetails.assetInfo.description || '',

--- a/src/pages/compose/send/form.tsx
+++ b/src/pages/compose/send/form.tsx
@@ -11,6 +11,7 @@ import { useComposer } from "@/contexts/composer-context-object";
 import { useWallet } from "@/contexts/wallet-context";
 import type { SendOptions } from "@/core/counterparty/compose";
 import { formatMoreOutputs } from "@/core/format";
+import { asDisplayUnits } from '@/core/numeric';
 import { validateAmount, validateQuantity } from "@/core/validation/amount";
 import type { Destination } from "@/core/validation/destinations";
 import { useAssetDetails } from "@/hooks/useAssetDetails";
@@ -165,7 +166,7 @@ export function SendForm({
           <BalanceHeader
             balance={{
               asset: initialAsset || initialFormData?.asset || "BTC",
-              quantity_normalized: assetDetails.availableBalance,
+              quantity_normalized: asDisplayUnits(assetDetails.availableBalance),
               asset_info: assetDetails.assetInfo ? {
                 asset_longname: assetDetails.assetInfo.asset_longname,
                 description: assetDetails.assetInfo.description || '',

--- a/src/pages/compose/utxo/attach/__tests__/form.test.tsx
+++ b/src/pages/compose/utxo/attach/__tests__/form.test.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ComposerProvider } from '@/contexts/composer-context';
 import { useSettings } from '@/contexts/settings-context';
+import { asBaseUnits, asDisplayUnits } from '@/core/numeric';
 import { DEFAULT_SETTINGS } from '@/core/settings';
 import { UtxoAttachForm } from '../form';
 
@@ -99,9 +100,9 @@ vi.mock('@/hooks/useAssetDetails', () => ({
         issuer: 'bc1qissuer',
         divisible: true,
         locked: false,
-        supply: '1000000'
+        supply: asBaseUnits('1000000')
       },
-      availableBalance: '100'
+      availableBalance: asDisplayUnits('100')
     }
   })
 }));

--- a/src/pages/compose/utxo/attach/form.tsx
+++ b/src/pages/compose/utxo/attach/form.tsx
@@ -6,6 +6,7 @@ import { BalanceHeader } from "@/components/domain/balance/balance-header";
 import { ErrorAlert } from "@/components/ui/error-alert";
 import { useComposer } from "@/contexts/composer-context-object";
 import type { AttachOptions } from "@/core/counterparty/compose";
+import { asDisplayUnits } from '@/core/numeric';
 import { useAssetDetails } from "@/hooks/useAssetDetails";
 
 /**
@@ -65,7 +66,7 @@ export function UtxoAttachForm({
                 locked: assetDetails.assetInfo?.locked ?? false,
                 supply: assetDetails.assetInfo?.supply
               },
-              quantity_normalized: assetDetails.availableBalance
+              quantity_normalized: asDisplayUnits(assetDetails.availableBalance)
             }}
             className="mt-1 mb-5"
           />

--- a/src/pages/compose/utxo/detach/__tests__/form.test.tsx
+++ b/src/pages/compose/utxo/detach/__tests__/form.test.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ComposerProvider } from '@/contexts/composer-context';
 import { useSettings } from '@/contexts/settings-context';
+import type { DisplayUnits } from '@/core/numeric';
 import { DEFAULT_SETTINGS } from '@/core/settings';
 import { UtxoDetachForm } from '../form';
 
@@ -64,7 +65,7 @@ vi.mock('@/contexts/loading-context', () => ({
 vi.mock('@/core/counterparty/api', () => ({
   fetchUtxoBalances: vi.fn().mockResolvedValue({
     result: [
-      { asset: 'TESTTOKEN', quantity_normalized: '100' }
+      { asset: 'TESTTOKEN', quantity_normalized: '100' as DisplayUnits }
     ]
   })
 }));
@@ -277,9 +278,9 @@ describe('UtxoDetachForm', () => {
     const { fetchUtxoBalances } = await import('@/core/counterparty/api');
     (fetchUtxoBalances as any).mockResolvedValueOnce({
       result: [
-        { asset: 'TESTTOKEN', quantity_normalized: '100' },
-        { asset: 'XCP', quantity_normalized: '50' },
-        { asset: 'RAREPEPE', quantity_normalized: '1' }
+        { asset: 'TESTTOKEN', quantity_normalized: '100' as DisplayUnits },
+        { asset: 'XCP', quantity_normalized: '50' as DisplayUnits },
+        { asset: 'RAREPEPE', quantity_normalized: '1' as DisplayUnits }
       ]
     });
 

--- a/src/pages/compose/utxo/move/__tests__/form.test.tsx
+++ b/src/pages/compose/utxo/move/__tests__/form.test.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ComposerProvider } from '@/contexts/composer-context';
 import { useSettings } from '@/contexts/settings-context';
+import type { DisplayUnits } from '@/core/numeric';
 import { DEFAULT_SETTINGS } from '@/core/settings';
 import { UtxoMoveForm } from '../form';
 
@@ -64,8 +65,8 @@ vi.mock('@/contexts/loading-context', () => ({
 vi.mock('@/core/counterparty/api', () => ({
   fetchUtxoBalances: vi.fn().mockResolvedValue({
     result: [
-      { asset: 'TESTTOKEN', quantity_normalized: '100' },
-      { asset: 'XCP', quantity_normalized: '50' }
+      { asset: 'TESTTOKEN', quantity_normalized: '100' as DisplayUnits },
+      { asset: 'XCP', quantity_normalized: '50' as DisplayUnits }
     ]
   })
 }));
@@ -279,7 +280,7 @@ describe('UtxoMoveForm', () => {
   it('should handle single balance correctly', async () => {
     const { fetchUtxoBalances } = await import('@/core/counterparty/api');
     (fetchUtxoBalances as any).mockResolvedValueOnce({
-      result: [{ asset: 'TESTTOKEN', quantity_normalized: '100' }]
+      result: [{ asset: 'TESTTOKEN', quantity_normalized: '100' as DisplayUnits }]
     });
 
     render(


### PR DESCRIPTION
Two mechanisms, both of which found a live bug on first use.

### Branded units

Confusing base units with display units was behind most of the unit defects in this pass — a fairminter price sold for a hundred-millionth of its value, a pool deposit shown as 150,000,000 XCP instead of 1.5, an order rate off by 1e8. They are the same JavaScript values and differ by a factor of 1e8, so every confusion produced a *plausible* number rather than an error.

`BaseUnits` and `DisplayUnits` are now distinct branded types. `ApiQuantity` is `BaseUnits`; the 31 `*_normalized` response fields are `DisplayUnits`; `asBaseUnits`/`asDisplayUnits` are the only constructors, so every point where a unit is *asserted* rather than derived is greppable.

Branded at the boundary rather than everywhere: of 329 sites doing arithmetic on monetary values, 92 operate on already-normalized display strings that are provably safe for divisible assets.

**It found one immediately.** The asset page filled `AssetInfo.supply` — base units — with `supply_normalized`, and said so in a comment. Masked because the same object hardcodes `divisible: false`, so nothing divided it: a wrong value that looked right only while a second wrong value held.

### Differential fuzzer

`/v2/transactions/unpack` *is* core's decoder over HTTP. The fuzzer generates payloads with our packer, decodes both ways, and compares with `verifyProviderTransaction` — the same comparator the approval screen uses, so a run exercises the comparator too.

**It found a live false-block.** Core resolves asset names through a ledger lookup; `get_asset_name` returns `0` for an asset the node doesn't know. `assetsEqual` read that as a contradiction, so an order, destroy or dividend naming an un-indexed asset reported **tampering and blocked signing** — failing on the state of a node's index rather than on the transaction.

Two details reading would not have caught: the marker arrives as the **number** `0`, so a guard placed after the existing falsy check could never see it; and the parameter is typed `string` while not always being one at runtime.

Lives under the existing `vitest.fuzz.config.ts`, so it stays out of the default suite. Requests are spaced and a 429 raises rather than counting as a pass.

Verified: 0 type errors, 3,998 tests, 396 fuzz tests, clean build.

https://claude.ai/code/session_01H6NZ7JtqTVvsVGkYf6hE6s