### PR TITLE
Merge what each decoder knows, and check the message against its transaction

### DIFF
--- a/src/components/domain/tx/tx-action-info.test.ts
+++ b/src/components/domain/tx/tx-action-info.test.ts
@@ -65,3 +65,53 @@ describe('getTxActionInfo', () => {
     expect(getTxActionInfo({} as never)).toBeNull();
   });
 });
+
+describe('getTxActionInfo merges what each decoder knows', () => {
+  /** Both sources present: local unpack fields, plus the API decode alongside them. */
+  const withBoth = (
+    messageType: string,
+    localData: Record<string, unknown>,
+    apiMessageData: Record<string, unknown>,
+  ) => ({
+    verification: { localUnpack: { success: true, messageType, data: localData } },
+    counterpartyMessage: { messageType, messageData: apiMessageData, description: 'API SAID THIS' },
+  }) as never;
+
+  it('uses the local name and the API divisibility together', () => {
+    // The endpoint returns 0 for an asset its ledger has not indexed, so the name must come from
+    // the local unpack (which derives it from the id). Divisibility only the API has. Used
+    // separately these produced "200,000,000 base units 0" — both blind spots in one sentence.
+    const info = getTxActionInfo(withBoth(
+      'pooldeposit',
+      {
+        assetA: 'XCP', quantityA: asBaseUnits(100000000),
+        assetB: 'A95428957068369062', quantityB: asBaseUnits(200000000),
+      },
+      {
+        asset_a: 'XCP', asset_a_info: { divisible: true },
+        asset_b: 0, asset_b_info: { divisible: true },
+      },
+    ));
+
+    expect(info?.description).toBe(
+      'Deposit liquidity: 1.00000000 XCP and 2.00000000 A95428957068369062'
+    );
+  });
+
+  it('falls back to base units when the API cannot supply divisibility either', () => {
+    const info = getTxActionInfo(withBoth(
+      'pooldeposit',
+      { assetA: 'XCP', quantityA: asBaseUnits(100000000), assetB: 'MYSTERY', quantityB: asBaseUnits(200000000) },
+      { asset_a: 'XCP', asset_a_info: { divisible: true }, asset_b: 0 },
+    ));
+
+    expect(info?.description).toContain('200,000,000 base units MYSTERY');
+  });
+
+  it('uses the API description when there is no local unpack to merge with', () => {
+    const info = getTxActionInfo({
+      counterpartyMessage: { messageType: 'enhanced_send', messageData: {}, description: 'API SAID THIS' },
+    } as never);
+    expect(info).toEqual({ label: 'Enhanced Send', description: 'API SAID THIS' });
+  });
+});

