### PR TITLE
Sweep the provider surface, and stop rejecting payloads core accepts

### DIFF
--- a/src/core/counterparty/unpack/messages/destroy.ts
+++ b/src/core/counterparty/unpack/messages/destroy.ts
@@ -5,7 +5,7 @@
  * Format: ">QQ" (16 bytes) + optional tag
  *   - asset_id (Q): 8 bytes - Asset to destroy
  *   - quantity (Q): 8 bytes - Quantity to destroy
- *   - tag: 0-34 bytes - Optional tag/reason
+ *   - tag: the remaining bytes - Optional tag/reason (compose caps this at 34; unpack does not)
  */
 
 import { assetIdToName } from '@/core/counterparty/unpack/assetId';
@@ -13,8 +13,6 @@ import { BinaryReader } from '@/core/counterparty/unpack/binary';
 
 /** Minimum length of destroy message (without tag) */
 const DESTROY_MIN_LENGTH = 16;
-/** Maximum tag length */
-const MAX_TAG_LENGTH = 34;
 
 /**
  * Unpacked destroy data
@@ -44,10 +42,10 @@ export function unpackDestroy(payload: Uint8Array): DestroyData {
     throw new Error(`Invalid destroy payload length: ${payload.length} (minimum ${DESTROY_MIN_LENGTH})`);
   }
 
+  // No cap on unpack. Core reads `tag = message[16:]` with no length check (destroy.py); the
+  // 34-byte limit is a compose-side rule, and enforcing it here rejected a destroy the chain
+  // accepts — blocking a valid transaction rather than catching a malformed one.
   const tagLength = payload.length - DESTROY_MIN_LENGTH;
-  if (tagLength > MAX_TAG_LENGTH) {
-    throw new Error(`Tag too long: ${tagLength} bytes (maximum ${MAX_TAG_LENGTH})`);
-  }
 
   const reader = new BinaryReader(payload);
 

--- a/src/core/counterparty/unpack/messages/fairminter.ts
+++ b/src/core/counterparty/unpack/messages/fairminter.ts
@@ -50,11 +50,15 @@ function block(value: CborValue, field: string): number {
 
 export function unpackFairminter(payload: Uint8Array): FairminterData {
   const fields = decodeCbor(payload);
-  if (!Array.isArray(fields) || (fields.length !== 19 && fields.length !== 21)) {
-    throw new Error('Invalid fairminter field count');
+  // Core reads `fields[:17]` and defaults everything after it — mime_type and description are
+  // taken only `if len(fields) > 17` / `> 18`, and the pool pair only when there are 21 or more
+  // (fairminter.py). Requiring exactly 19 or 21 rejected payloads core accepts, which fails
+  // verification and blocks signing on a transaction the chain would honour.
+  if (!Array.isArray(fields) || fields.length < 17) {
+    throw new Error(`Invalid fairminter field count: ${Array.isArray(fields) ? fields.length : 0} (minimum 17)`);
   }
 
-  const hasPool = fields.length === 21;
+  const hasPool = fields.length >= 21;
   const poolQuantity = hasPool ? integer(fields[17]!, 'pool quantity') : 0n;
   const lpAssetId = hasPool ? integer(fields[18]!, 'LP asset') : 0n;
   const mimeTypeIndex = hasPool ? 19 : 17;

--- a/src/services/__tests__/providerSurface.test.ts
+++ b/src/services/__tests__/providerSurface.test.ts
@@ -1,0 +1,188 @@
+import './setup'; // Must be first to setup browser mocks
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fakeBrowser } from 'wxt/testing/fake-browser';
+import { getConnectionService } from '../connectionService';
+import { createProviderService } from '../providerService';
+
+/**
+ * A sweep of the whole provider surface, rather than a test per method.
+ *
+ * The decoders got a differential fuzzer that compares every message type against core on every
+ * run; the provider surface had only spot checks — grants, origin handling and identity binding
+ * read by hand. Reading is what missed the wire-format defects for months, and a method added
+ * later is exactly the case a hand-written review does not revisit.
+ *
+ * The mechanism is the table below. Every method the service dispatches must appear in it with a
+ * stated contract, and the final test fails if the service grows a method the table does not
+ * classify. So the surface cannot expand without someone deciding, in writing, whether the new
+ * method needs a grant.
+ */
+
+vi.mock('webext-bridge/background', () => ({
+  sendMessage: vi.fn().mockResolvedValue({ success: true, data: {} }),
+  onMessage: vi.fn(),
+}));
+vi.mock('../walletService');
+vi.mock('@/platform/walletManager', () => ({
+  walletManager: {
+    getSettings: vi.fn().mockReturnValue({
+      connectedWebsites: [],
+      analyticsAllowed: true,
+      counterpartyApiBase: 'https://api.counterparty.io',
+    }),
+    updateSettings: vi.fn(),
+  },
+}));
+// Rate limiters must ALLOW here. Auto-mocking returns undefined from isAllowed(), which the
+// service reads as "limited" — every call then fails and the grant assertions below pass for
+// entirely the wrong reason. The first run of this file did exactly that.
+vi.mock('@/platform/provider/rateLimiter', () => {
+  const allow = { isAllowed: () => true, getResetTime: () => 0, reset: () => {} };
+  return { apiRateLimiter: allow, connectionRateLimiter: allow, transactionRateLimiter: allow };
+});
+vi.mock('../connectionService');
+vi.mock('../approvalService');
+
+/** What each method is allowed to do for a caller that holds no grant. */
+type Contract =
+  /** Must not return wallet data or act; an ungranted call has to fail or come back empty. */
+  | 'needs-grant'
+  /** Public constant. Safe without a grant because it discloses nothing about the wallet. */
+  | 'public-constant'
+  /** Deliberately unsupported — must reject regardless of grant. */
+  | 'unsupported'
+  /** Connection handshake or teardown; meaningful without an existing grant. */
+  | 'connection-flow';
+
+const CONTRACTS: Record<string, Contract> = {
+  xcp_requestAccounts: 'connection-flow',
+  xcp_disconnect: 'connection-flow',
+  xcp_accounts: 'needs-grant',
+  xcp_getAddresses: 'needs-grant',
+  xcp_getBalances: 'needs-grant',
+  xcp_signMessage: 'needs-grant',
+  xcp_signTransaction: 'needs-grant',
+  xcp_signPsbt: 'needs-grant',
+  xcp_broadcastTransaction: 'needs-grant',
+  xcp_chainId: 'public-constant',
+  xcp_getNetwork: 'public-constant',
+  xcp_getAssets: 'unsupported',
+  xcp_getHistory: 'unsupported',
+};
+
+const ORIGIN = 'https://dapp.example';
+
+/** Params shaped well enough to reach each handler's own logic rather than an arity check. */
+const PLAUSIBLE_PARAMS: Record<string, unknown[]> = {
+  xcp_signMessage: ['hello'],
+  xcp_signTransaction: ['0200000001' + '00'.repeat(40)],
+  xcp_signPsbt: ['70736274ff' + '00'.repeat(20)],
+  xcp_broadcastTransaction: ['0200000001' + '00'.repeat(40)],
+};
+
+describe('provider surface', () => {
+  let provider: ReturnType<typeof createProviderService>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fakeBrowser.reset();
+    // No grant for this origin, in every test below.
+    vi.mocked(getConnectionService).mockReturnValue({
+      hasPermission: vi.fn().mockResolvedValue(false),
+      getConnectedWebsites: vi.fn().mockResolvedValue([]),
+      disconnect: vi.fn().mockResolvedValue(true),
+      connect: vi.fn().mockResolvedValue(true),
+      hasPairedAddressPermission: vi.fn().mockResolvedValue(false),
+    } as never);
+    provider = createProviderService();
+  });
+
+  const call = async (method: string) => {
+    try {
+      const result = await provider.handleRequest(
+        ORIGIN,
+        method,
+        (PLAUSIBLE_PARAMS[method] ?? []) as never
+      );
+      return { ok: true as const, result };
+    } catch (error) {
+      return { ok: false as const, error };
+    }
+  };
+
+  describe('a caller holding no grant', () => {
+    const needsGrant = Object.entries(CONTRACTS)
+      .filter(([, c]) => c === 'needs-grant')
+      .map(([m]) => m);
+
+    it.each(needsGrant)('%s discloses nothing and does not act', async (method) => {
+      const outcome = await call(method);
+
+      if (!outcome.ok) return; // Rejecting is the expected shape.
+
+      // Some methods answer emptily rather than throwing — xcp_accounts returns [] when the site
+      // is not connected. Empty is acceptable; populated is not.
+      const value = outcome.result;
+      if (Array.isArray(value)) {
+        expect(value, `${method} returned data without a grant`).toEqual([]);
+      } else {
+        expect(
+          value === null || value === undefined || value === false,
+          `${method} returned ${JSON.stringify(value)} without a grant`
+        ).toBe(true);
+      }
+    });
+  });
+
+  describe('unsupported methods', () => {
+    const unsupported = Object.entries(CONTRACTS)
+      .filter(([, c]) => c === 'unsupported')
+      .map(([m]) => m);
+
+    it.each(unsupported)('%s rejects rather than answering', async (method) => {
+      const outcome = await call(method);
+      expect(outcome.ok, `${method} should be unsupported`).toBe(false);
+    });
+  });
+
+  describe('public constants', () => {
+    it('xcp_chainId and xcp_getNetwork answer without a grant and reveal nothing', async () => {
+      const chainId = await call('xcp_chainId');
+      const network = await call('xcp_getNetwork');
+      expect(chainId.ok && chainId.result).toBe('0x0');
+      expect(network.ok && network.result).toBe('mainnet');
+    });
+  });
+
+  describe('malformed input', () => {
+    const everyMethod = Object.keys(CONTRACTS);
+
+    it.each(everyMethod)('%s fails cleanly on junk params', async (method) => {
+      // A hostile page controls params entirely. Whatever happens, it must be a rejection or a
+      // benign value — never an unhandled shape that escapes the JSON-RPC envelope.
+      for (const params of [[null], [{}], [[]], ['x'.repeat(10000)], [1, 2, 3, 4, 5]]) {
+        const outcome = await provider
+          .handleRequest(ORIGIN, method, params as never)
+          .then((result) => ({ ok: true, result }))
+          .catch((error) => ({ ok: false, error }));
+        expect(outcome).toBeDefined();
+      }
+    });
+
+    it('rejects a method it does not implement', async () => {
+      const outcome = await call('xcp_notARealMethod');
+      expect(outcome.ok).toBe(false);
+    });
+  });
+
+  it('classifies every method the service dispatches', async () => {
+    // The point of the whole file: a method added without a stated contract fails here, so the
+    // surface cannot grow without someone deciding whether it needs a grant.
+    const source = await import('node:fs').then((fs) =>
+      fs.readFileSync('src/services/providerService.ts', 'utf8')
+    );
+    const dispatched = [...source.matchAll(/case '(xcp_\w+)':/g)].map((m) => m[1]!);
+
+    expect([...new Set(dispatched)].sort()).toEqual(Object.keys(CONTRACTS).sort());
+  });
+});


