### PR TITLE
Order approvals say 'at least', and the wallet checks the market itself

### DIFF
--- a/src/components/domain/approval/__tests__/order-card.test.tsx
+++ b/src/components/domain/approval/__tests__/order-card.test.tsx
@@ -1,0 +1,151 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { OrderAction } from '../order-card';
+import { OrderCard } from '../order-card';
+
+/**
+ * The card shows a guaranteed minimum beside the wallet's own market estimate. The estimate is
+ * decoration and must never gate signing; the warnings drawn from it are the part that can misfire,
+ * so the thresholds are pinned here rather than left to be noticed on a real approval.
+ */
+
+const mockFetchPoolQuote = vi.fn();
+vi.mock('@/core/counterparty/api', () => ({
+  fetchPoolQuote: (...args: unknown[]) => mockFetchPoolQuote(...args),
+}));
+
+/** An order giving 1 XCP for at least 100 units of a divisible asset. */
+const order = (overrides: Partial<OrderAction> = {}): OrderAction => ({
+  giveAmount: '1.00000000',
+  giveAsset: 'XCP',
+  getAmount: '100.00000000',
+  getAsset: 'MYASSET',
+  normalizedGive: 1,
+  normalizedGet: 100,
+  expiration: 1,
+  giveAssetRaw: 'XCP',
+  getAssetRaw: 'MYASSET',
+  giveQuantityRaw: '100000000',
+  getQuantityRaw: '10000000000',
+  getDivisor: 1e8,
+  ...overrides,
+});
+
+/** A quote whose estimate is `estimatedRaw` base units, routed through the pool. */
+const quote = (estimatedRaw: number) => ({
+  estimated_output: estimatedRaw,
+  pool_output: estimatedRaw,
+  book_output: 0,
+});
+
+describe('OrderCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetchPoolQuote.mockResolvedValue(quote(10_000_000_000));
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('names the receive amount as a minimum', async () => {
+    // No quote, and a give amount that keeps the price ratio from also reading 100.00000000.
+    mockFetchPoolQuote.mockRejectedValue(new Error('offline'));
+    render(<OrderCard order={order({ giveAmount: '2.00000000', normalizedGive: 2 })} />);
+
+    expect(screen.getByText('You receive at least')).toBeInTheDocument();
+    expect(screen.getByText(/100\.00000000/)).toBeInTheDocument();
+  });
+
+  it('shows the wallet\'s own estimate beside it', async () => {
+    // Estimate 101 units against a 100 minimum: a 1% cushion, no warning.
+    mockFetchPoolQuote.mockResolvedValue(quote(10_100_000_000));
+    render(<OrderCard order={order()} />);
+
+    expect(await screen.findByText(/~101\.00000000 at the pool price right now/)).toBeInTheDocument();
+    expect(screen.getByText(/not supplied by the site/)).toBeInTheDocument();
+    expect(screen.queryByText(/Make sure that is the slippage/)).not.toBeInTheDocument();
+  });
+
+  it('describes a book-routed estimate as the order book, not the pool', async () => {
+    mockFetchPoolQuote.mockResolvedValue({
+      estimated_output: 10_100_000_000,
+      pool_output: 0,
+      book_output: 10_100_000_000,
+    });
+    render(<OrderCard order={order()} />);
+
+    expect(await screen.findByText(/at the current order book price/)).toBeInTheDocument();
+  });
+
+  it('describes a split route as the market', async () => {
+    mockFetchPoolQuote.mockResolvedValue({
+      estimated_output: 10_100_000_000,
+      pool_output: 5_000_000_000,
+      book_output: 5_100_000_000,
+    });
+    render(<OrderCard order={order()} />);
+
+    expect(await screen.findByText(/at the current market price/)).toBeInTheDocument();
+  });
+
+  it('warns once the minimum sits 5% or more below the estimate', async () => {
+    // Minimum 100, estimate 105.264 -> 5.0% implied slippage.
+    mockFetchPoolQuote.mockResolvedValue(quote(10_526_400_000));
+    render(<OrderCard order={order()} />);
+
+    expect(await screen.findByText(/accepts up to 5\.0% less/)).toBeInTheDocument();
+  });
+
+  it('stays quiet just under the threshold', async () => {
+    // Minimum 100, estimate 104 -> 3.8%, below the 5% line.
+    mockFetchPoolQuote.mockResolvedValue(quote(10_400_000_000));
+    render(<OrderCard order={order()} />);
+
+    await screen.findByText(/~104\.00000000/);
+    expect(screen.queryByText(/Make sure that is the slippage/)).not.toBeInTheDocument();
+  });
+
+  it('says the order will likely rest when the market is below the minimum', async () => {
+    // Estimate 95 against a 100 minimum: nothing can fill this right now.
+    mockFetchPoolQuote.mockResolvedValue(quote(9_500_000_000));
+    render(<OrderCard order={order()} />);
+
+    expect(await screen.findByText(/likely to rest unfilled/)).toBeInTheDocument();
+    // The estimate line is for a cushion, not a shortfall — it would read as reassurance.
+    expect(screen.queryByText(/not supplied by the site/)).not.toBeInTheDocument();
+  });
+
+  it('shows the minimum alone when the node cannot be reached', async () => {
+    mockFetchPoolQuote.mockRejectedValue(new Error('offline'));
+    render(<OrderCard order={order()} />);
+
+    await waitFor(() => expect(mockFetchPoolQuote).toHaveBeenCalled());
+    expect(screen.getByText('You receive at least')).toBeInTheDocument();
+    expect(screen.queryByText(/at the/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/likely to rest unfilled/)).not.toBeInTheDocument();
+  });
+
+  it('does not quote a BTC pair, which has no market here', async () => {
+    render(<OrderCard order={order({ getAssetRaw: 'BTC', getAsset: 'BTC' })} />);
+
+    expect(screen.getByText('You receive at least')).toBeInTheDocument();
+    expect(mockFetchPoolQuote).not.toHaveBeenCalled();
+  });
+
+  it('withholds the estimate when divisibility is unknown', async () => {
+    // The local-unpack path cannot establish divisibility; scaling by a guess is wrong by 1e8.
+    render(<OrderCard order={order({ getDivisor: null })} />);
+
+    await waitFor(() => expect(mockFetchPoolQuote).toHaveBeenCalled());
+    expect(screen.queryByText(/at the pool price/)).not.toBeInTheDocument();
+  });
+
+  it('asks the node for the give quantity in base units', async () => {
+    render(<OrderCard order={order()} />);
+
+    await waitFor(() => {
+      expect(mockFetchPoolQuote).toHaveBeenCalledWith('XCP', 'MYASSET', '100000000');
+    });
+  });
+});

