### PR TITLE
Give the a11y roles real elements, and fix the three bugs that hid behind them

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -19,6 +19,8 @@
     "rules": {
       "recommended": false,
       "a11y": {
+        "noLabelWithoutControl": "error",
+        "noSvgWithoutTitle": "error",
         "useButtonType": "error"
       },
       "correctness": {

--- a/biome.json
+++ b/biome.json
@@ -23,7 +23,8 @@
         "noLabelWithoutControl": "error",
         "noSvgWithoutTitle": "error",
         "useButtonType": "error",
-        "useKeyWithClickEvents": "error"
+        "useKeyWithClickEvents": "error",
+        "useSemanticElements": "error"
       },
       "correctness": {
         "noUnusedImports": "error",

--- a/biome.json
+++ b/biome.json
@@ -21,7 +21,8 @@
       "a11y": {
         "noLabelWithoutControl": "error",
         "noSvgWithoutTitle": "error",
-        "useButtonType": "error"
+        "useButtonType": "error",
+        "useKeyWithClickEvents": "error"
       },
       "correctness": {
         "noUnusedImports": "error",

--- a/biome.json
+++ b/biome.json
@@ -19,6 +19,7 @@
     "rules": {
       "recommended": false,
       "a11y": {
+        "noAutofocus": "error",
         "noLabelWithoutControl": "error",
         "noSvgWithoutTitle": "error",
         "useButtonType": "error",

--- a/e2e/inputs/password-input.spec.ts
+++ b/e2e/inputs/password-input.spec.ts
@@ -226,7 +226,7 @@ walletTest.describe('PasswordInput Component', () => {
       const isInContainer = await passwordInput.evaluate((el: HTMLElement) => {
         // Check for form or structured container
         const form = el.closest('form');
-        const container = el.closest('.space-y-4, .space-y-6, [role="main"]');
+        const container = el.closest('.space-y-4, .space-y-6, main');
         return form !== null || container !== null;
       });
 

--- a/e2e/pages/actions/consolidate.spec.ts
+++ b/e2e/pages/actions/consolidate.spec.ts
@@ -304,7 +304,7 @@ walletTest.describe('Consolidation Accessibility', () => {
     await page.waitForLoadState('networkidle');
 
     // Should have some form of main content
-    const mainContent = page.locator('form, [role="main"], .p-4');
+    const mainContent = page.locator('form, main, .p-4');
     await expect(mainContent.first()).toBeVisible({ timeout: 10000 });
   });
 

--- a/e2e/pages/assets/[asset]/index.spec.ts
+++ b/e2e/pages/assets/[asset]/index.spec.ts
@@ -312,13 +312,13 @@ walletTest.describe('View Asset Page (/assets/:asset)', () => {
   // Page Structure Tests
   // ============================================================================
 
-  walletTest('page has proper role="main"', async ({ page }) => {
+  walletTest('page renders inside the main landmark', async ({ page }) => {
     await navigateToAsset(page, 'XCP');
 
     await expect(page.locator('text="Asset Details"')).toBeVisible({ timeout: 10000 });
 
-    // Main content should have role="main"
-    const mainContent = page.locator('[role="main"]');
+    // Page content sits inside the app's main landmark
+    const mainContent = page.getByRole('main');
     await expect(mainContent).toBeVisible({ timeout: 5000 });
   });
 

--- a/e2e/pages/keychain/secrets/show-private-key.spec.ts
+++ b/e2e/pages/keychain/secrets/show-private-key.spec.ts
@@ -256,7 +256,7 @@ walletTest.describe('Show Private Key Page (/secrets/show-private-key)', () => {
     await secrets.revealButton(page).click();
 
     // Private key display should have role="button" for copy
-    const keyDisplay = page.locator('[role="button"][aria-label*="Copy"]');
+    const keyDisplay = secrets.privateKeyDisplay(page);
     await expect(keyDisplay).toBeVisible({ timeout: 5000 });
   });
 

--- a/e2e/pages/keychain/wallets/index.spec.ts
+++ b/e2e/pages/keychain/wallets/index.spec.ts
@@ -26,11 +26,13 @@ walletTest.describe('Select Wallet Page (/keychain/wallets)', () => {
   walletTest('displays at least one wallet', async ({ page }) => {
     await navigateToSelectWallet(page);
 
-    // Wallets are displayed using HeadlessUI RadioGroup.Option which has role="radio"
+    // Wallets are displayed using HeadlessUI RadioGroup.Option which has role="radio".
+    // count() does not wait, so it has to follow a web-first assertion rather than
+    // race the list's first render.
     const walletItems = page.locator('[role="radio"]');
-    const count = await walletItems.count();
+    await expect(walletItems.first()).toBeVisible({ timeout: 5000 });
 
-    expect(count).toBeGreaterThanOrEqual(1);
+    expect(await walletItems.count()).toBeGreaterThanOrEqual(1);
   });
 
   walletTest('shows wallet names', async ({ page }) => {

--- a/e2e/pages/market/index.spec.ts
+++ b/e2e/pages/market/index.spec.ts
@@ -231,7 +231,7 @@ walletTest.describe('Market Page', () => {
     await expect(page.getByRole('tab', { name: 'Dispensers' })).toBeVisible({ timeout: 10000 });
 
     // Get the scrollable container
-    const scrollContainer = page.locator('[role="main"]').first();
+    const scrollContainer = page.getByRole('main').first();
 
     // Try to scroll down
     await scrollContainer.evaluate((el) => {

--- a/e2e/pages/settings/connected-sites.spec.ts
+++ b/e2e/pages/settings/connected-sites.spec.ts
@@ -147,12 +147,12 @@ walletTest.describe('Connected Sites Page (/settings/connected-sites)', () => {
   // Page Accessibility Tests
   // ============================================================================
 
-  walletTest('page has proper role="main"', async ({ page }) => {
+  walletTest('page renders inside the main landmark', async ({ page }) => {
     await page.goto(page.url().replace(/\/index.*/, '/settings/connected-sites'));
     await page.waitForLoadState('networkidle');
 
-    // Main content should have role="main"
-    const mainContent = page.locator('[role="main"]');
+    // Page content sits inside the app's main landmark
+    const mainContent = page.getByRole('main');
     await expect(mainContent).toBeVisible({ timeout: 5000 });
   });
 

--- a/e2e/selectors.ts
+++ b/e2e/selectors.ts
@@ -105,9 +105,11 @@ export const index = {
 export const viewAddress = {
   // QR code canvas - has aria-label="QR code for {address}"
   qrCode: (page: Page) => page.locator('canvas[aria-label^="QR code for"]'),
-  // Address display div (clickable) vs copy button - be specific about element type
-  addressDisplay: (page: Page) => page.locator('div[role="button"][aria-label="Copy address"]'),
-  copyButton: (page: Page) => page.locator('button[aria-label="Copy address"]'),
+  // Two controls copy the address: the address itself, and the button under it.
+  // Match on the accessible name, not the tag — the tag is an implementation
+  // detail that changes whenever a faked role becomes a real element.
+  addressDisplay: (page: Page) => page.getByRole('button', { name: 'Copy the address shown here' }),
+  copyButton: (page: Page) => page.getByRole('button', { name: 'Copy address', exact: true }),
 };
 
 // ============================================================================
@@ -471,13 +473,13 @@ export const market = {
   loadingState: (page: Page) => page.getByText(/Loading/i).first(),
   retryButton: (page: Page) => page.getByRole('button', { name: /Retry|Try Again/i }),
   // Order/dispenser cards in list views
-  orderCards: (page: Page) => page.getByRole('listitem').or(page.locator('[role="button"]').filter({ hasText: /BTC|XCP/ })).first(),
+  orderCards: (page: Page) => page.getByRole('listitem').or(page.getByRole('button').filter({ hasText: /BTC|XCP/ })).first(),
 
   // Pools tab
   poolsTab: (page: Page) => page.getByRole('tab', { name: 'Pools' }),
   poolSearchInput: (page: Page) => page.getByPlaceholder(/Search pools/i),
   poolManageSearchInput: (page: Page) => page.getByPlaceholder(/Search your pools/i),
-  poolCard: (page: Page) => page.locator('[role="button"]').filter({ hasText: /\/ XCP|XCP \// }),
+  poolCard: (page: Page) => page.getByRole('button').filter({ hasText: /\/ XCP|XCP \// }),
   poolEmptyState: (page: Page) => page.getByText(/No pools found|No pools matching/i).first(),
   poolPositionsEmptyState: (page: Page) => page.getByText(/You don't have any LP positions|No pool positions matching/i).first(),
   enterPoolLink: (page: Page) => page.getByRole('button', { name: /Enter Pool/i }),
@@ -586,9 +588,10 @@ export const secrets = {
 
   // Show private key page
   showPrivateKeyTitle: (page: Page) => page.getByText(/Show.*Private.*Key|Export.*Key/i).first(),
-  // The key itself: matching on text picked up the heading, and the accessible name is shared with
-  // the copy button below it, so pin to the element that actually renders the key.
-  privateKeyDisplay: (page: Page) => page.locator('div[role="button"][aria-label="Copy Private Key"]'),
+  // The key itself: matching on text picked up the heading, and the accessible name used to be
+  // shared with the copy button below it. The two are named apart now, so match on the name.
+  privateKeyDisplay: (page: Page) =>
+    page.getByRole('button', { name: 'Copy the private key shown here' }),
   warningMessage: (page: Page) => page.getByText(/never share|keep.*secret|dangerous/i).first(),
 };
 

--- a/e2e/tests/address-preview-cache.spec.ts
+++ b/e2e/tests/address-preview-cache.spec.ts
@@ -39,7 +39,7 @@ walletTest.describe('Address Preview Display', () => {
     await expect(addressTypeOption).toBeVisible({ timeout: 5000 });
 
     // The description shows the current address type - it's in a div, not p
-    const description = page.locator('[role="button"]').filter({ hasText: 'Address Type' }).locator('div.text-xs');
+    const description = page.getByRole('button', { name: 'Address Type' }).locator('div.text-xs');
     await expect(description).toBeVisible();
     const text = await description.textContent();
     expect(text).toMatch(/(Legacy|Native SegWit|Nested SegWit|Taproot|CounterWallet|P2PKH|P2WPKH|P2TR|P2SH)/i);

--- a/e2e/tests/address-preview.spec.ts
+++ b/e2e/tests/address-preview.spec.ts
@@ -16,7 +16,7 @@ walletTest.describe('Settings Address Preview', () => {
 
     // The description shows the current address type name - it's in a div, not p
     // The ActionCard renders description in div.text-xs.text-gray-500
-    const description = page.locator('[role="button"]').filter({ hasText: 'Address Type' }).locator('div.text-xs');
+    const description = page.getByRole('button', { name: 'Address Type' }).locator('div.text-xs');
     await expect(description).toBeVisible();
 
     const descriptionText = await description.textContent();
@@ -92,7 +92,7 @@ walletTest.describe('Settings Address Preview', () => {
     await expect(settings.addressTypeOption(page)).toBeVisible({ timeout: 5000 });
 
     // Description should show an address type - it's in a div, not p
-    const description = page.locator('[role="button"]').filter({ hasText: 'Address Type' }).locator('div.text-xs');
+    const description = page.getByRole('button', { name: 'Address Type' }).locator('div.text-xs');
     await expect(description).toBeVisible();
     const text = await description.textContent();
     expect(text).toMatch(/(Legacy|Native SegWit|Nested SegWit|Taproot|CounterWallet|P2PKH|P2WPKH|P2TR|P2SH)/i);

--- a/e2e/tests/flow-user-journeys.spec.ts
+++ b/e2e/tests/flow-user-journeys.spec.ts
@@ -93,7 +93,7 @@ test.describe('User Journey: Wallet Management Lifecycle', () => {
     await navigateTo(extensionPage, 'settings');
     await expect(extensionPage).toHaveURL(/settings/);
 
-    const addressTypeOption = extensionPage.locator('div[role="button"][aria-label="Address Type"]').first();
+    const addressTypeOption = extensionPage.getByRole('button', { name: 'Address Type' }).first();
     await expect(addressTypeOption).toBeVisible({ timeout: 5000 });
     await addressTypeOption.click();
     await expect(extensionPage).toHaveURL(/address-type/, { timeout: 5000 });

--- a/src/components/domain/asset/asset-card.tsx
+++ b/src/components/domain/asset/asset-card.tsx
@@ -58,38 +58,35 @@ export function AssetCard({
   };
 
   return (
-    <div
-      className={`relative flex items-center p-4 bg-white rounded-lg shadow-sm cursor-pointer hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${className}`}
-      onClick={handleClick}
-      role="button"
-      tabIndex={0}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          handleClick();
-        }
-      }}
-      aria-label={`View ${asset.asset} details`}
-    >
-      {/* Asset Icon */}
-      <AssetIcon asset={asset.asset} size="lg" className="flex-shrink-0" />
+    // The card is a container, not a control: the menu is its own button, and a
+    // button cannot contain another one. Opening the asset is the button here.
+    <div className={`relative bg-white rounded-lg shadow-sm ${className}`}>
+      <button
+        type="button"
+        className="flex w-full items-center p-4 text-left rounded-lg cursor-pointer hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+        onClick={handleClick}
+        aria-label={`View ${asset.asset} details`}
+      >
+        {/* Asset Icon */}
+        <AssetIcon asset={asset.asset} size="lg" className="flex-shrink-0" />
 
-      {/* Asset Information */}
-      <div className="ml-3 flex-grow">
-        {/* Asset Name/Symbol */}
-        <div className="font-medium text-sm text-gray-900">
-          {formatAsset(asset.asset, { assetInfo: { asset_longname: asset.asset_longname }, shorten: true })}
+        {/* Asset Information */}
+        <div className="ml-3 flex-grow">
+          {/* Asset Name/Symbol */}
+          <div className="font-medium text-sm text-gray-900">
+            {formatAsset(asset.asset, { assetInfo: { asset_longname: asset.asset_longname }, shorten: true })}
+          </div>
+
+          {/* Asset Supply */}
+          <div className="text-sm text-gray-500">
+            Supply: {formatAmount({
+              value: asset.supply_normalized,
+              minimumFractionDigits: 0,
+              maximumFractionDigits: 8
+            })}
+          </div>
         </div>
-        
-        {/* Asset Supply */}
-        <div className="text-sm text-gray-500">
-          Supply: {formatAmount({ 
-            value: asset.supply_normalized, 
-            minimumFractionDigits: 0, 
-            maximumFractionDigits: 8 
-          })}
-        </div>
-      </div>
+      </button>
 
       {/* Asset Menu (if enabled) */}
       {showMenu && (

--- a/src/components/domain/asset/asset-menu.test.tsx
+++ b/src/components/domain/asset/asset-menu.test.tsx
@@ -157,7 +157,7 @@ describe('AssetMenu', () => {
     const mockOnClick = vi.fn();
     
     render(
-      <div onClick={mockOnClick}>
+      <div role="presentation" onClick={mockOnClick}>
         <MemoryRouter>
           <AssetMenu ownedAsset={unlockedAsset} />
         </MemoryRouter>

--- a/src/components/domain/asset/asset-select-input.tsx
+++ b/src/components/domain/asset/asset-select-input.tsx
@@ -4,6 +4,7 @@ import {
   ComboboxInput,
   ComboboxOption,
   ComboboxOptions,
+  Label,
 } from "@headlessui/react";
 import { type ReactElement, useEffect, useState } from "react";
 import { FaCheck, FaSpinner, FiChevronDown } from "@/components/icons";
@@ -136,9 +137,11 @@ export function AssetSelectInput({
     <div className="relative">
       <Combobox value={selectedAsset} onChange={handleAssetChange}>
         <div className="relative">
-          <label className="block text-sm font-medium text-gray-700">
+          {/* Headless UI's Label, so it is wired to the Combobox input rather than only
+              looking like a label. Still renders a <label>, which the input specs select on. */}
+          <Label className="block text-sm font-medium text-gray-700">
             {label} {required && <span className="text-red-500">*</span>}
-          </label>
+          </Label>
           <div className="relative mt-1">
             <div className="relative w-full cursor-default overflow-hidden rounded-md bg-gray-50 text-left focus:outline-none sm:text-sm">
               <div className="flex items-center">

--- a/src/components/domain/asset/fairminter-select-input.tsx
+++ b/src/components/domain/asset/fairminter-select-input.tsx
@@ -4,6 +4,7 @@ import {
   ComboboxInput,
   ComboboxOption,
   ComboboxOptions,
+  Label,
 } from "@headlessui/react";
 import { type ReactElement, useEffect, useState } from "react";
 import { FaCheck, FiChevronDown } from "@/components/icons";
@@ -162,9 +163,11 @@ export function FairminterSelectInput({
     <div className="relative">
       <Combobox value={selectedAsset} onChange={handleAssetChange}>
         <div className="relative">
-          <label className="block text-sm font-medium text-gray-700">
+          {/* Headless UI's Label, so it is wired to the Combobox input rather than only
+              looking like a label. Still renders a <label>, which the input specs select on. */}
+          <Label className="block text-sm font-medium text-gray-700">
             {label} {required && <span className="text-red-500">*</span>}
-          </label>
+          </Label>
           <div className="relative mt-1">
             <div className="relative w-full cursor-default overflow-hidden rounded-md bg-gray-50 text-left focus:outline-none sm:text-sm">
               <div className="flex items-center">

--- a/src/components/domain/asset/search-result-card.test.tsx
+++ b/src/components/domain/asset/search-result-card.test.tsx
@@ -75,22 +75,15 @@ describe("SearchResultCard", () => {
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 
-  it("handles keyboard navigation with Enter key", () => {
+  // Keyboard activation is the platform's job now: a real <button> turns Enter
+  // and Space into a click. jsdom does not synthesise that, so asserting the
+  // element type is what actually pins the behaviour down.
+  it("is a real button, so the browser handles keyboard activation", () => {
     render(<SearchResultCard symbol="XCP" />);
 
     const card = screen.getByRole("button");
-    fireEvent.keyDown(card, { key: "Enter" });
-
-    expect(mockNavigate).toHaveBeenCalledWith("/assets/XCP");
-  });
-
-  it("handles keyboard navigation with Space key", () => {
-    render(<SearchResultCard symbol="XCP" />);
-
-    const card = screen.getByRole("button");
-    fireEvent.keyDown(card, { key: " " });
-
-    expect(mockNavigate).toHaveBeenCalledWith("/assets/XCP");
+    expect(card.tagName).toBe("BUTTON");
+    expect(card).toHaveAttribute("type", "button");
   });
 
   it("applies custom className", () => {
@@ -111,7 +104,6 @@ describe("SearchResultCard", () => {
     render(<SearchResultCard symbol="XCP" />);
 
     const card = screen.getByRole("button");
-    expect(card).toHaveAttribute("tabIndex", "0");
     expect(card).toHaveAttribute("aria-label", "View XCP");
   });
 

--- a/src/components/domain/asset/search-result-card.tsx
+++ b/src/components/domain/asset/search-result-card.tsx
@@ -68,17 +68,9 @@ export function SearchResultCard({
   };
   
   return (
-    <div
-      className={`relative flex items-center p-3 bg-white rounded-lg shadow-sm cursor-pointer hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${className}`}
+    <button type="button"
+      className={`text-left relative flex items-center p-3 bg-white rounded-lg shadow-sm cursor-pointer hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${className}`}
       onClick={handleClick}
-      role="button"
-      tabIndex={0}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          handleClick();
-        }
-      }}
       aria-label={`View ${symbol}`}
     >
       {/* Asset Icon */}
@@ -88,7 +80,7 @@ export function SearchResultCard({
       <div className="ml-3 flex-grow">
         <div className="font-medium text-sm text-gray-900">{symbol}</div>
       </div>
-    </div>
+    </button>
   );
 }
 

--- a/src/components/domain/balance/balance-card.tsx
+++ b/src/components/domain/balance/balance-card.tsx
@@ -60,41 +60,36 @@ export function BalanceCard({
   // Determine if the asset is divisible for proper decimal formatting
   const isDivisible = token.asset_info?.divisible ?? false;
 
-  const handleKeyDown = (event: React.KeyboardEvent) => {
-    if (event.key === "Enter" || event.key === " ") {
-      event.preventDefault();
-      handleClick();
-    }
-  };
-
   return (
-    <div
-      className={`relative flex items-center p-4 bg-white rounded-lg shadow-sm cursor-pointer hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${className}`}
-      onClick={handleClick}
-      onKeyDown={handleKeyDown}
-      role="button"
-      tabIndex={0}
-    >
-      {/* Asset Icon */}
-      <AssetIcon asset={token.asset} size="lg" className="flex-shrink-0" />
+    // The card is a container, not a control: the menu is its own button, and a
+    // button cannot contain another one. Opening the balance is the button here.
+    <div className={`relative bg-white rounded-lg shadow-sm ${className}`}>
+      <button
+        type="button"
+        className="flex w-full items-center p-4 text-left rounded-lg cursor-pointer hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+        onClick={handleClick}
+      >
+        {/* Asset Icon */}
+        <AssetIcon asset={token.asset} size="lg" className="flex-shrink-0" />
 
-      {/* Asset Information */}
-      <div className="ml-3 flex-grow">
-        {/* Asset Name/Symbol */}
-        <div className="font-medium text-sm text-gray-900">
-          {formatAsset(token.asset, { assetInfo: token.asset_info, shorten: true })}
+        {/* Asset Information */}
+        <div className="ml-3 flex-grow">
+          {/* Asset Name/Symbol */}
+          <div className="font-medium text-sm text-gray-900">
+            {formatAsset(token.asset, { assetInfo: token.asset_info, shorten: true })}
+          </div>
+
+          {/* Balance Amount */}
+          <div className="text-sm text-gray-500">
+            {formatAmount({
+              value: token.quantity_normalized,
+              minimumFractionDigits: isDivisible ? 8 : 0,
+              maximumFractionDigits: isDivisible ? 8 : 0,
+              useGrouping: true,
+            })}
+          </div>
         </div>
-        
-        {/* Balance Amount */}
-        <div className="text-sm text-gray-500">
-          {formatAmount({
-            value: token.quantity_normalized,
-            minimumFractionDigits: isDivisible ? 8 : 0,
-            maximumFractionDigits: isDivisible ? 8 : 0,
-            useGrouping: true,
-          })}
-        </div>
-      </div>
+      </button>
 
       {/* Balance Menu (if enabled) */}
       {showMenu && (

--- a/src/components/domain/balance/balance-menu.test.tsx
+++ b/src/components/domain/balance/balance-menu.test.tsx
@@ -115,7 +115,7 @@ describe('BalanceMenu', () => {
     const mockOnClick = vi.fn();
 
     render(
-      <div onClick={mockOnClick}>
+      <div role="presentation" onClick={mockOnClick}>
         <MemoryRouter>
           <BalanceMenu asset="BTC" />
         </MemoryRouter>
@@ -134,7 +134,7 @@ describe('BalanceMenu', () => {
     const mockOnClick = vi.fn();
 
     render(
-      <div onClick={mockOnClick}>
+      <div role="presentation" onClick={mockOnClick}>
         <MemoryRouter>
           <BalanceMenu asset="BTC" />
         </MemoryRouter>

--- a/src/components/domain/dispenser/manage-dispenser-card.test.tsx
+++ b/src/components/domain/dispenser/manage-dispenser-card.test.tsx
@@ -1,0 +1,67 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { ManageDispenserCard } from './manage-dispenser-card';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router', () => ({ useNavigate: () => mockNavigate }));
+vi.mock('@/components/domain/asset/asset-icon', () => ({
+  AssetIcon: () => <span data-testid="icon" />,
+}));
+
+const openDispenser: any = {
+  asset: 'RAREPEPE',
+  status: 0,
+  give_remaining_normalized: '5',
+  give_quantity_normalized: '1',
+  escrow_quantity_normalized: '5',
+  satoshirate: 100000,
+};
+
+describe('ManageDispenserCard', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('opens the dispenser when the card body is clicked', () => {
+    render(<ManageDispenserCard dispenser={openDispenser} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /RAREPEPE/ }));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/market/dispensers/RAREPEPE');
+  });
+
+  // Regression: Refill and Close used to sit inside a role="button" card whose
+  // onKeyDown ran preventDefault() and navigated. A keypress on either opened
+  // the dispenser AND suppressed the button's own activation, so neither action
+  // was reachable from the keyboard.
+  it.each(['Refill', 'Close'])(
+    'does not open the dispenser when a key is pressed on %s',
+    (name) => {
+      render(<ManageDispenserCard dispenser={openDispenser} />);
+
+      const action = screen.getByRole('button', { name });
+      const notPrevented = fireEvent.keyDown(action, { key: 'Enter' });
+
+      expect(mockNavigate).not.toHaveBeenCalled();
+      // The browser turns this keypress into a click; nothing may cancel it.
+      expect(notPrevented).toBe(true);
+    }
+  );
+
+  it('routes Refill and Close to their own destinations on click', () => {
+    render(<ManageDispenserCard dispenser={openDispenser} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+    expect(mockNavigate).toHaveBeenCalledWith('/compose/dispenser/close/RAREPEPE');
+
+    mockNavigate.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: 'Refill' }));
+    expect(mockNavigate.mock.calls[0]![0]).toContain('refill=true');
+  });
+
+  it('shows Closed instead of the actions once the dispenser is closed', () => {
+    render(<ManageDispenserCard dispenser={{ ...openDispenser, status: 10 }} />);
+
+    expect(screen.queryByRole('button', { name: 'Refill' })).not.toBeInTheDocument();
+    expect(screen.getByText('Closed')).toBeInTheDocument();
+  });
+});

--- a/src/components/domain/dispenser/manage-dispenser-card.tsx
+++ b/src/components/domain/dispenser/manage-dispenser-card.tsx
@@ -1,4 +1,4 @@
-import type { KeyboardEvent, ReactElement } from "react";
+import type { ReactElement } from "react";
 import { useNavigate } from "react-router";
 import { AssetIcon } from "@/components/domain/asset/asset-icon";
 import type { DispenserDetails } from "@/core/counterparty/api";
@@ -44,31 +44,28 @@ export function ManageDispenserCard({
     navigate(`/market/dispensers/${dispenser.asset}`);
   };
 
-  const handleKeyDown = (e: KeyboardEvent) => {
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      handleClick();
-    }
-  };
-
   return (
+    // Opening the dispenser is a button, not the whole card: Refill and Close sit
+    // inside, and a card-level key handler swallowed Enter before they could act.
     <div
-      className={`bg-white rounded-lg shadow-sm p-3 hover:shadow-md transition-shadow cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${className}`}
-      onClick={handleClick}
-      onKeyDown={handleKeyDown}
-      role="button"
-      tabIndex={0}
+      className={`bg-white rounded-lg shadow-sm p-3 hover:shadow-md transition-shadow ${className}`}
     >
       <div className="flex items-center gap-3">
-        <AssetIcon asset={dispenser.asset} size="md" />
-        <div className="flex-1 min-w-0">
-          <div className="font-medium text-gray-900 text-sm truncate">
-            {assetName}
+        <button
+          type="button"
+          onClick={handleClick}
+          className="flex flex-1 min-w-0 items-center gap-3 text-left cursor-pointer rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+        >
+          <AssetIcon asset={dispenser.asset} size="md" />
+          <div className="flex-1 min-w-0">
+            <div className="font-medium text-gray-900 text-sm truncate">
+              {assetName}
+            </div>
+            <div className="text-xs text-gray-500">
+              {formatAmount({ value: dispenser.give_remaining_normalized, maximumFractionDigits: 2 })} remaining
+            </div>
           </div>
-          <div className="text-xs text-gray-500">
-            {formatAmount({ value: dispenser.give_remaining_normalized, maximumFractionDigits: 2 })} remaining
-          </div>
-        </div>
+        </button>
         {isOpen ? (
           <div className="flex gap-2">
             <button type="button"

--- a/src/components/domain/utxo/utxo-card.test.tsx
+++ b/src/components/domain/utxo/utxo-card.test.tsx
@@ -134,19 +134,21 @@ describe("UtxoCard", () => {
     );
   });
 
-  it("navigates on Enter key press", () => {
+  // The card body is a real button now, so the browser supplies Enter and Space.
+  // jsdom does not synthesise that, so the element type is what pins it down —
+  // and being a button, rather than a wrapper around one, is the point: the menu
+  // is a button too, and one cannot contain the other.
+  it("exposes the card body as a button, separate from the menu", () => {
     render(
       <TestWrapper>
         <UtxoCard token={mockToken} />
       </TestWrapper>,
     );
 
-    const card = screen.getByText("XCP").closest('[role="button"]')!;
-    fireEvent.keyDown(card, { key: "Enter" });
-
-    expect(mockNavigate).toHaveBeenCalledWith(
-      `/assets/utxos/${mockToken.utxo}`,
-    );
+    const card = screen.getByText("XCP").closest("button")!;
+    expect(card.tagName).toBe("BUTTON");
+    expect(card).toHaveAttribute("type", "button");
+    expect(card.querySelector("button")).toBeNull();
   });
 
   it("handles indivisible tokens", () => {
@@ -167,8 +169,7 @@ describe("UtxoCard", () => {
       </TestWrapper>,
     );
 
-    const card = screen.getByText("XCP").closest('[role="button"]');
-    expect(card).toHaveAttribute("tabindex", "0");
+    const card = screen.getByText("XCP").closest("button");
     expect(card).toHaveClass("cursor-pointer");
   });
 });

--- a/src/components/domain/utxo/utxo-card.tsx
+++ b/src/components/domain/utxo/utxo-card.tsx
@@ -16,43 +16,38 @@ export function UtxoCard({ token }: UtxoCardProps): ReactElement {
     navigate(`/assets/utxos/${token.utxo}`);
   };
 
-  const handleKeyDown = (event: React.KeyboardEvent) => {
-    if (event.key === "Enter" || event.key === " ") {
-      event.preventDefault();
-      handleClick();
-    }
-  };
-
   const isDivisible = token.asset_info?.divisible ?? false;
 
   return (
-    <div
-      className="relative flex items-center p-4 bg-white rounded-lg shadow-sm cursor-pointer hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
-      onClick={handleClick}
-      onKeyDown={handleKeyDown}
-      role="button"
-      tabIndex={0}
-    >
-      <AssetIcon asset={token.asset} size="lg" className="flex-shrink-0" />
+    // The card is a container, not a control: the menu is its own button, and a
+    // button cannot contain another one. Opening the utxo is the button here.
+    <div className="relative bg-white rounded-lg shadow-sm">
+      <button
+        type="button"
+        className="flex w-full items-center p-4 text-left rounded-lg cursor-pointer hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+        onClick={handleClick}
+      >
+        <AssetIcon asset={token.asset} size="lg" className="flex-shrink-0" />
 
-      <div className="ml-3 flex-grow min-w-0">
-        <div className="font-medium text-sm text-gray-900">
-          {formatAsset(token.asset, { assetInfo: token.asset_info, shorten: true })}
+        <div className="ml-3 flex-grow min-w-0">
+          <div className="font-medium text-sm text-gray-900">
+            {formatAsset(token.asset, { assetInfo: token.asset_info, shorten: true })}
+          </div>
+          <div className="flex justify-between items-baseline">
+            <span className="text-sm text-gray-500">
+              {formatAmount({
+                value: token.quantity_normalized,
+                minimumFractionDigits: isDivisible ? 8 : 0,
+                maximumFractionDigits: isDivisible ? 8 : 0,
+                useGrouping: true,
+              })}
+            </span>
+            <span className="text-xs text-gray-400 font-mono ml-2">
+              {formatTxid(token.utxo)}
+            </span>
+          </div>
         </div>
-        <div className="flex justify-between items-baseline">
-          <span className="text-sm text-gray-500">
-            {formatAmount({
-              value: token.quantity_normalized,
-              minimumFractionDigits: isDivisible ? 8 : 0,
-              maximumFractionDigits: isDivisible ? 8 : 0,
-              useGrouping: true,
-            })}
-          </span>
-          <span className="text-xs text-gray-400 font-mono ml-2">
-            {formatTxid(token.utxo)}
-          </span>
-        </div>
-      </div>
+      </button>
 
       <div className="absolute top-2 right-2">
         <UtxoMenu utxo={token.utxo} />

--- a/src/components/domain/utxo/utxo-menu.test.tsx
+++ b/src/components/domain/utxo/utxo-menu.test.tsx
@@ -98,7 +98,7 @@ describe('UtxoMenu', () => {
     const mockOnClick = vi.fn();
 
     render(
-      <div onClick={mockOnClick}>
+      <div role="presentation" onClick={mockOnClick}>
         <MemoryRouter>
           <UtxoMenu utxo={testUtxo} />
         </MemoryRouter>

--- a/src/components/domain/wallet/wallet-card.test.tsx
+++ b/src/components/domain/wallet/wallet-card.test.tsx
@@ -245,6 +245,63 @@ describe('WalletCard', () => {
     expect(mockOnSelect).toHaveBeenCalledWith(mockMnemonicWallet);
   });
 
+  it('calls onSelect when the already-selected wallet is confirmed by keyboard', () => {
+    render(
+      <TestWrapper value={mockMnemonicWallet} onChange={mockOnSelect}>
+        <WalletCard
+          wallet={mockMnemonicWallet}
+          selected={true}
+          onSelect={mockOnSelect}
+          isOnlyWallet={false}
+        />
+      </TestWrapper>
+    );
+
+    // The radio group itself ignores this key, because the value would not change.
+    const radioOption = screen.getByRole('radio');
+    fireEvent.keyDown(radioOption, { key: 'Enter' });
+
+    expect(mockOnSelect).toHaveBeenCalledWith(mockMnemonicWallet);
+  });
+
+  it('calls onSelect once when an unselected wallet is confirmed by keyboard', () => {
+    render(
+      <TestWrapper value={mockPrivateKeyWallet} onChange={mockOnSelect}>
+        <WalletCard
+          wallet={mockMnemonicWallet}
+          selected={false}
+          onSelect={mockOnSelect}
+          isOnlyWallet={false}
+        />
+      </TestWrapper>
+    );
+
+    const radioOption = screen.getByRole('radio');
+    fireEvent.keyDown(radioOption, { key: ' ' });
+
+    expect(mockOnSelect).toHaveBeenCalledTimes(1);
+    expect(mockOnSelect).toHaveBeenCalledWith(mockMnemonicWallet);
+  });
+
+  it('does not select a disabled wallet by keyboard', () => {
+    render(
+      <TestWrapper value={mockMnemonicWallet} onChange={mockOnSelect}>
+        <WalletCard
+          wallet={mockHardwareWallet}
+          selected={false}
+          onSelect={mockOnSelect}
+          isOnlyWallet={false}
+          disabled
+          disabledMessage="Open in sidepanel"
+        />
+      </TestWrapper>
+    );
+
+    fireEvent.keyDown(screen.getByRole('radio'), { key: 'Enter' });
+
+    expect(mockOnSelect).not.toHaveBeenCalled();
+  });
+
   it('shows disabled message and does not select disabled hardware wallet', () => {
     render(
       <TestWrapper value={mockMnemonicWallet} onChange={mockOnSelect}>

--- a/src/components/domain/wallet/wallet-card.tsx
+++ b/src/components/domain/wallet/wallet-card.tsx
@@ -48,10 +48,25 @@ export function WalletCard({
     }
   };
 
+  // The radio group ignores a keypress on the option that is already checked, so
+  // re-selecting the current wallet — how these screens confirm and move on — is
+  // otherwise unreachable from the keyboard. Handle it here, on the focusable
+  // element, and stop the group from acting on the same key twice.
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (disabled) return;
+    if (e.key !== 'Enter' && e.key !== ' ') return;
+
+    e.preventDefault();
+    e.stopPropagation();
+    onSelect(wallet);
+  };
+
   return (
     <RadioGroup.Option
       value={wallet}
       disabled={disabled}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
       className={({ checked }) => `
         relative w-full rounded transition duration-300 p-4
         ${disabled ? 'cursor-not-allowed bg-gray-100 text-gray-500' : 'cursor-pointer'}
@@ -60,7 +75,7 @@ export function WalletCard({
       `}
     >
       {({ checked }) => (
-        <div onClick={handleClick} className="flex flex-col" aria-disabled={disabled}>
+        <div className="flex flex-col" aria-disabled={disabled}>
           <div className="flex justify-between items-center">
             <div className="text-sm font-medium">{wallet.name}</div>
             <div className="absolute top-2 right-2 wallet-menu">

--- a/src/components/domain/wallet/wallet-list.test.tsx
+++ b/src/components/domain/wallet/wallet-list.test.tsx
@@ -7,7 +7,8 @@ import { WalletList } from './wallet-list';
 // Mock WalletCard component
 vi.mock('@/components/domain/wallet/wallet-card', () => ({
   WalletCard: ({ wallet, selected, displayAddress, onSelect, isOnlyWallet, disabled, disabledMessage }: any) => (
-    <div
+    <button
+      type="button"
       data-testid={`wallet-card-${wallet.id}`}
       data-selected={selected}
       data-display-address={displayAddress?.address || ''}
@@ -20,7 +21,7 @@ vi.mock('@/components/domain/wallet/wallet-card', () => ({
       aria-disabled={disabled}
     >
       {wallet.name}
-    </div>
+    </button>
   )
 }));
 

--- a/src/components/domain/wallet/wallet-list.test.tsx
+++ b/src/components/domain/wallet/wallet-list.test.tsx
@@ -16,8 +16,6 @@ vi.mock('@/components/domain/wallet/wallet-card', () => ({
       data-disabled={disabled}
       data-disabled-message={disabledMessage || ''}
       onClick={() => !disabled && onSelect(wallet)}
-      role="radio"
-      aria-checked={selected}
       aria-disabled={disabled}
     >
       {wallet.name}
@@ -93,7 +91,6 @@ describe('WalletList', () => {
 
     const selectedCard = screen.getByTestId('wallet-card-wallet-2');
     expect(selectedCard).toHaveAttribute('data-selected', 'true');
-    expect(selectedCard).toHaveAttribute('aria-checked', 'true');
   });
 
   it('should pass selected address only to selected wallet', () => {

--- a/src/components/domain/wallet/wallet-menu.test.tsx
+++ b/src/components/domain/wallet/wallet-menu.test.tsx
@@ -169,7 +169,7 @@ describe('WalletMenu', () => {
     const mockOnClick = vi.fn();
     
     render(
-      <div onClick={mockOnClick}>
+      <div role="presentation" onClick={mockOnClick}>
         <MemoryRouter>
           <WalletMenu wallet={mnemonicWallet} isOnlyWallet={false} />
         </MemoryRouter>
@@ -191,7 +191,7 @@ describe('WalletMenu', () => {
     const mockOnClick = vi.fn();
     
     render(
-      <div onClick={mockOnClick}>
+      <div role="presentation" onClick={mockOnClick}>
         <MemoryRouter>
           <WalletMenu wallet={mnemonicWallet} isOnlyWallet={false} />
         </MemoryRouter>

--- a/src/components/icons/index.tsx
+++ b/src/components/icons/index.tsx
@@ -15,6 +15,11 @@ const Icon = ({ children, ...props }: IconProps & { children: ReactElement }): R
     height="1em"
     width="1em"
     xmlns="http://www.w3.org/2000/svg"
+    // Decorative by default: an icon repeats what its button or link already says, and a screen
+    // reader announcing it twice is noise. Icons that carry meaning alone are named by an
+    // aria-label on the control, and a caller can still override either through props.
+    aria-hidden="true"
+    focusable="false"
     {...props}
   >
     {children}
@@ -33,6 +38,9 @@ const FeatherIcon = ({ children, ...props }: IconProps & { children: ReactElemen
     height="1em"
     width="1em"
     xmlns="http://www.w3.org/2000/svg"
+    // Decorative by default, as above.
+    aria-hidden="true"
+    focusable="false"
     {...props}
   >
     {children}

--- a/src/components/screens/review-screen.tsx
+++ b/src/components/screens/review-screen.tsx
@@ -134,7 +134,7 @@ export function ReviewScreen({
       <div className="space-y-4">
         {/* Source Address */}
         <div className="space-y-1">
-          <label className="font-semibold text-gray-700">From:</label>
+          <span className="block font-semibold text-gray-700">From:</span>
           <div className="bg-gray-50 p-2 rounded break-all text-gray-900">
             {formatAddress(sourceAddress, true)}
           </div>
@@ -143,7 +143,7 @@ export function ReviewScreen({
         {/* Destination Address (if present) - show full address */}
         {destinationAddress && (
           <div className="space-y-1">
-            <label className="font-semibold text-gray-700">To:</label>
+            <span className="block font-semibold text-gray-700">To:</span>
             <div className="bg-gray-50 p-2 rounded break-all text-gray-900">
               {formatAddress(destinationAddress, false)}
             </div>
@@ -153,7 +153,7 @@ export function ReviewScreen({
         {/* Custom Fields */}
         {customFields.map((field, idx) => (
           <div key={`field-${idx}-${field.label}`} className="space-y-1">
-            <label className="font-semibold text-gray-700">{field.label}:</label>
+            <span className="block font-semibold text-gray-700">{field.label}:</span>
             <div className="bg-gray-50 p-2 rounded break-all text-gray-900">
               {typeof field.value === 'string' && field.value.includes('\n') ? (
                 <div className="whitespace-pre-line">{field.value}</div>
@@ -171,7 +171,7 @@ export function ReviewScreen({
 
         {xcpFee !== null && (
           <div className="space-y-1">
-            <label className="font-semibold text-gray-700">XCP Fee:</label>
+            <span className="block font-semibold text-gray-700">XCP Fee:</span>
             <div className="bg-gray-50 p-2 rounded text-gray-900">
               <div className="flex justify-between items-center">
                 <span>
@@ -194,7 +194,7 @@ export function ReviewScreen({
         
         {/* Transaction Fee */}
         <div className="space-y-1">
-          <label className="font-semibold text-gray-700">Fee:</label>
+          <span className="block font-semibold text-gray-700">Fee:</span>
           <div className="bg-gray-50 p-2 rounded text-gray-900">
             <div className="flex justify-between items-center">
               <div>

--- a/src/components/screens/success-screen.test.tsx
+++ b/src/components/screens/success-screen.test.tsx
@@ -47,13 +47,14 @@ describe('SuccessScreen', () => {
       expect(screen.getByText('Your transaction was broadcasted.')).toBeInTheDocument();
     });
 
-    it('displays transaction ID with label', () => {
+    it('displays transaction ID with a caption', () => {
       render(<SuccessScreen {...defaultProps} />);
 
-      // Find the label specifically (not the button text)
-      const label = screen.getByText('Transaction ID');
-      expect(label).toBeInTheDocument();
-      expect(label.tagName).toBe('LABEL');
+      // A caption over a read-only value, not a form label: there is no control for it to name,
+      // and a <label> that labels nothing is announced as one anyway.
+      const caption = screen.getByText('Transaction ID');
+      expect(caption).toBeInTheDocument();
+      expect(caption.tagName).toBe('SPAN');
       expect(screen.getByText('abc123def456ghi789jkl012mno345pqr678stu901vwx234yz')).toBeInTheDocument();
     });
 

--- a/src/components/screens/success-screen.tsx
+++ b/src/components/screens/success-screen.tsx
@@ -88,16 +88,13 @@ export function SuccessScreen({
           <span className="block text-xs font-medium text-gray-600 mb-1">
             Transaction ID
           </span>
-          <div
+          <button type="button"
             onClick={() => copy(txid)}
-            onKeyDown={(e) => (e.key === "Enter" || e.key === " ") && copy(txid)}
-            role="button"
-            tabIndex={0}
             aria-label="Click to copy transaction ID"
-            className="font-mono text-xs bg-white border border-gray-200 rounded-lg p-2 break-all text-gray-800 cursor-pointer hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 transition-colors select-all"
+            className="block w-full text-left font-mono text-xs bg-white border border-gray-200 rounded-lg p-2 break-all text-gray-800 cursor-pointer hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 transition-colors select-all"
           >
             {txid}
-          </div>
+          </button>
         </div>
 
         {/* Copy Button */}

--- a/src/components/screens/success-screen.tsx
+++ b/src/components/screens/success-screen.tsx
@@ -85,9 +85,9 @@ export function SuccessScreen({
 
         {/* Transaction ID Display - Clickable to copy */}
         <div className="mt-4">
-          <label className="block text-xs font-medium text-gray-600 mb-1">
+          <span className="block text-xs font-medium text-gray-600 mb-1">
             Transaction ID
-          </label>
+          </span>
           <div
             onClick={() => copy(txid)}
             onKeyDown={(e) => (e.key === "Enter" || e.key === " ") && copy(txid)}

--- a/src/components/ui/cards/action-card.test.tsx
+++ b/src/components/ui/cards/action-card.test.tsx
@@ -86,7 +86,10 @@ describe('ActionCard', () => {
     expect(mockOnClick).toHaveBeenCalledTimes(1);
   });
 
-  it('calls onClick when Enter key is pressed', () => {
+  // Keyboard activation is the platform's job now: a real <button> turns Enter
+  // and Space into a click, and ignores every other key. jsdom does not
+  // synthesise that, so asserting the element type is what pins it down.
+  it('is a real button, so the browser handles keyboard activation', () => {
     render(
       <ActionCard
         title="Test Action"
@@ -95,34 +98,8 @@ describe('ActionCard', () => {
     );
 
     const button = screen.getByRole('button');
-    fireEvent.keyDown(button, { key: 'Enter' });
-    expect(mockOnClick).toHaveBeenCalledTimes(1);
-  });
-
-  it('calls onClick when Space key is pressed', () => {
-    render(
-      <ActionCard
-        title="Test Action"
-        onClick={mockOnClick}
-      />
-    );
-
-    const button = screen.getByRole('button');
-    fireEvent.keyDown(button, { key: ' ' });
-    expect(mockOnClick).toHaveBeenCalledTimes(1);
-  });
-
-  it('does not call onClick for other keys', () => {
-    render(
-      <ActionCard
-        title="Test Action"
-        onClick={mockOnClick}
-      />
-    );
-
-    const button = screen.getByRole('button');
-    fireEvent.keyDown(button, { key: 'Tab' });
-    expect(mockOnClick).not.toHaveBeenCalled();
+    expect(button.tagName).toBe('BUTTON');
+    expect(button).toHaveAttribute('type', 'button');
   });
 
   it('applies custom className', () => {
@@ -170,8 +147,7 @@ describe('ActionCard', () => {
     );
 
     const button = screen.getByRole('button');
-    expect(button).toHaveAttribute('tabIndex', '0');
-    expect(button).toHaveAttribute('role', 'button');
+    expect(button).toHaveAttribute('aria-label', 'Test Action');
   });
 
   it('has hover and focus styles', () => {

--- a/src/components/ui/cards/action-card.tsx
+++ b/src/components/ui/cards/action-card.tsx
@@ -62,13 +62,6 @@ export function ActionCard({
     onClick();
   };
 
-  const handleKeyDown = (event: React.KeyboardEvent) => {
-    if (event.key === "Enter" || event.key === " ") {
-      event.preventDefault();
-      onClick();
-    }
-  };
-
   // Determine title color based on border class in className prop
   const getTitleColor = () => {
     if (className?.includes('border-green')) return 'text-green-600';
@@ -78,12 +71,9 @@ export function ActionCard({
   };
 
   return (
-    <div
+    <button type="button"
       onClick={handleClick}
-      onKeyDown={handleKeyDown}
-      className={`relative w-full rounded transition duration-300 p-4 cursor-pointer bg-white hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 ${className}`}
-      role="button"
-      tabIndex={0}
+      className={`block text-left relative w-full rounded transition duration-300 p-4 cursor-pointer bg-white hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 ${className}`}
       aria-label={ariaLabel || title}
     >
       <div className="flex items-center">
@@ -120,7 +110,7 @@ export function ActionCard({
           </div>
         )}
       </div>
-    </div>
+    </button>
   );
 }
 

--- a/src/components/ui/cards/connected-site-card.test.tsx
+++ b/src/components/ui/cards/connected-site-card.test.tsx
@@ -81,7 +81,7 @@ describe('ConnectedSiteCard', () => {
     const mockParentClick = vi.fn();
     
     render(
-      <div onClick={mockParentClick}>
+      <div role="presentation" onClick={mockParentClick}>
         <ConnectedSiteCard {...defaultProps} />
       </div>
     );

--- a/src/components/ui/cards/connected-site-card.tsx
+++ b/src/components/ui/cards/connected-site-card.tsx
@@ -68,9 +68,8 @@ export function ConnectedSiteCard({
   };
 
   return (
-    <div
+    <article
       className={`bg-white border border-gray-200 rounded-lg p-4 ${className}`}
-      role="article"
       aria-label={ariaLabel || `Connected site: ${hostname}`}
     >
       <div className="flex items-center justify-between">
@@ -111,7 +110,7 @@ export function ConnectedSiteCard({
           <FiX className="size-4 text-gray-400 group-hover:text-red-500 transition-colors" aria-hidden="true" />
         </button>
       </div>
-    </div>
+    </article>
   );
 }
 

--- a/src/components/ui/cards/manage-order-card.test.tsx
+++ b/src/components/ui/cards/manage-order-card.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { ManageOrderCard } from './manage-order-card';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router', () => ({ useNavigate: () => mockNavigate }));
+vi.mock('@/components/domain/asset/asset-icon', () => ({
+  AssetIcon: () => <span data-testid="icon" />,
+}));
+
+const openOrder: any = {
+  tx_hash: 'deadbeef',
+  status: 'open',
+  give_asset: 'XCP',
+  get_asset: 'PEPECASH',
+  give_quantity_normalized: '10',
+  get_quantity_normalized: '20',
+  give_remaining_normalized: '10',
+  get_remaining_normalized: '20',
+};
+
+describe('ManageOrderCard', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('opens the order when the card body is clicked', () => {
+    render(<ManageOrderCard order={openOrder} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /XCP/ }));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/market/orders/PEPECASH/XCP');
+  });
+
+  it('cancels, rather than opening the order, when Cancel is clicked', () => {
+    render(<ManageOrderCard order={openOrder} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/compose/order/cancel/deadbeef');
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+  });
+
+  // Regression: Cancel used to sit inside a role="button" card whose onKeyDown
+  // ran preventDefault() and navigated. A keypress on Cancel therefore opened
+  // the order AND suppressed the button's own activation, so cancelling was
+  // unreachable from the keyboard.
+  it('does not open the order when a key is pressed on Cancel', () => {
+    render(<ManageOrderCard order={openOrder} />);
+
+    const cancel = screen.getByRole('button', { name: 'Cancel' });
+    const notPrevented = fireEvent.keyDown(cancel, { key: 'Enter' });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+    // The browser turns this keypress into a click; nothing may cancel it.
+    expect(notPrevented).toBe(true);
+  });
+
+  it('shows the status instead of Cancel once the order is closed', () => {
+    render(<ManageOrderCard order={{ ...openOrder, status: 'filled' }} />);
+
+    expect(screen.queryByRole('button', { name: 'Cancel' })).not.toBeInTheDocument();
+    expect(screen.getByText('filled')).toBeInTheDocument();
+  });
+});

--- a/src/components/ui/cards/manage-order-card.tsx
+++ b/src/components/ui/cards/manage-order-card.tsx
@@ -1,4 +1,4 @@
-import type { KeyboardEvent, ReactElement } from "react";
+import type { ReactElement } from "react";
 import { useNavigate } from "react-router";
 import { AssetIcon } from "@/components/domain/asset/asset-icon";
 import type { Order } from "@/core/counterparty/api";
@@ -38,34 +38,31 @@ export function ManageOrderCard({
     navigate(`/market/orders/${baseAsset}/${quoteAsset}`);
   };
 
-  const handleKeyDown = (e: KeyboardEvent) => {
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      handleClick();
-    }
-  };
-
   return (
+    // Opening the order is a button, not the whole card: Cancel sits inside, and
+    // a card-level key handler swallowed Enter before Cancel could act on it.
     <div
-      className={`bg-white rounded-lg shadow-sm p-3 hover:shadow-md transition-shadow cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${className}`}
-      onClick={handleClick}
-      onKeyDown={handleKeyDown}
-      role="button"
-      tabIndex={0}
+      className={`bg-white rounded-lg shadow-sm p-3 hover:shadow-md transition-shadow ${className}`}
     >
       <div className="flex items-center gap-3">
-        <AssetIcon asset={baseAsset} size="md" />
-        <div className="flex-1 min-w-0">
-          <div className="font-medium text-gray-900 text-sm truncate">
-            {baseDisplay}/{quoteAsset}
+        <button
+          type="button"
+          onClick={handleClick}
+          className="flex flex-1 min-w-0 items-center gap-3 text-left cursor-pointer rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+        >
+          <AssetIcon asset={baseAsset} size="md" />
+          <div className="flex-1 min-w-0">
+            <div className="font-medium text-gray-900 text-sm truncate">
+              {baseDisplay}/{quoteAsset}
+            </div>
+            <div className="text-xs text-gray-500">
+              <span className={isBuy ? "text-green-600 font-medium" : "text-red-600 font-medium"}>
+                {isBuy ? "Buy" : "Sell"}
+              </span>
+              {" "}{formatAmount({ value: remainingAmount, maximumFractionDigits: 2 })} remaining
+            </div>
           </div>
-          <div className="text-xs text-gray-500">
-            <span className={isBuy ? "text-green-600 font-medium" : "text-red-600 font-medium"}>
-              {isBuy ? "Buy" : "Sell"}
-            </span>
-            {" "}{formatAmount({ value: remainingAmount, maximumFractionDigits: 2 })} remaining
-          </div>
-        </div>
+        </button>
         {isOpen ? (
           <button type="button"
             onClick={handleCancel}

--- a/src/components/ui/cards/pool-card.tsx
+++ b/src/components/ui/cards/pool-card.tsx
@@ -1,4 +1,4 @@
-import type { KeyboardEvent, ReactElement } from "react";
+import type { ReactElement } from "react";
 import { AssetIcon } from "@/components/domain/asset/asset-icon";
 import type { Pool, PoolPosition } from "@/core/counterparty/api";
 import { getCanonicalPoolAssets } from "@/core/counterparty/pool";
@@ -35,20 +35,10 @@ export function PoolCard({
   const quantity =
     "quantity" in pool ? ((pool.quantity_normalized ?? pool.quantity) as string | number) : null;
 
-  const handleKeyDown = (event: KeyboardEvent) => {
-    if (event.key === "Enter" || event.key === " ") {
-      event.preventDefault();
-      onClick();
-    }
-  };
-
   return (
-    <div
-      className={`bg-white rounded-lg shadow-sm p-3 hover:shadow-md transition-shadow cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${className}`}
+    <button type="button"
+      className={`block w-full text-left bg-white rounded-lg shadow-sm p-3 hover:shadow-md transition-shadow cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${className}`}
       onClick={onClick}
-      onKeyDown={handleKeyDown}
-      role="button"
-      tabIndex={0}
     >
       <div className="flex items-center gap-3">
         {/* Overlapping pair icons: solid white backing keeps transparent icon art
@@ -92,6 +82,6 @@ export function PoolCard({
           </div>
         </div>
       </div>
-    </div>
+    </button>
   );
 }

--- a/src/components/ui/copyable-stat.tsx
+++ b/src/components/ui/copyable-stat.tsx
@@ -20,26 +20,17 @@ export function CopyableStat({
   onCopy,
   isCopied,
 }: CopyableStatProps): ReactElement {
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      onCopy(rawValue);
-    }
-  };
-
   return (
     <div>
       <span className="text-gray-500">{label}</span>
       <div className="flex items-center gap-2">
-        <div
+        <button
+          type="button"
           onClick={() => onCopy(rawValue)}
-          onKeyDown={handleKeyDown}
-          role="button"
-          tabIndex={0}
-          className={`font-medium text-gray-900 truncate cursor-pointer rounded px-1 -mx-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${isCopied ? "bg-gray-200" : ""}`}
+          className={`text-left font-medium text-gray-900 truncate cursor-pointer rounded px-1 -mx-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${isCopied ? "bg-gray-200" : ""}`}
         >
           <span>{value}</span>
-        </div>
+        </button>
         {isCopied && <FaCheck className="size-3 text-green-500 flex-shrink-0" aria-hidden="true" />}
       </div>
     </div>

--- a/src/components/ui/lists/action-list.test.tsx
+++ b/src/components/ui/lists/action-list.test.tsx
@@ -6,7 +6,8 @@ import { ActionList, type ActionSection } from './action-list';
 // Mock the ActionCard component
 vi.mock('@/components/ui/cards/action-card', () => ({
   ActionCard: ({ title, description, onClick, icon, showChevron, className, ariaLabel }: any) => (
-    <div
+    <button
+      type="button"
       data-testid={`action-card-${title}`}
       className={`action-card ${className || ''}`}
       onClick={onClick}
@@ -16,7 +17,7 @@ vi.mock('@/components/ui/cards/action-card', () => ({
       {description && <div className="description">{description}</div>}
       {icon && <div className="icon">{icon}</div>}
       {showChevron !== false && <div className="chevron">→</div>}
-    </div>
+    </button>
   )
 }));
 

--- a/src/components/ui/lists/address-list.test.tsx
+++ b/src/components/ui/lists/address-list.test.tsx
@@ -123,6 +123,40 @@ describe('AddressList', () => {
     expect(onSelectAddress).toHaveBeenCalledWith(mockAddresses[0]);
   });
 
+  it('should call onSelectAddress when the already-selected address is confirmed by keyboard', () => {
+    const onSelectAddress = vi.fn();
+    render(
+      <AddressList
+        {...defaultProps}
+        selectedAddress={mockAddresses[0]}
+        onSelectAddress={onSelectAddress}
+      />
+    );
+
+    // The radio group itself ignores this key, because the value would not change.
+    const address1 = screen.getByText('Address 1').closest('div[role="radio"]');
+    fireEvent.keyDown(address1!, { key: 'Enter' });
+
+    expect(onSelectAddress).toHaveBeenCalledWith(mockAddresses[0]);
+  });
+
+  it('should call onSelectAddress once when a different address is confirmed by keyboard', () => {
+    const onSelectAddress = vi.fn();
+    render(
+      <AddressList
+        {...defaultProps}
+        selectedAddress={mockAddresses[0]}
+        onSelectAddress={onSelectAddress}
+      />
+    );
+
+    const address2 = screen.getByText('Address 2').closest('div[role="radio"]');
+    fireEvent.keyDown(address2!, { key: ' ' });
+
+    expect(onSelectAddress).toHaveBeenCalledTimes(1);
+    expect(onSelectAddress).toHaveBeenCalledWith(mockAddresses[1]);
+  });
+
   it('should copy address to clipboard when copy button clicked', async () => {
     render(<AddressList {...defaultProps} />);
     

--- a/src/components/ui/lists/address-list.tsx
+++ b/src/components/ui/lists/address-list.tsx
@@ -36,6 +36,18 @@ export const AddressList = ({ addresses, selectedAddress, onSelectAddress, walle
     }
   };
 
+  // The radio group ignores a keypress on the option that is already checked, so
+  // re-selecting the current address — how these screens confirm and move on — is
+  // otherwise unreachable from the keyboard. Handle it here, on the focusable
+  // element, and stop the group from acting on the same key twice.
+  const handleAddressKeyDown = (e: React.KeyboardEvent, address: Address) => {
+    if (e.key !== 'Enter' && e.key !== ' ') return;
+
+    e.preventDefault();
+    e.stopPropagation();
+    onSelectAddress(address);
+  };
+
   return (
     <RadioGroup
       // Use the address string as the value
@@ -54,11 +66,12 @@ export const AddressList = ({ addresses, selectedAddress, onSelectAddress, walle
           key={address.path}
           // Set each option's value to the unique address string
           value={address.address}
+          onClick={(e: React.MouseEvent) => handleAddressClick(e, address)}
+          onKeyDown={(e: React.KeyboardEvent) => handleAddressKeyDown(e, address)}
           className="focus-visible:outline-none"
         >
           {({ checked }) => (
             <div
-              onClick={(e) => handleAddressClick(e, address)}
               className={`
                 relative w-full rounded transition-colors duration-300 p-4 cursor-pointer
                 ${checked

--- a/src/components/ui/lists/dispenser-list.test.tsx
+++ b/src/components/ui/lists/dispenser-list.test.tsx
@@ -6,7 +6,8 @@ import { DispenserList, type DispenserOption } from './dispenser-list';
 // Mock the DispenserCard component
 vi.mock('@/components/domain/dispenser/dispenser-card', () => ({
   DispenserCard: ({ option, isSelected, onSelect, disabled }: any) => (
-    <div
+    <button
+      type="button"
       data-testid={`dispenser-card-${option.index}`}
       className={`dispenser-card ${isSelected ? 'selected' : ''} ${disabled ? 'disabled' : ''}`}
       onClick={onSelect}
@@ -14,7 +15,7 @@ vi.mock('@/components/domain/dispenser/dispenser-card', () => ({
       <div className="asset">{option.dispenser.asset}</div>
       <div className="btc-amount">{option.btcAmount} BTC</div>
       <div className="selected-state">{isSelected ? 'Selected' : 'Not Selected'}</div>
-    </div>
+    </button>
   )
 }));
 

--- a/src/components/ui/menus/address-menu.test.tsx
+++ b/src/components/ui/menus/address-menu.test.tsx
@@ -135,7 +135,7 @@ describe('AddressMenu', () => {
     const mockOnClick = vi.fn();
     
     render(
-      <div onClick={mockOnClick}>
+      <div role="presentation" onClick={mockOnClick}>
         <MemoryRouter>
           <AddressMenu 
             address={mockAddress}

--- a/src/entrypoints/sidepanel/index.html
+++ b/src/entrypoints/sidepanel/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="h-full">
+<html lang="en" class="h-full">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/src/pages/actions/index.tsx
+++ b/src/pages/actions/index.tsx
@@ -177,13 +177,13 @@ export default function ActionsPage(): ReactElement {
   }, [setHeaderProps, navigate, lockKeychain]);
 
   return (
-    <div className="flex flex-col h-full" role="main" aria-labelledby="actions-title">
+    <section className="flex flex-col h-full" aria-labelledby="actions-title">
       <h2 id="actions-title" className="sr-only">
         Wallet Actions
       </h2>
       <div className="flex-1 overflow-auto no-scrollbar p-4">
         <ActionList sections={actionSections} />
       </div>
-    </div>
+    </section>
   );
 }

--- a/src/pages/addresses/details.tsx
+++ b/src/pages/addresses/details.tsx
@@ -120,7 +120,9 @@ function CopyAddress({ address }: CopyAddressProps): ReactElement {
       <div className="w-full text-center">
         <button type="button"
           onClick={handleCopyAddress}
-          aria-label="Copy address"
+          // Distinct from the button below, which copies the same thing: two
+          // controls sharing one accessible name is ambiguous to announce.
+          aria-label="Copy the address shown here"
           className="block w-full font-mono text-sm bg-white border border-gray-200 rounded-lg p-4 break-all text-gray-800 select-all cursor-pointer hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 transition-colors duration-200"
         >
           {address}

--- a/src/pages/addresses/details.tsx
+++ b/src/pages/addresses/details.tsx
@@ -68,9 +68,8 @@ export default function AddressDetailsPage(): ReactElement {
   })();
 
   return (
-    <div
+    <section
       className="flex flex-col items-center p-4 space-y-4"
-      role="main"
       aria-labelledby="view-address-title"
     >
       <div id="view-address-title" className="text-center font-medium text-gray-600">
@@ -78,7 +77,7 @@ export default function AddressDetailsPage(): ReactElement {
       </div>
       <QRCode text={activeAddress?.address} ariaLabel="Address QR Code" />
       <CopyAddress address={activeAddress?.address} />
-    </div>
+    </section>
   );
 }
 

--- a/src/pages/addresses/details.tsx
+++ b/src/pages/addresses/details.tsx
@@ -115,29 +115,16 @@ function CopyAddress({ address }: CopyAddressProps): ReactElement {
     }
   };
 
-  /**
-   * Handles keyboard events for copying the address.
-   */
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
-    if (event.key === "Enter" || event.key === " ") {
-      event.preventDefault();
-      handleCopyAddress();
-    }
-  };
-
   return (
     <>
       <div className="w-full text-center">
-        <div
+        <button type="button"
           onClick={handleCopyAddress}
-          onKeyDown={handleKeyDown}
-          role="button"
-          tabIndex={0}
           aria-label="Copy address"
-          className="font-mono text-sm bg-white border border-gray-200 rounded-lg p-4 break-all text-gray-800 select-all cursor-pointer hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 transition-colors duration-200"
+          className="block w-full font-mono text-sm bg-white border border-gray-200 rounded-lg p-4 break-all text-gray-800 select-all cursor-pointer hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 transition-colors duration-200"
         >
           {address}
-        </div>
+        </button>
       </div>
       <Button
         onClick={handleCopyAddress}

--- a/src/pages/addresses/history.tsx
+++ b/src/pages/addresses/history.tsx
@@ -166,7 +166,7 @@ export default function AddressHistoryPage(): ReactElement {
   if (error) return <ErrorAlert message={error} onClose={() => setError(null)} />;
 
   return (
-    <div className="flex flex-col h-full" role="main" aria-labelledby="history-title">
+    <section className="flex flex-col h-full" aria-labelledby="history-title">
       <div className="flex-1 overflow-auto no-scrollbar p-4">
         {transactions.length > 0 ? (
           <div className="space-y-4">
@@ -197,6 +197,6 @@ export default function AddressHistoryPage(): ReactElement {
         )}
       </div>
       {transactions.length > 0 && totalPages > 1 && <div className="p-4">{renderPagination()}</div>}
-    </div>
+    </section>
   );
 }

--- a/src/pages/addresses/index.tsx
+++ b/src/pages/addresses/index.tsx
@@ -104,7 +104,7 @@ export default function AddressesPage(): ReactElement {
   if (!activeWallet) return <div className="p-4">No active wallet found</div>;
 
   return (
-    <div className="flex flex-col h-full" role="main" aria-labelledby="address-selection-title">
+    <section className="flex flex-col h-full" aria-labelledby="address-selection-title">
       <div className="flex-grow overflow-y-auto p-4">
         {error && <ErrorAlert message={error} onClose={() => setError(null)} />}
         <h2 id="address-selection-title" className="sr-only">Select an Address</h2>
@@ -133,6 +133,6 @@ export default function AddressesPage(): ReactElement {
           {isAddingAddress ? "Adding…" : keychainLocked ? "Unlock to Add Address" : "Add Address"}
         </Button>
       </div>
-    </div>
+    </section>
   );
 }

--- a/src/pages/assets/[asset]/balance.tsx
+++ b/src/pages/assets/[asset]/balance.tsx
@@ -199,7 +199,7 @@ export default function AssetBalancePage(): ReactElement {
   })();
 
   return (
-    <div className="p-4 space-y-6" role="main" aria-labelledby="balance-title">
+    <section className="p-4 space-y-6" aria-labelledby="balance-title">
       <BalanceHeader balance={balanceData} className="mt-1 mb-5" />
       {poolDetails && (
         <div className="bg-white rounded-lg p-4 shadow-sm">
@@ -233,6 +233,6 @@ export default function AssetBalancePage(): ReactElement {
         </div>
       )}
       <ActionList sections={getActionSections()} />
-    </div>
+    </section>
   );
 }

--- a/src/pages/assets/[asset]/index.tsx
+++ b/src/pages/assets/[asset]/index.tsx
@@ -334,13 +334,10 @@ export default function AssetPage(): ReactElement {
             ) : (
               <div className="p-4 space-y-3">
                 {dividends.map((dividend) => (
-                  <div
+                  <button type="button"
                     key={dividend.tx_hash}
                     onClick={() => navigate(`/transaction/${dividend.tx_hash}`)}
-                    onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); navigate(`/transaction/${dividend.tx_hash}`); } }}
-                    className="border border-gray-200 rounded-lg p-3 hover:bg-gray-50 cursor-pointer transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
-                    role="button"
-                    tabIndex={0}
+                    className="block w-full text-left border border-gray-200 rounded-lg p-3 hover:bg-gray-50 cursor-pointer transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                     aria-label={`View dividend transaction ${dividend.tx_hash}`}
                   >
                     <div className="flex justify-between items-start mb-2">
@@ -367,7 +364,7 @@ export default function AssetPage(): ReactElement {
                     <div className="text-xs text-gray-400 break-all">
                       TX: {dividend.tx_hash}
                     </div>
-                  </div>
+                  </button>
                 ))}
                 
                 {hasMoreDividends && (

--- a/src/pages/assets/[asset]/index.tsx
+++ b/src/pages/assets/[asset]/index.tsx
@@ -255,7 +255,7 @@ export default function AssetPage(): ReactElement {
   }
 
   return (
-    <div className="p-4 space-y-6" role="main" aria-labelledby="asset-title">
+    <section className="p-4 space-y-6" aria-labelledby="asset-title">
       <AssetHeader
         className="mt-1 mb-5"
         assetInfo={headerAssetInfo}
@@ -387,6 +387,6 @@ export default function AssetPage(): ReactElement {
           </div>
         )}
       </div>
-    </div>
+    </section>
   );
 }

--- a/src/pages/assets/index.tsx
+++ b/src/pages/assets/index.tsx
@@ -245,9 +245,8 @@ export default function AssetsPage(): ReactElement {
   };
 
   return (
-    <div
+    <section
       className="h-full flex flex-col"
-      role="main"
       aria-labelledby="select-assets-title"
     >
       <div className="flex-shrink-0 p-4">
@@ -357,6 +356,6 @@ export default function AssetsPage(): ReactElement {
           </div>
         )}
       </div>
-    </div>
+    </section>
   );
 }

--- a/src/pages/assets/utxos/[txHash].tsx
+++ b/src/pages/assets/utxos/[txHash].tsx
@@ -138,7 +138,7 @@ export default function UtxoPage(): ReactElement {
   if (error) return <ErrorAlert message={error} onClose={() => setError(null)} />;
 
   return (
-    <div className="p-4 space-y-6" role="main" aria-labelledby="utxo-title">
+    <section className="p-4 space-y-6" aria-labelledby="utxo-title">
       {activeAddress && (
         <AddressHeader
           address={activeAddress.address}
@@ -200,6 +200,6 @@ export default function UtxoPage(): ReactElement {
         )}
       </div>
       <ActionList sections={getActionSections()} />
-    </div>
+    </section>
   );
 }

--- a/src/pages/compose/utxo/detach/form.tsx
+++ b/src/pages/compose/utxo/detach/form.tsx
@@ -94,17 +94,9 @@ export function UtxoDetachForm({
           {(initialUtxo || initialFormData?.sourceUtxo) && (
             <div>
               <span className="block text-sm font-medium text-gray-700">Output <span className="text-red-500">*</span></span>
-              <div
+              <button type="button"
                 onClick={() => navigate(`/assets/utxos/${initialUtxo || initialFormData?.sourceUtxo}`)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' || e.key === ' ') {
-                    e.preventDefault();
-                    navigate(`/assets/utxos/${initialUtxo || initialFormData?.sourceUtxo}`);
-                  }
-                }}
-                className="mt-1 block w-full p-2.5 rounded-md border border-gray-300 bg-gray-50 hover:bg-gray-100 cursor-pointer flex justify-between items-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
-                role="button"
-                tabIndex={0}
+                className="text-left mt-1 block w-full p-2.5 rounded-md border border-gray-300 bg-gray-50 hover:bg-gray-100 cursor-pointer flex justify-between items-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
               >
                 <span className="text-sm font-mono text-blue-600 hover:text-blue-800">
                   {formatTxid(initialUtxo || initialFormData?.sourceUtxo || '')}
@@ -119,7 +111,7 @@ export function UtxoDetachForm({
                     `${utxoBalances.length} ${utxoBalances.length === 1 ? 'Balance' : 'Balances'}`
                   )}
                 </span>
-              </div>
+              </button>
             </div>
           )}
           

--- a/src/pages/compose/utxo/detach/form.tsx
+++ b/src/pages/compose/utxo/detach/form.tsx
@@ -93,7 +93,7 @@ export function UtxoDetachForm({
           {/* UTXO Display - styled like an input */}
           {(initialUtxo || initialFormData?.sourceUtxo) && (
             <div>
-              <label className="text-sm font-medium text-gray-700">Output <span className="text-red-500">*</span></label>
+              <span className="block text-sm font-medium text-gray-700">Output <span className="text-red-500">*</span></span>
               <div
                 onClick={() => navigate(`/assets/utxos/${initialUtxo || initialFormData?.sourceUtxo}`)}
                 onKeyDown={(e) => {

--- a/src/pages/compose/utxo/move/form.tsx
+++ b/src/pages/compose/utxo/move/form.tsx
@@ -90,7 +90,7 @@ export function UtxoMoveForm({
           {/* UTXO Display - styled like an input */}
           {(initialUtxo || initialFormData?.sourceUtxo) && (
             <div>
-              <label className="text-sm font-medium text-gray-700">Output <span className="text-red-500">*</span></label>
+              <span className="block text-sm font-medium text-gray-700">Output <span className="text-red-500">*</span></span>
               <div
                 onClick={() => navigate(`/assets/utxos/${initialUtxo || initialFormData?.sourceUtxo}`)}
                 onKeyDown={(e) => {

--- a/src/pages/compose/utxo/move/form.tsx
+++ b/src/pages/compose/utxo/move/form.tsx
@@ -91,17 +91,9 @@ export function UtxoMoveForm({
           {(initialUtxo || initialFormData?.sourceUtxo) && (
             <div>
               <span className="block text-sm font-medium text-gray-700">Output <span className="text-red-500">*</span></span>
-              <div
+              <button type="button"
                 onClick={() => navigate(`/assets/utxos/${initialUtxo || initialFormData?.sourceUtxo}`)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' || e.key === ' ') {
-                    e.preventDefault();
-                    navigate(`/assets/utxos/${initialUtxo || initialFormData?.sourceUtxo}`);
-                  }
-                }}
-                className="mt-1 block w-full p-2.5 rounded-md border border-gray-300 bg-gray-50 hover:bg-gray-100 cursor-pointer flex justify-between items-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
-                role="button"
-                tabIndex={0}
+                className="text-left mt-1 block w-full p-2.5 rounded-md border border-gray-300 bg-gray-50 hover:bg-gray-100 cursor-pointer flex justify-between items-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
               >
                 <span className="text-sm font-mono text-blue-600 hover:text-blue-800">
                   {formatTxid(initialUtxo || initialFormData?.sourceUtxo || '')}
@@ -116,7 +108,7 @@ export function UtxoMoveForm({
                     `${utxoBalances.length} ${utxoBalances.length === 1 ? 'Balance' : 'Balances'}`
                   )}
                 </span>
-              </div>
+              </button>
             </div>
           )}
           

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -246,7 +246,7 @@ export default function HomePage(): ReactElement {
   );
 
   return (
-    <div className="flex flex-col h-full" role="main" aria-labelledby="index-title">
+    <section className="flex flex-col h-full" aria-labelledby="index-title">
       <h2 id="index-title" className="sr-only">Wallet Dashboard</h2>
       <div className="flex flex-col flex-grow min-h-0">
         <div className="p-4 pb-0 flex-shrink-0">
@@ -264,6 +264,6 @@ export default function HomePage(): ReactElement {
           </div>
         )}
       </div>
-    </div>
+    </section>
   );
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -121,44 +121,34 @@ export default function HomePage(): ReactElement {
     // button, and saying so is what lets the keyboard reach it. The classes below are the branch
     // that always won, so this renders identically.
     return (
-      <div
-        className="relative w-full rounded p-4 cursor-pointer bg-blue-600 text-white shadow-md"
-        onClick={handleCopyAddress}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            handleCopyAddress();
-          }
-        }}
-        role="button"
-        tabIndex={0}
-        aria-label="Current address"
-      >
+      // Copying and choosing another address are two buttons side by side, not one
+      // inside the other. Neither needs to guard the other's keypresses.
+      <div className="relative w-full rounded bg-blue-600 text-white shadow-md">
+        <button
+          type="button"
+          className="block w-full rounded p-4 cursor-pointer text-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
+          onClick={handleCopyAddress}
+          aria-label="Current address"
+        >
+          <div className="text-sm mb-1 font-medium">{activeAddress.name}</div>
+          <div className="flex justify-center items-center">
+            <span className="font-mono text-sm">{formatAddress(activeAddress.address)}</span>
+            {copiedToClipboard ? (
+              <FaCheck className="ml-2 text-green-500" aria-hidden="true" />
+            ) : (
+              <FaClipboard className="ml-2" aria-hidden="true" />
+            )}
+          </div>
+        </button>
         <div className="absolute top-1/2 right-4 -translate-y-1/2">
           <button
             type="button"
             className="block py-6 px-3 -m-2 cursor-pointer hover:bg-white/5 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
             onClick={handleAddressSelection}
-            // The button activates itself on Enter and Space; this only keeps the
-            // keypress from reaching the surrounding card, which copies the address.
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' || e.key === ' ') {
-                e.stopPropagation();
-              }
-            }}
             aria-label="Select another address"
           >
             <FaChevronRight className="size-4" aria-hidden="true" />
           </button>
-        </div>
-        <div className="text-sm mb-1 font-medium text-center">{activeAddress.name}</div>
-        <div className="flex justify-center items-center">
-          <span className="font-mono text-sm">{formatAddress(activeAddress.address)}</span>
-          {copiedToClipboard ? (
-            <FaCheck className="ml-2 text-green-500" aria-hidden="true" />
-          ) : (
-            <FaClipboard className="ml-2" aria-hidden="true" />
-          )}
         </div>
       </div>
     );

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,3 @@
-import { Radio, RadioGroup } from "@headlessui/react";
 import type { ReactElement } from "react";
 import { useEffect, useState } from "react";
 import { useLocation, useNavigate, useSearchParams } from "react-router";
@@ -117,48 +116,52 @@ export default function HomePage(): ReactElement {
 
   const renderCurrentAddress = (): ReactElement => {
     if (!activeAddress) return <div className="p-4">No address selected</div>;
+    // Not a RadioGroup: there was one option, its onChange did nothing, and `checked` was always
+    // true — it existed so the ternary would pick the selected styling. Copying the address is a
+    // button, and saying so is what lets the keyboard reach it. The classes below are the branch
+    // that always won, so this renders identically.
     return (
-      <RadioGroup value={activeAddress} onChange={() => {}}>
-        <Radio value={activeAddress}>
-          {({ checked }) => (
-            <div
-              className={`relative w-full rounded p-4 cursor-pointer ${
-                checked ? "bg-blue-600 text-white shadow-md" : "bg-blue-200 hover:bg-blue-300 text-gray-800"
-              }`}
-              onClick={handleCopyAddress}
-              aria-label="Current address"
-            >
-              <div className="absolute top-1/2 right-4 -translate-y-1/2">
-                <div
-                  className="py-6 px-3 -m-2 cursor-pointer hover:bg-white/5 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
-                  onClick={handleAddressSelection}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      handleAddressSelection(e as unknown as React.MouseEvent);
-                    }
-                  }}
-                  role="button"
-                  tabIndex={0}
-                  aria-label="Select another address"
-                >
-                  <FaChevronRight className="size-4" aria-hidden="true" />
-                </div>
-              </div>
-              <div className="text-sm mb-1 font-medium text-center">{activeAddress.name}</div>
-              <div className="flex justify-center items-center">
-                <span className="font-mono text-sm">{formatAddress(activeAddress.address)}</span>
-                {copiedToClipboard ? (
-                  <FaCheck className="ml-2 text-green-500" aria-hidden="true" />
-                ) : (
-                  <FaClipboard className="ml-2" aria-hidden="true" />
-                )}
-              </div>
-            </div>
+      <div
+        className="relative w-full rounded p-4 cursor-pointer bg-blue-600 text-white shadow-md"
+        onClick={handleCopyAddress}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            handleCopyAddress();
+          }
+        }}
+        role="button"
+        tabIndex={0}
+        aria-label="Current address"
+      >
+        <div className="absolute top-1/2 right-4 -translate-y-1/2">
+          <div
+            className="py-6 px-3 -m-2 cursor-pointer hover:bg-white/5 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
+            onClick={handleAddressSelection}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                e.stopPropagation();
+                handleAddressSelection(e as unknown as React.MouseEvent);
+              }
+            }}
+            role="button"
+            tabIndex={0}
+            aria-label="Select another address"
+          >
+            <FaChevronRight className="size-4" aria-hidden="true" />
+          </div>
+        </div>
+        <div className="text-sm mb-1 font-medium text-center">{activeAddress.name}</div>
+        <div className="flex justify-center items-center">
+          <span className="font-mono text-sm">{formatAddress(activeAddress.address)}</span>
+          {copiedToClipboard ? (
+            <FaCheck className="ml-2 text-green-500" aria-hidden="true" />
+          ) : (
+            <FaClipboard className="ml-2" aria-hidden="true" />
           )}
-        </Radio>
-      </RadioGroup>
+        </div>
+      </div>
     );
   };
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -135,22 +135,21 @@ export default function HomePage(): ReactElement {
         aria-label="Current address"
       >
         <div className="absolute top-1/2 right-4 -translate-y-1/2">
-          <div
-            className="py-6 px-3 -m-2 cursor-pointer hover:bg-white/5 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
+          <button
+            type="button"
+            className="block py-6 px-3 -m-2 cursor-pointer hover:bg-white/5 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
             onClick={handleAddressSelection}
+            // The button activates itself on Enter and Space; this only keeps the
+            // keypress from reaching the surrounding card, which copies the address.
             onKeyDown={(e) => {
               if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
                 e.stopPropagation();
-                handleAddressSelection(e as unknown as React.MouseEvent);
               }
             }}
-            role="button"
-            tabIndex={0}
             aria-label="Select another address"
           >
             <FaChevronRight className="size-4" aria-hidden="true" />
-          </div>
+          </button>
         </div>
         <div className="text-sm mb-1 font-medium text-center">{activeAddress.name}</div>
         <div className="flex justify-center items-center">

--- a/src/pages/keychain/onboarding.tsx
+++ b/src/pages/keychain/onboarding.tsx
@@ -35,7 +35,7 @@ function OnboardingPage() {
   }
 
   return (
-    <div className="flex flex-col h-full" role="main" aria-labelledby="onboarding-title">
+    <section className="flex flex-col h-full" aria-labelledby="onboarding-title">
       <div className="flex-grow flex items-center justify-center p-4">
         <div className="w-full max-w-md mx-auto bg-white rounded-lg shadow-md p-6 text-center">
           <h1
@@ -88,7 +88,7 @@ function OnboardingPage() {
         </a>
         .
       </div>
-    </div>
+    </section>
   );
 }
 

--- a/src/pages/keychain/secrets/show-passphrase.tsx
+++ b/src/pages/keychain/secrets/show-passphrase.tsx
@@ -80,7 +80,7 @@ export default function ShowPassphrasePage(): ReactElement {
   }
 
   return (
-    <div className="flex flex-col h-full p-4" role="main" aria-labelledby="show-passphrase-title">
+    <section className="flex flex-col h-full p-4" aria-labelledby="show-passphrase-title">
       <h2 id="show-passphrase-title" className="sr-only">Show Recovery Phrase</h2>
       {submissionError && <ErrorAlert message={submissionError} onClose={() => setSubmissionError("")} />}
       {!isConfirmed ? (
@@ -134,6 +134,6 @@ export default function ShowPassphrasePage(): ReactElement {
           </div>
         </div>
       )}
-    </div>
+    </section>
   );
 }

--- a/src/pages/keychain/secrets/show-private-key.tsx
+++ b/src/pages/keychain/secrets/show-private-key.tsx
@@ -142,7 +142,9 @@ export default function ShowPrivateKeyPage(): ReactElement {
             </div>
             <button type="button"
               onClick={handleCopyPrivateKey}
-              aria-label="Copy Private Key"
+              // Distinct from the button below, which copies the same thing: two
+              // controls sharing one accessible name is ambiguous to announce.
+              aria-label="Copy the private key shown here"
               className="block w-full text-left font-mono text-sm bg-white border border-gray-200 rounded-lg p-4 break-all text-gray-800 select-all cursor-pointer hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 transition-colors duration-200"
             >
               {privateKey}

--- a/src/pages/keychain/secrets/show-private-key.tsx
+++ b/src/pages/keychain/secrets/show-private-key.tsx
@@ -115,7 +115,7 @@ export default function ShowPrivateKeyPage(): ReactElement {
   };
 
   return (
-    <div className="flex flex-col h-full p-4" role="main" aria-labelledby="show-private-key-title">
+    <section className="flex flex-col h-full p-4" aria-labelledby="show-private-key-title">
       <h2 id="show-private-key-title" className="sr-only">Show Private Key</h2>
       {submissionError && <ErrorAlert message={submissionError} onClose={() => setSubmissionError("")} />}
       {!isConfirmed ? (
@@ -174,6 +174,6 @@ export default function ShowPrivateKeyPage(): ReactElement {
           </div>
         </div>
       )}
-    </div>
+    </section>
   );
 }

--- a/src/pages/keychain/secrets/show-private-key.tsx
+++ b/src/pages/keychain/secrets/show-private-key.tsx
@@ -107,13 +107,6 @@ export default function ShowPrivateKeyPage(): ReactElement {
     await copy(privateKey);
   };
 
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
-    if (event.key === "Enter" || event.key === " ") {
-      event.preventDefault();
-      handleCopyPrivateKey();
-    }
-  };
-
   return (
     <section className="flex flex-col h-full p-4" aria-labelledby="show-private-key-title">
       <h2 id="show-private-key-title" className="sr-only">Show Private Key</h2>
@@ -147,16 +140,13 @@ export default function ShowPrivateKeyPage(): ReactElement {
                 This is your private key in Wallet Import Format. Never share it with anyone.
               </p>
             </div>
-            <div
+            <button type="button"
               onClick={handleCopyPrivateKey}
-              onKeyDown={handleKeyDown}
-              role="button"
-              tabIndex={0}
               aria-label="Copy Private Key"
-              className="font-mono text-sm bg-white border border-gray-200 rounded-lg p-4 break-all text-gray-800 select-all cursor-pointer hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 transition-colors duration-200"
+              className="block w-full text-left font-mono text-sm bg-white border border-gray-200 rounded-lg p-4 break-all text-gray-800 select-all cursor-pointer hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 transition-colors duration-200"
             >
               {privateKey}
-            </div>
+            </button>
             <Button
               onClick={handleCopyPrivateKey}
               color="blue"

--- a/src/pages/keychain/setup/create-mnemonic.tsx
+++ b/src/pages/keychain/setup/create-mnemonic.tsx
@@ -149,18 +149,15 @@ function CreateMnemonicPage() {
               </ol>
             </div>
             {!isRecoveryPhraseVisible && (
-              <div
+              <button type="button"
                 className="absolute inset-0 flex flex-col items-center justify-center text-center p-4 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-inset rounded-md"
                 onClick={handleRevealPhrase}
-                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleRevealPhrase(); } }}
-                role="button"
-                tabIndex={0}
                 aria-label="Reveal recovery phrase"
               >
                 <FaEyeSlash className="size-6 mb-2" aria-hidden="true" />
                 <p className="mb-2 font-bold">View 12-word Secret Phrase</p>
                 <p>Make sure no one is looking!</p>
-              </div>
+              </button>
             )}
           </div>
           {isRecoveryPhraseVisible && (

--- a/src/pages/keychain/setup/create-mnemonic.tsx
+++ b/src/pages/keychain/setup/create-mnemonic.tsx
@@ -106,9 +106,8 @@ function CreateMnemonicPage() {
   }
 
   return (
-    <div
+    <section
       className="flex-grow overflow-y-auto p-4"
-      role="main"
       aria-labelledby="create-wallet-title"
     >
       <div className="w-full max-w-md mx-auto bg-white rounded-lg shadow-md p-6">
@@ -206,7 +205,7 @@ function CreateMnemonicPage() {
           Watch Tutorial: How to Create a Wallet
         </Button>
       )}
-    </div>
+    </section>
   );
 }
 

--- a/src/pages/keychain/setup/import-mnemonic.tsx
+++ b/src/pages/keychain/setup/import-mnemonic.tsx
@@ -185,7 +185,7 @@ function ImportMnemonicPage() {
           aria-describedby="import-instructions"
           onSubmit={(e) => { if (!canSubmit) e.preventDefault(); }}
         >
-          <div className="bg-gray-100 p-2 rounded-md mb-4" role="region" aria-label="Recovery phrase input">
+          <section className="bg-gray-100 p-2 rounded-md mb-4" aria-label="Recovery phrase input">
             <ol className="list-none p-0 m-0 grid grid-flow-col grid-cols-2 grid-rows-6 gap-2" aria-label="Recovery phrase words">
               {[...Array(12)].map((_, index) => {
                 const isFocused = focusedIndex === index;
@@ -230,7 +230,7 @@ function ImportMnemonicPage() {
                 );
               })}
             </ol>
-          </div>
+          </section>
           <CheckboxInput
             name="confirmed"
             label="I have saved my secret recovery phrase."

--- a/src/pages/keychain/setup/import-mnemonic.tsx
+++ b/src/pages/keychain/setup/import-mnemonic.tsx
@@ -172,7 +172,7 @@ function ImportMnemonicPage() {
   }
 
   return (
-    <div className="flex-grow overflow-y-auto p-4" role="main" aria-labelledby="import-wallet-title">
+    <section className="flex-grow overflow-y-auto p-4" aria-labelledby="import-wallet-title">
       <div className="w-full max-w-md mx-auto bg-white rounded-lg shadow-md p-6">
         {state.error && !errorDismissed && (
           <ErrorAlert message={state.error} onClose={() => setErrorDismissed(true)} />
@@ -266,7 +266,7 @@ function ImportMnemonicPage() {
           Watch Tutorial: How to Import a Wallet
         </Button>
       )}
-    </div>
+    </section>
   );
 }
 

--- a/src/pages/keychain/setup/import-private-key.tsx
+++ b/src/pages/keychain/setup/import-private-key.tsx
@@ -134,7 +134,7 @@ function ImportPrivateKeyPage() {
   }
 
   return (
-    <div className="flex-grow overflow-y-auto p-4" role="main" aria-labelledby="import-private-key-title">
+    <section className="flex-grow overflow-y-auto p-4" aria-labelledby="import-private-key-title">
       <div className="w-full max-w-md mx-auto bg-white rounded-lg shadow-md p-6">
         {state.error && !errorDismissed && (
           <ErrorAlert message={state.error} onClose={() => setErrorDismissed(true)} />
@@ -238,7 +238,7 @@ function ImportPrivateKeyPage() {
           Watch Tutorial: How to Import a Private Key
         </Button>
       )}
-    </div>
+    </section>
   );
 }
 

--- a/src/pages/keychain/setup/import-test-address.tsx
+++ b/src/pages/keychain/setup/import-test-address.tsx
@@ -88,6 +88,7 @@ function ImportTestAddressPage() {
                     }
                   }}
                   disabled={isLoading}
+                  // biome-ignore lint/a11y/noAutofocus: this screen redirects away unless NODE_ENV is development, so the focus grab never reaches a user
                   autoFocus
                 />
               </div>

--- a/src/pages/keychain/unlock.tsx
+++ b/src/pages/keychain/unlock.tsx
@@ -88,7 +88,7 @@ function UnlockPage() {
   }
 
   return (
-    <div className="flex flex-col h-full" role="main" aria-labelledby="unlock-wallet-title">
+    <section className="flex flex-col h-full" aria-labelledby="unlock-wallet-title">
       <div className="flex-grow flex items-center justify-center p-4">
         <div className="w-full max-w-md mx-auto bg-white rounded-lg shadow-md p-6">
           <h1 id="unlock-wallet-title" className="text-3xl mb-5 flex justify-between items-center">
@@ -123,7 +123,7 @@ function UnlockPage() {
           </form>
         </div>
       </div>
-    </div>
+    </section>
   );
 }
 

--- a/src/pages/keychain/wallets/add.tsx
+++ b/src/pages/keychain/wallets/add.tsx
@@ -99,7 +99,7 @@ function AddWalletPage() {
   }, [removeWallet, hardwareWallet, navigate]);
 
   return (
-    <div className="flex flex-col h-full" role="main" aria-labelledby="add-wallet-title">
+    <section className="flex flex-col h-full" aria-labelledby="add-wallet-title">
       <div className="flex-grow flex items-center justify-center p-4">
         <div className="w-full max-w-md mx-auto bg-white rounded-lg shadow-md p-6 text-center">
           <h2 id="add-wallet-title" className="text-2xl font-bold mb-6">
@@ -169,7 +169,7 @@ function AddWalletPage() {
           </div>
         </div>
       </div>
-    </div>
+    </section>
   );
 }
 

--- a/src/pages/keychain/wallets/index.tsx
+++ b/src/pages/keychain/wallets/index.tsx
@@ -71,9 +71,8 @@ function WalletsPage() {
   };
 
   return (
-    <div
+    <section
       className="flex flex-col h-full"
-      role="main"
       aria-labelledby="wallet-selection-title"
     >
       <div className="flex-grow overflow-y-auto p-4">
@@ -102,7 +101,7 @@ function WalletsPage() {
           Add Wallet
         </Button>
       </div>
-    </div>
+    </section>
   );
 }
 

--- a/src/pages/keychain/wallets/remove.tsx
+++ b/src/pages/keychain/wallets/remove.tsx
@@ -85,7 +85,7 @@ function RemoveWalletPage() {
   }
 
   return (
-    <div className="flex flex-col h-full p-4" role="main" aria-labelledby="remove-wallet-title">
+    <section className="flex flex-col h-full p-4" aria-labelledby="remove-wallet-title">
       <h2 id="remove-wallet-title" className="sr-only text-2xl font-bold mb-2">Remove Wallet</h2>
       {submissionError && <ErrorAlert message={submissionError} onClose={() => setSubmissionError("")} />}
       <form action={handleFormAction} className="flex flex-col items-center justify-center flex-grow" aria-describedby="remove-wallet-warning">
@@ -108,7 +108,7 @@ function RemoveWalletPage() {
           </Button>
         </div>
       </form>
-    </div>
+    </section>
   );
 }
 

--- a/src/pages/keychain/wallets/reset.tsx
+++ b/src/pages/keychain/wallets/reset.tsx
@@ -67,7 +67,7 @@ function ResetWalletPage() {
   }
 
   return (
-    <div className="flex flex-col h-full p-4" role="main" aria-labelledby="reset-wallet-title">
+    <section className="flex flex-col h-full p-4" aria-labelledby="reset-wallet-title">
       <h2 id="reset-wallet-title" className="sr-only text-2xl font-bold mb-2">Reset Wallet</h2>
       {submissionError && <ErrorAlert message={submissionError} onClose={() => setSubmissionError("")} />}
       <form action={handleFormAction} className="flex flex-col items-center justify-center flex-grow" aria-describedby="reset-wallet-warning">
@@ -90,7 +90,7 @@ function ResetWalletPage() {
           </Button>
         </div>
       </form>
-    </div>
+    </section>
   );
 }
 

--- a/src/pages/market/btc.tsx
+++ b/src/pages/market/btc.tsx
@@ -173,7 +173,7 @@ export default function BtcPricePage(): ReactElement {
   }
 
   return (
-    <div className="flex flex-col h-full" role="main">
+    <div className="flex flex-col h-full">
       <div className="flex-1 overflow-auto no-scrollbar p-4">
         {/* Price Stats Card */}
         <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4 mb-4">

--- a/src/pages/market/dispensers/[asset].tsx
+++ b/src/pages/market/dispensers/[asset].tsx
@@ -370,7 +370,7 @@ export default function AssetDispensersPage(): ReactElement {
   };
 
   return (
-    <div className="flex flex-col h-full" role="main">
+    <div className="flex flex-col h-full">
       <div className="flex flex-col flex-grow min-h-0">
         {/* Fixed Header */}
         <div className="p-4 pb-0 flex-shrink-0">

--- a/src/pages/market/index.tsx
+++ b/src/pages/market/index.tsx
@@ -330,22 +330,21 @@ export default function MarketPage(): ReactElement {
               aria-label="Current address"
             >
               <div className="absolute top-1/2 right-4 -translate-y-1/2">
-                <div
-                  className="py-6 px-3 -m-2 cursor-pointer hover:bg-white/5 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
+                <button
+                  type="button"
+                  className="block py-6 px-3 -m-2 cursor-pointer hover:bg-white/5 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
                   onClick={handleAddressSelection}
+                  // The button activates itself on Enter and Space; this only keeps the
+                  // keypress from reaching the surrounding card, which copies the address.
                   onKeyDown={(e) => {
                     if (e.key === 'Enter' || e.key === ' ') {
-                      e.preventDefault();
                       e.stopPropagation();
-                      handleAddressSelection(e as unknown as React.MouseEvent);
                     }
                   }}
-                  role="button"
-                  tabIndex={0}
                   aria-label="Select another address"
                 >
                   <FaChevronRight className="size-4" aria-hidden="true" />
-                </div>
+                </button>
               </div>
               <div className="text-sm mb-1 font-medium text-center">{activeAddress.name}</div>
               <div className="flex justify-center items-center">

--- a/src/pages/market/index.tsx
+++ b/src/pages/market/index.tsx
@@ -1,4 +1,3 @@
-import { Radio, RadioGroup } from "@headlessui/react";
 import type { ReactElement } from "react";
 import { useCallback, useEffect, useState } from "react";
 import { useLocation, useNavigate, useSearchParams } from "react-router";
@@ -313,47 +312,51 @@ export default function MarketPage(): ReactElement {
         <div className="p-4 pb-0 flex-shrink-0">
           {/* Address Selector */}
           {activeAddress && (
-            <RadioGroup value={activeAddress} onChange={() => {}} className="mb-4">
-              <Radio value={activeAddress}>
-                {({ checked }) => (
-                  <div
-                    className={`relative w-full rounded p-4 cursor-pointer ${
-                      checked ? "bg-blue-600 text-white shadow-md" : "bg-blue-200 hover:bg-blue-300 text-gray-800"
-                    }`}
-                    onClick={handleCopyAddress}
-                    aria-label="Current address"
-                  >
-                    <div className="absolute top-1/2 right-4 -translate-y-1/2">
-                      <div
-                        className="py-6 px-3 -m-2 cursor-pointer hover:bg-white/5 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
-                        onClick={handleAddressSelection}
-                        onKeyDown={(e) => {
-                          if (e.key === 'Enter' || e.key === ' ') {
-                            e.preventDefault();
-                            e.stopPropagation();
-                            handleAddressSelection(e as unknown as React.MouseEvent);
-                          }
-                        }}
-                        role="button"
-                        tabIndex={0}
-                        aria-label="Select another address"
-                      >
-                        <FaChevronRight className="size-4" aria-hidden="true" />
-                      </div>
-                    </div>
-                    <div className="text-sm mb-1 font-medium text-center">{activeAddress.name}</div>
-                    <div className="flex justify-center items-center">
-                      <span className="font-mono text-sm">{formatAddress(activeAddress.address)}</span>
-                      {addressCopied ? (
-                        <FaCheck className="ml-2 text-green-500" aria-hidden="true" />
-                      ) : (
-                        <FaClipboard className="ml-2" aria-hidden="true" />
-                      )}
-                    </div>
-                  </div>
+            // Not a RadioGroup: one option, an onChange that did nothing, and `checked` always
+            // true — it existed so the ternary would pick the selected styling. Copying the
+            // address is a button, and saying so is what lets the keyboard reach it. The classes
+            // are the branch that always won, so this renders identically.
+            <div
+              className="relative w-full rounded p-4 cursor-pointer bg-blue-600 text-white shadow-md mb-4"
+              onClick={handleCopyAddress}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  handleCopyAddress();
+                }
+              }}
+              role="button"
+              tabIndex={0}
+              aria-label="Current address"
+            >
+              <div className="absolute top-1/2 right-4 -translate-y-1/2">
+                <div
+                  className="py-6 px-3 -m-2 cursor-pointer hover:bg-white/5 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
+                  onClick={handleAddressSelection}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      handleAddressSelection(e as unknown as React.MouseEvent);
+                    }
+                  }}
+                  role="button"
+                  tabIndex={0}
+                  aria-label="Select another address"
+                >
+                  <FaChevronRight className="size-4" aria-hidden="true" />
+                </div>
+              </div>
+              <div className="text-sm mb-1 font-medium text-center">{activeAddress.name}</div>
+              <div className="flex justify-center items-center">
+                <span className="font-mono text-sm">{formatAddress(activeAddress.address)}</span>
+                {addressCopied ? (
+                  <FaCheck className="ml-2 text-green-500" aria-hidden="true" />
+                ) : (
+                  <FaClipboard className="ml-2" aria-hidden="true" />
                 )}
-              </Radio>
-            </RadioGroup>
+              </div>
+            </div>
           )}
 
           <PriceTicker

--- a/src/pages/market/index.tsx
+++ b/src/pages/market/index.tsx
@@ -306,7 +306,7 @@ export default function MarketPage(): ReactElement {
   const isSearching = searchQuery.trim().length > 0;
 
   return (
-    <div className="flex flex-col h-full" role="main">
+    <div className="flex flex-col h-full">
       <div className="flex flex-col flex-grow min-h-0">
         {/* Fixed Header */}
         <div className="p-4 pb-0 flex-shrink-0">

--- a/src/pages/market/index.tsx
+++ b/src/pages/market/index.tsx
@@ -316,44 +316,34 @@ export default function MarketPage(): ReactElement {
             // true — it existed so the ternary would pick the selected styling. Copying the
             // address is a button, and saying so is what lets the keyboard reach it. The classes
             // are the branch that always won, so this renders identically.
-            <div
-              className="relative w-full rounded p-4 cursor-pointer bg-blue-600 text-white shadow-md mb-4"
-              onClick={handleCopyAddress}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault();
-                  handleCopyAddress();
-                }
-              }}
-              role="button"
-              tabIndex={0}
-              aria-label="Current address"
-            >
+            // Copying and choosing another address are two buttons side by side, not
+            // one inside the other. Neither needs to guard the other's keypresses.
+            <div className="relative w-full rounded bg-blue-600 text-white shadow-md mb-4">
+              <button
+                type="button"
+                className="block w-full rounded p-4 cursor-pointer text-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
+                onClick={handleCopyAddress}
+                aria-label="Current address"
+              >
+                <div className="text-sm mb-1 font-medium">{activeAddress.name}</div>
+                <div className="flex justify-center items-center">
+                  <span className="font-mono text-sm">{formatAddress(activeAddress.address)}</span>
+                  {addressCopied ? (
+                    <FaCheck className="ml-2 text-green-500" aria-hidden="true" />
+                  ) : (
+                    <FaClipboard className="ml-2" aria-hidden="true" />
+                  )}
+                </div>
+              </button>
               <div className="absolute top-1/2 right-4 -translate-y-1/2">
                 <button
                   type="button"
                   className="block py-6 px-3 -m-2 cursor-pointer hover:bg-white/5 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
                   onClick={handleAddressSelection}
-                  // The button activates itself on Enter and Space; this only keeps the
-                  // keypress from reaching the surrounding card, which copies the address.
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      e.stopPropagation();
-                    }
-                  }}
                   aria-label="Select another address"
                 >
                   <FaChevronRight className="size-4" aria-hidden="true" />
                 </button>
-              </div>
-              <div className="text-sm mb-1 font-medium text-center">{activeAddress.name}</div>
-              <div className="flex justify-center items-center">
-                <span className="font-mono text-sm">{formatAddress(activeAddress.address)}</span>
-                {addressCopied ? (
-                  <FaCheck className="ml-2 text-green-500" aria-hidden="true" />
-                ) : (
-                  <FaClipboard className="ml-2" aria-hidden="true" />
-                )}
               </div>
             </div>
           )}

--- a/src/pages/market/orders/[baseAsset]/[quoteAsset].tsx
+++ b/src/pages/market/orders/[baseAsset]/[quoteAsset].tsx
@@ -408,7 +408,7 @@ export default function AssetOrdersPage(): ReactElement {
   const isFetching = tab === "history" && isFetchingMoreMatches;
 
   return (
-    <div className="flex flex-col h-full" role="main">
+    <div className="flex flex-col h-full">
       <div className="flex flex-col flex-grow min-h-0">
         {/* Fixed Header */}
         <div className="p-4 pb-0 flex-shrink-0">

--- a/src/pages/market/xcp.tsx
+++ b/src/pages/market/xcp.tsx
@@ -162,7 +162,7 @@ export default function XcpPricePage(): ReactElement {
   }
 
   return (
-    <div className="flex flex-col h-full" role="main">
+    <div className="flex flex-col h-full">
       <div className="flex-1 overflow-auto no-scrollbar p-4">
         {/* Price Stats Card */}
         <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4 mb-4">

--- a/src/pages/pools/[assetA]/[assetB].tsx
+++ b/src/pages/pools/[assetA]/[assetB].tsx
@@ -50,7 +50,7 @@ export default function PoolPage(): ReactElement {
 
   if (!pool) {
     return (
-      <div className="p-4 space-y-4" role="main" aria-label={pair}>
+      <section className="p-4 space-y-4" aria-label={pair}>
         <div className="rounded border border-gray-200 bg-white p-4">
           <div className="text-xs font-medium uppercase text-gray-500">Pool</div>
           <div className="mt-1 text-lg font-semibold text-gray-900">{pair}</div>
@@ -66,7 +66,7 @@ export default function PoolPage(): ReactElement {
             Enter Pool
           </Button>
         </div>
-      </div>
+      </section>
     );
   }
 

--- a/src/pages/pools/pool-overview.tsx
+++ b/src/pages/pools/pool-overview.tsx
@@ -48,7 +48,7 @@ export function PoolOverview({ pool, position }: PoolOverviewProps): ReactElemen
     : null;
 
   return (
-    <div className="p-4 space-y-6" role="main" aria-label={pair}>
+    <section className="p-4 space-y-6" aria-label={pair}>
       <section className="space-y-5">
         <PoolHeader pool={pool} className="mt-1 mb-5" />
 
@@ -142,6 +142,6 @@ export function PoolOverview({ pool, position }: PoolOverviewProps): ReactElemen
           },
         ]}
       />
-    </div>
+    </section>
   );
 }

--- a/src/pages/settings/address-types.tsx
+++ b/src/pages/settings/address-types.tsx
@@ -161,7 +161,7 @@ export default function AddressTypesPage(): ReactElement {
   const isHardwareWallet = activeWallet.type === 'hardware';
 
   return (
-    <div className="space-y-2 p-4" role="main" aria-labelledby="address-type-settings-title">
+    <section className="space-y-2 p-4" aria-labelledby="address-type-settings-title">
       <h2 id="address-type-settings-title" className="sr-only">
         Address Type Settings
       </h2>
@@ -217,6 +217,6 @@ export default function AddressTypesPage(): ReactElement {
           })}
         </SelectionCardGroup>
       </RadioGroup>
-    </div>
+    </section>
   );
 }

--- a/src/pages/settings/advanced.tsx
+++ b/src/pages/settings/advanced.tsx
@@ -61,7 +61,7 @@ export default function AdvancedSettingsPage(): ReactElement {
   const shouldShowHelpText = isHelpTextOverride ? !settings.showHelpText : settings.showHelpText;
 
   return (
-    <div className="space-y-8 p-4 mb-2" role="main" aria-labelledby="advanced-settings-title">
+    <section className="space-y-8 p-4 mb-2" aria-labelledby="advanced-settings-title">
       <h2 id="advanced-settings-title" className="sr-only">
         Advanced Settings
       </h2>
@@ -181,7 +181,7 @@ export default function AdvancedSettingsPage(): ReactElement {
           />
         </SettingsSection>
       )}
-    </div>
+    </section>
   );
 }
 

--- a/src/pages/settings/connected-sites.tsx
+++ b/src/pages/settings/connected-sites.tsx
@@ -105,7 +105,7 @@ export default function ConnectedSitesPage(): ReactElement {
   }
 
   return (
-    <div className={connectedSites.length === 0 ? 'h-full flex items-center justify-center' : 'p-4 space-y-4'} role="main" aria-labelledby="connected-sites-title">
+    <section className={connectedSites.length === 0 ? 'h-full flex items-center justify-center' : 'p-4 space-y-4'} aria-labelledby="connected-sites-title">
       <h2 id="connected-sites-title" className="sr-only">
         Connected Sites
       </h2>
@@ -130,6 +130,6 @@ export default function ConnectedSitesPage(): ReactElement {
           ))}
         </div>
       )}
-    </div>
+    </section>
   );
 }

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -114,7 +114,7 @@ export default function SettingsPage(): ReactElement {
   ];
 
   return (
-    <div className="flex flex-col h-full" role="main">
+    <div className="flex flex-col h-full">
       <div className="flex-1 overflow-auto no-scrollbar">
         <div className="p-4">
           <ActionList sections={settingSections} />

--- a/src/pages/settings/pinned-assets.tsx
+++ b/src/pages/settings/pinned-assets.tsx
@@ -221,7 +221,7 @@ export default function PinnedAssetsPage(): ReactElement {
   };
 
   return (
-    <div className="flex flex-col h-full" role="main" aria-labelledby="pinned-assets-title">
+    <section className="flex flex-col h-full" aria-labelledby="pinned-assets-title">
       <h2 id="pinned-assets-title" className="sr-only">
         Pinned Assets Settings
       </h2>
@@ -247,6 +247,6 @@ export default function PinnedAssetsPage(): ReactElement {
         </div>
       </div>
 
-    </div>
+    </section>
   );
 } 

--- a/src/pages/settings/security.tsx
+++ b/src/pages/settings/security.tsx
@@ -120,7 +120,7 @@ export default function SecuritySettingsPage(): ReactElement {
   const shouldShowHelpText = isHelpTextOverride ? !settings.showHelpText : settings.showHelpText;
 
   return (
-    <div className="flex flex-col h-full p-4" role="main" aria-labelledby="security-settings-title">
+    <section className="flex flex-col h-full p-4" aria-labelledby="security-settings-title">
       <h2 id="security-settings-title" className="sr-only">
         Security Settings
       </h2>
@@ -186,6 +186,6 @@ export default function SecuritySettingsPage(): ReactElement {
           </div>
         </div>
       </div>
-    </div>
+    </section>
   );
 }


### PR DESCRIPTION
Five a11y lint rules are now enforced in `biome.json`: `useButtonType`,
`noLabelWithoutControl`, `noSvgWithoutTitle`, `useKeyWithClickEvents`,
`noAutofocus` and `useSemanticElements`. Satisfying them turned up three
real bugs, which are the reason this is bigger than a lint pass.

**Two nested `main` landmarks on every screen.** `Layout` already wraps the
router `Outlet` in a `<main>`, and all 33 page components declared
`role="main"` on their own wrapper inside it — invalid HTML and an
ambiguous skip-to-content target. Named wrappers became `<section>`;
unnamed ones dropped the role. `getByRole('main')` fails on the previous
build with two matches and passes here.

**The keyboard could not re-select the current wallet or address.** The
click handler sat on a div inside `RadioGroup.Option`; keyboard events
fire on the Option, so they never reached a child. Headless UI's own
`change()` returns early when the value would not change, so confirming
the current selection — how those screens move forward — did nothing.

**Cancel, Refill and Close were unreachable by keyboard.** Those buttons
sat inside cards with `role="button"` whose `onKeyDown` ran
`preventDefault()` and navigated. Enter on Refill went to the dispenser
page *and* suppressed the button's own activation. The cards are now
containers, with the clickable body a button beside the actions rather
than around them.

Twenty e2e tests broke on the way, all the same way: locators matched
`role` as a CSS attribute, so `div[role="button"]` found nothing once the
div was a button. They match on accessible name via `getByRole` now. That
also required naming two copy controls apart — the address and private-key
screens each had a display and a button answering to one name.

Verified in the built extension, not just in tests: the restructured cards
measure identically to the old markup against the compiled CSS, and no
`<button>` contains another on any screen checked.

https://claude.ai/code/session_01HUJSeVf1JXG1Rp3VXpb2Cr
