### PR TITLE
Let a dispenser actually be closed

### DIFF
--- a/src/core/counterparty/unpack/__tests__/composeFlowVerification.test.ts
+++ b/src/core/counterparty/unpack/__tests__/composeFlowVerification.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Every compose flow's real parameter set, run through the verifier.
+ *
+ * A wallet flow does not submit the full parameter list for its message type. The dispenser close
+ * form sends `asset` and `status: 10` and nothing else; the composer fills give_quantity,
+ * escrow_quantity and mainchainrate with 0, and a verifier that compares those against a request
+ * that never carried them reports tampering and blocks the flow. That shipped: closing a dispenser
+ * failed with three CRITICAL mismatches reading "expected undefined, got 0".
+ *
+ * `verifyTypes.test.ts` covers each message type once, with a complete parameter set — which is
+ * exactly the case that cannot catch this. The table below is keyed on flows instead, and each row
+ * is the parameter set its form actually submits, read off the form rather than assumed.
+ *
+ * A row failing here means a legitimate transaction cannot be composed. That is not a lesser
+ * failure than missing tampering: a check that blocks correct work gets removed, and takes the
+ * tampering coverage with it.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { COUNTERPARTY_PREFIX_HEX } from '../messageTypes';
+import { verifyTransaction } from '../verify';
+
+const PREFIX = COUNTERPARTY_PREFIX_HEX;
+const u64 = (n: bigint) => n.toString(16).padStart(16, '0');
+const u32 = (n: number) => n.toString(16).padStart(8, '0');
+
+/** A flow, its submitted params, and the message the composer produces for them. */
+interface Flow {
+  /** The form this comes from, so a failure points at the code to read. */
+  form: string;
+  type: Parameters<typeof verifyTransaction>[1];
+  message: string;
+  params: Record<string, unknown>;
+}
+
+const ASSET_ID_XCP = u64(1n);
+
+const FLOWS: Flow[] = [
+  {
+    // Submits asset, give_remaining_normalized, status=10. The composer zeroes the three
+    // quantities, which the request never named.
+    form: 'dispenser/close/form.tsx',
+    type: 'dispenser',
+    message: PREFIX + '0c' + ASSET_ID_XCP + u64(0n) + u64(0n) + u64(0n) + '0a',
+    params: { asset: 'XCP', status: 10 },
+  },
+  {
+    form: 'dispenser/close-by-hash/form.tsx',
+    type: 'dispenser',
+    message: PREFIX + '0c' + ASSET_ID_XCP + u64(0n) + u64(0n) + u64(0n) + '0a',
+    params: { asset: 'XCP', status: 10, open_address: undefined },
+  },
+  {
+    // The open flow, for contrast: it does supply all three.
+    form: 'dispenser/form.tsx',
+    type: 'dispenser',
+    message: PREFIX + '0c' + ASSET_ID_XCP + u64(100n) + u64(1000n) + u64(1000000n) + '00',
+    params: {
+      asset: 'XCP',
+      give_quantity: 100,
+      escrow_quantity: 1000,
+      mainchainrate: 1000000,
+      status: 0,
+    },
+  },
+  {
+    // Submits asset, divisible, quantity=0, lock=true. No description: a reissuance carries the
+    // asset's existing one forward, which the request cannot predict.
+    form: 'issuance/lock-supply/form.tsx',
+    type: 'issuance',
+    message: PREFIX + '14' + ASSET_ID_XCP + u64(0n) + '01' + '01' + '00' + '00',
+    params: { asset: 'XCP', quantity: 0, divisible: true, lock: true },
+  },
+  {
+    form: 'issuance/reset-supply/form.tsx',
+    type: 'issuance',
+    message: PREFIX + '14' + ASSET_ID_XCP + u64(0n) + '01' + '00' + '01' + '00',
+    params: { asset: 'XCP', quantity: 0, divisible: true, reset: true },
+  },
+  {
+    form: 'issuance/transfer-ownership/form.tsx',
+    type: 'issuance',
+    message: PREFIX + '14' + ASSET_ID_XCP + u64(0n) + '01' + '00' + '00' + '00',
+    params: { asset: 'XCP', quantity: 0, divisible: true },
+  },
+  {
+    // Submits offer_hash alone.
+    form: 'order/cancel/form.tsx',
+    type: 'cancel',
+    message: PREFIX + '46' + 'aa'.repeat(32),
+    params: { offer_hash: 'aa'.repeat(32) },
+  },
+  {
+    // Submits text; value and fee_fraction are fixed at 0 by the form.
+    form: 'broadcast/form.tsx',
+    type: 'broadcast',
+    message:
+      PREFIX +
+      '1e' +
+      u32(Math.floor(Date.now() / 1000)) +
+      u64(0n) +
+      u32(0) +
+      '05' +
+      Buffer.from('hello').toString('hex'),
+    params: { text: 'hello', value: 0, fee_fraction: 0 },
+  },
+];
+
+describe('every compose flow verifies against its own parameter set', () => {
+  for (const flow of FLOWS) {
+    it(`accepts ${flow.form}`, () => {
+      const result = verifyTransaction(flow.message, flow.type, flow.params);
+
+      // The message is what the composer returns for these params, so any mismatch is the verifier
+      // demanding a field the flow does not send.
+      expect(result.errors, `${flow.form} would be blocked`).toHaveLength(0);
+      expect(result.valid).toBe(true);
+    });
+  }
+});

--- a/src/core/counterparty/unpack/__tests__/verifyTypes.test.ts
+++ b/src/core/counterparty/unpack/__tests__/verifyTypes.test.ts
@@ -104,5 +104,25 @@ describe('verifyTransaction activation per type', () => {
       const r = verifyTransaction(message, 'dispenser', { ...intent, mainchainrate: 1 });
       expect(r.valid).toBe(false);
     });