--- a/src/components/domain/approval/order-card.tsx
+++ b/src/components/domain/approval/order-card.tsx
@@ -26,11 +26,11 @@
 import { useEffect, useState } from 'react';
 import { isAssetDivisible, normalizeQuantity } from '@/components/domain/tx/tx-action-info';
 import { FiArrowDown } from '@/components/icons';
-import { useSettings } from '@/contexts/settings-context';
+import { fetchPoolQuote, type PoolQuote } from '@/core/counterparty/api';
 import type { CounterpartyMessage } from '@/core/counterparty/transaction';
 import type { ProviderVerificationResult } from '@/core/counterparty/unpack';
 import { formatPriceRatio } from '@/core/format';
-import { divide, toNumber } from '@/core/numeric';
+import { type BigNumber, divide, isGreaterThan, subtract, toBigNumber, toNumber } from '@/core/numeric';
 
 export interface OrderAction {
   giveAmount: string;
@@ -55,6 +55,12 @@ export interface OrderAction {
   getAssetRaw: string;
   giveQuantityRaw: string;
   getQuantityRaw: string;
+  /**
+   * What the get side's base units divide by for display: 1e8, 1, or null when divisibility could
+   * not be established. Carried rather than recovered from the normalized figure, which would mean
+   * dividing two floats to recover a constant this builder already computed.
+   */
+  getDivisor: number | null;
 }
 
 /** The parts of a decoded transaction or PSBT this builder reads — both screens supply them. */
@@ -102,6 +108,7 @@ export function buildOrderAction(source: OrderSource): OrderAction | null {
       getAssetRaw,
       giveQuantityRaw: String(messageData.give_quantity ?? ''),
       getQuantityRaw: String(messageData.get_quantity ?? ''),
+      getDivisor,
     };
   }
 
