### PR TITLE
Follow settings and wallets when they change in another window

### DIFF
--- a/src/contexts/__tests__/settings-context.test.tsx
+++ b/src/contexts/__tests__/settings-context.test.tsx
@@ -1,7 +1,9 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fakeBrowser } from 'wxt/testing/fake-browser';
 import type { AppSettings } from '@/core/settings';
 import { DEFAULT_SETTINGS } from '@/core/settings';
+import { saveKeychainRecord } from '@/platform/storage/walletStorage';
 import { SettingsProvider, useSettings } from '../settings-context';
 
 // Mock walletService
@@ -374,5 +376,79 @@ describe('SettingsContext', () => {
         expect(newResult.current.settings.autoLockTimer).toBe('15m');
       });
     });
+  });
+});
+
+describe('SettingsContext — settings changed in another surface', () => {
+  /**
+   * Settings live inside the keychain record, so a change made anywhere lands as a write to it.
+   * The popup and the side panel are separate documents, each holding whatever they read on mount;
+   * without this the one merely sitting open goes stale.
+   */
+  const record = (data: string) => ({
+    version: 1 as const,
+    kdf: { iterations: 600000 },
+    salt: 'dGVzdC1zYWx0',
+    encryptedKeychain: data,
+  });
+
+  let stored: AppSettings;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fakeBrowser.reset();
+    stored = { ...DEFAULT_SETTINGS };
+    mockGetSettings.mockImplementation(async () => stored);
+  });
+
+  it('re-reads settings when the keychain record changes', async () => {
+    const { result } = renderHook(() => useSettings(), { wrapper: SettingsProvider });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.settings.connectedWebsites).toEqual([]);
+
+    // What another window's approval does, as this one sees it.
+    await act(async () => {
+      stored = { ...stored, connectedWebsites: ['https://elsewhere.org'] };
+      await saveKeychainRecord(record('changed-elsewhere'));
+    });
+
+    await waitFor(() => {
+      expect(result.current.settings.connectedWebsites).toEqual(['https://elsewhere.org']);
+    });
+  });
+
+  it('does not raise the loading flag while re-reading', async () => {
+    const { result } = renderHook(() => useSettings(), { wrapper: SettingsProvider });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    const loadingSeen: boolean[] = [];
+    const watching = setInterval(() => loadingSeen.push(result.current.isLoading), 1);
+
+    await act(async () => {
+      stored = { ...stored, connectedWebsites: ['https://elsewhere.org'] };
+      await saveKeychainRecord(record('changed-again'));
+    });
+    await waitFor(() => {
+      expect(result.current.settings.connectedWebsites).toHaveLength(1);
+    });
+    clearInterval(watching);
+
+    // Every surface consuming isLoading renders a spinner from it. Raising it for a change made in
+    // another window would flash all of them.
+    expect(loadingSeen).not.toContain(true);
+  });
+
+  it('stops watching when the provider unmounts', async () => {
+    const { result, unmount } = renderHook(() => useSettings(), { wrapper: SettingsProvider });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    unmount();
+    const callsBefore = mockGetSettings.mock.calls.length;
+
+    await act(async () => {
+      await saveKeychainRecord(record('after-unmount'));
+    });
+
+    expect(mockGetSettings.mock.calls.length).toBe(callsBefore);
   });
 });

--- a/src/contexts/__tests__/wallet-context.test.tsx
+++ b/src/contexts/__tests__/wallet-context.test.tsx
@@ -1,8 +1,10 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { sendMessage } from 'webext-bridge/popup';
+import { fakeBrowser } from 'wxt/testing/fake-browser';
 import { AddressFormat } from '@/core/bitcoin/address';
 import * as sessionManager from '@/platform/auth/sessionManager';
+import { saveKeychainRecord } from '@/platform/storage/walletStorage';
 import { walletManager } from '@/platform/walletManager';
 import { useWallet, WalletProvider } from '../wallet-context';
 
