### PR TITLE
Seed the one sign-flow record the approval screens now read

### DIFF
--- a/e2e/tests/approval-gallery.spec.ts
+++ b/e2e/tests/approval-gallery.spec.ts
@@ -230,12 +230,25 @@ walletTest('captures every provider approval screen', async ({ context, page, ex
 
   const scenarios = Object.entries(scenarioFixtures.scenarios);
 
+  // One record per signing request, in the shape `beginSignFlow` writes (`signFlow.ts`). Seeded
+  // directly rather than through a dApp connection, so `requestKey` only has to be present — it
+  // exists for rejoining a duplicate request, which this gallery never makes.
   const seed = async (id: string, rawTxHex: string) => {
     await page.evaluate(
       async (req) => {
-        await chrome.storage.session.set({ pending_sign_transaction_requests: [req] });
+        await chrome.storage.session.set({ pending_sign_flow: [req] });
       },
-      { id, origin: 'https://launchpad.xcp.fun', timestamp: Date.now(), address: '', walletId: '', rawTxHex }
+      {
+        id,
+        origin: 'https://launchpad.xcp.fun',
+        timestamp: Date.now(),
+        address: '',
+        walletId: '',
+        requestKey: `xcp_signTransaction:${id}`,
+        kind: 'sign-transaction',
+        status: 'pending',
+        rawTxHex,
+      }
     );
   };
 
@@ -307,7 +320,7 @@ walletTest('captures every provider approval screen', async ({ context, page, ex
     const id = `gallery-psbt-${name}`;
     await page.evaluate(
       async (req) => {
-        await chrome.storage.session.set({ pending_sign_psbt_requests: [req] });
+        await chrome.storage.session.set({ pending_sign_flow: [req] });
       },
       {
         id,
@@ -315,6 +328,9 @@ walletTest('captures every provider approval screen', async ({ context, page, ex
         timestamp: Date.now(),
         address: signerAddress!,
         walletId: '',
+        requestKey: `xcp_signPsbt:${id}`,
+        kind: 'sign-psbt',
+        status: 'pending',
         psbtHex: toPsbt(rebuildForSigner(rawTxHex, signerAddress!, name === 'dispense')),
       }
     );

--- a/e2e/tests/ux-visual-check.spec.ts
+++ b/e2e/tests/ux-visual-check.spec.ts
@@ -43,10 +43,23 @@ async function readActiveAddress(page: Page): Promise<string> {
 
 async function seedPsbtAndOpenApproval(page: Page, psbtHex: string, origin = 'https://app.example.com') {
   const address = await readActiveAddress(page);
+  // One record per signing request, in the shape `beginSignFlow` writes (`signFlow.ts`). Seeded
+  // directly rather than through a dApp connection, so `requestKey` only has to be present — it
+  // exists for rejoining a duplicate request, which this test never makes.
   await page.evaluate(async ({ address, psbtHex, origin }) => {
     await chrome.storage.session.set({
-      pending_sign_psbt_requests: [
-        { id: 'visual-check', origin, timestamp: Date.now(), address, walletId: '', psbtHex },
+      pending_sign_flow: [
+        {
+          id: 'visual-check',
+          origin,
+          timestamp: Date.now(),
+          address,
+          walletId: '',
+          requestKey: 'xcp_signPsbt:visual-check',
+          kind: 'sign-psbt',
+          status: 'pending',
+          psbtHex,
+        },
       ],
     });
   }, { address, psbtHex, origin });


### PR DESCRIPTION
## Main is red; this is why

E2E batches 14 and 17 fail on `main` — `approval-gallery.spec.ts` and
`ux-visual-check.spec.ts`. Both fail the same way: the provider approval
screen renders neither its origin nor a Sign button.

```
Error: expect(locator).toBeVisible() failed
  - waiting for getByRole('button', { name: /^(sign|blocked)$/i })
```

#280 replaced three per-method stores with a single `pending_sign_flow`
record carrying `requestKey`, `kind` and `status`. Three E2E seed sites still
wrote the old keys:

| file | wrote |
|---|---|
| `approval-gallery.spec.ts:236` | `pending_sign_transaction_requests` |
| `approval-gallery.spec.ts:310` | `pending_sign_psbt_requests` |
| `ux-visual-check.spec.ts:48` | `pending_sign_psbt_requests` |

So `getSignFlow(id)` found nothing and the screen had no request to render.

**The product code is fine.** Only the fixtures were stale — the same class of
problem as the compose placeholder in #281, and it slipped through for the
same reason: #280's base was a feature branch, so it merged without a CI run
of its own.

## The fix

Seed the record in the shape `beginSignFlow` writes. `requestKey` only has to
be present — it exists for rejoining a duplicate request, which neither test
makes.

## Verification

Run locally, one file at a time:

- `ux-visual-check.spec.ts` — 2 passed
- `approval-gallery.spec.ts` — 1 passed, all 25 approval screens captured

https://claude.ai/code/session_01HUJSeVf1JXG1Rp3VXpb2Cr