+
+    // Core constrains give_quantity, escrow_quantity and mainchainrate for the open statuses only
+    // (`dispenser.py`); a close leaves them unset and the composer sends 0. The close form submits
+    // status alone, so comparing 0 against a request that never carried the field reported three
+    // CRITICAL mismatches and blocked every attempt to close a dispenser.
+    describe('closing', () => {
+      const closeMessage = PREFIX + '0c' + u64(1n) + u64(0n) + u64(0n) + u64(0n) + '0a';
+
+      it('accepts a close that omits the quantities the composer defaults', () => {
+        const r = verifyTransaction(closeMessage, 'dispenser', { asset: 'XCP', status: 10 });
+        expect(r.errors).toHaveLength(0);
+        expect(r.valid).toBe(true);
+      });
+
+      it('still rejects a close carrying an escrow it was not asked for', () => {
+        const escrowed = PREFIX + '0c' + u64(1n) + u64(0n) + u64(5000n) + u64(0n) + '0a';
+        const r = verifyTransaction(escrowed, 'dispenser', { asset: 'XCP', status: 10 });
+        expect(r.valid).toBe(false);
+      });
+    });
   });
 });

--- a/src/core/counterparty/unpack/verify.ts
+++ b/src/core/counterparty/unpack/verify.ts
@@ -491,23 +491,24 @@ function verifyDispenser(
       'Wrong asset = dispensing wrong tokens');
   }
 
-  // Give quantity - critical
-  if (!valuesEqual(data.giveQuantity, params.give_quantity)) {
-    addMismatch(result, 'give_quantity', params.give_quantity, data.giveQuantity, 'critical',
-      'Wrong amount = giving wrong amount per dispense');
-  }
+  // Give quantity, escrow and rate - critical, but only the open flows supply them.
+  //
+  // Core constrains these for STATUS_OPEN and STATUS_OPEN_EMPTY_ADDRESS only (`dispenser.py`:
+  // give_quantity and mainchainrate must be positive, escrow >= give); a close leaves them
+  // unconstrained and the composer sends 0. Comparing the composed 0 against a request that never
+  // carried the field reported three CRITICAL mismatches — "expected undefined, got 0" — on every
+  // attempt to close a dispenser, which blocked the flow outright.
+  //
+  // verifyOptional keeps the check rather than dropping it: with the field absent the expectation
+  // becomes 0, so a response that closes a dispenser while carrying a non-zero escrow still fails.
+  verifyOptional(result, 'give_quantity', params.give_quantity, data.giveQuantity, 0, 'critical',
+    'Wrong amount = giving wrong amount per dispense');
 
-  // Escrow quantity - critical
-  if (!valuesEqual(data.escrowQuantity, params.escrow_quantity)) {
-    addMismatch(result, 'escrow_quantity', params.escrow_quantity, data.escrowQuantity, 'critical',
-      'Wrong amount = locking wrong total amount');
-  }
+  verifyOptional(result, 'escrow_quantity', params.escrow_quantity, data.escrowQuantity, 0, 'critical',
+    'Wrong amount = locking wrong total amount');
 
-  // Mainchainrate - critical
-  if (!valuesEqual(data.mainchainrate, params.mainchainrate)) {
-    addMismatch(result, 'mainchainrate', params.mainchainrate, data.mainchainrate, 'critical',
-      'Wrong rate = selling at wrong price');
-  }
+  verifyOptional(result, 'mainchainrate', params.mainchainrate, data.mainchainrate, 0, 'critical',
+    'Wrong rate = selling at wrong price');
 
   // Status - dangerous. Opening a dispenser omits status (the compose layer defaults it to 0);
   // the close flows submit it explicitly. Either way the composed status must match, so a response


### PR DESCRIPTION
Closing a dispenser failed verification outright, with three CRITICAL mismatches reading `expected undefined, got 0` for `give_quantity`, `escrow_quantity` and `mainchainrate`. The flow was unusable.

## Cause

Core constrains those three for the open statuses only (`dispenser.py`: give and rate positive, escrow >= give). A close leaves them unconstrained and the composer sends 0. The close form submits `asset` and `status: 10` and nothing else, so the verifier was comparing a composer default against a field the request never carried — and treating the difference as tampering.

`verifyOptional` already encodes exactly this: absent from the request means the composer defaults it. The `status` check immediately below the three broken ones was already using it. They now do too, so the check is kept rather than dropped — a response that closes a dispenser while carrying a non-zero escrow still fails, which the second test pins.

## Not a regression from 0.8.0

0.8.0 fixed how a dispenser close is *described* on the provider approval screen, where it had rendered identically to an open. This is the compose verifier — a different file with the same blind spot, untouched by that release.

## The check that would have caught it

`verifyTypes.test.ts` covers each message type once with a *complete* parameter set, which is precisely the case that cannot catch a verifier demanding a field some flow omits.

`composeFlowVerification.test.ts` is keyed on flows instead. Each row is the parameter set a form actually submits — read off the form, not assumed — against the message the composer returns for it. A failing row means a legitimate transaction cannot be composed, and the message names the form. Reverting the fix makes the two dispenser close rows fail.

## Audit of the other types

No second instance. `verifyMove` and `verifyDetach` already document the same reasoning explicitly, and the issuance `description` check is guarded on presence. The pattern was understood; `verifyDispenser` was where it had not been applied.

Worth recording: a static audit could not have found this. `DispenserOptions` declares `give_quantity` **required** while the close form omits it, so the options types do not model per-flow optionality and neither TypeScript nor a scan of them would flag it. Only exercising the flows does.

https://claude.ai/code/session_01H6NZ7JtqTVvsVGkYf6hE6s