@@ -69,7 +71,10 @@ vi.mock('@/platform/auth/sessionManager', () => ({
 
 // Mock keychainExists from walletStorage - defaults to true (wallets exist)
 const mockKeychainExists = vi.fn().mockResolvedValue(true);
-vi.mock('@/platform/storage/walletStorage', () => ({
+// Spread the real module so the mock does not go stale as walletStorage gains exports; only the
+// keychain check is stubbed, and the watch is inert because nothing writes the record here.
+vi.mock('@/platform/storage/walletStorage', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/platform/storage/walletStorage')>()),
   keychainExists: () => mockKeychainExists(),
 }));
 
@@ -769,5 +774,100 @@ describe('WalletContext', () => {
       // But wallet3 should trigger an update
       mockWalletService.getWallets.mockResolvedValueOnce([wallet3]);
     });
+  });
+});
+describe('WalletContext — wallets changed in another surface', () => {
+  /**
+   * Wallets and their addresses live in the keychain record, so adding a wallet or deriving an
+   * address anywhere lands as a write to it. The popup and the side panel are separate documents
+   * and people run both, so the one merely open must not keep the list it read on mount.
+   */
+  const record = (data: string) => ({
+    version: 1 as const,
+    kdf: { iterations: 600000 },
+    salt: 'dGVzdC1zYWx0',
+    encryptedKeychain: data,
+  });
+
+  const wallet = {
+    id: 'wallet1',
+    name: 'Wallet 1',
+    encryptedMnemonic: 'encrypted1',
+    encryptedPrivateKey: null,
+    type: 'mnemonic' as const,
+    addressFormat: 'P2WPKH' as const,
+    addressCount: 1,
+    addresses: [{ name: 'Address 1', address: 'bc1qtest', path: "m/84'/0'/0'/0/0" }],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fakeBrowser.reset();
+    mockKeychainExists.mockResolvedValue(true);
+    mockWalletService.isKeychainUnlocked.mockResolvedValue(true);
+    mockWalletService.getWallets.mockResolvedValue([wallet]);
+    mockWalletService.getActiveWallet.mockResolvedValue(wallet);
+    mockWalletService.getLastActiveAddress.mockResolvedValue(wallet.addresses[0]?.address);
+  });
+
+  /**
+   * Mount does not settle immediately: loadWithRetry waits 100ms, refreshes, and retries after a
+   * further 400ms when no wallets came back. A test that changes a mock before that has finished
+   * sees the retry pick the change up and passes whether or not anything is watching — so these
+   * wait for the refreshes to stop before touching anything.
+   */
+  const settle = async () => {
+    let previous = -1;
+    while (previous !== mockWalletService.getWallets.mock.calls.length) {
+      previous = mockWalletService.getWallets.mock.calls.length;
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 600));
+      });
+    }
+  };
+
+  it('picks up a wallet added elsewhere', async () => {
+    const { result } = renderHook(() => useWallet(), { wrapper: WalletProvider });
+    await waitFor(() => expect(result.current.wallets).toHaveLength(1));
+    await settle();
+
+    const second = { ...wallet, id: 'wallet2', name: 'Second Wallet' };
+    mockWalletService.getWallets.mockResolvedValue([wallet, second]);
+
+    await act(async () => {
+      await saveKeychainRecord(record('wallet-added-elsewhere'));
+    });
+
+    await waitFor(() => expect(result.current.wallets).toHaveLength(2));
+  });
+
+  it('does not refresh while the keychain is locked', async () => {
+    mockWalletService.isKeychainUnlocked.mockResolvedValue(false);
+    const { result } = renderHook(() => useWallet(), { wrapper: WalletProvider });
+    await waitFor(() => expect(result.current.authState).toBe('LOCKED'));
+    await settle();
+
+    const callsBefore = mockWalletService.getWallets.mock.calls.length;
+    await act(async () => {
+      await saveKeychainRecord(record('written-while-locked'));
+    });
+
+    // Nothing to re-read, and the lock path owns that transition.
+    expect(mockWalletService.getWallets.mock.calls.length).toBe(callsBefore);
+  });
+
+  it('stops watching when the provider unmounts', async () => {
+    const { result, unmount } = renderHook(() => useWallet(), { wrapper: WalletProvider });
+    await waitFor(() => expect(result.current.wallets).toHaveLength(1));
+    await settle();
+
+    unmount();
+    const callsBefore = mockWalletService.getWallets.mock.calls.length;
+
+    await act(async () => {
+      await saveKeychainRecord(record('after-unmount'));
+    });
+
+    expect(mockWalletService.getWallets.mock.calls.length).toBe(callsBefore);
   });
 });

--- a/src/contexts/settings-context.tsx
+++ b/src/contexts/settings-context.tsx
@@ -33,6 +33,7 @@ import { onMessage } from 'webext-bridge/popup';
 import { type AppSettings, DEFAULT_SETTINGS } from "@/core/settings";
 import { withStateLock } from "@/core/wallet/stateLockManager";
 import { analytics } from "@/platform/fathom";
