### PR TITLE
Give every button an explicit type, and keep it that way

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -18,6 +18,9 @@
     "enabled": true,
     "rules": {
       "recommended": false,
+      "a11y": {
+        "useButtonType": "error"
+      },
       "correctness": {
         "noUnusedImports": "error",
         "noUnusedVariables": "warn"

--- a/src/components/composer/composer.test.tsx
+++ b/src/components/composer/composer.test.tsx
@@ -120,7 +120,7 @@ vi.mock('@/components/screens/success-screen', () => ({
   SuccessScreen: ({ apiResponse, onReset }: any) => (
     <div data-testid="success-screen">
       <div>Success! TX: {apiResponse?.result?.tx_hash}</div>
-      <button onClick={onReset}>Reset</button>
+      <button type="button" onClick={onReset}>Reset</button>
     </div>
   )
 }));
@@ -182,10 +182,10 @@ describe('Composer', () => {
   const MockReviewComponent = ({ apiResponse, onSign, onBack }: any): ReactElement => (
     <div data-testid="review-component">
       <div>Transaction: {apiResponse?.result?.rawtransaction}</div>
-      <button onClick={onSign}>
+      <button type="button" onClick={onSign}>
         Sign
       </button>
-      <button onClick={onBack}>Back</button>
+      <button type="button" onClick={onBack}>Back</button>
     </div>
   );
 

--- a/src/components/domain/asset/asset-card.test.tsx
+++ b/src/components/domain/asset/asset-card.test.tsx
@@ -8,7 +8,7 @@ import { AssetCard } from "./asset-card";
 // Mock the AssetMenu component
 vi.mock("@/components/domain/asset/asset-menu", () => ({
   AssetMenu: ({ ownedAsset }: { ownedAsset: OwnedAsset }) => (
-    <button data-testid={`asset-menu-${ownedAsset.asset}`}>Menu</button>
+    <button type="button" data-testid={`asset-menu-${ownedAsset.asset}`}>Menu</button>
   ),
 }));
 

--- a/src/components/domain/asset/asset-info-popover.tsx
+++ b/src/components/domain/asset/asset-info-popover.tsx
@@ -44,7 +44,7 @@ export function AssetInfoPopover({
 
   return (
     <div ref={containerRef} className={`relative ${className}`}>
-      <button
+      <button type="button"
         onClick={() => setIsOpen(!isOpen)}
         className="p-2 text-gray-400 hover:text-gray-600 transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
         aria-label="View asset details"
@@ -59,7 +59,7 @@ export function AssetInfoPopover({
             <span className="text-xs font-medium text-gray-700">
               Asset Details
             </span>
-            <button
+            <button type="button"
               onClick={() => setIsOpen(false)}
               className="p-0.5 text-gray-400 hover:text-gray-600 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
               aria-label="Close"

--- a/src/components/domain/asset/pinnable-asset-card.tsx
+++ b/src/components/domain/asset/pinnable-asset-card.tsx
@@ -99,7 +99,7 @@ export function PinnableAssetCard({
         {/* Up/Down arrows */}
         {showArrows && (
           <div className="flex flex-col">
-            <button
+            <button type="button"
               onClick={(e) => {
                 e.preventDefault();
                 e.stopPropagation();
@@ -115,7 +115,7 @@ export function PinnableAssetCard({
             >
               <FiChevronUp className="size-3" aria-hidden="true" />
             </button>
-            <button
+            <button type="button"
               onClick={(e) => {
                 e.preventDefault();
                 e.stopPropagation();
@@ -135,7 +135,7 @@ export function PinnableAssetCard({
         )}
 
         {/* Pin/Unpin Button */}
-        <button
+        <button type="button"
           onClick={handlePinClick}
           className={`p-2 rounded-md transition-colors hover:scale-110 cursor-pointer ${
             isPinned

--- a/src/components/domain/balance/balance-card.test.tsx
+++ b/src/components/domain/balance/balance-card.test.tsx
@@ -8,7 +8,7 @@ import { BalanceCard } from "./balance-card";
 // Mock the BalanceMenu component
 vi.mock("@/components/domain/balance/balance-menu", () => ({
   BalanceMenu: ({ asset }: { asset: string }) => (
-    <button data-testid={`balance-menu-${asset}`}>Menu</button>
+    <button type="button" data-testid={`balance-menu-${asset}`}>Menu</button>
   ),
 }));
 

--- a/src/components/domain/dispenser/asset-dispenser-card.tsx
+++ b/src/components/domain/dispenser/asset-dispenser-card.tsx
@@ -82,7 +82,7 @@ export function AssetDispenserCard({
               {formatAddress(dispenser.source, true)}
             </span>
             {onCopyAddress && (
-              <button
+              <button type="button"
                 onClick={handleCopyClick}
                 className={`flex-shrink-0 p-0.5 rounded transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
                   isCopied

--- a/src/components/domain/dispenser/manage-dispenser-card.tsx
+++ b/src/components/domain/dispenser/manage-dispenser-card.tsx
@@ -71,13 +71,13 @@ export function ManageDispenserCard({
         </div>
         {isOpen ? (
           <div className="flex gap-2">
-            <button
+            <button type="button"
               onClick={handleRefill}
               className="px-3 py-1.5 text-xs font-medium text-blue-600 hover:text-blue-700 hover:bg-blue-50 rounded transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
             >
               Refill
             </button>
-            <button
+            <button type="button"
               onClick={handleClose}
               className="px-3 py-1.5 text-xs font-medium text-red-600 hover:text-red-700 hover:bg-red-50 rounded transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
             >

--- a/src/components/domain/utxo/utxo-card.test.tsx
+++ b/src/components/domain/utxo/utxo-card.test.tsx
@@ -7,7 +7,7 @@ import { UtxoCard } from "./utxo-card";
 
 vi.mock("@/components/domain/utxo/utxo-menu", () => ({
   UtxoMenu: ({ utxo }: { utxo: string }) => (
-    <button data-testid={`utxo-menu-${utxo}`}>Menu</button>
+    <button type="button" data-testid={`utxo-menu-${utxo}`}>Menu</button>
   ),
 }));
 

--- a/src/components/domain/wallet/wallet-card.test.tsx
+++ b/src/components/domain/wallet/wallet-card.test.tsx
@@ -17,7 +17,7 @@ vi.mock('@/core/format', () => ({
 // Mock the WalletMenu component
 vi.mock('@/components/domain/wallet/wallet-menu', () => ({
   WalletMenu: ({ wallet, isOnlyWallet }: { wallet: any; isOnlyWallet: boolean }) => (
-    <button data-testid={`wallet-menu-${wallet.id}`} className="wallet-menu">
+    <button type="button" data-testid={`wallet-menu-${wallet.id}`} className="wallet-menu">
       Menu {isOnlyWallet ? '(Only)' : ''}
     </button>
   )

--- a/src/components/layout/api-status-banner.tsx
+++ b/src/components/layout/api-status-banner.tsx
@@ -27,7 +27,7 @@ export function ApiStatusBanner(): ReactElement | null {
       role="alert"
     >
       <span>{displayMessage}</span>
-      <button
+      <button type="button"
         onClick={dismiss}
         className="p-1 hover:opacity-75 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-white rounded"
         aria-label="Dismiss"

--- a/src/components/layout/error-boundary.tsx
+++ b/src/components/layout/error-boundary.tsx
@@ -70,7 +70,7 @@ export class ErrorBoundary extends Component<Props, State> {
               An unexpected error occurred. Please try again.
             </p>
 
-            <button
+            <button type="button"
               onClick={this.handleReset}
               className="w-full flex items-center justify-center px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
             >

--- a/src/components/ui/cards/asset-dispense-card.tsx
+++ b/src/components/ui/cards/asset-dispense-card.tsx
@@ -59,7 +59,7 @@ export function AssetDispenseCard({
           </div>
           <div className="flex items-center justify-end gap-2 mt-0.5">
             {onCopyTx && (
-              <button
+              <button type="button"
                 onClick={() => onCopyTx(dispense.tx_hash)}
                 className={`flex items-center gap-1 text-xs cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded ${
                   isCopied

--- a/src/components/ui/cards/connected-site-card.tsx
+++ b/src/components/ui/cards/connected-site-card.tsx
@@ -102,7 +102,7 @@ export function ConnectedSiteCard({
         </div>
         
         {/* Disconnect Button */}
-        <button
+        <button type="button"
           onClick={handleDisconnect}
           onKeyDown={handleDisconnectKeyDown}
           className="flex-shrink-0 p-2 hover:bg-red-50 rounded-lg transition-colors group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-1"

--- a/src/components/ui/cards/manage-order-card.tsx
+++ b/src/components/ui/cards/manage-order-card.tsx
@@ -67,7 +67,7 @@ export function ManageOrderCard({
           </div>
         </div>
         {isOpen ? (
-          <button
+          <button type="button"
             onClick={handleCancel}
             className="px-3 py-1.5 text-xs font-medium text-red-600 hover:text-red-700 hover:bg-red-50 rounded transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
           >

--- a/src/components/ui/cards/market-match-card.tsx
+++ b/src/components/ui/cards/market-match-card.tsx
@@ -69,7 +69,7 @@ export function MarketMatchCard({
           </div>
           <div className="flex items-center justify-end gap-2 mt-0.5">
             {onCopyTx && (
-              <button
+              <button type="button"
                 onClick={(e) => { e.stopPropagation(); onCopyTx(match.tx0_hash); }}
                 className={`flex items-center gap-1 text-xs cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded ${
                   isCopied

--- a/src/components/ui/empty-state.tsx
+++ b/src/components/ui/empty-state.tsx
@@ -40,7 +40,7 @@ export function EmptyState({
         )}
       </div>
       {linkAction && (
-        <button
+        <button type="button"
           onClick={linkAction.onClick}
           className="w-full py-2 text-sm text-blue-600 hover:text-blue-800 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
         >

--- a/src/components/ui/inputs/api-url-input.tsx
+++ b/src/components/ui/inputs/api-url-input.tsx
@@ -92,7 +92,7 @@ export const ApiUrlInput = ({
           aria-label="API URL"
           className={`flex-1 p-2.5 rounded-md border bg-gray-50 outline-none focus-visible:ring-2 disabled:opacity-50 transition-colors ${getBorderClass()}`}
         />
-        <button
+        <button type="button"
           onClick={handleReset}
           disabled={disabled || isValidating || isDefault}
           className="p-2.5 rounded-md border border-gray-300 bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"

--- a/src/components/ui/lists/address-list.test.tsx
+++ b/src/components/ui/lists/address-list.test.tsx
@@ -18,7 +18,7 @@ vi.mock('@/core/format', () => ({
 vi.mock('@/components/ui/menus/address-menu', () => ({
   AddressMenu: ({ address, onCopyAddress }: any) => (
     <div data-testid={`address-menu-${address.path}`}>
-      <button 
+      <button type="button" 
         onClick={() => onCopyAddress(address.address)}
         data-testid={`copy-${address.path}`}
       >

--- a/src/components/ui/tab-button.tsx
+++ b/src/components/ui/tab-button.tsx
@@ -18,7 +18,7 @@ export function TabButton({
   className = "",
 }: TabButtonProps): ReactElement {
   return (
-    <button
+    <button type="button"
       role="tab"
       aria-selected={isActive}
       onClick={onClick}

--- a/src/pages/actions/consolidate/history.tsx
+++ b/src/pages/actions/consolidate/history.tsx
@@ -75,7 +75,7 @@ export function ConsolidationHistory({ address }: ConsolidationHistoryProps) {
 
   return (
     <div className="mt-4 bg-white rounded-lg shadow-sm">
-      <button
+      <button type="button"
         onClick={() => setShowHistory(!showHistory)}
         className="w-full p-4 flex justify-between items-center hover:bg-gray-50 transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-inset rounded-lg"
         aria-expanded={showHistory}

--- a/src/pages/actions/consolidate/status.tsx
+++ b/src/pages/actions/consolidate/status.tsx
@@ -100,7 +100,7 @@ function ConsolidateStatusPage() {
       <div className="bg-white rounded-lg shadow-lg p-4">
         <div className="flex justify-between items-start mb-4">
           <h2 className="font-semibold">Consolidation Overview</h2>
-          <button
+          <button type="button"
             onClick={handleRefresh}
             className={`p-2 hover:bg-gray-100 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${isRefreshing ? 'animate-spin' : ''}`}
             aria-label="Refresh status"
@@ -172,7 +172,7 @@ function ConsolidateStatusPage() {
                       </span>
                     </div>
                   </div>
-                  <button
+                  <button type="button"
                     onClick={() => openInExplorer(tx.txid)}
                     className="p-1 hover:bg-gray-200 rounded transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                     aria-label="View in explorer"

--- a/src/pages/actions/consolidate/success.tsx
+++ b/src/pages/actions/consolidate/success.tsx
@@ -145,14 +145,14 @@ function ConsolidateSuccessPage() {
                   <span className="text-xs text-gray-600 font-mono break-all flex-1">
                     {result.txid}
                   </span>
-                  <button
+                  <button type="button"
                     onClick={() => copyToClipboard(result.txid)}
                     className="p-1 hover:bg-gray-200 rounded transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                     aria-label="Copy transaction ID"
                   >
                     <FaCopy className="size-4 text-gray-600" aria-hidden="true" />
                   </button>
-                  <button
+                  <button type="button"
                     onClick={() => openInExplorer(result.txid)}
                     className="p-1 hover:bg-gray-200 rounded transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                     aria-label="View in explorer"

--- a/src/pages/actions/sign-message.tsx
+++ b/src/pages/actions/sign-message.tsx
@@ -193,7 +193,7 @@ export default function SignMessagePage(): ReactElement {
             {message.length} characters
           </span>
           {message && (
-            <button
+            <button type="button"
               onClick={() => handleCopy(message, 'message')}
               className={`text-xs transition-colors duration-200 cursor-pointer flex items-center gap-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded ${
                 copiedField === 'message'
@@ -231,7 +231,7 @@ export default function SignMessagePage(): ReactElement {
                 <FaCheckCircle className="size-3" aria-hidden="true" />
                 Signed
               </span>
-              <button
+              <button type="button"
                 onClick={() => handleCopy(signature, 'signature')}
                 className={`text-xs transition-colors duration-200 cursor-pointer flex items-center gap-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded ${
                   copiedField === 'signature'

--- a/src/pages/actions/verify-message.tsx
+++ b/src/pages/actions/verify-message.tsx
@@ -120,7 +120,7 @@ export default function VerifyMessagePage(): ReactElement {
     <div className="p-4 space-y-4">
       {/* Quick Actions */}
       <div className="flex gap-2">
-        <button
+        <button type="button"
           onClick={handleUploadJSON}
           className="inline-flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 cursor-pointer"
         >

--- a/src/pages/assets/[asset]/index.tsx
+++ b/src/pages/assets/[asset]/index.tsx
@@ -300,7 +300,7 @@ export default function AssetPage(): ReactElement {
       
       {/* Dividend History Section - Collapsible */}
       <div className="bg-white rounded-lg shadow-sm">
-        <button
+        <button type="button"
           onClick={() => setShowDividends(!showDividends)}
           className="w-full p-4 flex justify-between items-center hover:bg-gray-50 transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
           aria-expanded={showDividends}
@@ -371,7 +371,7 @@ export default function AssetPage(): ReactElement {
                 ))}
                 
                 {hasMoreDividends && (
-                  <button
+                  <button type="button"
                     onClick={(e) => {
                       e.stopPropagation();
                       loadDividends();

--- a/src/pages/compose/send/mpma/__tests__/review.test.tsx
+++ b/src/pages/compose/send/mpma/__tests__/review.test.tsx
@@ -14,8 +14,8 @@ vi.mock('@/components/screens/review-screen', () => ({
           {field.rightElement}
         </div>
       ))}
-      <button onClick={onSign}>Sign</button>
-      <button onClick={onBack}>Back</button>
+      <button type="button" onClick={onSign}>Sign</button>
+      <button type="button" onClick={onBack}>Back</button>
       {error && <div>{error}</div>}
       {isSigning && <div>Signing...</div>}
     </div>

--- a/src/pages/compose/utxo/attach/review.tsx
+++ b/src/pages/compose/utxo/attach/review.tsx
@@ -30,7 +30,7 @@ export function ReviewUtxoAttach({
         <div className="bg-red-50 border border-red-200 rounded-md p-4">
           <p className="text-red-700">Unable to review transaction. Please go back and try again.</p>
         </div>
-        <button
+        <button type="button"
           onClick={onBack}
           className="mt-4 w-full bg-gray-500 text-white py-2 px-4 rounded hover:bg-gray-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
         >

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -183,7 +183,7 @@ export default function HomePage(): ReactElement {
     return (
       <div className="flex justify-between items-center mb-2">
         <div className="flex space-x-4">
-          <button
+          <button type="button"
             className="text-lg font-semibold bg-transparent p-0 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 rounded"
             style={{ textDecoration: activeTab === "Assets" ? "underline" : "none" }}
             onClick={() => setSearchParams({ tab: "Assets" })}
@@ -191,7 +191,7 @@ export default function HomePage(): ReactElement {
           >
             Assets
           </button>
-          <button
+          <button type="button"
             className="text-lg font-semibold bg-transparent p-0 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 rounded"
             style={{ textDecoration: activeTab === "Balances" ? "underline" : "none" }}
             onClick={() => setSearchParams({ tab: "Balances" })}
@@ -200,7 +200,7 @@ export default function HomePage(): ReactElement {
             Balances
           </button>
           {hasUtxos && (
-            <button
+            <button type="button"
               className="text-lg font-semibold bg-transparent p-0 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 rounded"
               style={{ textDecoration: activeTab === "UTXOs" ? "underline" : "none" }}
               onClick={() => setSearchParams({ tab: "UTXOs" })}
@@ -211,14 +211,14 @@ export default function HomePage(): ReactElement {
           )}
         </div>
         <div className="flex items-center space-x-2">
-          <button
+          <button type="button"
             onClick={() => navigate(PATHS.BUY_XCP)}
             className="px-2 py-1 text-xs font-medium text-blue-600 bg-blue-50 hover:bg-blue-100 rounded transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
             aria-label="Get XCP"
           >
             Get XCP
           </button>
-          <button
+          <button type="button"
             onClick={() => navigate(PATHS.PINNED_ASSETS)}
             className="p-1 hover:bg-gray-100 rounded-full transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
             aria-label="Manage Pinned Assets"

--- a/src/pages/market/btc.tsx
+++ b/src/pages/market/btc.tsx
@@ -186,7 +186,7 @@ export default function BtcPricePage(): ReactElement {
               {/* Currency Selector - only show if multiple currencies available */}
               {CURRENCIES.length > 1 ? (
                 <div className="relative mt-1">
-                  <button
+                  <button type="button"
                     onClick={() => setShowCurrencyMenu(!showCurrencyMenu)}
                     className="flex items-center gap-1 text-xs text-gray-500 hover:text-gray-700 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
                   >
@@ -196,7 +196,7 @@ export default function BtcPricePage(): ReactElement {
                   {showCurrencyMenu && (
                     <div className="absolute top-full left-0 mt-1 bg-white rounded-lg shadow-lg border border-gray-200 py-1 z-10 min-w-[120px]">
                       {CURRENCIES.map((c) => (
-                        <button
+                        <button type="button"
                           key={c}
                           onClick={() => handleCurrencyChange(c)}
                           className={`w-full px-3 py-1.5 text-left text-xs hover:bg-gray-50 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
@@ -217,7 +217,7 @@ export default function BtcPricePage(): ReactElement {
               {statsError ? (
                 <div className="text-sm text-red-600">
                   <span className="block">{statsError}</span>
-                  <button
+                  <button type="button"
                     onClick={() => loadStats(currency)}
                     className="text-xs text-blue-600 hover:text-blue-800 underline mt-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
                   >
@@ -244,7 +244,7 @@ export default function BtcPricePage(): ReactElement {
         <div className="flex items-center justify-between mb-2">
           <div className="flex gap-1">
             {TIME_RANGES.map((t) => (
-              <button
+              <button type="button"
                 key={t.id}
                 onClick={() => handleRangeChange(t.id)}
                 className={`px-2 py-1 text-xs rounded transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
@@ -276,7 +276,7 @@ export default function BtcPricePage(): ReactElement {
               style={{ height: CHART_HEIGHT }}
             >
               <span className="text-sm text-red-600 mb-2">{chartError}</span>
-              <button
+              <button type="button"
                 onClick={() => loadChartData(range, currency)}
                 className="px-3 py-1.5 text-xs bg-gray-100 hover:bg-gray-200 text-gray-700 rounded-md transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
               >

--- a/src/pages/market/dispensers/[asset].tsx
+++ b/src/pages/market/dispensers/[asset].tsx
@@ -446,7 +446,7 @@ export default function AssetDispensersPage(): ReactElement {
                   </>
                 )}
               </div>
-              <button
+              <button type="button"
                 onClick={togglePriceUnit}
                 className="p-1 text-gray-400 hover:text-gray-600 transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
                 aria-label={`Switch price display to ${getNextPriceUnit(priceUnit, btcPrice !== null).toUpperCase()}`}
@@ -466,7 +466,7 @@ export default function AssetDispensersPage(): ReactElement {
                 History
               </TabButton>
             </div>
-            <button
+            <button type="button"
               onClick={() => navigate(`/market?tab=dispensers&mode=manage&search=${asset}`)}
               className="text-xs text-blue-600 hover:text-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded cursor-pointer"
             >

--- a/src/pages/market/index.tsx
+++ b/src/pages/market/index.tsx
@@ -370,7 +370,7 @@ export default function MarketPage(): ReactElement {
             <div className="flex items-center justify-between">
               <div className="flex space-x-4" role="tablist" aria-label="Market sections">
                 {(["Dispensers", "Orders", "Pools"] as const).map((label, idx) => (
-                  <button
+                  <button type="button"
                     key={label}
                     role="tab"
                     aria-selected={activeTab === idx}
@@ -433,7 +433,7 @@ export default function MarketPage(): ReactElement {
                             />
                           ))}
                           {dispenserResults.length >= PAGE_SIZE && (
-                            <button
+                            <button type="button"
                               onClick={() => navigate(`/market/dispensers/${searchQuery.toUpperCase()}`)}
                               className="w-full py-2 text-sm text-blue-600 hover:text-blue-800 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
                             >
@@ -501,7 +501,7 @@ export default function MarketPage(): ReactElement {
                       ) : (
                         <EmptyState message="You don't have any open dispensers" />
                       )}
-                      <button
+                      <button type="button"
                         onClick={() => navigate(searchQuery.trim() ? `/compose/dispenser/${searchQuery.toUpperCase()}` : "/compose/dispenser")}
                         className="w-full py-2 text-sm text-blue-600 hover:text-blue-800 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
                       >
@@ -548,7 +548,7 @@ export default function MarketPage(): ReactElement {
                             />
                           ))}
                           {orderResults.length >= PAGE_SIZE && (
-                            <button
+                            <button type="button"
                               onClick={() => navigate(`/market/orders/${searchQuery.toUpperCase()}/XCP`)}
                               className="w-full py-2 text-sm text-blue-600 hover:text-blue-800 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
                             >
@@ -615,7 +615,7 @@ export default function MarketPage(): ReactElement {
                       ) : (
                         <EmptyState message="You don't have any open orders" />
                       )}
-                      <button
+                      <button type="button"
                         onClick={() => navigate(searchQuery.trim() ? `/compose/order/${searchQuery.toUpperCase()}` : "/compose/order")}
                         className="w-full py-2 text-sm text-blue-600 hover:text-blue-800 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
                       >
@@ -662,7 +662,7 @@ export default function MarketPage(): ReactElement {
                   ) : (
                     <EmptyState message={searchQuery.trim() ? `No pools matching "${searchQuery}"` : "No pools found"} />
                   )}
-                  <button
+                  <button type="button"
                     onClick={() => navigate(searchQuery.trim() ? `/compose/pool/deposit/${searchQuery.toUpperCase()}/XCP` : "/compose/pool/deposit")}
                     className="w-full py-2 text-sm text-blue-600 hover:text-blue-800 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
                   >
@@ -705,7 +705,7 @@ export default function MarketPage(): ReactElement {
                       ) : (
                         <EmptyState message="You don't have any LP positions" />
                       )}
-                      <button
+                      <button type="button"
                         onClick={() => navigate(searchQuery.trim() ? `/compose/pool/deposit/${searchQuery.toUpperCase()}/XCP` : "/compose/pool/deposit")}
                         className="w-full py-2 text-sm text-blue-600 hover:text-blue-800 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
                       >

--- a/src/pages/market/orders/[baseAsset]/[quoteAsset].tsx
+++ b/src/pages/market/orders/[baseAsset]/[quoteAsset].tsx
@@ -542,7 +542,7 @@ export default function AssetOrdersPage(): ReactElement {
                 History
               </TabButton>
             </div>
-            <button
+            <button type="button"
               onClick={() => navigate(`/market?tab=orders&mode=manage&search=${baseAsset}`)}
               className="text-xs text-blue-600 hover:text-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded cursor-pointer"
             >

--- a/src/pages/market/xcp.tsx
+++ b/src/pages/market/xcp.tsx
@@ -183,7 +183,7 @@ export default function XcpPricePage(): ReactElement {
               {statsError ? (
                 <div className="text-sm text-red-600">
                   <span className="block">{statsError}</span>
-                  <button
+                  <button type="button"
                     onClick={loadStats}
                     className="text-xs text-blue-600 hover:text-blue-800 underline mt-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
                   >
@@ -210,7 +210,7 @@ export default function XcpPricePage(): ReactElement {
         <div className="flex items-center justify-between mb-2">
           <div className="flex gap-1">
             {TIME_RANGES.map((t) => (
-              <button
+              <button type="button"
                 key={t.id}
                 onClick={() => setRange(t.id)}
                 className={`px-2 py-1 text-xs rounded transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
@@ -223,7 +223,7 @@ export default function XcpPricePage(): ReactElement {
               </button>
             ))}
           </div>
-          <button
+          <button type="button"
             onClick={handleBuyXcp}
             className="text-xs text-blue-600 hover:text-blue-800 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
           >
@@ -239,7 +239,7 @@ export default function XcpPricePage(): ReactElement {
               style={{ height: CHART_HEIGHT }}
             >
               <span className="text-sm text-red-600 mb-2">{chartError}</span>
-              <button
+              <button type="button"
                 onClick={loadHistory}
                 className="px-3 py-1.5 text-xs bg-gray-100 hover:bg-gray-200 text-gray-700 rounded-md transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
               >
@@ -265,7 +265,7 @@ export default function XcpPricePage(): ReactElement {
             {floor ? (
               <div className={`flex items-center justify-between ${historyData?.ath ? "pb-2 border-b border-gray-100" : ""}`}>
                 <span className="text-sm text-gray-600">Floor Price</span>
-                <button
+                <button type="button"
                   onClick={() => navigate(`/compose/dispenser/dispense?address=${floor.source}&asset=XCP`)}
                   className="text-sm font-medium text-blue-600 hover:text-blue-800 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
                   aria-label="Buy from the cheapest open XCP dispenser"


### PR DESCRIPTION
First a11y pass: the one that is mechanical and safe.

A `<button>` with no `type` defaults to `type="submit"`. I checked whether any
of the 63 untyped buttons could actually hijack a form submit — **none of them
sit inside a `<form>`**. The only untyped button in a file containing a form is
in `composer.test.tsx`, a test fixture. So this is hygiene, not a latent bug,
and I would rather say that than oversell it. It is still one refactor away
from being a real one, and the explicit role helps assistive tech regardless.

## How

A brace- and quote-aware codemod, not sed and not 63 hand edits. JSX attributes
routinely contain `>` inside arrow functions (`onClick={() => ...}`), so the
first `>` after `<button` is not reliably the end of the opening tag. The diff
is one attribute per tag with no reflow:

```diff
-    <button
+    <button type="button"
```

biome cannot auto-fix this rule even with `--unsafe`, which is why it had
accumulated.

## Keeping it fixed

`a11y/useButtonType` is now enabled in `biome.json`. The linter had
`"recommended": false` with only three rules on, so nothing was watching this.

## What I did not do

The rest of the recommended a11y set stays off. It is ~85 more findings and
they are not mechanical:

| rule | count | why not now |
|---|---|---|
| `useSemanticElements` | 54 | `role="x"` on a div → real markup changes |
| `useKeyWithClickEvents` | 15 | needs a keyboard handler written per site |
| `noLabelWithoutControl` | 10 | needs the right control associated |
| `noSvgWithoutTitle` | 2 | needs a human-written title |
| `useHtmlLang`, `noAutofocus`, `useFocusableInteractive` | 3 | one-offs |

Each wants judgement per site. Happy to take them next.

## Verification

`tsc --noEmit` clean, `biome check src` clean, 1142 component and page tests
pass.

https://claude.ai/code/session_01HUJSeVf1JXG1Rp3VXpb2Cr
