### PR TITLE
Compose a real transaction in the E2E mock instead of a placeholder

### DIFF
--- a/e2e/compose-fixture-tx.ts
+++ b/e2e/compose-fixture-tx.ts
@@ -1,0 +1,168 @@
+/**
+ * Builds the raw transaction the compose mock returns.
+ *
+ * The composer verifies what it is about to sign: it rebuilds the message the request should have
+ * produced and requires the transaction's own bytes to carry exactly that (`composer-context.tsx`,
+ * ADR-019). A placeholder rawtransaction therefore fails verification for every compose type that
+ * can pack a message — correctly, because a placeholder really does carry no message.
+ *
+ * So the mock composes for real: it packs the message with the same code the extension uses,
+ * ARC4-obfuscates it against the first input's txid the way counterparty-core does, and emits an
+ * OP_RETURN plus the outputs the request implies. The verification then runs in full against the
+ * fixture, which is the point — a test that bypassed it would prove nothing about the code whose
+ * whole job is refusing bad transactions.
+ *
+ * Types that legitimately pack no message (a BTC send, a subasset whose id only the server can
+ * draw) return null here and keep the placeholder, which is what the composer already tolerates.
+ */
+
+import { Address, OutScript, Transaction } from '@scure/btc-signer';
+import { packComposeMessage } from '../src/core/counterparty/pack/messages';
+import { arc4, bytesToHex, hexToBytes } from '../src/core/counterparty/unpack/binary';
+
+/** Value of the single input the fixture spends. Matches the mock's long-standing `btc_in`. */
+const INPUT_VALUE = 174891;
+/** Fee the fixture pays. Small enough to sit under the fee bound at any rate a test would pick. */
+const FIXTURE_FEE = 669;
+/** Value of a destination output the message does not itself carry. */
+const DUST = 546;
+
+/**
+ * The outpoint spent when the request offered no `inputs_set`. Any txid works — it is the ARC4 key
+ * and nothing more — but it must be a plausible 32-byte hash so the prevout lookup can be mocked.
+ */
+const FALLBACK_TXID = '4c9c1a12ebe071ea2abc3ec6a7ba380904485bdb9b0075de40cfcf1ac4b6dd4c';
+const FALLBACK_VOUT = 1;
+
+export interface FixtureTransaction {
+  rawtransaction: string;
+  /** The unobfuscated payload, as the API reports it in `data`. */
+  data: string;
+  btc_in: number;
+  btc_out: number;
+  btc_change: number;
+  btc_fee: number;
+}
+
+/** Params the packers read as booleans rather than as the strings a query string carries. */
+const BOOLEAN_PARAMS = new Set([
+  'divisible',
+  'lock',
+  'reset',
+  'memo_is_hex',
+  'memos_are_hex',
+  'no_dispense',
+  'use_enhanced_send',
+  'lock_description',
+  'lock_quantity',
+  'soft_cap_deadline_block',
+]);
+
+/**
+ * Rebuild the packer's view of the request from the compose URL.
+ *
+ * The query string is built straight from the normalized form data (`composeTransaction`), so the
+ * field names already line up; only the types need restoring, since a query string carries
+ * everything as text and the packers distinguish a boolean from the string "false".
+ */
+function packParamsFromUrl(url: URL): Record<string, unknown> {
+  const params: Record<string, unknown> = {};
+  for (const [key, value] of url.searchParams) {
+    params[key] = BOOLEAN_PARAMS.has(key) ? value === 'true' : value;
+  }
+  return params;
+}
+
+/** An OP_RETURN carrying `data`, using OP_PUSHDATA1 once a direct push can no longer hold it. */
+function opReturnScript(data: Uint8Array): Uint8Array {
+  const prefix = data.length <= 75 ? [0x6a, data.length] : [0x6a, 0x4c, data.length];
+  return new Uint8Array([...prefix, ...data]);
+}
+
+function scriptForAddress(address: string): Uint8Array {
+  const decoded = Address().decode(address);
+  if (!decoded) throw new Error(`fixture: cannot build an output script for ${address}`);
+  return OutScript.encode(decoded);
+}
+
+/**
+ * The outpoint the fixture spends. Taken from `inputs_set` when the request offered one, because
+ * the composer rejects a transaction that spends a coin the wallet did not offer
+ * (`checkInputPolicy`) — the mock has to respect the same rule a real composer does.
+ */
+function firstOfferedInput(url: URL): { txid: string; vout: number } {
+  const offered = url.searchParams.get('inputs_set');
+  const first = offered?.split(',')[0]?.trim();
+  const [txid, vout] = first ? first.split(':') : [];
+  if (txid && txid.length === 64 && vout !== undefined) {
+    return { txid: txid.toLowerCase(), vout: Number(vout) };
+  }
+  return { txid: FALLBACK_TXID, vout: FALLBACK_VOUT };
+}
+
+/**
+ * Compose a fixture transaction that really carries `composeType`'s message, or null when this
+ * request packs no message and the placeholder remains appropriate.
+ *
+ * @param composeType - Compose endpoint name, e.g. 'issuance'
+ * @param requestUrl - The intercepted compose URL, whose path names the source address
+ */
+export function buildFixtureTransaction(
+  composeType: string,
+  requestUrl: string
+): FixtureTransaction | null {
+  try {
+    return composeFixture(composeType, requestUrl);
+  } catch {
+    // A request this helper cannot build for — an address it cannot decode, a quantity that does
+    // not fit — keeps the placeholder, exactly as an unpackable type does. Tests that reach the
+    // review page will fail on the missing message, which is the honest outcome: the fixture was
+    // not built, rather than the verification being waved through.
+    return null;
+  }
+}
+
+function composeFixture(composeType: string, requestUrl: string): FixtureTransaction | null {
+  const url = new URL(requestUrl);
+  const sourceMatch = url.pathname.match(/\/addresses\/([^/]+)\/compose\//);
+  const source = sourceMatch?.[1];
+  if (!source) return null;
+
+  const packed = packComposeMessage(composeType, packParamsFromUrl(url));
+  if (!packed) return null;
+
+  const input = firstOfferedInput(url);
+
+  // Counterparty keys the stream with the first input's txid in display order, which is the order
+  // @scure/btc-signer both accepts and returns (`unpack/opReturn.ts`).
+  const obfuscated = arc4(hexToBytes(input.txid), packed.bytes);
+
+  const tx = new Transaction({ allowUnknownOutputs: true, disableScriptCheck: true });
+  tx.addInput({ txid: hexToBytes(input.txid), index: input.vout });
+
+  // An ownership transfer names its new owner nowhere in the message: core writes it to the output
+  // immediately ahead of the data output, and the composer checks that position specifically.
+  let paidOut = 0;
+  const transferDestination = url.searchParams.get('transfer_destination');
+  if (composeType === 'issuance' && transferDestination) {
+    tx.addOutput({ script: scriptForAddress(transferDestination), amount: BigInt(DUST) });
+    paidOut += DUST;
+  }
+
+  tx.addOutput({ script: opReturnScript(obfuscated), amount: 0n });
+
+  const change = INPUT_VALUE - paidOut - FIXTURE_FEE;
+  tx.addOutput({ script: scriptForAddress(source), amount: BigInt(change) });
+
+  return {
+    rawtransaction: bytesToHex(tx.toBytes(true, false)),
+    data: bytesToHex(packed.bytes),
+    btc_in: INPUT_VALUE,
+    btc_out: paidOut,
+    btc_change: change,
+    btc_fee: FIXTURE_FEE,
+  };
+}
+
+/** The prevout value the fixture's input must resolve to, for mocking the lookup. */
+export const FIXTURE_INPUT_VALUE = INPUT_VALUE;

--- a/e2e/compose-test-helpers.ts
+++ b/e2e/compose-test-helpers.ts
@@ -6,6 +6,7 @@
  */
 
 import { Page, expect } from '@playwright/test';
+import { FIXTURE_INPUT_VALUE, buildFixtureTransaction } from './compose-fixture-tx';
 import { TEST_ADDRESSES } from './test-data';
 
 /**
@@ -62,6 +63,22 @@ export async function enableValidationBypass(page: Page): Promise<void> {
       name: 'send',
     },
   };
+
+  // The composer bounds the fee using the transaction's own inputs, which means resolving what
+  // each input is worth from a block explorer. Answer for the fixture's outpoint instead of
+  // letting the lookup reach the network — an unresolved input is a hard failure, by design.
+  await context.route(/https:\/\/(mempool\.space|blockstream\.info)\/api\/tx\/[0-9a-f]{64}$/i, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        vout: Array.from({ length: 10 }, () => ({
+          value: FIXTURE_INPUT_VALUE,
+          scriptpubkey_address: mockComposeResponse.result.params.source,
+        })),
+      }),
+    });
+  });
 
   // Single unified route handler for all Counterparty API requests
   await context.route('**/api.counterparty.io**', async (route) => {
@@ -230,11 +247,21 @@ export async function enableValidationBypass(page: Page): Promise<void> {
         };
       }
 