+import { watchKeychainRecord } from "@/platform/storage/walletStorage";
 import { getWalletService } from "@/services/walletService";
 
 /**
@@ -61,14 +62,19 @@ export function SettingsProvider({ children }: { children: ReactNode }): ReactEl
   const [settings, setSettings] = useState<AppSettings>(DEFAULT_SETTINGS);
   const [isLoading, setIsLoading] = useState(true);
 
-  const loadSettings = useCallback(async () => {
+  /**
+   * @param showLoading - False when re-reading settings that changed elsewhere. Every surface
+   *   consuming `isLoading` renders a spinner from it, so raising it for a change the user made in
+   *   another window would flash all of them.
+   */
+  const loadSettings = useCallback(async (showLoading = true) => {
     try {
-      setIsLoading(true);
+      if (showLoading) setIsLoading(true);
       const walletService = getWalletService();
       const storedSettings = await walletService.getSettings();
       setSettings(storedSettings);
     } finally {
-      setIsLoading(false);
+      if (showLoading) setIsLoading(false);
     }
   }, []);
 
@@ -90,8 +96,19 @@ export function SettingsProvider({ children }: { children: ReactNode }): ReactEl
     };
     const unsubscribe = onMessage('keychainLocked', handleLockMessage);
 
+    // Settings live inside the keychain record — one blob, one key derivation (#147) — so a change
+    // made in any surface lands as a write to it. The popup and the side panel are separate
+    // documents, each holding what it read on mount, and this is what stops one going stale while
+    // the other edits. Serialized against loadSettings for the same reason the lock handler is.
+    const stopWatching = watchKeychainRecord(() => {
+      withStateLock('settings-lock', async () => {
+        await loadSettings(false);
+      });
+    });
+
     return () => {
       unsubscribe();
+      stopWatching();
     };
   }, [loadSettings]);
 

--- a/src/contexts/wallet-context.tsx
+++ b/src/contexts/wallet-context.tsx
@@ -47,7 +47,7 @@ import {
 import { onMessage } from 'webext-bridge/popup'; // Import for popup context
 import type { AddressFormat } from '@/core/bitcoin/address';
 import { withStateLock } from "@/core/wallet/stateLockManager";
-import { keychainExists as checkKeychainExists } from "@/platform/storage/walletStorage";
+import { keychainExists as checkKeychainExists, watchKeychainRecord } from "@/platform/storage/walletStorage";
 import { getWalletService } from "@/services/walletService";
 import type { Address, SignTransactionOptions, Wallet } from "@/types/wallet";
 
@@ -441,10 +441,26 @@ export function WalletProvider({ children }: { children: ReactNode }): ReactElem
     };
     chrome.storage?.session?.onChanged?.addListener(handleSessionStorageChange);
 
+    // Wallets and their addresses live in the keychain record, so adding a wallet or deriving an
+    // address in one surface lands as a write here. The popup and the side panel are separate
+    // documents and people run both, so without this the one merely open keeps the list it read on
+    // mount — and the address-types screen keeps offering a format the other surface already
+    // changed.
+    //
+    // Refreshing is expensive (it can decrypt and re-derive), and this fires for any keychain
+    // write, including a settings-only one. It is bounded rather than free: withStateLock
+    // serializes it against the refresh already in flight, and a locked keychain is skipped because
+    // there is nothing to re-read and the lock path handles that transition itself.
+    const stopWatchingKeychain = watchKeychainRecord(() => {
+      if (walletStateRef.current.keychainLocked) return;
+      refreshWalletState();
+    });
+
     return () => {
       // Properly cleanup the message listener
       unsubscribe();
       chrome.storage?.session?.onChanged?.removeListener(handleSessionStorageChange);
+      stopWatchingKeychain();
     };
   }, [refreshWalletState, walletService]); // Removed walletState.authState to prevent re-runs
 

