### PR TITLE
Pause the bounty, and say which door these should come through

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,25 +1,58 @@
-# Bug Bounty Program
+# Security
 
-We offer rewards for responsibly disclosed security vulnerabilities. Rewards are paid in XCP.
+## Reporting a vulnerability
 
-| Severity | Reward | Examples |
-|----------|--------|----------|
-| Critical | Up to 2,500 XCP | Private key extraction, seed phrase exposure, unauthorized fund transfers, remote code execution, bypassing transaction signing approval |
-| High | Up to 500 XCP | Session hijacking, authentication bypass, signature forgery, transaction manipulation, permission escalation allowing unauthorized actions |
-| Medium | Up to 50 XCP | Sensitive data leakage (non-key material), clickjacking with security impact, CSP bypass, origin spoofing in provider API |
+Report privately via [GitHub Security Advisories](https://github.com/XCP/extension/security/advisories/new).
 
-## Eligibility
+We read every report and fix what is real, whether or not a reward is attached.
 
-To qualify for a reward, your report must:
+## The bug bounty is paused
 
-- Describe a reproducible vulnerability with clear steps
-- Include proof of concept (code, screenshots, or video)
-- Affect the current published release. Unreleased code on `main` is developed in the open and sits
-  outside the programme — such reports are welcome and credited, but are not eligible for a reward
-- Not be a duplicate of a known issue or previously reported vulnerability
-- Be reported privately via GitHub Security Advisories
+**Paused August 2026.** No new submissions are eligible for a reward until it reopens.
 
-## In Scope
+We are receiving a high volume of automated, agent-generated submissions. Most are technically
+competent and most describe real code — that is not the problem. The problem is that they arrive as
+security advisories when what they are is patches:
+
+- written against `main` rather than a published release, so a report can describe code that was
+  fixed hours before it was filed;
+- often restating a limitation we document ourselves, sometimes quoting the very comment that
+  documents it — reading our notes back to us with a severity label attached;
+- filed under embargo, where they cannot be discussed in the open or simply merged.
+
+A private advisory costs a maintainer far more than an issue does. It has to be triaged alone, on a
+clock, in a channel built for coordinated disclosure — and coordinated disclosure is not what most
+of these need. They need a patch.
+
+So the rules below have not changed much. What has changed is the volume arriving through the wrong
+door, and the reward is what points at that door.
+
+### Send these as issues or pull requests instead
+
+If your finding is any of the following, open an [issue](https://github.com/XCP/extension/issues) or
+a pull request. It will be read sooner, discussed in the open, and credited the same:
+
+- a limitation this repository documents in a comment, an ADR, or a header;
+- a hardening suggestion, a missing check, or a defence-in-depth improvement;
+- anything you could have fixed yourself in the time it took to write it up.
+
+Use the advisory channel when there is a way to take a user's funds or keys, that user-visible
+outcome is demonstrated, and telling us privately first actually protects someone.
+
+### When it reopens
+
+Three things will be true of it:
+
+1. **A proof of concept against a tagged release.** Already the rule; it will be enforced rather
+   than assumed. `main` is developed in the open and is not the product anyone is running.
+2. **A documented limitation needs a demonstrated loss.** Citing the comment that describes a gap is
+   not a finding. Show a user losing something.
+3. **Tiered by demonstrated impact.** "This guard is skipped here" and "here is BTC leaving the
+   wallet" are not the same report and will not be paid the same.
+
+## Scope
+
+**In scope**
 
 - Browser extension code (background, content scripts, popup)
 - Key derivation, encryption, and signing logic
@@ -27,38 +60,44 @@ To qualify for a reward, your report must:
 - Session management and auto-lock
 - Transaction construction and verification
 
-## Out of Scope
+**Out of scope**
 
 - Vulnerabilities in third-party dependencies (report upstream, but let us know)
 - Attacks requiring physical access to an unlocked device
 - Social engineering or phishing attacks
 - Denial of service without security impact
-- Issues already documented in ADRs as known limitations
+- Limitations already documented in the code, in an ADR, or in this file
 - Theoretical vulnerabilities without demonstrated impact
+- Behaviour already fixed on `main` at the time of the report
 
-## Severity Definitions
+## Severity
 
-**Critical**: Direct loss of funds or private keys. Attacker can steal assets, extract seeds/keys, or sign transactions without user consent.
+**Critical**: Direct loss of funds or private keys. An attacker can steal assets, extract seeds or
+keys, or get a transaction signed without the user's consent.
 
-**High**: Significant security impact but requires user interaction or specific conditions. Includes auth bypass, session theft, or transaction manipulation that could lead to fund loss with additional steps.
+**High**: Significant impact, but requires user interaction or specific conditions — auth bypass,
+session theft, or transaction manipulation that leads to fund loss with additional steps.
 
-**Medium**: Security issues with limited direct impact. Information disclosure, UI spoofing that could mislead users, or bypasses of defense-in-depth measures.
+**Medium**: Limited direct impact. Information disclosure, UI spoofing that could mislead a user, or
+a bypass of a defence-in-depth measure.
 
-**Low/Informational**: Best practice violations, minor issues, or hardening suggestions. These are appreciated but not eligible for rewards. We may acknowledge contributors in a security hall of fame.
+**Low / Informational**: Best practices, minor issues, hardening. Appreciated, credited, never
+rewarded — and better sent as a pull request.
 
 ## Rules
 
-- Give us reasonable time to fix issues before public disclosure (90 days)
+- Give us reasonable time to fix before public disclosure (90 days)
 - Do not access or modify other users' data
-- Do not perform attacks against infrastructure or other users
-- One vulnerability per report (unless chained for impact)
+- Do not attack our infrastructure or other users
+- One vulnerability per report, unless chained for impact
 
 ## Hall of Fame
 
-We recognize all valid security contributions, regardless of severity:
+We recognise valid security contributions regardless of severity, and regardless of which channel
+they arrived through.
 
-| Contributor | Finding | PR |
-|-------------|---------|-----|
+| Contributor | Finding | Reference |
+|-------------|---------|-----------|
 | Niftyboss | Password memory cleanup | [#178](https://github.com/XCP/extension/pull/178) |
 | refangga1337 | Approval summary priced a PSBT without regard to what the signature committed to | [GHSA-xm3c-v5fj-mxqv](https://github.com/XCP/extension/security/advisories/GHSA-xm3c-v5fj-mxqv) |
 | refangga1337 | Attached-asset warning suppressible by padding a PSBT past the lookup cap | [GHSA-6mmc-r2hj-qq43](https://github.com/XCP/extension/security/advisories/GHSA-6mmc-r2hj-qq43) |


### PR DESCRIPTION
Pauses the bug bounty and rewrites SECURITY.md to say plainly why.

## What prompted it

A high volume of automated, agent-generated submissions. They are mostly competent and mostly describe real code — that is not the complaint. The complaint is that they arrive as **security advisories when what they are is patches**.

Two from today are representative:

- **GHSA-g47h** — a real finding, filed against `main`, and already fixed hours before it was written.
- **GHSA-2wjj** — real and worth fixing (see #277), but it reported an exemption documented in `outputPolicy.ts`'s own audit table. An agent read the table, found the row saying "exempt", and filed it as a discovery.

A private advisory costs a maintainer far more than an issue does: triaged alone, on a clock, in a channel built for coordinated disclosure that most of these do not need.

## The rules were already right

Worth stating, because it changes what the fix is. "Affect the current published release" and "issues already documented as known limitations" were **both already out of scope**. One report violated the first; the other cited a limitation documented in the very file it quoted.

So this adds almost no rules. What changed is the volume arriving through the wrong door — and the reward is what points at that door.

## What the file now does

- **Says the bounty is paused**, dated, with the reasoning in the open rather than a vague notice.
- **Names what to send as an issue or PR instead**: documented limitations, hardening, and anything the reporter could have fixed in the time it took to write it up. Reserves the advisory channel for a demonstrated path to funds or keys where telling us privately first actually protects someone.
- **Credits by contribution, not by channel.** The Hall of Fame column becomes "Reference" and mixes PRs and advisories, so routing correctly costs a reporter nothing.
- **Writes down three conditions for reopening**: a PoC against a tagged release; a demonstrated loss rather than a citation for anything already documented; and tiering, so "this guard is skipped here" and "here is BTC leaving the wallet" are not paid alike.

Docs only — no code changes.