### PR TITLE
Clear four correctness rules, and enforce them

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,12 @@
 {
   "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
   "files": {
-    "includes": ["src/**/*.ts", "src/**/*.tsx", "e2e/**/*.ts"]
+    "includes": [
+      "src/**/*.ts",
+      "src/**/*.tsx",
+      "e2e/**/*.ts",
+      "!src/core/qr-code/qrcodegen.ts"
+    ]
   },
   "formatter": {
     "enabled": false
@@ -27,11 +32,17 @@
         "useSemanticElements": "error"
       },
       "correctness": {
+        "noEmptyPattern": "error",
+        "noSwitchDeclarations": "error",
         "noUnusedImports": "error",
         "noUnusedVariables": "warn"
       },
       "style": {
         "useImportType": "error"
+      },
+      "suspicious": {
+        "noImplicitAnyLet": "error",
+        "useIterableCallbackReturn": "error"
       }
     }
   }

--- a/src/contexts/header-context.tsx
+++ b/src/contexts/header-context.tsx
@@ -178,14 +178,15 @@ function areOwnedAssetsEqual(prev: OwnedAssetCache | undefined, next: OwnedAsset
  */
 function headerReducer(state: HeaderState, action: HeaderAction): HeaderState {
   switch (action.type) {
-    case "SET_MAIN_PROPS":
+    case "SET_MAIN_PROPS": {
       const newMainProps = { ...EMPTY_HEADER_PROPS, ...action.payload };
       return arePropsEqual(state.mainHeader, newMainProps)
         ? state
         : { ...state, mainHeader: newMainProps };
+    }
     case "RESET_MAIN":
       return { ...state, mainHeader: EMPTY_HEADER_PROPS };
-    case "SET_ADDRESS":
+    case "SET_ADDRESS": {
       const { address, walletName, formatted } = action.payload;
       const existingAddress = state.subheadings.addresses[address];
       if (
@@ -205,7 +206,8 @@ function headerReducer(state: HeaderState, action: HeaderAction): HeaderState {
           },
         },
       };
-    case "SET_ASSET":
+    }
+    case "SET_ASSET": {
       const asset = action.payload.asset;
       if (areAssetsEqual(state.subheadings.assets[asset], action.payload)) {
         return state;
@@ -217,7 +219,8 @@ function headerReducer(state: HeaderState, action: HeaderAction): HeaderState {
           assets: { ...state.subheadings.assets, [asset]: action.payload },
         },
       };
-    case "SET_BALANCE":
+    }
+    case "SET_BALANCE": {
       const balanceAsset = action.payload.asset;
       if (areBalancesEqual(state.subheadings.balances[balanceAsset], action.payload)) {
         return state;
@@ -229,7 +232,8 @@ function headerReducer(state: HeaderState, action: HeaderAction): HeaderState {
           balances: { ...state.subheadings.balances, [balanceAsset]: action.payload },
         },
       };
-    case "SET_OWNED_ASSET":
+    }
+    case "SET_OWNED_ASSET": {
       const ownedAsset = action.payload.asset;
       if (areOwnedAssetsEqual(state.subheadings.ownedAssets[ownedAsset], action.payload)) {
         return state;
@@ -241,6 +245,7 @@ function headerReducer(state: HeaderState, action: HeaderAction): HeaderState {
           ownedAssets: { ...state.subheadings.ownedAssets, [ownedAsset]: action.payload },
         },
       };
+    }
     case "CACHE_BALANCES": {
       const newBalances = { ...state.subheadings.balances };
       let hasChanges = false;

--- a/src/core/api/status.ts
+++ b/src/core/api/status.ts
@@ -30,7 +30,7 @@ export function emitApiStatus(event: ApiStatusEvent): void {
     return;
   }
   currentStatus = event;
-  listeners.forEach(listener => listener(event));
+  listeners.forEach(listener => { listener(event); });
 }
 
 /**

--- a/src/core/bitcoin/consolidateBatch.ts
+++ b/src/core/bitcoin/consolidateBatch.ts
@@ -63,7 +63,7 @@ function verifyUtxoAgainstPrevTx(
     prevTxCache.set(utxo.txid, prevTx);
   }
 
-  let prevOutput;
+  let prevOutput: ReturnType<typeof prevTx.getOutput> | undefined;
   try {
     prevOutput = prevTx.getOutput(utxo.vout);
   } catch {

--- a/src/core/counterparty/dispenseOutcome.ts
+++ b/src/core/counterparty/dispenseOutcome.ts
@@ -60,7 +60,7 @@ export async function resolveDispensersAt(
   address: string,
   satoshis: number
 ): Promise<DispensePayout[]> {
-  let dispensers;
+  let dispensers: NonNullable<Awaited<ReturnType<typeof fetchAddressDispensers>>['result']>;
   try {
     const response = await fetchAddressDispensers(address, { limit: 50 });
     dispensers = response.result ?? [];

--- a/src/core/counterparty/inscriptionEnvelope.ts
+++ b/src/core/counterparty/inscriptionEnvelope.ts
@@ -113,7 +113,7 @@ function splitMessage(messageBytes: Uint8Array): {
   const messageTypeId = messageBytes[prefix.length]!;
   const body = messageBytes.slice(prefix.length + 1);
 
-  let decoded;
+  let decoded: ReturnType<typeof decodeCbor>;
   try {
     decoded = decodeCbor(body);
   } catch {

--- a/src/core/counterparty/pack/messages.ts
+++ b/src/core/counterparty/pack/messages.ts
@@ -707,7 +707,7 @@ function packMpma(sends: MpmaSend[], globalMemo: string | null, globalMemoIsHex:
   const lutBytes = new Uint8Array(2 + lut.length * 21);
   lutBytes[0] = lut.length >> 8;
   lutBytes[1] = lut.length & 0xff;
-  lut.forEach((packed, index) => lutBytes.set(packed, 2 + index * 21));
+  lut.forEach((packed, index) => { lutBytes.set(packed, 2 + index * 21); });
 
   const body = new Uint8Array([...lutBytes, ...writer.toBytes()]);
   return withPrefix(MessageTypeId.MPMA_SEND, body);

--- a/src/core/format.ts
+++ b/src/core/format.ts
@@ -60,11 +60,10 @@ export function formatAmount({
     signDisplay,
   };
 
-  Object.keys(formatOptions).forEach(
-    (key) =>
-      formatOptions[key as keyof Intl.NumberFormatOptions] === undefined &&
-      delete formatOptions[key as keyof Intl.NumberFormatOptions]
-  );
+  Object.keys(formatOptions).forEach((key) => {
+    const k = key as keyof Intl.NumberFormatOptions;
+    if (formatOptions[k] === undefined) delete formatOptions[k];
+  });
 
   // `toFixed` rather than `toString`, which switches to exponent notation at the extremes.
   const exact = typeof value === "number" || typeof value === "string"

--- a/src/core/hardware/__tests__/trezorAdapter.emulator.test.ts
+++ b/src/core/hardware/__tests__/trezorAdapter.emulator.test.ts
@@ -212,7 +212,7 @@ describe.skipIf(!(await isEmulatorAvailable()))('TrezorAdapter Emulator Integrat
       const results = await adapter.getAddresses(AddressFormat.P2WPKH, 0, 0, 5);
 
       console.log('Batch addresses:');
-      results.forEach((addr, i) => console.log(`  [${i}] ${addr.address}`));
+      results.forEach((addr, i) => { console.log(`  [${i}] ${addr.address}`); });
 
       expect(results).toHaveLength(5);
 
@@ -376,7 +376,7 @@ describe.skipIf(!(await isEmulatorAvailable()))('TrezorAdapter Emulator Integrat
       const addresses = await adapter.getAddresses(AddressFormat.P2WPKH, 0, 0, 3);
       expect(addresses.length).toBe(3);
       console.log(`  ✓ Derived ${addresses.length} addresses`);
-      addresses.forEach((a, i) => console.log(`    [${i}] ${a.address}`));
+      addresses.forEach((a, i) => { console.log(`    [${i}] ${a.address}`); });
 
       // This proves our wallet implementation can:
       // - Connect to Trezor devices

--- a/src/core/priceFormat.ts
+++ b/src/core/priceFormat.ts
@@ -16,14 +16,16 @@ export function formatPrice(
   switch (unit) {
     case "sats":
       return `${formatAmount({ value: sats, maximumFractionDigits: 0 })} sats`;
-    case "btc":
+    case "btc": {
       const btc = sats / SATS_PER_BTC;
       return `${formatAmount({ value: btc, minimumFractionDigits: 8, maximumFractionDigits: 8 })} BTC`;
-    case "fiat":
+    }
+    case "fiat": {
       if (!btcPrice) return "—";
       const fiatValue = (sats / SATS_PER_BTC) * btcPrice;
       const { symbol, decimals } = CURRENCY_INFO[currency];
       return `${symbol}${formatAmount({ value: fiatValue, maximumFractionDigits: decimals })}`;
+    }
   }
 }
 
@@ -41,10 +43,11 @@ export function getRawPrice(
       return formatAmount({ value: sats, maximumFractionDigits: 0 });
     case "btc":
       return formatAmount({ value: sats / SATS_PER_BTC, minimumFractionDigits: 8, maximumFractionDigits: 8 });
-    case "fiat":
+    case "fiat": {
       if (!btcPrice) return "";
       const decimals = CURRENCY_INFO[currency].decimals;
       return formatAmount({ value: (sats / SATS_PER_BTC) * btcPrice, maximumFractionDigits: decimals });
+    }
   }
 }
 

--- a/src/core/validation/__tests__/bitcoin.fuzz.test.ts
+++ b/src/core/validation/__tests__/bitcoin.fuzz.test.ts
@@ -333,7 +333,7 @@ describe('Bitcoin Address Validation Fuzz Tests', () => {
       const startTime = performance.now();
       
       for (let i = 0; i < iterations; i++) {
-        addresses.forEach(addr => isValidBitcoinAddress(addr));
+        addresses.forEach(addr => { isValidBitcoinAddress(addr); });
       }
       
       const endTime = performance.now();

--- a/src/core/validation/bitcoin.ts
+++ b/src/core/validation/bitcoin.ts
@@ -69,7 +69,7 @@ function validateBech32Address(address: string): AddressValidationResult {
   
   try {
     // Try bech32 first (for witness v0)
-    let decoded;
+    let decoded: ReturnType<typeof bech32.decode>;
     let encoding: 'bech32' | 'bech32m' = 'bech32';
     
     try {

--- a/src/core/validation/session.ts
+++ b/src/core/validation/session.ts
@@ -156,7 +156,7 @@ function cleanupRateLimitMap(): void {
   });
   // Remove the oldest half
   const toRemove = Math.floor(entries.length / 2);
-  entries.slice(0, toRemove).forEach(([key]) => rateLimitMap.delete(key));
+  entries.slice(0, toRemove).forEach(([key]) => { rateLimitMap.delete(key); });
 }
 
 /**

--- a/src/core/wallet/__tests__/stateLockManager.test.ts
+++ b/src/core/wallet/__tests__/stateLockManager.test.ts
@@ -228,7 +228,7 @@ describe('StateLockManager', () => {
       }
 
       // Release all locks
-      releases.forEach(release => release());
+      releases.forEach(release => { release(); });
 
       // All resources should be unlocked and cleaned up
       for (let i = 0; i < resourceCount; i++) {

--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -411,11 +411,12 @@ export default defineBackground(() => {
   if (chrome?.alarms?.onAlarm) {
     chrome.alarms.onAlarm.addListener(async (alarm) => {
       switch (alarm.name) {
-        case SESSION_EXPIRY_ALARM_NAME:
+        case SESSION_EXPIRY_ALARM_NAME: {
           console.log('[Background] Session expired via alarm');
           const walletService = getWalletService();
           await walletService.lockKeychain();
           break;
+        }
           
         case KEEP_ALIVE_ALARM_NAME:
           // Perform minimal activity to keep service worker alive

--- a/src/hooks/useIdleTimer.ts
+++ b/src/hooks/useIdleTimer.ts
@@ -123,7 +123,7 @@ export function useIdleTimer(options: UseIdleTimerOptions) {
   useEffect(() => {
 
     // Cleanup previous event listeners
-    eventsListenersRef.current.forEach(cleanup => cleanup());
+    eventsListenersRef.current.forEach(cleanup => { cleanup(); });
     eventsListenersRef.current = [];
 
     clearTimeout(timeoutRef.current);
@@ -154,7 +154,7 @@ export function useIdleTimer(options: UseIdleTimerOptions) {
     // Cleanup function
     return () => {
       clearTimeout(timeoutRef.current);
-      eventsListenersRef.current.forEach(cleanup => cleanup());
+      eventsListenersRef.current.forEach(cleanup => { cleanup(); });
       eventsListenersRef.current = [];
     };
   }, [disabled, timeout, events, reset]);

--- a/src/pages/compose/fairminter/fairmint/form.tsx
+++ b/src/pages/compose/fairminter/fairmint/form.tsx
@@ -31,7 +31,7 @@ export function FairmintForm({
   const { activeAddress, showHelpText, feeRate } = useComposer();
   
   // Form status from React hook
-  const {} = useFormStatus();
+  useFormStatus();
   
   // Determine if we're minting with BTC or XCP based on the route
   const currencyType = asset === "BTC" ? "BTC" : asset === "XCP" ? "XCP" : "";

--- a/src/pages/compose/issuance/lock-description/form.tsx
+++ b/src/pages/compose/issuance/lock-description/form.tsx
@@ -30,7 +30,7 @@ export function LockDescriptionForm({
   initialFormData,
   asset,
 }: LockDescriptionFormProps): ReactElement {
-  const {} = useComposer();
+  useComposer();
   const { error: assetError, data: assetInfo, isLoading: assetLoading } = useAssetInfo(asset);
   const { pending } = useFormStatus();
   const [isChecked, setIsChecked] = useState(false);

--- a/src/pages/compose/issuance/lock-supply/form.tsx
+++ b/src/pages/compose/issuance/lock-supply/form.tsx
@@ -29,7 +29,7 @@ export function LockSupplyForm({
   asset,
 }: LockSupplyFormProps): ReactElement {
   // Context hooks
-  const {} = useComposer();
+  useComposer();
   
   // Data fetching hooks
   const { error: assetError, data: assetInfo, isLoading: assetLoading } = useAssetInfo(asset);

--- a/src/pages/compose/issuance/reset-supply/form.tsx
+++ b/src/pages/compose/issuance/reset-supply/form.tsx
@@ -24,7 +24,7 @@ export function ResetSupplyForm({
   asset,
 }: ResetSupplyFormProps): ReactElement {
   // Context hooks
-  const {} = useComposer();
+  useComposer();
   
   // Data fetching hooks
   const { error: assetError, data: assetInfo } = useAssetInfo(asset);

--- a/src/pages/compose/sweep/index.tsx
+++ b/src/pages/compose/sweep/index.tsx
@@ -7,8 +7,8 @@ import { SweepForm } from "@/pages/compose/sweep/form";
 import { ReviewSweep } from "@/pages/compose/sweep/review";
 
 function ComposeSweepPage() {
-  const {} = useParams<{ address?: string }>();
-  const {} = useWallet();
+  useParams<{ address?: string }>();
+  useWallet();
   
 
   return (

--- a/src/pages/keychain/setup/import-test-address.tsx
+++ b/src/pages/keychain/setup/import-test-address.tsx
@@ -88,8 +88,6 @@ function ImportTestAddressPage() {
                     }
                   }}
                   disabled={isLoading}
-                  // biome-ignore lint/a11y/noAutofocus: this screen redirects away unless NODE_ENV is development, so the focus grab never reaches a user
-                  autoFocus
                 />
               </div>
               

--- a/src/platform/__tests__/proxy.integration.test.ts
+++ b/src/platform/__tests__/proxy.integration.test.ts
@@ -24,8 +24,8 @@ function createMockPort(name: string) {
       addListener: vi.fn((fn: PortDisconnectListener) => disconnectListeners.push(fn)),
       removeListener: vi.fn(),
     },
-    _fireMessage: (msg: any) => messageListeners.forEach(fn => fn(msg)),
-    _fireDisconnect: () => disconnectListeners.forEach(fn => fn()),
+    _fireMessage: (msg: any) => messageListeners.forEach(fn => { fn(msg); }),
+    _fireDisconnect: () => disconnectListeners.forEach(fn => { fn(); }),
   };
 }
 
@@ -124,7 +124,7 @@ describe('Proxy Service Integration', () => {
       });
 
       // Notify background of new connection
-      setTimeout(() => onConnectListeners.forEach(fn => fn(serverPort)), 0);
+      setTimeout(() => onConnectListeners.forEach(fn => { fn(serverPort); }), 0);
 
       return clientPort;
     });

--- a/src/platform/__tests__/proxy.test.ts
+++ b/src/platform/__tests__/proxy.test.ts
@@ -28,8 +28,8 @@ function createMockPort(name: string) {
       removeListener: vi.fn(),
     },
     // Test helpers
-    _fireMessage: (msg: any) => messageListeners.forEach(fn => fn(msg)),
-    _fireDisconnect: () => disconnectListeners.forEach(fn => fn()),
+    _fireMessage: (msg: any) => messageListeners.forEach(fn => { fn(msg); }),
+    _fireDisconnect: () => disconnectListeners.forEach(fn => { fn(); }),
   };
 }
 
@@ -165,7 +165,7 @@ describe('defineProxyService', () => {
       register();
 
       const port = createMockPort(`proxy:${currentServiceName}`);
-      onConnectListeners.forEach(fn => fn(port));
+      onConnectListeners.forEach(fn => { fn(port); });
 
       port._fireMessage({ id: 1, methodName: 'getValue', args: [] });
       await new Promise(r => setTimeout(r, 0));
@@ -178,7 +178,7 @@ describe('defineProxyService', () => {
       register();
 
       const port = createMockPort(`proxy:${currentServiceName}`);
-      onConnectListeners.forEach(fn => fn(port));
+      onConnectListeners.forEach(fn => { fn(port); });
 
       port._fireMessage({ id: 1, methodName: 'throwError', args: [] });
       await new Promise(r => setTimeout(r, 0));
@@ -192,7 +192,7 @@ describe('defineProxyService', () => {
       register();
 
       const port = createMockPort(`proxy:${currentServiceName}`);
-      onConnectListeners.forEach(fn => fn(port));
+      onConnectListeners.forEach(fn => { fn(port); });
 
       port._fireMessage({ id: 1, methodName: 'throwCoded', args: [] });
       await new Promise(r => setTimeout(r, 0));
@@ -206,7 +206,7 @@ describe('defineProxyService', () => {
       register();
 
       const port = createMockPort(`proxy:${currentServiceName}`);
-      onConnectListeners.forEach(fn => fn(port));
+      onConnectListeners.forEach(fn => { fn(port); });
 
       port._fireMessage({ id: 1, methodName: 'nonExistent', args: [] });
       await new Promise(r => setTimeout(r, 0));
@@ -220,7 +220,7 @@ describe('defineProxyService', () => {
       register();
 
       const port = createMockPort('proxy:OtherService');
-      onConnectListeners.forEach(fn => fn(port));
+      onConnectListeners.forEach(fn => { fn(port); });
 
       expect(port.onMessage.addListener).not.toHaveBeenCalled();
     });

--- a/src/platform/auth/__tests__/sessionManager.test.ts
+++ b/src/platform/auth/__tests__/sessionManager.test.ts
@@ -289,7 +289,7 @@ describe('sessionManager', () => {
       const secrets = ['secret1', 'secret2', 'secret3'];
       
       // Simulate concurrent writes
-      secrets.forEach(secret => storeUnlockedSecret(walletId, secret));
+      secrets.forEach(secret => { storeUnlockedSecret(walletId, secret); });
       
       // Should have the last value
       expect(await getUnlockedSecret(walletId)).toBe('secret3');

--- a/src/platform/auth/sessionManager.ts
+++ b/src/platform/auth/sessionManager.ts
@@ -251,7 +251,7 @@ export function clearUnlockedSecret(walletId: string): void {
  * Clears all stored unlocked secrets and session metadata.
  */
 export async function clearAllUnlockedSecrets(): Promise<void> {
-  Object.keys(unlockedSecrets).forEach((walletId) => clearUnlockedSecret(walletId));
+  Object.keys(unlockedSecrets).forEach((walletId) => { clearUnlockedSecret(walletId); });
 
   // Clear all rate limiting data
   clearAllRateLimits();

--- a/src/platform/walletManager.ts
+++ b/src/platform/walletManager.ts
@@ -971,7 +971,7 @@ export class WalletManager {
 
   public async lockKeychain(): Promise<void> {
     await sessionManager.clearAllUnlockedSecrets();
-    this.wallets.forEach((wallet) => (wallet.addresses = []));
+    this.wallets.forEach((wallet) => { wallet.addresses = []; });
 
     // Clear keychain from memory (settings are inside keychain)
     this.keychain = null;


### PR DESCRIPTION
`biome.json` sets `"recommended": false`, so almost every Biome rule is
off and had never reported anything. Turning the recommended set on
reports ~2,000 findings, and most of that number is noise worth naming
so nobody chases it:

- `noDoubleEquals` — 51 hits, **all 51** in `src/core/qr-code/qrcodegen.ts`,
  which is vendored from Project Nayuki. None in our own code.
- `noPrecisionLoss` — 3 hits, **all 3** in tests that deliberately assert
  precision-loss behaviour.

Excluding vendored and test code leaves ~660, dominated by
`noNonNullAssertion` (264) and `noExplicitAny` (127) — real debt, but bulk.

This clears the four rules that are small enough to finish in one pass,
and enforces them so they cannot come back:

| rule | sites | what it was |
|---|---|---|
| `noSwitchDeclarations` | 11 | `const` in a bare case arm is scoped to the whole switch |
| `useIterableCallbackReturn` | 23 | expression-bodied `forEach` callbacks returning a value nobody reads |
| `noImplicitAnyLet` | 4 | `let x; try { x = ... }` in core, implicitly `any` |
| `noEmptyPattern` | 6 | `const {} = useThing()` |

**None of these were bugs**, and the diff is not the point — the rules are.
Every one of them was reported nowhere before this.

Judgement calls worth reviewing:

- The empty patterns kept their hook calls rather than deleting them.
  `useComposer()` and friends subscribe to context and throw outside their
  provider, so dropping the call is a separate decision from dropping the
  destructuring.
- `qrcodegen.ts` is now excluded from linting. It is vendored deliberately,
  to avoid a live npm dependency; that makes byte-identity with upstream
  worth more than our formatting rules, since it is what lets anyone verify
  the copy. Restyling it would destroy that.

Also removes the `noAutofocus` suppression by removing the `autoFocus` it
protected — it was on a screen that redirects away unless `NODE_ENV` is
development. `src/` now carries no `biome-ignore` comments at all.

Verified: 4134 unit tests, plus the sweep and issuance e2e specs (34) for
the pages whose empty patterns changed. Lint and types clean.

https://claude.ai/code/session_01HUJSeVf1JXG1Rp3VXpb2Cr