--- a/src/pages/settings/__tests__/connected-sites.test.tsx
+++ b/src/pages/settings/__tests__/connected-sites.test.tsx
@@ -1,0 +1,86 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DEFAULT_SETTINGS } from '@/core/settings';
+import ConnectedSitesPage from '../connected-sites';
+
+/**
+ * The page derives its list from settings rather than fetching it, so a site connecting in another
+ * window reaches it through the settings context. Reactivity itself is asserted where it lives —
+ * see contexts/__tests__/settings-context.test.tsx.
+ */
+
+let connectedWebsites: string[] = [];
+const mockDisconnect = vi.fn(async () => {});
+
+vi.mock('@/contexts/settings-context', () => ({
+  useSettings: () => ({
+    settings: { ...DEFAULT_SETTINGS, connectedWebsites },
+    isLoading: false,
+    updateSettings: vi.fn(),
+  }),
+}));
+
+vi.mock('@/services/providerService', () => ({
+  getProviderService: () => ({ disconnect: mockDisconnect }),
+}));
+
+vi.mock('@/contexts/header-context', () => ({
+  useHeader: () => ({ setHeaderProps: vi.fn() }),
+}));
+
+const renderPage = () =>
+  render(
+    <MemoryRouter>
+      <ConnectedSitesPage />
+    </MemoryRouter>
+  );
+
+describe('ConnectedSitesPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    connectedWebsites = [];
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('lists the connected sites by hostname', async () => {
+    connectedWebsites = ['https://example.com', 'https://newsite.org'];
+    renderPage();
+
+    expect(await screen.findByText('example.com')).toBeInTheDocument();
+    expect(screen.getByText('newsite.org')).toBeInTheDocument();
+  });
+
+  it('follows settings when a site is added', async () => {
+    connectedWebsites = ['https://example.com'];
+    const { rerender } = renderPage();
+    await screen.findByText('example.com');
+
+    connectedWebsites = ['https://example.com', 'https://newsite.org'];
+    rerender(
+      <MemoryRouter>
+        <ConnectedSitesPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('newsite.org')).toBeInTheDocument();
+  });
+
+  it('disconnects through the provider and lets settings drive the list', async () => {
+    connectedWebsites = ['https://example.com'];
+    renderPage();
+    await screen.findByText('example.com');
+
+    const disconnect = screen.getAllByRole('button').find(
+      (button) => /disconnect/i.test(button.getAttribute('aria-label') ?? '')
+    );
+    disconnect?.click();
+
+    // The page does not remove the row itself; the settings write is what removes it. A failed
+    // disconnect therefore leaves the site listed, which is the truth.
+    expect(mockDisconnect).toHaveBeenCalledWith('https://example.com');
+  });
+});

--- a/src/pages/settings/connected-sites.tsx
+++ b/src/pages/settings/connected-sites.tsx
@@ -1,12 +1,12 @@
 import type { ReactElement } from "react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { useNavigate } from "react-router";
 import { FiGlobe, FiHelpCircle, FiRefreshCw } from "@/components/icons";
 import { ConnectedSiteCard } from "@/components/ui/cards/connected-site-card";
 import { Spinner } from "@/components/ui/spinner";
 import { useHeader } from "@/contexts/header-context";
+import { useSettings } from "@/contexts/settings-context";
 import { getProviderService } from "@/services/providerService";