@@ -140,6 +147,7 @@ export function buildOrderAction(source: OrderSource): OrderAction | null {
       getAssetRaw: data.getAsset,
       giveQuantityRaw: String(data.giveQuantity),
       getQuantityRaw: String(data.getQuantity),
+      getDivisor,
     };
   }
 
@@ -147,69 +155,102 @@ export function buildOrderAction(source: OrderSource): OrderAction | null {
 }
 
 /**
- * The wallet's own read of the pool, fetched from the configured node at approval time. `null`
- * while loading or when there is no pool for the pair — in both cases the card simply shows the
- * decoded minimum alone. The estimate is decoration; the minimum is the contract. Signing is never
- * blocked on this lookup.
+ * The wallet's own read of the market, fetched from the configured node at approval time.
+ *
+ * `estimated_output` spans the pool *and* the order book — the API reports `pool_output` and
+ * `book_output` separately and this is their sum — so the figure is a market estimate, not a pool
+ * price, and the wording says so.
+ *
+ * `null` while loading, when the pair has no market, or when the node cannot be reached. In every
+ * one of those cases the card shows the decoded minimum alone: the estimate is decoration, the
+ * minimum is the contract, and signing is never blocked on this lookup.
  */
 interface OwnQuote {
-  estimatedRaw: number;
+  /** Estimated output in base units. */
+  estimatedRaw: BigNumber;
+  /** Which venues the estimate came from, for the label. */
+  route: 'pool' | 'book' | 'both' | null;
 }
 
