### PR TITLE
Share the sign-request analysis between the PSBT and transaction screens

### DIFF
--- a/src/core/counterparty/__tests__/signRequestAnalysis.test.ts
+++ b/src/core/counterparty/__tests__/signRequestAnalysis.test.ts
@@ -1,0 +1,176 @@
+/**
+ * The gate that decides whether this wallet will sign for a website.
+ *
+ * This logic used to be written out twice, once inside each approval hook, and neither copy was
+ * covered by a test — the hooks had none at all. It is the check that stops a site using the
+ * wallet as a plain Bitcoin signer, so it is pinned here now that it lives in one place.
+ *
+ * The lookups that reach the network are mocked; everything that decides safety is the real code.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { InputAttachedAssets } from '../inputAssets';
+import type { ProtocolContext } from '../protocolContext';
+import { type AnalyzedOutput, analyzeSignRequest } from '../signRequestAnalysis';
+
+vi.mock('@/core/counterparty/transaction', () => ({
+  decodeCounterpartyMessage: vi.fn(async () => null),
+  resolveMpmaRecipients: vi.fn(async () => []),
+  describeMpmaSend: vi.fn(() => 'described locally'),
+}));
+
+vi.mock('@/core/counterparty/protocolContext', () => ({
+  resolveProtocolContext: vi.fn(async () => ({ context: {} as ProtocolContext, warnings: [] })),
+}));
+
+vi.mock('@/core/counterparty/unpack', () => ({
+  verifyProviderTransaction: vi.fn(() => ({ localUnpack: undefined })),
+}));
+
+const { decodeCounterpartyMessage, resolveMpmaRecipients } = await import('../transaction');
+const { resolveProtocolContext } = await import('../protocolContext');
+const { verifyProviderTransaction } = await import('../unpack');
+
+const SIGNER = 'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq';
+
+const OUTPUTS: AnalyzedOutput[] = [
+  { index: 0, value: 10_000, type: 'witness_v0_keyhash', address: SIGNER },
+];
+
+const INPUTS = [{ txid: 'a'.repeat(64), vout: 0 }];
+
+/** An input carrying assets, at the given index. */
+function withAssets(inputIndex: number): InputAttachedAssets {
+  return {
+    inputIndex,
+    utxo: `${'a'.repeat(64)}:${inputIndex}`,
+    assets: [{ asset: 'XCP', quantity_normalized: '1.0' }],
+  };
+}
+
+function run(overrides: Partial<Parameters<typeof analyzeSignRequest>[0]> = {}) {
+  return analyzeSignRequest({
+    counterpartyDataHex: undefined,
+    inputs: INPUTS,
+    outputs: OUTPUTS,
+    signerAddresses: [SIGNER],
+    signedInputIndices: [0],
+    transactionId: undefined,
+    attachedAssets: Promise.resolve([]),
+    ...overrides,
+  });
+}
+
+const blockedOnNotCounterparty = (warnings: { title: string }[]) =>
+  warnings.some((w) => w.title === 'Blocked: Not a Counterparty Transaction');
+
+describe('the not-a-Counterparty-transaction gate', () => {
+  beforeEach(() => {
+    vi.mocked(verifyProviderTransaction).mockReturnValue({ localUnpack: undefined } as never);
+    vi.mocked(resolveProtocolContext).mockResolvedValue({
+      context: {} as ProtocolContext,
+      warnings: [],
+    });
+  });
+
+  it('blocks a transaction carrying no message and spending nothing attached', async () => {
+    const analysis = await run();
+
+    expect(analysis.safety.blocked).toBe(true);
+    expect(blockedOnNotCounterparty(analysis.safety.warnings)).toBe(true);
+    // The block is stated first, ahead of whatever else the outputs earned.
+    expect(analysis.safety.warnings[0]?.title).toBe('Blocked: Not a Counterparty Transaction');
+  });
+
+  it('allows a transaction that carries a Counterparty message', async () => {
+    const analysis = await run({ counterpartyDataHex: '434e5452505254590a00' });
+
+    expect(blockedOnNotCounterparty(analysis.safety.warnings)).toBe(false);
+  });
+
+  it('allows a transaction spending an input that carries attached assets', async () => {
+    const analysis = await run({ attachedAssets: Promise.resolve([withAssets(0)]) });
+
+    expect(blockedOnNotCounterparty(analysis.safety.warnings)).toBe(false);
+  });
+
+  it('still blocks when the attached assets sit on an input this wallet is not signing', async () => {
+    // Assets on an input we do not sign are somebody else's side of the transaction, so they are
+    // no reason to sign a transaction that does nothing for us.
+    const analysis = await run({
+      attachedAssets: Promise.resolve([withAssets(3)]),
+      signedInputIndices: [0],
+    });
+
+    expect(analysis.safety.blocked).toBe(true);
+    expect(blockedOnNotCounterparty(analysis.safety.warnings)).toBe(true);
+  });
+});
+
+describe('policy warnings from the ledger lookups', () => {
+  beforeEach(() => {
+    vi.mocked(verifyProviderTransaction).mockReturnValue({ localUnpack: undefined } as never);
+  });
+
+  it('escalates a blocking policy warning and puts it ahead of the rest', async () => {
+    vi.mocked(resolveProtocolContext).mockResolvedValue({
+      context: {} as ProtocolContext,
+      warnings: [{ severity: 'block', title: 'Blocked: Oracle Dispenser', message: 'x' }],
+    });
+
+    const analysis = await run({ counterpartyDataHex: '434e5452505254590a00' });
+
+    expect(analysis.safety.blocked).toBe(true);
+    expect(analysis.safety.warnings[0]?.title).toBe('Blocked: Oracle Dispenser');
+  });
+
+  it('carries a non-blocking policy warning through without blocking', async () => {
+    vi.mocked(resolveProtocolContext).mockResolvedValue({
+      context: {} as ProtocolContext,
+      warnings: [{ severity: 'warning', title: 'Priced by an oracle', message: 'x' }],
+    });
+
+    const analysis = await run({ counterpartyDataHex: '434e5452505254590a00' });
+
+    expect(analysis.safety.blocked).toBe(false);
+    expect(analysis.safety.warnings.some((w) => w.title === 'Priced by an oracle')).toBe(true);
+  });
+});
+
+describe('reading the message', () => {
+  beforeEach(() => {
+    vi.mocked(resolveProtocolContext).mockResolvedValue({
+      context: {} as ProtocolContext,
+      warnings: [],
+    });
+  });
+
+  it('survives a decode failure rather than failing the whole analysis', async () => {
+    // The API's rendering is for display only, so losing it must not stop the checks that matter.
+    vi.mocked(verifyProviderTransaction).mockReturnValue({ localUnpack: undefined } as never);
+    vi.mocked(decodeCounterpartyMessage).mockRejectedValueOnce(new Error('API down'));
+
+    const analysis = await run({ counterpartyDataHex: '434e5452505254590a00' });
+
+    expect(analysis.counterpartyMessage).toBeUndefined();
+    expect(analysis.safety).toBeDefined();
+  });
+
+  it('describes an mpma_send from the bytes, replacing the API description', async () => {
+    vi.mocked(verifyProviderTransaction).mockReturnValue({
+      localUnpack: { messageType: 'mpma_send', data: { sends: [{ asset: 'XCP' }] } },
+    } as never);
+    vi.mocked(decodeCounterpartyMessage).mockResolvedValueOnce({
+      messageType: 'mpma_send',
+      description: 'whatever the API said',
+    } as never);
+    vi.mocked(resolveMpmaRecipients).mockResolvedValueOnce([
+      { address: SIGNER, asset: 'XCP', quantity_normalized: '1.0' },
+    ] as never);
+
+    const analysis = await run({ counterpartyDataHex: '434e545250525459030' });
+
+    expect(analysis.mpmaRecipients).toHaveLength(1);
+    expect(analysis.counterpartyMessage?.description).toBe('described locally');
+  });
+});