+      // The composer rebuilds the message this request should have produced and requires the
+      // transaction to carry exactly it, so the fixture has to be composed for real rather than
+      // stubbed. Types that pack no message keep the placeholder — the composer expects no message
+      // from them either. See compose-fixture-tx.ts.
+      const fixture = buildFixtureTransaction(composeType, url);
+      if (fixture) {
+        console.log(`[E2E Mock] Built a real ${composeType} transaction carrying its message`);
+      }
+
       // Build dynamic response with params from request
       const dynamicResponse = {
         ...mockComposeResponse,
         result: {
           ...mockComposeResponse.result,
+          ...fixture,
           params: responseParams,
           name: composeType,
         },

--- a/e2e/tests/compose-fixture-tx.spec.ts
+++ b/e2e/tests/compose-fixture-tx.spec.ts
@@ -1,0 +1,99 @@
+/**
+ * Guards the compose mock's transaction builder against drift.
+ *
+ * The builder packs a message with the same code the extension verifies against, so a change to
+ * either side that breaks the agreement should fail here — pointing at the fixture — rather than
+ * as a wall of unexplained review-page timeouts across every compose suite.
+ *
+ * Pure functions only: no browser, no extension, no network.
+ */
+
+import { expect, test } from '@playwright/test';
+import { buildFixtureTransaction } from '../compose-fixture-tx';
+import { checkOutputPolicy } from '../../src/core/counterparty/outputPolicy';
+import { packComposeMessage } from '../../src/core/counterparty/pack/messages';
+import { bytesToHex } from '../../src/core/counterparty/unpack/binary';
+import { extractCounterpartyPayload } from '../../src/core/counterparty/unpack/opReturn';
+
+const SOURCE = '14udFRS6AdnQNJZn9RZ1H3LtSqP7k2UeTC';
+const OTHER = '1BoatSLRHtKNngkdXEeobR76b53LETtpyT';
+const composeUrl = (type: string, query: string) =>
+  `https://api.counterparty.io/v2/addresses/${SOURCE}/compose/${type}?${query}&sat_per_vbyte=5`;
+
+test.describe('compose fixture transactions', () => {
+  test('an order fixture carries exactly the message the request packs', async () => {
+    const fixture = buildFixtureTransaction('order', composeUrl('order',
+      'give_asset=XCP&give_quantity=100000000&get_asset=PEPECASH'
+      + '&get_quantity=200000000&expiration=8064&fee_required=0'));
+    expect(fixture).not.toBeNull();
+
+    // What the composer rebuilds and demands the transaction match, byte for byte.
+    const expected = packComposeMessage('order', {
+      give_asset: 'XCP', give_quantity: '100000000', get_asset: 'PEPECASH',
+      get_quantity: '200000000', expiration: '8064', fee_required: '0',
+    });
+    expect(extractCounterpartyPayload(fixture!.rawtransaction)).toBe(bytesToHex(expected!.bytes));
+
+    expect(checkOutputPolicy({
+      rawTransaction: fixture!.rawtransaction,
+      ownAddresses: [SOURCE],
+      intendedDestinations: [],
+    }).ok).toBe(true);
+  });
+
+  test('an issuance fixture packs its booleans rather than the strings the query carries', async () => {
+    // divisible=false survives only if the builder restores it as a boolean: the packer treats the
+    // string "false" as absent, and would pack a divisible asset instead.
+    const fixture = buildFixtureTransaction('issuance', composeUrl('issuance',
+      'asset=TESTUNLOCKED&quantity=100000000&divisible=false&lock=false&reset=false'));
+    expect(fixture).not.toBeNull();
+
+    const expected = packComposeMessage('issuance', {
+      asset: 'TESTUNLOCKED', quantity: '100000000', divisible: false, lock: false, reset: false,
+    });
+    expect(extractCounterpartyPayload(fixture!.rawtransaction)).toBe(bytesToHex(expected!.bytes));
+  });
+
+  test('an ownership transfer pays its new owner in the position core reads it from', async () => {
+    const fixture = buildFixtureTransaction('issuance', composeUrl('issuance',
+      `asset=TESTUNLOCKED&quantity=0&divisible=true&lock=false&reset=false`
+      + `&transfer_destination=${OTHER}`));
+    expect(fixture).not.toBeNull();
+
+    // positionalDestination is what pins the new owner: the output immediately ahead of the data
+    // output. A fixture that ordered its outputs any other way would fail here.
+    expect(checkOutputPolicy({
+      rawTransaction: fixture!.rawtransaction,
+      ownAddresses: [SOURCE],
+      intendedDestinations: [{ address: OTHER }],
+      positionalDestination: OTHER,
+    }).ok).toBe(true);
+  });
+
+  test('the fixture spends the coin the request offered, and keys the message with it', async () => {
+    const offered = 'a'.repeat(64);
+    const fixture = buildFixtureTransaction('order', composeUrl('order',
+      `give_asset=XCP&give_quantity=1&get_asset=PEPECASH&get_quantity=1&expiration=100`
+      + `&fee_required=0&inputs_set=${offered}:3`));
+    expect(fixture).not.toBeNull();
+    // Spending an unoffered coin is refused by checkInputPolicy, so the builder has to honour the
+    // offer — and the payload only decrypts if that same txid keyed it.
+    expect(fixture!.rawtransaction).toContain(offered);
+    expect(extractCounterpartyPayload(fixture!.rawtransaction)).not.toBeNull();
+  });
+
+  test('a type that packs no message keeps the placeholder', async () => {
+    // A BTC send has no Counterparty message to carry, and the composer expects none.
+    expect(buildFixtureTransaction('send', composeUrl('send',
+      `asset=BTC&quantity=10000&destination=${OTHER}`))).toBeNull();
+  });
+
+  test('the fee stays under the bound the composer applies', async () => {
+    const fixture = buildFixtureTransaction('order', composeUrl('order',
+      'give_asset=XCP&give_quantity=1&get_asset=PEPECASH&get_quantity=1&expiration=100&fee_required=0'));
+    expect(fixture!.btc_in - fixture!.btc_out - fixture!.btc_change).toBe(fixture!.btc_fee);
+    // MIN_BOUND_SATS floors the composer's fee bound at 10,000 sats, so anything under it passes
+    // whatever rate a test picks.
+    expect(fixture!.btc_fee).toBeLessThan(10_000);
+  });
+});


### PR DESCRIPTION
## The problem

The E2E compose mock returned a placeholder for every compose type:

```
rawtransaction: '0200000001abcdef',
data: null,
```

That string is not a transaction, and it carries no Counterparty message. The
composer rebuilds the message a request should have produced and requires the
transaction it is about to sign to carry exactly that (ADR-019), so it refused
the fixture — correctly. Every suite that reached the review page with a type
that packs a message failed.

The pattern fits precisely: the mock's default params describe a BTC send,
which legitimately has no message, so the check is skipped and those specs
passed. Issuance, order, broadcast and dispenser all pack a message, so the
check fired and refused the placeholder.

**There is no shipped bug here.** The verification is doing its job on a
fixture that was never a real transaction.

## The fix

`e2e/compose-fixture-tx.ts` composes for real, from the intercepted request:

- packs the message with `packComposeMessage` — the same code the composer
  verifies against
- restores the types a query string flattens, so `divisible=false` packs as a
  boolean rather than as the string the packer reads as absent
- ARC4-obfuscates against the first input's txid, the way counterparty-core does
- writes an OP_RETURN plus the outputs the request implies, with an ownership
  transfer's new owner in the position core reads it from
- takes its input from `inputs_set`, so the transaction only spends coins the
  wallet offered (`checkInputPolicy`)
- keeps the fee under the composer's bound, and reports `btc_in`/`btc_out`/
  `btc_change`/`btc_fee` consistent with the transaction it built

Types that pack no message — a BTC send, a subasset whose asset id only the
server can draw — keep the placeholder, which is what the composer expects of
them. That keeps the blast radius to exactly the suites that were failing.

The fee check also resolves each input's value from a block explorer, so the
mock now answers that lookup instead of letting it reach the network.

## What this deliberately does not do

Add a flag that skips verification under test. That would put a bypass in the
code path whose entire job is refusing bad transactions.

## Verification

Run locally one file at a time, per `CLAUDE.md`. All seven suites that reach
the review page pass — issuance, order, broadcast, dispenser, send, pool
deposit, pool withdraw — plus the six issuance sub-flows. Broadcast and
dispenser turn out to have been composing real messages too, and now verify
rather than being refused.

`e2e/tests/compose-fixture-tx.spec.ts` guards the builder against drift: if
packing and the fixture ever disagree, it fails there rather than as a wall of
unexplained review-page timeouts across every compose suite.

This belongs on main ahead of #279 and #280, which sit behind these same two
red batches.

https://claude.ai/code/session_01HUJSeVf1JXG1Rp3VXpb2Cr