### PR DESCRIPTION
### Two fail-closed divergences

Both blocked valid transactions. A false block is not a safe default — it's the untrusted-API-veto problem in another form, and this pass has now found four of them.

- **fairminter**: core reads `fields[:17]` and defaults everything after (`mime_type` only `if len(fields) > 17`, the pool pair only at 21+). Requiring exactly 19 or 21 rejected payloads the chain honours.
- **destroy**: core's tag is `message[16:]` with no length check. The 34-byte limit is a *compose-side* rule; enforcing it on unpack refused a valid destroy.

### A sweep for the provider surface

The decoders have a differential fuzzer; the provider surface had only spot checks — read by hand, and a method added later is exactly what a hand review doesn't revisit.

This drives all thirteen methods through `handleRequest` with no grant, with junk params, and with an unknown method, against a table stating each method's contract (`needs-grant`, `public-constant`, `unsupported`, `connection-flow`).

**The last test is the mechanism**: it fails if the service dispatches a method the table doesn't classify. The surface cannot grow without someone deciding, in writing, whether the new method needs a grant.

### The first run passed for the wrong reason

Worth recording. Auto-mocking `rateLimiter` returns `undefined` from `isAllowed()`, which the service reads as *limited* — so every call failed and every grant assertion passed vacuously. The mock now allows, and the assertions exercise what they claim.

A harness that cannot fail is worth less than no harness, because it reports confidence it hasn't earned.

Verified: 0 type errors, 4,034 tests (25 new), biome clean, build clean.

https://claude.ai/code/session_01H6NZ7JtqTVvsVGkYf6hE6s