--- a/src/core/counterparty/signRequestAnalysis.ts
+++ b/src/core/counterparty/signRequestAnalysis.ts
@@ -1,0 +1,206 @@
+/**
+ * The checks a transaction gets before this wallet will sign it for a website.
+ *
+ * A PSBT and a raw transaction reach this code by different routes — one is parsed from a PSBT,
+ * the other from raw bytes, and they resolve their Counterparty payload differently — but once the
+ * payload is in hand, everything that decides whether signing is safe is the same. It used to be
+ * written out twice, once per approval hook, with each copy carrying comments explaining that it
+ * matched the other. It only takes one fix landing in one copy for the two screens to disagree
+ * about whether the same transaction is safe, so they share this instead.
+ *
+ * Everything here reads the transaction's own bytes. Nothing decides safety from a remote party's
+ * account of them (ADR-019).
+ */
+
+import {
+  type AttachedAssetDestination,
+  movesCounterpartyValue,
+  resolveAttachedAssetDestination,
+} from '@/core/counterparty/attachedAssetMovement';
+import type { InputAttachedAssets } from '@/core/counterparty/inputAssets';
+import { checkMessageStructure, type StructureFinding } from '@/core/counterparty/messageStructure';
+import { type ProtocolContext, resolveProtocolContext } from '@/core/counterparty/protocolContext';
+import {
+  type CounterpartyMessage,
+  decodeCounterpartyMessage,
+  describeMpmaSend,
+  type MpmaRecipient,
+  resolveMpmaRecipients,
+} from '@/core/counterparty/transaction';
+import {
+  analyzeTransactionSafety,
+  type SafetyAnalysis,
+} from '@/core/counterparty/transactionSafety';
+import { type ProviderVerificationResult, verifyProviderTransaction } from '@/core/counterparty/unpack';
+import type { MPMAData } from '@/core/counterparty/unpack/messages/mpma';
+
+/** An input being signed, identified by the outpoint it spends. */
+export interface AnalyzedInput {
+  txid: string;
+  vout: number;
+}
+
+/**
+ * An output, in the shape every check below needs. Both approval paths already produce this — the
+ * PSBT parser and the raw-transaction parser agree on these fields.
+ */
+export interface AnalyzedOutput {
+  index: number;
+  value: number;
+  type: string;
+  address?: string;
+  script?: string;
+}
+
+export interface SignRequestAnalysisInput {
+  /** The Counterparty payload the outputs carry, read from the bytes, or undefined if none. */
+  counterpartyDataHex: string | undefined;
+  inputs: AnalyzedInput[];
+  /** Mutated by neither this function nor its callees; enrichment happens before the call. */
+  outputs: AnalyzedOutput[];
+  /** Addresses this wallet would sign with. Empty when the caller has none to name. */
+  signerAddresses: string[];
+  /**
+   * Indices of the inputs this wallet is being asked to sign. Assets on inputs it does not sign
+   * belong to someone else's side of the transaction.
+   */
+  signedInputIndices: number[];
+  /** Transaction id, where the caller could establish one. Only the detail lookups use it. */
+  transactionId: string | undefined;
+  /**
+   * The per-input attached-asset lookup, started by the caller before its own decoding so the two
+   * overlap. Passed as a promise rather than a value to keep that overlap.
+   */
+  attachedAssets: Promise<InputAttachedAssets[]>;
+}
+
+export interface SignRequestAnalysis {
+  /** The API's rendering of the message, when it could supply one. Never used to decide safety. */
+  counterpartyMessage: CounterpartyMessage | undefined;
+  verification: ProviderVerificationResult;
+  safety: SafetyAnalysis;
+  attachedAssets: InputAttachedAssets[];
+  mpmaRecipients: MpmaRecipient[];
+  structureFindings: StructureFinding[];
+  protocolContext: ProtocolContext;
+  attachedAssetDestination: AttachedAssetDestination | null;
+}
+
+/**
+ * Run every safety check that applies to a transaction a website has asked this wallet to sign.
+ *
+ * @param input - the transaction, already parsed, with its Counterparty payload resolved
+ * @returns the analysis both approval screens render, including any blocking warnings
+ */
+export async function analyzeSignRequest(
+  input: SignRequestAnalysisInput
+): Promise<SignRequestAnalysis> {
+  const {
+    counterpartyDataHex,
+    inputs,
+    outputs,
+    signerAddresses,
+    signedInputIndices,
+    transactionId,
+  } = input;
+
+  // The API's rendering is for display only — richer than the local unpack, and not trusted by
+  // anything below that decides whether signing is safe.
+  let counterpartyMessage: CounterpartyMessage | undefined;
+  if (counterpartyDataHex) {
+    try {
+      const message = await decodeCounterpartyMessage(counterpartyDataHex);
+      if (message) counterpartyMessage = message;
+    } catch (err) {
+      console.warn('Failed to decode Counterparty message:', err);
+    }
+  }
+
+  // Compares the local binary unpack against the API's result; the local one wins.
+  const verification = verifyProviderTransaction(counterpartyDataHex, counterpartyMessage);
+
+  const messageType = counterpartyMessage?.messageType ?? verification.localUnpack?.messageType;
+  const safety = analyzeTransactionSafety(messageType, outputs, signerAddresses);
+
+  // mpma_send is described from the bytes, not from the API's rendering of them — see
+  // resolveMpmaRecipients for why the API cannot be used for this type. Without it the screen says
+  // "Send to 3 recipients" and names none of them.
+  let mpmaRecipients: MpmaRecipient[] = [];
+  if (verification.localUnpack?.messageType === 'mpma_send' && verification.localUnpack.data) {
+    const sends = (verification.localUnpack.data as MPMAData).sends ?? [];
+    if (sends.length > 0) {
+      mpmaRecipients = await resolveMpmaRecipients(sends);
+      if (counterpartyMessage) {
+        counterpartyMessage = {
+          ...counterpartyMessage,
+          description: describeMpmaSend(mpmaRecipients),
+        };
+      }
+    }
+  }
+
+  // Independent of both decoders: does the message's own account of this transaction hold up
+  // against the transaction? Uses the local decode, since the point is to test the bytes.
+  const structureFindings = checkMessageStructure(
+    verification.localUnpack?.messageType,
+    verification.localUnpack?.data,
+    { inputs, outputs }
+  );
+
+  const { context: protocolContext, warnings: policyWarnings } = await resolveProtocolContext({
+    messageType: verification.localUnpack?.messageType,
+    data: verification.localUnpack?.data,
+    transactionId,
+    apiMessageData: counterpartyMessage?.messageData,
+    outputs,
+    signerAddresses,
+    spentUtxos: inputs.map((i) => `${i.txid}:${i.vout}`),
+  });
+
+  // Policy blocks come from the same lookups as the detail list — an oracle-priced dispenser is
+  // only visible once the dispensers behind the paid address have been read.
+  if (policyWarnings.length > 0) {
+    safety.warnings = [...policyWarnings, ...safety.warnings];
+    safety.blocked = safety.blocked || policyWarnings.some((w) => w.severity === 'block');
+  }
+
+  const attachedAssets = await input.attachedAssets;
+
+  // The gate: a transaction this wallet signs on a site's behalf either carries a Counterparty
+  // message or spends an input carrying attached assets. Anything else is a plain Bitcoin
+  // transaction, which a site has no Counterparty reason to ask this wallet for and which the user
+  // can make in the wallet directly. Both halves are required — a message alone would miss an
+  // attached UTXO being spent alongside it, and attached assets alone miss every ordinary send.
+  if (!movesCounterpartyValue(Boolean(counterpartyDataHex), attachedAssets, signedInputIndices)) {
+    safety.warnings = [
+      {
+        severity: 'block',
+        title: 'Blocked: Not a Counterparty Transaction',
+        message:
+          'This carries no Counterparty message and spends nothing holding Counterparty assets, ' +
+          'so signing it would move only bitcoin at a site’s direction. Make plain Bitcoin ' +
+          'payments in the wallet, where you choose the destination.',
+      },
+      ...safety.warnings,
+    ];
+    safety.blocked = true;
+  }
+
+  const attachedAssetDestination = resolveAttachedAssetDestination(
+    outputs,
+    attachedAssets,
+    signedInputIndices,
+    signerAddresses
+  );
+
+  return {
+    counterpartyMessage,
+    verification,
+    safety,
+    attachedAssets,
+    mpmaRecipients,
+    structureFindings,
+    protocolContext,
+    attachedAssetDestination,
+  };
+}

