### PR TITLE
Make the numeric check read CRLF files correctly

### DIFF
--- a/scripts/numeric-discipline.baseline.json
+++ b/scripts/numeric-discipline.baseline.json
@@ -32,7 +32,7 @@
   "src/core/hardware/trezorAdapter.ts": 1,
   "src/core/counterparty/describe.ts": 1,
   "src/core/counterparty/outputPolicy.ts": 1,
-  "src/core/counterparty/price.ts": 2,
+  "src/core/counterparty/price.ts": 1,
   "src/core/counterparty/unpack/messages/broadcast.ts": 1,
   "src/core/bitcoin/consolidateBatch.ts": 5,
   "src/core/bitcoin/feeVerification.ts": 5,
@@ -58,6 +58,5 @@
   "src/components/domain/balance/balance-list.tsx": 1,
   "src/components/domain/asset/asset-card.tsx": 1,
   "src/components/domain/asset/asset-header.tsx": 1,
-  "src/components/domain/asset/fairminter-select-input.tsx": 3,
-  "src/components/domain/approval/order-card.tsx": 1
+  "src/components/domain/asset/fairminter-select-input.tsx": 3
 }

--- a/scripts/numeric-discipline.ts
+++ b/scripts/numeric-discipline.ts
@@ -55,7 +55,12 @@ export function importsBigNumberDirectly(source: string): boolean {
 
 export function violationsIn(source: string): number {
   let count = 0;
-  for (const line of source.split('\n')) {
+  // Split on either convention rather than on '\n' alone. JavaScript's `.` does not match `\r`, so
+  // on a CRLF checkout `//.*$` never reaches end-of-line and strips nothing: comments were scanned
+  // as code, and a comment containing the word `Number()` scored as a violation. It also made the
+  // count differ between a Windows working copy and CI's Linux one, so a baseline recorded on one
+  // could not be checked against the other.
+  for (const line of source.split(/\r?\n/)) {
     const code = line.replace(/\/\/.*$/, '').replace(/^\s*\*.*$/, '');
     if (!MONEY.test(code) || NOT_MONEY.test(code)) continue;
     const matches = code.match(RAW_NUMERIC);


### PR DESCRIPTION
The check shipped in #269 counted comments.

JavaScript's `.` does not match `\r`, so on a CRLF checkout `//.*$` never reaches end-of-line and strips nothing. Comments were scanned as code, and a comment containing the word `Number()` scored as a violation — which is how `main` came to fail lint immediately after #269 merged, on a file whose only change was a comment explaining the fix.

The sharper problem is that it made the count depend on the checkout's line endings. The baseline was recorded on Windows (CRLF, inflated) and checked on CI's Linux (LF, lower), so CI passed while the same tree failed locally. A ratchet that disagrees with itself across platforms cannot hold the line it exists to hold.

Splitting on `/\r?\n/` makes both agree — verified by counting the same file written out in each convention.

Baseline regenerated: 145 → 143 sites across 60 files. The difference is false positives that were never real.

https://claude.ai/code/session_01H6NZ7JtqTVvsVGkYf6hE6s