### PR TITLE
Read the order match, so a BTCPay cannot pay someone else too

### DIFF
--- a/src/contexts/composer-context.tsx
+++ b/src/contexts/composer-context.tsx
@@ -55,6 +55,8 @@ import { useSettings } from "@/contexts/settings-context";
 import { useWallet } from "@/contexts/wallet-context";
 import { isApiError } from "@/core/api/client";
 import { checkTransactionFee } from "@/core/bitcoin/feeVerification";
+import { fetchOrderMatch } from "@/core/counterparty/api";
+import { btcPayPayment } from "@/core/counterparty/btcpayPayment";
 import type { ApiResponse } from "@/core/counterparty/compose";
 import {
   verifyInscriptionEnvelope,
@@ -84,14 +86,6 @@ import { analytics, classifyTransactionError, getBtcBucket } from "@/platform/fa
  * After this time, UTXOs may have been spent or fee rates may have changed significantly.
  */
 const STALE_TRANSACTION_MS = 5 * 60 * 1000;
-
-/**
- * Compose types whose payee is derived server-side and so cannot appear in the request. A BTCPay is
- * settled against an order match, and the address to pay comes from that match rather than from
- * anything the user typed — output accounting would have nothing to match it against. These skip
- * the output policy; every other type is accounted for.
- */
-const SERVER_DERIVED_DESTINATION_TYPES = new Set(['btcpay']);
 
 /**
  * Where a burn sends its BTC. These are protocol constants rather than anything the user types, so
@@ -418,9 +412,35 @@ export function ComposerProvider<T>({
       // Account for every output: each must be the data output, an address the request names, or
       // change to one of our own addresses. Anything else rejects the transaction, so a response
       // that adds a recipient fails closed even though no field-level check covers it (ADR-019).
-      if (activeAddress && !SERVER_DERIVED_DESTINATION_TYPES.has(composeType)) {
+      if (activeAddress) {
         const intendedDestinations: IntendedDestination[] =
           addressesNamedIn(dataForApi).map(address => ({ address }));
+        // A BTCPay pays an address the request never names — it comes from the order match — so
+        // this used to skip output accounting altogether, and an added output went unexamined. The
+        // match decides both the payee and the amount (`messages/btcpay.py`), so the wallet reads
+        // the match itself and holds the transaction to what it says. Refusing when the match
+        // cannot be read is the point: the alternative is accepting the composer's word for where
+        // the money goes, which is the thing being guarded against.
+        if (composeType === 'btcpay') {
+          const matchId = typeof dataForApi.order_match_id === 'string'
+            ? dataForApi.order_match_id
+            : '';
+          const match = matchId ? await fetchOrderMatch(matchId) : null;
+          if (!match) {
+            throw new Error(
+              'Transaction verification failed: this order match could not be read, so the '
+              + 'payment it settles could not be checked.'
+            );
+          }
+          const payment = btcPayPayment(match);
+          if (!payment) {
+            throw new Error(
+              'Transaction verification failed: neither side of this order match is BTC, so it '
+              + 'is not settled by a BTCPay.'
+            );
+          }
+          intendedDestinations.push({ address: payment.address, value: payment.quantity });
+        }
         // The inscription commit output pays an address the request cannot name, but one that was
         // just derived from an envelope verified to carry this request's message — so it is
         // explained by proof rather than by exemption.

--- a/src/core/counterparty/__tests__/btcpayPayment.test.ts
+++ b/src/core/counterparty/__tests__/btcpayPayment.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import type { OrderMatch } from '../api';
+import { btcPayPayment } from '../btcpayPayment';
+
+/**
+ * Mirrors `messages/btcpay.py`: whichever side of the match is BTC is the side being paid, and the
+ * other side's address receives it. Getting this backwards would pin the wrong payee and reject
+ * every legitimate BTCPay — or worse, accept a redirected one.
+ */
+const match = (overrides: Partial<OrderMatch>): OrderMatch => ({
+  id: 'a'.repeat(64) + '_' + 'b'.repeat(64),
+  tx0_hash: 'a'.repeat(64),
+  tx0_index: 0,
+  tx0_address: 'bc1qmaker',
+  tx1_hash: 'b'.repeat(64),
+  tx1_index: 1,
+  tx1_address: 'bc1qtaker',
+  forward_asset: 'XCP',
+  forward_quantity: 500,
+  forward_quantity_normalized: '0.00000500' as OrderMatch['forward_quantity_normalized'],
+  backward_asset: 'BTC',
+  backward_quantity: 300_000,
+  backward_quantity_normalized: '0.00300000' as OrderMatch['backward_quantity_normalized'],
+  tx0_block_index: 1,
+  tx1_block_index: 2,
+  block_index: 2,
+  block_time: 0,
+  match_expire_index: 100,
+  fee_paid: 0,
+  fee_paid_normalized: '0.00000000' as OrderMatch['fee_paid_normalized'],
+  status: 'pending',
+  ...overrides,
+});
+
+describe('btcPayPayment', () => {
+  it('pays tx0 when the backward side is BTC', () => {
+    expect(btcPayPayment(match({}))).toEqual({ address: 'bc1qmaker', quantity: 300_000 });
+  });
+
+  it('pays tx1 when the forward side is BTC', () => {
+    const forwardBtc = match({
+      forward_asset: 'BTC',
+      forward_quantity: 250_000,
+      backward_asset: 'XCP',
+      backward_quantity: 500,
+    });
+
+    expect(btcPayPayment(forwardBtc)).toEqual({ address: 'bc1qtaker', quantity: 250_000 });
+  });
+
+  it('declines a match with no BTC side rather than guessing a payee', () => {
+    expect(btcPayPayment(match({ backward_asset: 'PEPECASH' }))).toBeNull();
+  });
+});

--- a/src/core/counterparty/btcpayPayment.ts
+++ b/src/core/counterparty/btcpayPayment.ts
@@ -1,0 +1,45 @@
+/**
+ * Who a BTCPay pays, and how much — derived from the order match rather than taken from the
+ * composer's answer.
+ *
+ * A BTCPay settles a matched order by paying the BTC side. The message carries only the 64-byte
+ * `order_match_id`, so byte-equality verification accepts any output layout that quotes the right
+ * id: the payee and the amount are nowhere in the signed bytes. Output accounting could not help
+ * either, because the payee is not an address the user typed — it comes from the match — so the
+ * compose path exempted BTCPay entirely and an added output went unexamined (GHSA-2wjj-rfjm-hcqh).
+ *
+ * The match itself is the answer. `messages/btcpay.py` decides the destination and quantity from
+ * it with no other input, so a wallet holding the match can reach the same two values on its own
+ * and hold the transaction to them. Reading ledger state is not the same act as trusting a composed
+ * transaction: a composer would have to corrupt the match record as well to move the payment, and
+ * the match is what every other party settles against.
+ */
+
+import type { OrderMatch } from '@/core/counterparty/api';
+
+/** The single output a BTCPay must pay, in satoshis. */
+export interface BtcPayPayment {
+  address: string;
+  /** Satoshis. Core takes this straight from the match's BTC side. */
+  quantity: number;
+}
+
+/** Counterparty's name for bitcoin on the ledger. */
+const BTC = 'BTC';
+
+/**
+ * The payment a BTCPay for this match owes, or null when neither side is BTC.
+ *
+ * Mirrors `btcpay.validate`: whichever side of the match is BTC is the side being paid, and the
+ * *other* side's address receives it. Null rather than a guess — a match with no BTC leg is not a
+ * BTCPay, and inventing a payee would be worse than declining to check one.
+ */
+export function btcPayPayment(match: OrderMatch): BtcPayPayment | null {
+  if (match.backward_asset === BTC) {
+    return { address: match.tx0_address, quantity: match.backward_quantity };
+  }
+  if (match.forward_asset === BTC) {
+    return { address: match.tx1_address, quantity: match.forward_quantity };
+  }
+  return null;
+}

--- a/src/core/counterparty/outputPolicy.ts
+++ b/src/core/counterparty/outputPolicy.ts
@@ -35,7 +35,7 @@
  * | attach | a new UTXO at the source's own address | recognized as change |
  * | move (utxo) | the destination, or the source address when none is given | named in the request, else change |
  * | burn | the protocol's unspendable address | supplied by the caller as a constant, with the amount pinned |
- * | btcpay | derived from the order match, so unnameable | exempt (`SERVER_DERIVED_DESTINATION_TYPES`) |
+ * | btcpay | the BTC side of the order match | read from the match and pinned (`btcpayPayment.ts`) |
  *
  * `bet` is the one core module with an implicit payee (its feed address) that is not covered — the
  * wallet composes no bets, so it never reaches here. Adding bet composition would require adding the


### PR DESCRIPTION
Fixes **GHSA-2wjj-rfjm-hcqh**.

## The gap

A BTCPay carries only the 64-byte `order_match_id`. Byte-equality verification therefore accepts *any* output layout that quotes the right id — the payee and the amount are nowhere in the signed bytes.

Output accounting could not help either, because the payee is not an address the user typed: it comes from the order match. So the compose path exempted BTCPay entirely (`SERVER_DERIVED_DESTINATION_TYPES`), an added output went unexamined, and the review screen shows only the match id, so nothing on screen contradicted it.

The fee check can't catch it — an attacker output reduces change rather than raising the fee.

## The fix

The premise behind the exemption was wrong. The payee is not unnameable; it is *derivable*. `messages/btcpay.py` decides both the destination and the quantity from the match alone — whichever side is BTC is the side being paid, and the other side's address receives it — so the wallet reads the match itself and pins the output to what it says.

`fetchOrderMatch` already existed, used by the approval screen for the expiry warning.

The exemption is gone entirely, along with the constant, so BTCPay now goes through the same deny-by-default accounting as everything else.

## Refusing when the match cannot be read

This is the point, not a rough edge. The alternative is taking the composer's word for where the money goes, which is what ADR-019 says not to do. It costs nothing in practice: composing already required that node to answer, so a node that can compose can also return the match.

## Note on order fees

Checked while here, since it came up: `fee_required` gates whether two orders **match at all**, settled then against the BTC-side order's `fee_provided` (`order.py:678-681`). `btcpay.py` has no fee logic of its own — zero occurrences. So there is no per-payment minimum a BTCPay can fall below, and no warning is needed. Recorded in the commit so it isn't re-investigated.

## Tests

Three on the derivation, which is the part that would silently pin the wrong payee if inverted: BTC on the backward side pays `tx0_address`, BTC on the forward side pays `tx1_address`, and a match with no BTC leg declines rather than guessing.