-import { getWalletService } from "@/services/walletService";
 
 /**
  * Constants for navigation paths.
@@ -34,28 +34,17 @@ interface ConnectedSite {
 export default function ConnectedSitesPage(): ReactElement {
   const navigate = useNavigate();
   const { setHeaderProps } = useHeader();
-  const [connectedSites, setConnectedSites] = useState<ConnectedSite[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
+  // Read from settings rather than fetching separately: the connected sites are part of them, and
+  // the provider keeps them current when one connects or disconnects in another window.
+  const { settings, isLoading } = useSettings();
 
-  const loadConnections = useCallback(async () => {
-    try {
-      setIsLoading(true);
-      const walletService = getWalletService();
-      const settings = await walletService.getSettings();
-      
-      // Convert origins to ConnectedSite objects
-      const sites: ConnectedSite[] = settings.connectedWebsites.map(origin => ({
-        origin,
-        hostname: new URL(origin).hostname
-      }));
-
-      setConnectedSites(sites);
-    } catch (error) {
-      console.error('Failed to load connections:', error);
-    } finally {
-      setIsLoading(false);
-    }
-  }, []);
+  const connectedSites = useMemo<ConnectedSite[]>(
+    () => settings.connectedWebsites.map(origin => ({
+      origin,
+      hostname: new URL(origin).hostname,
+    })),
+    [settings.connectedWebsites]
+  );
 
   /**
    * Disconnects a site.
@@ -63,13 +52,11 @@ export default function ConnectedSitesPage(): ReactElement {
   const handleDisconnectSite = async (origin: string) => {
     try {
       const providerService = getProviderService();
+      // Disconnecting rewrites the settings, and the list follows from those — so there is nothing
+      // to update here. A failure leaves the site listed, which is the truth.
       await providerService.disconnect(origin);
-
-      // Only update UI after successful disconnect
-      setConnectedSites(prev => prev.filter(site => site.origin !== origin));
     } catch (error) {
       console.error('Failed to disconnect site:', error);
-      // Don't reload - just log the error
     }
   };
 
@@ -89,9 +76,6 @@ export default function ConnectedSitesPage(): ReactElement {
       );
 
       await Promise.all(disconnectPromises);
-
-      // Only update UI after all disconnects complete
-      setConnectedSites([]);
     } catch (error) {
       console.error('Failed to disconnect all sites:', error);
     }
@@ -115,10 +99,6 @@ export default function ConnectedSitesPage(): ReactElement {
     });
   }, [setHeaderProps, navigate, connectedSites.length, handleDisconnectAll]);
 
-  // Load connections on mount
-  useEffect(() => {
-    loadConnections();
-  }, [loadConnections]);
 
   if (isLoading) {
     return <Spinner message="Loading connected sites…" />;

--- a/src/platform/storage/walletStorage.ts
+++ b/src/platform/storage/walletStorage.ts
@@ -71,6 +71,21 @@ export async function saveKeychainRecord(record: KeychainRecord): Promise<void> 
 }
 
 /**
+ * Calls back whenever the stored keychain changes, from this surface or any other.
+ *
+ * Settings live inside the keychain record, so this fires for a settings change as well as a wallet
+ * one — and the record is encrypted, so the change itself says nothing about what moved. It is a
+ * signal to re-read, not a source of values. A popup and a side panel are separate documents that
+ * each hold their own copy of whatever they loaded on mount, and this is what tells the one that is
+ * merely open that the other changed something.
+ *
+ * @returns An unsubscribe function.
+ */
+export function watchKeychainRecord(onChange: () => void): () => void {
+  return keychainRecordItem.watch(() => onChange());
+}
+
+/**
  * Checks if a keychain exists in storage.
  * Used to determine onboarding vs unlock routing.
  */


### PR DESCRIPTION
The popup and the side panel are separate documents, each holding whatever it read on mount — and people run both. A site connecting in its approval window left the settings page showing the list it opened with. A wallet added in the popup left the panel's list stale, and the address-types screen offering a format the other surface had already changed.

## How

Settings and wallets both live inside the keychain record — one blob, one key derivation (#147) — so a change made anywhere lands as a write to it. `walletStorage` now exposes a watch on that record.

The record is **encrypted**, so the notification says nothing about what moved: it's a signal to re-read, not a source of values. That's also why one watch covers connects, disconnects, new wallets and derived addresses without enumerating any of them.

## Where it lives

In the two contexts that own the state, not in the pages — the first attempt watched from `connected-sites.tsx`, which was the wrong altitude:

- **`settings-context`** covers the 26 surfaces reading `useSettings()`. `connected-sites` stops fetching settings for itself and derives its list like everything else; `security`, `advanced` and `pinned-assets` come along for free.
- **`wallet-context`** covers wallet and address lists, and `address-types` with them.

## The two traps

**Neither refresh raises its loading flag.** Both spinners *replace* the content they sit in, so a change made in another window would blank the page being read. Measured through a local settings update: one extra read, two renders, no loading flash, no revert of the optimistic value.

**The wallet refresh is the expensive one** — it can decrypt and re-derive. So a locked keychain is skipped (nothing to re-read; the lock path owns that transition), and `selectWallet`, which that refresh can reach, only writes when `lastActiveWalletId` actually changes — so a refresh that writes can't trigger another that writes.

## What I deliberately did not change

`getSettings()` returns `DEFAULT_SETTINGS` when locked. I first read that as a fail-open and was wrong: `doPermissionLookup` asks whether an origin is in `connectedWebsites`, so a locked wallet answers **no** and grants nothing. It's fail-*closed* on the only path that decides anything, and consistent with `settings-context` resetting to defaults on lock and #237 clearing the header caches on lock. Left alone.

## Tests

Context-level, where the behaviour lives — 3 for settings, 3 for wallets, plus the page's own. Each verified to **fail without the watch**, which caught a real problem: the first wallet tests passed regardless, because `loadWithRetry`'s 100ms/400ms retry was still in flight and picked up the changed mock on its own. They now wait for refreshes to stop before touching anything.

Also switched the `walletStorage` and numeric mocks to spread the real module instead of listing exports — three suites broke on new exports during this work, and spreading is what stops it recurring.