--- a/src/hooks/useSignMessageRequest.ts
+++ b/src/hooks/useSignMessageRequest.ts
@@ -10,22 +10,8 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router';
+import { emitToBackground } from '@/platform/provider/emitToBackground';
 import { getSignFlow, recordSignOutcome, type SignMessageRequest } from '@/platform/provider/signFlow';
-
-/**
- * Send an event to the background script's EventEmitterService.
- * This is necessary because the popup and background have separate instances.
- */
-function emitToBackground(event: string, data: unknown): void {
-  chrome.runtime.sendMessage({
-    type: 'COMPOSE_EVENT',
-    event,
-    data
-  }).catch((error) => {
-    // Popup might be closing, which is fine
-    console.debug('Failed to emit sign message event to background:', error);
-  });
-}
 
 export function useSignMessageRequest() {
   const [searchParams] = useSearchParams();

--- a/src/hooks/useSignPsbtRequest.ts
+++ b/src/hooks/useSignPsbtRequest.ts
@@ -13,85 +13,24 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router';
 import { extractPsbtDetails, type PsbtDetails } from '@/core/bitcoin/psbt';
+import { fetchInputsAttachedAssets } from '@/core/counterparty/inputAssets';
 import {
-  type AttachedAssetDestination,
-  movesCounterpartyValue,
-  resolveAttachedAssetDestination,
-} from '@/core/counterparty/attachedAssetMovement';
-import {
-  fetchInputsAttachedAssets,
-  type InputAttachedAssets,
-} from '@/core/counterparty/inputAssets';
-import { checkMessageStructure, type StructureFinding } from '@/core/counterparty/messageStructure';
-import { type ProtocolContext, resolveProtocolContext } from '@/core/counterparty/protocolContext';
-import {
-  type CounterpartyMessage, 
-  decodeCounterpartyMessage,
-  decodeRawTransaction, 
-  describeMpmaSend,
-  type MpmaRecipient,
-  resolveMpmaRecipients
-} from '@/core/counterparty/transaction';
-import {
-  analyzeTransactionSafety,
-  type SafetyAnalysis,
-} from '@/core/counterparty/transactionSafety';
-import {
-  type ProviderVerificationResult, 
-  verifyProviderTransaction
-} from '@/core/counterparty/unpack';
-import type { MPMAData } from '@/core/counterparty/unpack/messages/mpma';
+  analyzeSignRequest,
+  type SignRequestAnalysis,
+} from '@/core/counterparty/signRequestAnalysis';
+import { decodeRawTransaction } from '@/core/counterparty/transaction';
 import { extractPayloadFromOutputs } from '@/core/counterparty/unpack/opReturn';
