### PR TITLE
Decline a send layout this wallet does not compose

### DIFF
--- a/src/core/counterparty/pack/__tests__/onchainRoundTrip.test.ts
+++ b/src/core/counterparty/pack/__tests__/onchainRoundTrip.test.ts
@@ -49,12 +49,21 @@ interface OnChainTransaction {
  * rather than failed.
  */
 const PARAMS_FROM_DECODED: Record<string, (data: Record<string, any>) => Record<string, unknown> | null> = {
-  enhanced_send: (data) => ({
-    asset: data.asset,
-    destination: data.destination,
-    quantity: data.quantity,
-    memo: data.memo ?? '',
-  }),
+  // Core composes CBOR wherever `taproot_support` is active and the `>QQ21s` struct otherwise, and
+  // its unpack accepts both — so clients predating the activation are still sending the struct
+  // form, and it is still on chain today. This wallet composes only the modern layout: it is a
+  // wallet, not an indexer, and reproducing every historical encoding is not its job. A struct
+  // send is therefore one it can read and deliberately cannot rebuild, which counts as declined
+  // rather than as a defect.
+  enhanced_send: (data) =>
+    data.layout === 'legacy'
+      ? null
+      : {
+          asset: data.asset,
+          destination: data.destination,
+          quantity: data.quantity,
+          memo: data.memo ?? '',
+        },
   sweep: (data) => (data.memoIsBinary ? null : {
     destination: data.destination,
     flags: data.flags,

--- a/src/core/counterparty/unpack/messages/enhancedSend.ts
+++ b/src/core/counterparty/unpack/messages/enhancedSend.ts
@@ -40,6 +40,15 @@ export interface EnhancedSendData {
   memo?: string;
   /** Raw memo bytes */
   memoBytes?: Uint8Array;
+  /**
+   * Which layout the bytes were in.
+   *
+   * Core composes CBOR wherever `taproot_support` is active and falls back to the `>QQ21s` struct
+   * otherwise, and its unpack accepts both — so clients predating the activation are still sending
+   * the struct form. This wallet composes only the modern one, so a struct-layout message is one
+   * it can read but deliberately cannot rebuild.
+   */
+  layout?: 'cbor' | 'legacy';
 }
 
 /**
@@ -70,6 +79,7 @@ function tryCbor2Decode(payload: Uint8Array): EnhancedSendData | null {
     destination: unpackAddress(addressValue),
     memo: memoBytes ? bytesToTextOrHex(memoBytes) : undefined,
     memoBytes,
+    layout: 'cbor',
   };
 }
 
@@ -118,6 +128,7 @@ function unpackLegacy(payload: Uint8Array): EnhancedSendData {
     destination,
     memo,
     memoBytes,
+    layout: 'legacy',
   };
 }
 


### PR DESCRIPTION
Fixes the nightly on-chain round-trip, which has failed for `enhanced_send` since 2026-08-05 — 13 real messages whose rebuilt bytes differed from the chain.

Closes #268
Closes #252

## Why it started

#264 added the `enhanced_send` packer. The round-trip only exercises a type once a packer exists for it, so the check began comparing on that merge and immediately disagreed. Nothing regressed; a previously-unchecked area started being checked.

## Why the bytes differ

Core composes CBOR wherever `taproot_support` is active and the `>QQ21s` struct otherwise, and its unpack tries CBOR before falling back to struct (`versions/enhancedsend.py`). Clients predating that activation are still sending the struct form today, with base58 address packing (`00` + hash160) rather than the modern packer's (`01` + hash160). Both are valid and both are on chain.

## The decision

This wallet composes only the modern layout, and keeps it that way. It is a wallet, not an indexer — reproducing every historical encoding is not its job.

Nothing is lost by that. The decoder already reads both layouts, so those sends still display correctly. The repack proof simply cannot prove one, which fails **safe**: unproved, not approved.

So the decoder now reports which layout it read, and the round-trip counts a struct-layout send as **declined** — the bucket it already maintains for shapes the compose path never produces — rather than as a failure.

## Verification

Run against live chain data with `COUNTERPARTY_API_URL` set: all 11 types pass. 4,064 unit tests, lint and tsc clean.

https://claude.ai/code/session_01H6NZ7JtqTVvsVGkYf6hE6s