-function useOwnPoolQuote(order: OrderAction): OwnQuote | null {
-  const { settings } = useSettings();
+function routeOf(quote: PoolQuote): OwnQuote['route'] {
+  const pool = isGreaterThan(quote.pool_output ?? 0, 0);
+  const book = isGreaterThan(quote.book_output ?? 0, 0);
+  if (pool && book) return 'both';
+  if (pool) return 'pool';
+  if (book) return 'book';
+  return null;
+}
+
+function useOwnMarketQuote(order: OrderAction): OwnQuote | null {
   const [quote, setQuote] = useState<OwnQuote | null>(null);
 
   useEffect(() => {
-    // BTC has no pools, and a zero quantity has no quote.
+    // BTC has no pool or book here, and a zero quantity has nothing to quote.
     if (
       order.giveAssetRaw === 'BTC' ||
       order.getAssetRaw === 'BTC' ||
       !order.giveQuantityRaw ||
-      order.giveQuantityRaw === '0'
+      !isGreaterThan(order.giveQuantityRaw, 0)
     ) {
       return;
     }
-    const controller = new AbortController();
+
+    let cancelled = false;
     (async () => {
       try {
-        const res = await fetch(
-          `${settings.counterpartyApiBase}/v2/pools/${order.giveAssetRaw}/${order.getAssetRaw}/quote?quantity=${order.giveQuantityRaw}`,
-          { signal: controller.signal }
+        // fetchPoolQuote rather than a hand-rolled fetch: it encodes the asset names, skips the
+        // cache, and parses through the lossless JSON boundary — a base-unit quantity read with
+        // JSON.parse is already rounded above 2^53 (see core/api/losslessJson.ts).
+        const result = await fetchPoolQuote(
+          order.giveAssetRaw,
+          order.getAssetRaw,
+          order.giveQuantityRaw
         );
-        if (!res.ok) return;
-        const estimated = Number((await res.json())?.result?.estimated_output);
-        if (Number.isFinite(estimated) && estimated > 0) {
-          setQuote({ estimatedRaw: estimated });
+        if (cancelled) return;
+        const estimatedRaw = toBigNumber(result.estimated_output ?? 0);
+        if (estimatedRaw.isFinite() && estimatedRaw.isGreaterThan(0)) {
+          setQuote({ estimatedRaw, route: routeOf(result) });
         }
       } catch {
-        // No pool, no node, no answer — the minimum stands on its own.
+        // No market, no node, no answer — the minimum stands on its own.
       }
     })();
-    return () => controller.abort();
-  }, [settings.counterpartyApiBase, order.giveAssetRaw, order.getAssetRaw, order.giveQuantityRaw]);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [order.giveAssetRaw, order.getAssetRaw, order.giveQuantityRaw]);
 
   return quote;
 }
 
+/** How the estimate is described, given where it came from. */
+const ROUTE_LABEL: Record<NonNullable<OwnQuote['route']>, string> = {
+  pool: 'at the pool price right now',
+  book: 'at the current order book price',
+  both: 'at the current market price',
+};
+
 /** The give/receive card, with a rate the user can flip. */
 export function OrderCard({ order }: { order: OrderAction }) {
   const [priceFlipped, setPriceFlipped] = useState(false);
-  const ownQuote = useOwnPoolQuote(order);
+  const ownQuote = useOwnMarketQuote(order);
 
-  const minRaw = Number(order.getQuantityRaw);
-  // Scale the raw estimate into display units by the same divisor the decoded minimum used —
-  // derivable only when the normalized figure exists, so the estimate is withheld exactly when
-  // the price ratio is.
-  const getScale =
-    order.normalizedGet !== null && order.normalizedGet > 0 && minRaw > 0
-      ? minRaw / order.normalizedGet
-      : null;
+  // Both figures are base-unit quantities, so they are compared as such and scaled for display by
+  // the divisor the builder already established. Withheld when divisibility is unknown, exactly as
+  // the price ratio is — showing an amount scaled by a guess is how a figure is wrong by 1e8.
+  const minRaw = toBigNumber(order.getQuantityRaw || 0);
   const estimateDisplay =
-    ownQuote && getScale !== null ? (ownQuote.estimatedRaw / getScale).toFixed(8) : null;
-  /** How far below the wallet's own quote this order is willing to settle, as a fraction. */
+    ownQuote && order.getDivisor !== null
+      ? divide(ownQuote.estimatedRaw, order.getDivisor).toFixed(8)
+      : null;
+
+  /** How far below the wallet's own estimate this order is willing to settle, as a fraction. */
   const impliedSlippage =
-    ownQuote && minRaw > 0 && ownQuote.estimatedRaw > 0 ? 1 - minRaw / ownQuote.estimatedRaw : null;
+    ownQuote && minRaw.isGreaterThan(0)
+      ? toNumber(subtract(1, divide(minRaw, ownQuote.estimatedRaw)))
+      : null;
+  const routeLabel = ownQuote?.route ? ROUTE_LABEL[ownQuote.route] : null;
 
   return (
     <div className="mb-3">
@@ -252,10 +293,11 @@ export function OrderCard({ order }: { order: OrderAction }) {
           {order.getAmount}{' '}
           <span className="text-base font-normal text-gray-500">{order.getAsset}</span>
         </p>
-        {estimateDisplay !== null && impliedSlippage !== null && impliedSlippage >= 0 && (
+        {estimateDisplay !== null && routeLabel !== null && impliedSlippage !== null
+          && impliedSlippage >= 0 && (
           <>
             <p className="text-xs text-gray-500 mt-1.5">
-              ~{estimateDisplay} at the pool price right now
+              ~{estimateDisplay} {routeLabel}
             </p>
             <p className="text-[11px] text-gray-400">
               Checked by your wallet, not supplied by the site.
@@ -264,14 +306,14 @@ export function OrderCard({ order }: { order: OrderAction }) {
         )}
         {impliedSlippage !== null && impliedSlippage < 0 && (
           <p className="text-xs text-red-600 mt-1.5">
-            The pool price has moved below this minimum. This order is likely to rest unfilled
-            instead of executing.
+            The market has moved below this minimum. This order is likely to rest unfilled instead
+            of executing.
           </p>
         )}
         {impliedSlippage !== null && impliedSlippage >= 0.05 && (
           <p className="text-xs text-amber-600 mt-1.5">
             This order accepts up to {(impliedSlippage * 100).toFixed(1)}% less than the wallet's
-            own pool quote. Make sure that is the slippage you chose.
+            own estimate. Make sure that is the slippage you chose.
           </p>
         )}
       </div>

--- a/src/components/domain/approval/order-card.tsx
+++ b/src/components/domain/approval/order-card.tsx
@@ -11,11 +11,22 @@
  * a rule with two implementations gets fixed in whichever one the author is looking at. Here the
  * cost is milder (a person recognises one screen and not the other) but the cause is identical, so
  * the card and the builder live together and both screens call them.
+ *
+ * The receive box says "at least", because that is what an order's get_quantity is: the guaranteed
+ * minimum, not a prediction. Sites show pool estimates; the signed message carries the bound. Every
+ * major wallet simulates and shows the estimate, so a decoded minimum with no label reads as the
+ * site's number gone wrong — a real user cancelled a correct transaction over exactly this. The
+ * card therefore names the category, and beside it fetches its own pool quote from the wallet's
+ * configured node — never from anything the site supplied — so the user sees the wallet
+ * independently agree with what the site promised. When the order's minimum sits far below the
+ * wallet's own quote, that same fetch turns into a warning: either the pool moved, or the site
+ * composed against a number it shouldn't have.
  */
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { isAssetDivisible, normalizeQuantity } from '@/components/domain/tx/tx-action-info';
 import { FiArrowDown } from '@/components/icons';
+import { useSettings } from '@/contexts/settings-context';
 import type { CounterpartyMessage } from '@/core/counterparty/transaction';
 import type { ProviderVerificationResult } from '@/core/counterparty/unpack';
 import { formatPriceRatio } from '@/core/format';
@@ -35,6 +46,15 @@ export interface OrderAction {
   normalizedGive: number | null;
   normalizedGet: number | null;
   expiration: number;
+  /**
+   * Raw asset names and base-unit quantities, for the wallet's own pool-quote lookup. Raw names
+   * because the API routes on them (a longname is display-only); strings because a 64-bit quantity
+   * through Number() is already rounded.
+   */
+  giveAssetRaw: string;
+  getAssetRaw: string;
+  giveQuantityRaw: string;
+  getQuantityRaw: string;
 }
 
 /** The parts of a decoded transaction or PSBT this builder reads — both screens supply them. */
@@ -78,6 +98,10 @@ export function buildOrderAction(source: OrderSource): OrderAction | null {
       normalizedGive: toNumber(divide(String(messageData.give_quantity), giveDivisor)),
       normalizedGet: toNumber(divide(String(messageData.get_quantity), getDivisor)),
       expiration: Number(messageData.expiration ?? 0),
+      giveAssetRaw,
+      getAssetRaw,
+      giveQuantityRaw: String(messageData.give_quantity ?? ''),
+      getQuantityRaw: String(messageData.get_quantity ?? ''),
     };
   }
 
@@ -112,15 +136,80 @@ export function buildOrderAction(source: OrderSource): OrderAction | null {
       normalizedGet:
         getDivisor === null ? null : toNumber(divide(String(data.getQuantity), getDivisor)),
       expiration: data.expiration,
+      giveAssetRaw: data.giveAsset,
+      getAssetRaw: data.getAsset,
+      giveQuantityRaw: String(data.giveQuantity),
+      getQuantityRaw: String(data.getQuantity),
     };
   }
 
   return null;
 }
 
+/**
+ * The wallet's own read of the pool, fetched from the configured node at approval time. `null`
+ * while loading or when there is no pool for the pair — in both cases the card simply shows the
+ * decoded minimum alone. The estimate is decoration; the minimum is the contract. Signing is never
+ * blocked on this lookup.
+ */
+interface OwnQuote {
+  estimatedRaw: number;
+}
+
+function useOwnPoolQuote(order: OrderAction): OwnQuote | null {
+  const { settings } = useSettings();
+  const [quote, setQuote] = useState<OwnQuote | null>(null);
+
+  useEffect(() => {
+    // BTC has no pools, and a zero quantity has no quote.
+    if (
+      order.giveAssetRaw === 'BTC' ||
+      order.getAssetRaw === 'BTC' ||
+      !order.giveQuantityRaw ||
+      order.giveQuantityRaw === '0'
+    ) {
+      return;
+    }
+    const controller = new AbortController();
+    (async () => {
+      try {
+        const res = await fetch(
+          `${settings.counterpartyApiBase}/v2/pools/${order.giveAssetRaw}/${order.getAssetRaw}/quote?quantity=${order.giveQuantityRaw}`,
+          { signal: controller.signal }
+        );
+        if (!res.ok) return;
+        const estimated = Number((await res.json())?.result?.estimated_output);
+        if (Number.isFinite(estimated) && estimated > 0) {
+          setQuote({ estimatedRaw: estimated });
+        }
+      } catch {
+        // No pool, no node, no answer — the minimum stands on its own.
+      }
+    })();
+    return () => controller.abort();
+  }, [settings.counterpartyApiBase, order.giveAssetRaw, order.getAssetRaw, order.giveQuantityRaw]);
+
+  return quote;
+}
+
 /** The give/receive card, with a rate the user can flip. */
 export function OrderCard({ order }: { order: OrderAction }) {
   const [priceFlipped, setPriceFlipped] = useState(false);
+  const ownQuote = useOwnPoolQuote(order);
+
+  const minRaw = Number(order.getQuantityRaw);
+  // Scale the raw estimate into display units by the same divisor the decoded minimum used —
+  // derivable only when the normalized figure exists, so the estimate is withheld exactly when
+  // the price ratio is.
+  const getScale =
+    order.normalizedGet !== null && order.normalizedGet > 0 && minRaw > 0
+      ? minRaw / order.normalizedGet
+      : null;
+  const estimateDisplay =
+    ownQuote && getScale !== null ? (ownQuote.estimatedRaw / getScale).toFixed(8) : null;
+  /** How far below the wallet's own quote this order is willing to settle, as a fraction. */
+  const impliedSlippage =
+    ownQuote && minRaw > 0 && ownQuote.estimatedRaw > 0 ? 1 - minRaw / ownQuote.estimatedRaw : null;
 
   return (
     <div className="mb-3">
@@ -154,12 +243,37 @@ export function OrderCard({ order }: { order: OrderAction }) {
         </button>
       </div>
 
-      <div className="bg-gray-50 rounded-lg p-4">
-        <p className="text-xs text-gray-500 mb-1">You receive</p>
+      <div
+        className="bg-gray-50 rounded-lg p-4"
+        title={`This amount is guaranteed by the transaction itself. If the market can't deliver at least this much, the order rests or refunds and you keep your ${order.giveAsset}.`}
+      >
+        <p className="text-xs text-gray-500 mb-1">You receive at least</p>
         <p className="text-xl font-bold text-gray-900">
           {order.getAmount}{' '}
           <span className="text-base font-normal text-gray-500">{order.getAsset}</span>
         </p>
+        {estimateDisplay !== null && impliedSlippage !== null && impliedSlippage >= 0 && (
+          <>
+            <p className="text-xs text-gray-500 mt-1.5">
+              ~{estimateDisplay} at the pool price right now
+            </p>
+            <p className="text-[11px] text-gray-400">
+              Checked by your wallet, not supplied by the site.
+            </p>
+          </>
+        )}
+        {impliedSlippage !== null && impliedSlippage < 0 && (
+          <p className="text-xs text-red-600 mt-1.5">
+            The pool price has moved below this minimum. This order is likely to rest unfilled
+            instead of executing.
+          </p>
+        )}
+        {impliedSlippage !== null && impliedSlippage >= 0.05 && (
+          <p className="text-xs text-amber-600 mt-1.5">
+            This order accepts up to {(impliedSlippage * 100).toFixed(1)}% less than the wallet's
+            own pool quote. Make sure that is the slippage you chose.
+          </p>
+        )}
       </div>
 
       <p className="text-xs text-gray-400 text-center mt-2">


### PR DESCRIPTION
An order's `get_quantity` is a guaranteed **minimum**, not a prediction. Sites show a market estimate; the signed message carries the bound. Every major wallet simulates and shows the estimate, so a decoded minimum with no label reads as the site's number gone wrong — a real user cancelled a correct transaction over exactly this: the site said 7,388.99, the popup said 7,315.09, and nothing named the difference.

## What the card does now

The receive box is labelled **"You receive at least"**, with a tooltip stating the guarantee.

Beside it, the wallet fetches **its own quote from the configured node** — never anything the site supplied — so the site's number and the wallet's number visibly agree, with no trust extended. The same quote doubles as protection: when the minimum sits ≥5% below the wallet's own read, the card says so and asks the user to confirm that was the slippage they chose; when the market has moved below the minimum entirely, it warns the order will likely rest unfilled.

The lookup is decoration. It degrades silently and **never blocks signing** — the minimum is the contract.

## Verified against the site it has to agree with

Read `launchpad`'s swap widget to confirm the wallet reproduces the site's figure rather than a plausible-looking one. The site calls `/pools/{give}/{get}/quote?quantity={raw}`, displays `estimated_output`, and composes `get_quantity = floor(estimated × (1 − slippage))`. The wallet asks the same endpoint with the same base-unit quantity, so `1 − min/estimated` recovers exactly the slippage the user picked.

That reading also corrected the label. `estimated_output` spans the pool **and** the order book — the API reports `pool_output` and `book_output` separately, and the site labels its route from them. "At the pool price" would have been factually wrong for anything the book filled, so the card now says pool, order book, or market, according to where the estimate came from.

## Second commit — corrections to the first

- **Uses `fetchPoolQuote`** instead of a hand-rolled `fetch`. That helper already existed, and it matters beyond tidiness: `apiClient` parses through `parseJsonLossless`, and `estimated_output` is a base-unit quantity — `res.json()` rounds one above 2^53. The first version reintroduced the defect `losslessJson.ts` exists to prevent, at a new boundary.
- **Routes the arithmetic through `@/core/numeric`.** The first version failed the numeric-discipline rule merged in #274.
- **Carries the divisor** rather than recovering it by dividing the raw minimum by the normalized one — the builder already computed it. The estimate is now withheld exactly when divisibility is unknown, the same rule the price ratio follows, instead of being scaled by a recovered float.

## Tests

Eleven, where there were none: both warning thresholds (5.0% warns, 3.8% doesn't), the below-minimum case, all three route labels, an unreachable node, a BTC pair, unknown divisibility, and that the node is asked in base units.

## Worth a second opinion

The **5% threshold** is a judgement call. Launchpad's presets are 0.5/1/2%, so a preset never trips it — by design, since a preset is self-evidently chosen. That leaves someone who typed a large custom slippage (for whom the confirm costs nothing) and someone composing against a stale or manipulated quote (the entire point). If real usage shows deliberate 5–10% traders getting fatigue, revisit.