+import { emitToBackground } from '@/platform/provider/emitToBackground';
 import { getSignFlow, recordSignOutcome, type SignPsbtRequest } from '@/platform/provider/signFlow';
 
 /**
- * Extended PSBT details with address enrichment and Counterparty message
+ * PSBT details with address enrichment, plus the safety analysis every signing request gets
+ * (`signRequestAnalysis.ts`, shared with the raw-transaction screen).
  */
-export interface DecodedPsbtInfo {
+export interface DecodedPsbtInfo extends SignRequestAnalysis {
   psbtDetails: PsbtDetails;
-  counterpartyMessage?: CounterpartyMessage;
   /** Decoded transaction ID (if available from API) */
   txid?: string;
-  /** Local verification result */
-  verification: ProviderVerificationResult;
-  /** Security analysis (dangerous types, suspicious outputs) */
-  safety: SafetyAnalysis;
-  /** Inputs whose UTXOs carry Counterparty assets (empty if none). */
-  attachedAssets: InputAttachedAssets[];
-  /**
-   * Recipients of an mpma_send, read from the local unpack. Empty for every other message type.
-   *
-   * A PSBT can carry any Counterparty payload a raw transaction can, and MPMA recipients travel
-   * inside the payload rather than as outputs — so without this the PSBT screen said "Send to 3
-   * recipients" and named none of them, while the transaction screen listed all three.
-   */
-  mpmaRecipients: MpmaRecipient[];
-  /**
-   * Where the assets attached to the signed inputs end up. Null when nothing attached is moving.
-   *
-   * Spending an attached UTXO moves its balances with no Counterparty message, so this is the only
-   * account of an atomic swap the screen can give.
-   */
-  attachedAssetDestination: AttachedAssetDestination | null;
-  /** Message fields that reference this transaction and do not resolve against it. */
-  structureFindings: StructureFinding[];
-  /** Ledger facts the message does not carry, for the protocol detail list. */
-  protocolContext: ProtocolContext;
-}
-
-/**
- * Send an event to the background script's EventEmitterService.
- * This is necessary because the popup and background have separate instances.
- */
-function emitToBackground(event: string, data: unknown): void {
-  chrome.runtime.sendMessage({
-    type: 'COMPOSE_EVENT',
-    event,
-    data
-  }).catch((error) => {
-    // Popup might be closing, which is fine
-    console.debug('Failed to emit sign PSBT event to background:', error);
-  });
 }
 
 export function useSignPsbtRequest(signerAddress?: string) {
@@ -116,7 +55,6 @@ export function useSignPsbtRequest(signerAddress?: string) {
     // OP_RETURN/txid API decodes below rather than adding a serial round-trip.
     const attachedAssetsPromise = fetchInputsAttachedAssets(psbtDetails.inputs, signedInputIndices);
 
-    let counterpartyMessage: CounterpartyMessage | undefined;
     let txid: string | undefined;
     let counterpartyDataHex: string | undefined;
 
@@ -131,19 +69,8 @@ export function useSignPsbtRequest(signerAddress?: string) {
       ) ?? undefined;
     }
 
-    // If the outputs carried Counterparty data, try API unpack for rich message info
-    if (counterpartyDataHex) {
-      try {
-        const msg = await decodeCounterpartyMessage(counterpartyDataHex);
-        if (msg) {
-          counterpartyMessage = msg;
-        }
-      } catch (err) {
-        console.warn('Failed to decode Counterparty message:', err);
-      }
-    }
-
-    // Try to get txid and enrich outputs with addresses from API
+    // Enrich the outputs before analysing them, so the safety checks see every address that could
+    // be resolved. Try to get txid and enrich outputs with addresses from API.
     if (psbtDetails.rawTxHex) {
       try {
         const decoded = await decodeRawTransaction(psbtDetails.rawTxHex, true);
@@ -166,93 +93,20 @@ export function useSignPsbtRequest(signerAddress?: string) {
       }
     }
 
-    // Verify locally (compares local binary unpack against API result)
-    const verification = verifyProviderTransaction(counterpartyDataHex, counterpartyMessage);
-
-    // Analyze for security risks (dangerous types, suspicious outputs)
-    const messageType = counterpartyMessage?.messageType
-      ?? verification.localUnpack?.messageType;
-    const safety = analyzeTransactionSafety(messageType, psbtDetails.outputs, signerAddresses ?? []);
-
-    // Same checks the raw-transaction path runs. A PSBT carries the same payloads, so anything
-    // that path establishes about a message holds here too.
-    let mpmaRecipients: MpmaRecipient[] = [];
-    if (verification.localUnpack?.messageType === 'mpma_send' && verification.localUnpack.data) {
-      const sends = (verification.localUnpack.data as MPMAData).sends ?? [];
-      if (sends.length > 0) {
-        mpmaRecipients = await resolveMpmaRecipients(sends);
-        if (counterpartyMessage) {
-          counterpartyMessage = {
-            ...counterpartyMessage,
-            description: describeMpmaSend(mpmaRecipients),
-          };
-        }
-      }
-    }
-
-    const structureFindings = checkMessageStructure(
-      verification.localUnpack?.messageType,
-      verification.localUnpack?.data,
-      { inputs: psbtDetails.inputs, outputs: psbtDetails.outputs }
-    );
-
-    // Same ledger lookups the raw-transaction path runs: a PSBT carries the same messages, so a
-    // cancel, dividend or dispense in one deserves the same account of itself as in the other.
-    const { context: protocolContext, warnings: policyWarnings } = await resolveProtocolContext({
-      messageType: verification.localUnpack?.messageType,
-      data: verification.localUnpack?.data,
-      transactionId: txid,
-      apiMessageData: counterpartyMessage?.messageData,
+    const analysis = await analyzeSignRequest({
+      counterpartyDataHex,
+      inputs: psbtDetails.inputs,
       outputs: psbtDetails.outputs,
       signerAddresses: signerAddresses ?? [],
-      spentUtxos: psbtDetails.inputs.map((input) => `${input.txid}:${input.vout}`),
+      signedInputIndices: signedInputIndices ?? [],
+      transactionId: txid,
+      attachedAssets: attachedAssetsPromise,
     });
-
-    if (policyWarnings.length > 0) {
-      safety.warnings = [...policyWarnings, ...safety.warnings];
-      safety.blocked = safety.blocked || policyWarnings.some((w) => w.severity === 'block');
-    }
-
-    const attachedAssets = await attachedAssetsPromise;
-
-    // The gate: a transaction this wallet signs on a site's behalf either carries a Counterparty
-    // message or spends an input carrying attached assets. Anything else is a plain Bitcoin
-    // transaction, which a site has no Counterparty reason to ask this wallet for and which the
-    // user can make in the wallet directly. Both halves are required — a message alone would miss
-    // an attached UTXO being spent alongside it, and attached assets alone miss every ordinary send.
-    if (!movesCounterpartyValue(Boolean(counterpartyDataHex), attachedAssets, signedInputIndices ?? [])) {
-      safety.warnings = [
-        {
-          severity: 'block',
-          title: 'Blocked: Not a Counterparty Transaction',
-          message:
-            'This carries no Counterparty message and spends nothing holding Counterparty assets, ' +
-            'so signing it would move only bitcoin at a site’s direction. Make plain Bitcoin ' +
-            'payments in the wallet, where you choose the destination.',
-        },
-        ...safety.warnings,
-      ];
-      safety.blocked = true;
-    }
-
-    const attachedAssetDestination = resolveAttachedAssetDestination(
-      psbtDetails.outputs,
-      attachedAssets,
-      signedInputIndices ?? [],
-      signerAddresses ?? []
-    );
 
     return {
       psbtDetails,
-      counterpartyMessage,
       txid,
-      verification,
-      safety,
-      attachedAssets,
-      mpmaRecipients,
-      structureFindings,
-      attachedAssetDestination,
-      protocolContext,
+      ...analysis,
     };
   }, []);
 

--- a/src/hooks/useSignTransactionRequest.ts
+++ b/src/hooks/useSignTransactionRequest.ts
@@ -12,44 +12,21 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router';
 import { parseRawTransactionLocally } from '@/core/bitcoin/localTransactionParse';
+import { fetchInputsAttachedAssets } from '@/core/counterparty/inputAssets';
 import {
-  type AttachedAssetDestination,
-  movesCounterpartyValue,
-  resolveAttachedAssetDestination,
-} from '@/core/counterparty/attachedAssetMovement';
-import {
-  fetchInputsAttachedAssets,
-  type InputAttachedAssets,
-} from '@/core/counterparty/inputAssets';
-import {
-  checkMessageStructure,
-  type StructureFinding,
-} from '@/core/counterparty/messageStructure';
-import { type ProtocolContext, resolveProtocolContext } from '@/core/counterparty/protocolContext';
-import {
-  type CounterpartyMessage,
-  decodeCounterpartyMessage,
-  describeMpmaSend,
-  fetchInputPrevouts,
-  type MpmaRecipient,
-  resolveMpmaRecipients
-} from '@/core/counterparty/transaction';
-import {
-  analyzeTransactionSafety,
-  type SafetyAnalysis,
-} from '@/core/counterparty/transactionSafety';
-import {
-  type ProviderVerificationResult, 
-  verifyProviderTransaction
-} from '@/core/counterparty/unpack';
-import type { MPMAData } from '@/core/counterparty/unpack/messages/mpma';
+  analyzeSignRequest,
+  type SignRequestAnalysis,
+} from '@/core/counterparty/signRequestAnalysis';
+import { fetchInputPrevouts } from '@/core/counterparty/transaction';
 import { extractCounterpartyPayload } from '@/core/counterparty/unpack/opReturn';
+import { emitToBackground } from '@/platform/provider/emitToBackground';
 import { getSignFlow, recordSignOutcome, type SignTransactionRequest } from '@/platform/provider/signFlow';
 
 /**
- * Decoded transaction details
+ * Decoded transaction details: what the bytes say, plus the safety analysis every signing request
+ * gets (`signRequestAnalysis.ts`, shared with the PSBT screen).
  */
-export interface DecodedTransactionInfo {
+export interface DecodedTransactionInfo extends SignRequestAnalysis {
   txid: string;
   inputs: Array<{
     txid: string;
@@ -72,47 +49,6 @@ export interface DecodedTransactionInfo {
   /** Transaction virtual size in vbytes (for fee rate calculation) */
   vsize?: number;
   hasOpReturn: boolean;
-  counterpartyMessage?: CounterpartyMessage;
-  /** Local verification result */
-  verification: ProviderVerificationResult;
-  /** Security analysis (dangerous types, suspicious outputs) */
-  safety: SafetyAnalysis;
-  /** Inputs whose UTXOs carry Counterparty assets, or whose lookup failed. */
-  attachedAssets: InputAttachedAssets[];
-  /**
-   * Message fields that reference this transaction and do not resolve against it — an attach
-   * naming an output that does not exist, a move naming a UTXO the transaction does not spend.
-   */
-  structureFindings: StructureFinding[];
-  /**
-   * Ledger facts the message does not carry, so the detail list can say what the transaction means
-   * rather than only what it contains — the order behind a cancel, the supply a destroy is measured
-   * against, the total a dividend costs.
-   */
-  protocolContext: ProtocolContext;
-  /** Where the assets attached to the signed inputs end up. Null when nothing attached moves. */
-  attachedAssetDestination: AttachedAssetDestination | null;
-  /**
-   * Recipients of an mpma_send, read from the local unpack. Empty for every other message type.
-   * These are carried in the payload rather than as outputs, so the approval screen has no other
-   * source for them.
-   */
-  mpmaRecipients: MpmaRecipient[];
-}
-
-/**
- * Send an event to the background script's EventEmitterService.
- * This is necessary because the popup and background have separate instances.
- */
-function emitToBackground(event: string, data: unknown): void {
-  chrome.runtime.sendMessage({
-    type: 'COMPOSE_EVENT',
-    event,
-    data
-  }).catch((error) => {
-    // Popup might be closing, which is fine
-    console.debug('Failed to emit sign transaction event to background:', error);
-  });
 }
 
 export function useSignTransactionRequest(signerAddress?: string) {
@@ -184,109 +120,26 @@ export function useSignTransactionRequest(signerAddress?: string) {
 
     const hasOpReturn = parsed.hasOpReturn;
 
-    let counterpartyMessage: CounterpartyMessage | undefined;
-    let counterpartyDataHex: string | undefined;
-
     // Resolve any Counterparty payload the outputs carry — plaintext or ARC4 OP_RETURN, or
     // bare-multisig data outputs, which produce no OP_RETURN at all. Classifying every encoding
     // here is what lets the sweep block apply regardless of how the message is carried.
     //
     // Read from the raw bytes, not from the API's rendering of them. Extracting from an API-
     // supplied script list keyed by an API-supplied txid would leave both sides of the comparison
-    // below rooted in the same source, so agreement would prove nothing about the bytes.
-    counterpartyDataHex = extractCounterpartyPayload(rawTxHex) ?? undefined;
+    // rooted in the same source, so agreement would prove nothing about the bytes.
+    const counterpartyDataHex = extractCounterpartyPayload(rawTxHex) ?? undefined;
 
-    // If the outputs carried Counterparty data, try API unpack for rich message info
-    if (counterpartyDataHex) {
-      try {
-        const msg = await decodeCounterpartyMessage(counterpartyDataHex);
-        if (msg) {
-          counterpartyMessage = msg;
-        }
-      } catch (err) {
-        console.warn('Failed to decode Counterparty message:', err);
-      }
-    }
-
-    // Verify locally (compares local binary unpack against API result)
-    const verification = verifyProviderTransaction(counterpartyDataHex, counterpartyMessage);
-
-    // Analyze for security risks (dangerous types, suspicious outputs)
-    const messageType = counterpartyMessage?.messageType
-      ?? verification.localUnpack?.messageType;
-    const safety = analyzeTransactionSafety(messageType, outputs, signerAddress || '');
-
-    // mpma_send is described from the bytes, not from the API's rendering of them — see
-    // resolveMpmaRecipients for why the API cannot be used for this type.
-    let mpmaRecipients: MpmaRecipient[] = [];
-    if (verification.localUnpack?.messageType === 'mpma_send' && verification.localUnpack.data) {
-      const sends = (verification.localUnpack.data as MPMAData).sends ?? [];
-      if (sends.length > 0) {
-        mpmaRecipients = await resolveMpmaRecipients(sends);
-        if (counterpartyMessage) {
-          counterpartyMessage = {
-            ...counterpartyMessage,
-            description: describeMpmaSend(mpmaRecipients),
-          };
-        }
-      }
-    }
-
-    // Independent of both decoders: does the message's own account of this transaction hold up
-    // against the transaction? Uses the local decode, since the point is to test the bytes.
-    const structureFindings = checkMessageStructure(
-      verification.localUnpack?.messageType,
-      verification.localUnpack?.data,
-      { inputs, outputs }
-    );
-
-    const { context: protocolContext, warnings: policyWarnings } = await resolveProtocolContext({
-      messageType: verification.localUnpack?.messageType,
-      data: verification.localUnpack?.data,
-      transactionId: parsed.txid,
-      apiMessageData: counterpartyMessage?.messageData,
+    // Every input is being signed here, so all of them count as sources for attached assets — a
+    // raw transaction can spend an attached UTXO just as a PSBT can, and does so with no message.
+    const analysis = await analyzeSignRequest({
+      counterpartyDataHex,
+      inputs,
       outputs,
       signerAddresses: signerAddress ? [signerAddress] : [],
-      spentUtxos: inputs.map((input) => `${input.txid}:${input.vout}`),
+      signedInputIndices: inputs.map((_, index) => index),
+      transactionId: parsed.txid,
+      attachedAssets: attachedAssetsPromise,
     });
-
-    // Policy blocks come from the same lookups as the detail list — an oracle-priced dispenser is
-    // only visible once the dispensers behind the paid address have been read.
-    if (policyWarnings.length > 0) {
-      safety.warnings = [...policyWarnings, ...safety.warnings];
-      safety.blocked = safety.blocked || policyWarnings.some((w) => w.severity === 'block');
-    }
-
-    const attachedAssets = await attachedAssetsPromise;
-
-    // The gate: a transaction this wallet signs on a site's behalf either carries a Counterparty
-    // message or spends an input carrying attached assets. Anything else is a plain Bitcoin
-    // transaction, which a site has no Counterparty reason to ask this wallet for and which the
-    // user can make in the wallet directly. Both halves are required — a message alone would miss
-    // an attached UTXO being spent alongside it, and attached assets alone miss every ordinary send.
-    if (!movesCounterpartyValue(Boolean(counterpartyDataHex), attachedAssets, inputs.map((_, index) => index))) {
-      safety.warnings = [
-        {
-          severity: 'block',
-          title: 'Blocked: Not a Counterparty Transaction',
-          message:
-            'This carries no Counterparty message and spends nothing holding Counterparty assets, ' +
-            'so signing it would move only bitcoin at a site’s direction. Make plain Bitcoin ' +
-            'payments in the wallet, where you choose the destination.',
-        },
-        ...safety.warnings,
-      ];
-      safety.blocked = true;
-    }
-
-    // A raw transaction can spend an attached UTXO just as a PSBT can, and does so with no
-    // message. Every input is being signed here, so all of them count as sources.
-    const attachedAssetDestination = resolveAttachedAssetDestination(
-      outputs,
-      attachedAssets,
-      inputs.map((_, index) => index),
-      signerAddress ? [signerAddress] : []
-    );
 
     return {
       txid: parsed.txid,
@@ -297,14 +150,7 @@ export function useSignTransactionRequest(signerAddress?: string) {
       fee,
       vsize: parsed.vsize,
       hasOpReturn,
-      counterpartyMessage,
-      verification,
-      safety,
-      attachedAssets,
-      structureFindings,
-      protocolContext,
-      attachedAssetDestination,
-      mpmaRecipients,
+      ...analysis,
     };
   }, []);
 

--- a/src/platform/provider/emitToBackground.ts
+++ b/src/platform/provider/emitToBackground.ts
@@ -1,0 +1,23 @@
+/**
+ * Send an event to the background script's EventEmitterService.
+ *
+ * The popup and the background run separate instances of the emitter, so an approval screen cannot
+ * resolve a dApp's pending request by emitting locally — the message has to cross.
+ */
+
+/**
+ * @param event - the event name the background is waiting on, e.g. `sign-psbt-complete-<id>`
+ * @param data - the payload delivered to the waiting request
+ */
+export function emitToBackground(event: string, data: unknown): void {
+  chrome.runtime
+    .sendMessage({
+      type: 'COMPOSE_EVENT',
+      event,
+      data,
+    })
+    .catch((error) => {
+      // The popup is usually closing at this point, which is not a failure worth surfacing.
+      console.debug('Failed to emit sign event to background:', error);
+    });
+}


### PR DESCRIPTION
## The duplication

`useSignPsbtRequest` (364 lines) and `useSignTransactionRequest` (406) ran the
same pipeline, written out twice — payload decode, local verification, safety
analysis, MPMA recipients, structure findings, protocol context, policy-warning
merge, and the not-a-Counterparty-transaction gate. Each copy carried comments
saying it matched the other:

> `// Same checks the raw-transaction path runs.`
> `// Same ledger lookups the raw-transaction path runs.`

That is the code deciding whether the wallet will sign for a website. One fix
landing in one copy is all it takes for the two approval screens to disagree
about whether the same transaction is safe.

`emitToBackground` was copy-pasted into all three sign hooks, differing only in
a log string.

## The change

- `analyzeSignRequest` (`core/counterparty/signRequestAnalysis.ts`) holds the
  pipeline once; both hooks call it.
- `emitToBackground` moves to one module.
- `DecodedPsbtInfo` and `DecodedTransactionInfo` extend the shared result,
  which removes the parallel field-by-field interface declarations too.

Net: the PSBT hook drops from 364 lines to 175, the transaction hook from 406
to 243.

## One ordering change

The PSBT path now decodes its raw transaction *before* analysing rather than
after. Both calls were already awaited serially and neither depends on the
other; the ordering that matters is that output-address enrichment still lands
before the safety checks read the outputs, which it does.

## Tests

All three hooks had **zero** coverage, so both copies of this gate were
untested. Extracting it into a pure function made it testable without React or
chrome APIs, and `signRequestAnalysis.test.ts` now pins:

- blocks with no message and nothing attached
- allows when a message is present
- allows when a signed input carries attached assets
- **still blocks** when the attached assets sit on an input this wallet is not
  signing — someone else's side of the transaction
- a blocking policy warning escalates and sorts first
- a decode failure does not take the analysis down with it
- mpma_send is described from the bytes, not the API's rendering

Mutation-checked: disabling the gate fails exactly the two tests that assert it
blocks, so they are not passing vacuously.

`tsc --noEmit` clean, `biome check src` clean, 1004 unit tests pass.

https://claude.ai/code/session_01HUJSeVf1JXG1Rp3VXpb2Cr