--- a/src/components/domain/tx/tx-action-info.ts
+++ b/src/components/domain/tx/tx-action-info.ts
@@ -77,23 +77,62 @@ export function normalizeLpQuantity(quantity: unknown): string {
  * Build a human-readable label and description from decoded transaction data.
  * Prefers the API counterpartyMessage, else falls back to the local unpack.
  */
+/**
+ * Canonical asset slot → the API field carrying its `*_info`.
+ *
+ * Divisibility has to be matched by slot rather than by name: the endpoint returns 0 for an asset
+ * its ledger cannot resolve, so matching on the name fails for exactly the assets whose name the
+ * local unpack had to supply.
+ */
+const ASSET_SLOT_TO_API_FIELD: Record<string, string> = {
+  asset: 'asset',
+  giveAsset: 'give_asset',
+  getAsset: 'get_asset',
+  dividendAsset: 'dividend_asset',
+  assetA: 'asset_a',
+  assetB: 'asset_b',
+};
+
+/**
+ * Build a human-readable label and description from decoded transaction data.
+ *
+ * Neither decoder is sufficient alone, and each is blind where the other sees. The local unpack
+ * derives an asset name arithmetically from its id, so it always has one; the API resolves names
+ * through a ledger lookup and returns 0 for anything it has not indexed. The API carries
+ * divisibility in `*_info`; the local unpack carries none, so on its own it can only label a
+ * quantity as base units.
+ *
+ * Used separately, each blind spot reached the screen: "Deposit liquidity: … and 200,000,000 base
+ * units 0" is both of them in one sentence — an unresolvable name printed as 0 by the API, beside
+ * a quantity the local path could not scale. So when both are present the description is built
+ * from the local fields and formatted with the API's divisibility.
+ */
 export function getTxActionInfo(decodedInfo: TxActionSource): { label: string; description: string } | null {
-  // The API decode already carries a description built by the shared describer.
-  if (decodedInfo.counterpartyMessage) {
-    return {
-      label: labelFor(decodedInfo.counterpartyMessage.messageType),
-      description: decodedInfo.counterpartyMessage.description,
-    };
+  const unpack = decodedInfo.verification?.localUnpack;
+  const api = decodedInfo.counterpartyMessage;
+  const localUsable = unpack?.success && unpack.messageType && unpack.data;
+
+  if (localUsable && api) {
+    const merged = describeMessage(
+      unpack.messageType!,
+      fromLocalUnpack(unpack.data, api.messageData)
+    );
+    if (merged) {
+      return { label: labelFor(unpack.messageType!), description: merged };
+    }
   }
 
-  // Otherwise describe from the local unpack, through the same switch rather than a parallel one.
-  const unpack = decodedInfo.verification?.localUnpack;
-  if (!unpack?.success || !unpack.messageType || !unpack.data) return null;
+  // Only one source available — use whichever it is, with its own limitations stated by the
+  // adapter rather than papered over.
+  if (api) {
+    return { label: labelFor(api.messageType), description: api.description };
+  }
 
-  const description = describeMessage(unpack.messageType, fromLocalUnpack(unpack.data));
+  if (!localUsable) return null;
+  const description = describeMessage(unpack!.messageType!, fromLocalUnpack(unpack!.data));
   return {
-    label: labelFor(unpack.messageType),
-    description: description ?? unpack.messageType,
+    label: labelFor(unpack!.messageType!),
+    description: description ?? unpack!.messageType!,
   };
 }
 
@@ -105,9 +144,26 @@ export function getTxActionInfo(decodedInfo: TxActionSource): { label: string; d
  * That is the honest rendering: this path runs precisely when the API decode failed and the
  * wallet is relying on its own bytes.
  */
-function fromLocalUnpack(raw: unknown): DescribableMessage {
+function fromLocalUnpack(
+  raw: unknown,
+  apiData?: Record<string, unknown>
+): DescribableMessage {
   const data = raw as Record<string, unknown>;
   const sends = data.sends as unknown[] | undefined;
+
+  /** Divisibility for a local asset slot, taken from the API's info for the matching field. */
+  const divisibilityOf = (asset?: string): boolean | undefined => {
+    const upper = String(asset ?? '').toUpperCase();
+    if (upper === 'BTC' || upper === 'XCP') return true;
+    if (!apiData) return undefined;
+
+    for (const [slot, apiField] of Object.entries(ASSET_SLOT_TO_API_FIELD)) {
+      if (data[slot] !== asset) continue;
+      const info = apiData[`${apiField}_info`] as Record<string, unknown> | undefined;
+      if (typeof info?.divisible === 'boolean') return info.divisible;
+    }
+    return undefined;
+  };
 
   return {
     asset: data.asset as string | undefined,
@@ -130,6 +186,12 @@ function fromLocalUnpack(raw: unknown): DescribableMessage {
     quantityB: data.quantityB,
     recipientCount: sends?.length,
     subassetLongname: data.subassetLongname as string | undefined,
-    format: (quantity, asset) => normalizeQuantity(quantity, asset ?? ''),
+    format: (quantity, asset) => {
+      if (quantity == null) return '?';
+      const divisible = divisibilityOf(asset);
+      if (divisible === true) return fromSatoshis(String(quantity), { removeTrailingZeros: false });
+      if (divisible === false) return BigInt(String(quantity)).toLocaleString();
+      return `${BigInt(String(quantity)).toLocaleString()} base units`;
+    },
   };
 }

--- a/src/core/counterparty/__tests__/messageStructure.test.ts
+++ b/src/core/counterparty/__tests__/messageStructure.test.ts
@@ -1,0 +1,57 @@
+/**
+ * These checks exist because a payload can be internally perfect and still describe something the
+ * transaction cannot do. Neither the API comparison (which never looks at the transaction) nor the
+ * repack proof (which only shows the decode explains every payload byte) would notice.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { checkMessageStructure } from '@/core/counterparty/messageStructure';
+
+const TXID = '3f7b5cb0889cfe00ec42c1484411487fbdf5837246cd016784ffba6e9f44a5d6';
+
+const tx = {
+  inputs: [{ txid: TXID, vout: 2 }],
+  outputs: [{ index: 0 }, { index: 1 }],
+};
+
+describe('attach', () => {
+  it('accepts a vout the transaction actually has', () => {
+    expect(checkMessageStructure('attach', { destinationVout: 1 }, tx)).toEqual([]);
+  });
+
+  it('flags a vout past the end of the outputs', () => {
+    // core builds the destination as `${tx_hash}:${destination_vout}`, so this names a UTXO that
+    // will never exist.
+    const found = checkMessageStructure('attach', { destinationVout: 7 }, tx);
+    expect(found).toHaveLength(1);
+    expect(found[0]!.title).toMatch(/does not exist/i);
+  });
+
+  it('says nothing when the message carries no vout', () => {
+    expect(checkMessageStructure('attach', { asset: 'XCP' }, tx)).toEqual([]);
+  });
+});
+
+describe('utxo move', () => {
+  it('accepts a source among the inputs being signed', () => {
+    expect(checkMessageStructure('utxo', { source: `${TXID}:2` }, tx)).toEqual([]);
+  });
+
+  it('flags a source the transaction does not spend', () => {
+    const found = checkMessageStructure('utxo', { source: `${TXID}:3` }, tx);
+    expect(found).toHaveLength(1);
+    expect(found[0]!.title).toMatch(/does not spend/i);
+  });
+
+  it('flags a source naming an entirely different transaction', () => {
+    const other = 'a'.repeat(64);
+    expect(checkMessageStructure('utxo_move', { source: `${other}:2` }, tx)).toHaveLength(1);
+  });
+});
+
+describe('scope', () => {
+  it('says nothing for types that make no structural claim', () => {
+    expect(checkMessageStructure('enhanced_send', { asset: 'XCP' }, tx)).toEqual([]);
+    expect(checkMessageStructure(undefined, {}, tx)).toEqual([]);
+  });
+});

--- a/src/core/counterparty/messageStructure.ts
+++ b/src/core/counterparty/messageStructure.ts
@@ -1,0 +1,96 @@
+/**
+ * Check a decoded message against the transaction that carries it.
+ *
+ * A third source of truth, independent of both decoders. Some message bodies name parts of their
+ * own transaction — `attach` gives an output index, `utxo` (move) gives the outpoint it spends —
+ * and those references are verifiable against the bytes already parsed locally, with no packer and
+ * no API call. Where they disagree, the message cannot mean what it appears to: core resolves the
+ * same references against the same transaction and would reject or credit elsewhere.
+ *
+ * This catches a class neither existing check can. The API comparison reads the same payload
+ * through a second decoder and never looks at the transaction. The repack proof shows the decode
+ * accounts for every payload byte, and would still pass for a payload that is internally perfect
+ * but points at an output that does not exist.
+ *
+ * Findings are warnings, not blocks. A reference that does not resolve makes the transaction
+ * ineffective rather than dangerous — core rejects it — so the honest report is that the screen
+ * cannot describe what it claims to do.
+ */
+
+import type { AttachData, MoveData } from '@/core/counterparty/unpack/messages/attach';
+
+/** The parts of the parsed transaction these checks need. */
+export interface TransactionShape {
+  inputs: Array<{ txid: string; vout: number }>;
+  outputs: Array<{ index: number }>;
+}
+
+export interface StructureFinding {
+  title: string;
+  message: string;
+}
+
+/**
+ * @param messageType - the locally decoded type
+ * @param data - the locally decoded payload; the API's shape is not accepted here, because these
+ *   checks exist to test the bytes against the transaction rather than a remote reading of them
+ */
+export function checkMessageStructure(
+  messageType: string | undefined,
+  data: unknown,
+  tx: TransactionShape
+): StructureFinding[] {
+  if (!messageType || data == null) return [];
+  const findings: StructureFinding[] = [];
+
+  switch (messageType) {
+    case 'attach': {
+      const { destinationVout } = data as AttachData;
+      if (destinationVout === undefined) break;
+
+      // core attach.py builds the destination as `${tx_hash}:${destination_vout}`, so the index
+      // must name an output of this transaction. Out of range, and the assets are attached to a
+      // UTXO that will never exist.
+      const exists = tx.outputs.some((o) => o.index === destinationVout);
+      if (!exists) {
+        findings.push({
+          title: 'Attaches to an output that does not exist',
+          message:
+            `This attaches assets to output #${destinationVout}, but the transaction has ` +
+            `${tx.outputs.length} output${tx.outputs.length === 1 ? '' : 's'}. The attachment ` +
+            'cannot take effect as described.',
+        });
+      }
+      break;
+    }
+
+    case 'utxo':
+    case 'utxo_move': {
+      const { source } = data as MoveData;
+      if (!source) break;
+
+      // The source names the outpoint whose balances move. Core moves assets from that UTXO, so
+      // it has to be one this transaction actually spends — otherwise the message describes a
+      // movement out of a UTXO untouched by the bytes being signed.
+      const [txid, voutText] = source.split(':');
+      const vout = Number(voutText);
+      const spent = tx.inputs.some(
+        (i) => i.txid.toLowerCase() === (txid ?? '').toLowerCase() && i.vout === vout
+      );
+      if (!spent) {
+        findings.push({
+          title: 'Moves a UTXO this transaction does not spend',
+          message:
+            `This moves assets from ${source}, which is not among the inputs being signed. ` +
+            'The move cannot take effect as described.',
+        });
+      }
+      break;
+    }
+
+    default:
+      break;
+  }
+
+  return findings;
+}

--- a/src/hooks/useSignTransactionRequest.ts
+++ b/src/hooks/useSignTransactionRequest.ts
@@ -17,6 +17,10 @@ import {
   type InputAttachedAssets,
 } from '@/core/counterparty/inputAssets';
 import {
+  checkMessageStructure,
+  type StructureFinding,
+} from '@/core/counterparty/messageStructure';
+import {
   type CounterpartyMessage,
   decodeCounterpartyMessage,
   describeMpmaSend,
@@ -70,6 +74,11 @@ export interface DecodedTransactionInfo {
   safety: SafetyAnalysis;
   /** Inputs whose UTXOs carry Counterparty assets, or whose lookup failed. */
   attachedAssets: InputAttachedAssets[];
+  /**
+   * Message fields that reference this transaction and do not resolve against it — an attach
+   * naming an output that does not exist, a move naming a UTXO the transaction does not spend.
+   */
+  structureFindings: StructureFinding[];
   /**
    * Recipients of an mpma_send, read from the local unpack. Empty for every other message type.
    * These are carried in the payload rather than as outputs, so the approval screen has no other
@@ -210,6 +219,14 @@ export function useSignTransactionRequest(signerAddress?: string) {
       }
     }
 
+    // Independent of both decoders: does the message's own account of this transaction hold up
+    // against the transaction? Uses the local decode, since the point is to test the bytes.
+    const structureFindings = checkMessageStructure(
+      verification.localUnpack?.messageType,
+      verification.localUnpack?.data,
+      { inputs, outputs }
+    );
+
     const attachedAssets = await attachedAssetsPromise;
 
     return {
@@ -225,6 +242,7 @@ export function useSignTransactionRequest(signerAddress?: string) {
       verification,
       safety,
       attachedAssets,
+      structureFindings,
       mpmaRecipients,
     };
   }, []);

--- a/src/pages/requests/transaction/approve.tsx
+++ b/src/pages/requests/transaction/approve.tsx
@@ -280,6 +280,18 @@ export default function ApproveTransactionPage() {
     title: warning.title,
     description: warning.message,
   }));
+  // The message's own references to this transaction, where they do not resolve against it. A
+  // warning rather than a block: core rejects such a transaction, so it is ineffective rather than
+  // dangerous — but the screen cannot describe what it claims to do.
+  for (const [idx, finding] of (decodedInfo.structureFindings ?? []).entries()) {
+    warningItems.push({
+      key: `structure-${idx}`,
+      severity: 'warning',
+      title: finding.title,
+      description: finding.message,
+    });
+  }
+
   if (signedInputsWithAssets.length > 0) {
     warningItems.push({
       key: 'attached-assets',


### PR DESCRIPTION
Two gaps, both cases of accepting a limitation rather than working around it.

### Neither decoder is sufficient alone

Each is blind where the other sees:

| | asset name | divisibility |
|---|---|---|
| local unpack | ✅ derived arithmetically from the id | ❌ none |
| API decode | ❌ ledger lookup, returns `0` if unindexed | ✅ in `*_info` |

Used separately, **both blind spots reached the screen in one sentence**:

> Deposit liquidity: 1.00000000 XCP and 200,000,000 base units **0**

An unresolvable name printed as `0` by the API, beside a quantity the local path could not scale. When both decodes are present the description is now built from the local fields and formatted with the API's divisibility. Divisibility is matched by *asset slot* rather than by name — because the name is precisely what's missing for the assets that need it.

### Messages that name their own transaction

`attach` gives an output index (core builds the destination as `${tx_hash}:${destination_vout}`) and `utxo` move gives the outpoint whose balances move. Nothing checked those references. They're verifiable against bytes already parsed locally — **no packer, no API call**.

This catches a class neither existing check can:

- the **API comparison** reads the same payload through a second decoder and never looks at the transaction
- the **repack proof** shows the decode accounts for every payload byte, and passes happily for a payload that is internally perfect and points at an output that does not exist

Reported as warnings, not blocks: core rejects such a transaction, so it's ineffective rather than dangerous — but the screen cannot describe what it claims to do, and should say so.

Verified: 0 type errors, 4,009 tests (10 new), biome clean, gallery regenerates.

https://claude.ai/code/session_01H6NZ7JtqTVvsVGkYf6hE6s