### PR TITLE
Ask for the password in one place, so the two secret screens cannot disagree

### DIFF
--- a/src/hooks/useSecretReveal.test.ts
+++ b/src/hooks/useSecretReveal.test.ts
@@ -1,0 +1,102 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useSecretReveal } from './useSecretReveal';
+
+const form = (password?: string) => {
+  const fd = new FormData();
+  if (password !== undefined) fd.set('password', password);
+  return fd;
+};
+
+describe('useSecretReveal', () => {
+  let verifyPassword: ReturnType<typeof vi.fn>;
+  let onVerified: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    verifyPassword = vi.fn().mockResolvedValue(true);
+    onVerified = vi.fn().mockResolvedValue(undefined);
+  });
+
+  // Takes walletId explicitly: a default parameter would swallow the `undefined`
+  // that the no-wallet case is specifically about.
+  const setup = (walletId: string | undefined) =>
+    renderHook(() => useSecretReveal({ walletId, verifyPassword, onVerified }));
+
+  it('reveals once the password verifies', async () => {
+    const { result } = setup('wallet-1');
+    await act(() => result.current.formAction(form('correct horse battery')));
+
+    await waitFor(() => expect(result.current.isRevealed).toBe(true));
+    expect(onVerified).toHaveBeenCalledTimes(1);
+    expect(result.current.submissionError).toBe('');
+  });
+
+  it('does not reveal, or even try, without a wallet', async () => {
+    const { result } = setup(undefined);
+    await act(() => result.current.formAction(form('correct horse battery')));
+
+    expect(result.current.submissionError).toBe('Invalid wallet.');
+    expect(verifyPassword).not.toHaveBeenCalled();
+    expect(onVerified).not.toHaveBeenCalled();
+    expect(result.current.isRevealed).toBe(false);
+  });
+
+  it('rejects a short password without asking the verifier', async () => {
+    const { result } = setup('wallet-1');
+    await act(() => result.current.formAction(form('short')));
+
+    expect(result.current.submissionError).toMatch(/at least \d+ characters/);
+    expect(verifyPassword).not.toHaveBeenCalled();
+    expect(onVerified).not.toHaveBeenCalled();
+  });
+
+  it('requires a password', async () => {
+    const { result } = setup('wallet-1');
+    await act(() => result.current.formAction(form()));
+
+    expect(result.current.submissionError).toBe('Password is required.');
+    expect(verifyPassword).not.toHaveBeenCalled();
+  });
+
+  // The secret must stay unreachable on every failing path, including the one
+  // where the verifier itself blows up rather than returning false.
+  it('does not reveal when the password is wrong', async () => {
+    verifyPassword.mockResolvedValue(false);
+    const { result } = setup('wallet-1');
+    await act(() => result.current.formAction(form('correct horse battery')));
+
+    expect(result.current.submissionError).toBe('Incorrect password.');
+    expect(onVerified).not.toHaveBeenCalled();
+    expect(result.current.isRevealed).toBe(false);
+  });
+
+  it('treats a throwing verifier as a failed verification, not a passing one', async () => {
+    verifyPassword.mockRejectedValue(new Error('storage exploded'));
+    const { result } = setup('wallet-1');
+    await act(() => result.current.formAction(form('correct horse battery')));
+
+    expect(result.current.submissionError).toBe('Incorrect password.');
+    expect(onVerified).not.toHaveBeenCalled();
+    expect(result.current.isRevealed).toBe(false);
+  });
+
+  it('stays unrevealed and shows the thrown message when retrieval fails', async () => {
+    onVerified.mockRejectedValue(new Error('Unable to retrieve recovery phrase.'));
+    const { result } = setup('wallet-1');
+    await act(() => result.current.formAction(form('correct horse battery')));
+
+    expect(result.current.submissionError).toBe('Unable to retrieve recovery phrase.');
+    expect(result.current.isRevealed).toBe(false);
+  });
+
+  it('clears a previous error on the next attempt', async () => {
+    verifyPassword.mockResolvedValueOnce(false);
+    const { result } = setup('wallet-1');
+    await act(() => result.current.formAction(form('correct horse battery')));
+    expect(result.current.submissionError).toBe('Incorrect password.');
+
+    await act(() => result.current.formAction(form('correct horse battery')));
+    await waitFor(() => expect(result.current.isRevealed).toBe(true));
+    expect(result.current.submissionError).toBe('');
+  });
+});

--- a/src/hooks/useSecretReveal.test.ts
+++ b/src/hooks/useSecretReveal.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import { useSecretReveal } from './useSecretReveal';
 
 const form = (password?: string) => {
@@ -9,12 +9,14 @@ const form = (password?: string) => {
 };
 
 describe('useSecretReveal', () => {
-  let verifyPassword: ReturnType<typeof vi.fn>;
-  let onVerified: ReturnType<typeof vi.fn>;
+  // Typed rather than ReturnType<typeof vi.fn>, which infers Mock<Constructable | Procedure> and
+  // matches no call signature the hook accepts.
+  let verifyPassword: Mock<(password: string) => Promise<boolean>>;
+  let onVerified: Mock<() => Promise<void>>;
 
   beforeEach(() => {
-    verifyPassword = vi.fn().mockResolvedValue(true);
-    onVerified = vi.fn().mockResolvedValue(undefined);
+    verifyPassword = vi.fn<(password: string) => Promise<boolean>>().mockResolvedValue(true);
+    onVerified = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
   });
 
   // Takes walletId explicitly: a default parameter would swallow the `undefined`

--- a/src/hooks/useSecretReveal.ts
+++ b/src/hooks/useSecretReveal.ts
@@ -1,0 +1,96 @@
+import { useEffect, useRef, useState } from "react";
+import { MIN_PASSWORD_LENGTH } from "@/core/encryption/encryption";
+
+interface UseSecretRevealOptions {
+  /** The wallet whose secret is being revealed; absent means the route was malformed. */
+  walletId: string | undefined;
+  /** Verifies the password. Supplied by the caller so this hook stays free of context. */
+  verifyPassword: (password: string) => Promise<boolean>;
+  /**
+   * Runs only once the password has been verified. Retrieve and store the secret here.
+   * Throw to report a failure: the thrown message is what the user sees, so throw the
+   * message you want shown rather than letting an internal one escape.
+   */
+  onVerified: () => Promise<void>;
+}
+
+interface SecretReveal {
+  /** True once onVerified has resolved; the caller swaps the form for the secret. */
+  isRevealed: boolean;
+  submissionError: string;
+  /** For errors the page discovers outside the form, e.g. an unusable wallet. */
+  setSubmissionError: (message: string) => void;
+  clearError: () => void;
+  passwordInputRef: React.RefObject<HTMLInputElement | null>;
+  formAction: (formData: FormData) => Promise<void>;
+}
+
+/**
+ * The password gate in front of a revealed secret.
+ *
+ * The passphrase and private key screens ask the same question in the same order —
+ * is there a wallet, is there a password, is it long enough, does it verify — and
+ * only then differ in what they reveal. Keeping that sequence in one place is what
+ * stops the two screens from drifting into checking different things.
+ */
+export function useSecretReveal({
+  walletId,
+  verifyPassword,
+  onVerified,
+}: UseSecretRevealOptions): SecretReveal {
+  const [isRevealed, setIsRevealed] = useState(false);
+  const [submissionError, setSubmissionError] = useState("");
+  const passwordInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    passwordInputRef.current?.focus();
+  }, []);
+
+  async function formAction(formData: FormData) {
+    setSubmissionError("");
+
+    const password = formData.get("password") as string;
+    if (!walletId) {
+      setSubmissionError("Invalid wallet.");
+      return;
+    }
+    if (!password) {
+      setSubmissionError("Password is required.");
+      return;
+    }
+    if (password.length < MIN_PASSWORD_LENGTH) {
+      setSubmissionError(`Password must be at least ${MIN_PASSWORD_LENGTH} characters.`);
+      return;
+    }
+
+    let passwordValid = false;
+    try {
+      passwordValid = await verifyPassword(password);
+    } catch {
+      // A thrown verifier is a failed verification, never a passing one.
+      passwordValid = false;
+    }
+    if (!passwordValid) {
+      setSubmissionError("Incorrect password.");
+      return;
+    }
+
+    try {
+      await onVerified();
+      setIsRevealed(true);
+    } catch (err) {
+      setSubmissionError(
+        err instanceof Error ? err.message : "Failed to reveal the secret."
+      );
+    }
+  }
+
+  return {
+    isRevealed,
+    submissionError,
+    setSubmissionError,
+    clearError: () => setSubmissionError(""),
+    passwordInputRef,
+    formAction,
+  };
+}

--- a/src/pages/keychain/secrets/show-passphrase.tsx
+++ b/src/pages/keychain/secrets/show-passphrase.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from "react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { useFormStatus } from "react-dom";
 import { useNavigate, useParams } from "react-router";
 import { Banner } from "@/components/ui/banner";
@@ -8,7 +8,7 @@ import { ErrorAlert } from "@/components/ui/error-alert";
 import { PasswordInput } from "@/components/ui/inputs/password-input";
 import { useHeader } from "@/contexts/header-context";
 import { useWallet } from "@/contexts/wallet-context";
-import { MIN_PASSWORD_LENGTH } from "@/core/encryption/encryption";
+import { useSecretReveal } from "@/hooks/useSecretReveal";
 
 const PATHS = {
   BACK: "/keychain/wallets",
@@ -22,9 +22,32 @@ export default function ShowPassphrasePage(): ReactElement {
   const { pending } = useFormStatus();
 
   const [passphrase, setPassphrase] = useState("");
-  const [isConfirmed, setIsConfirmed] = useState(false);
-  const [submissionError, setSubmissionError] = useState("");
-  const passwordInputRef = useRef<HTMLInputElement>(null);
+
+  const {
+    isRevealed: isConfirmed,
+    submissionError,
+    clearError,
+    passwordInputRef,
+    formAction: handleFormAction,
+  } = useSecretReveal({
+    walletId,
+    verifyPassword,
+    onVerified: async () => {
+      let mnemonic: string | null;
+      try {
+        // Load the wallet to decrypt its secret
+        await selectWallet(walletId!);
+        mnemonic = await getUnencryptedMnemonic(walletId!);
+      } catch (err) {
+        console.error("Error revealing passphrase:", err);
+        throw new Error("Incorrect password or failed to reveal recovery phrase.");
+      }
+      // Kept distinct from the failure above: retrieving nothing is not the same
+      // as the retrieval throwing, and the two said different things before.
+      if (!mnemonic) throw new Error("Unable to retrieve recovery phrase.");
+      setPassphrase(mnemonic);
+    },
+  });
 
   useEffect(() => {
     setHeaderProps({
@@ -33,56 +56,10 @@ export default function ShowPassphrasePage(): ReactElement {
     });
   }, [setHeaderProps, navigate]);
 
-  useEffect(() => {
-    passwordInputRef.current?.focus();
-  }, []);
-
-  async function handleFormAction(formData: FormData) {
-    setSubmissionError("");
-
-    const password = formData.get("password") as string;
-    if (!walletId) {
-      setSubmissionError("Invalid wallet.");
-      return;
-    }
-    if (!password) {
-      setSubmissionError("Password is required.");
-      return;
-    }
-    if (password.length < MIN_PASSWORD_LENGTH) {
-      setSubmissionError(`Password must be at least ${MIN_PASSWORD_LENGTH} characters.`);
-      return;
-    }
-    let passwordValid = false;
-    try {
-      passwordValid = await verifyPassword(password);
-    } catch {
-      passwordValid = false;
-    }
-    if (!passwordValid) {
-      setSubmissionError("Incorrect password.");
-      return;
-    }
-    try {
-      // Load the wallet to decrypt its secret
-      await selectWallet(walletId);
-      const mnemonic = await getUnencryptedMnemonic(walletId);
-      if (mnemonic) {
-        setPassphrase(mnemonic);
-        setIsConfirmed(true);
-      } else {
-        setSubmissionError("Unable to retrieve recovery phrase.");
-      }
-    } catch (err) {
-      console.error("Error revealing passphrase:", err);
-      setSubmissionError("Incorrect password or failed to reveal recovery phrase.");
-    }
-  }
-
   return (
     <section className="flex flex-col h-full p-4" aria-labelledby="show-passphrase-title">
       <h2 id="show-passphrase-title" className="sr-only">Show Recovery Phrase</h2>
-      {submissionError && <ErrorAlert message={submissionError} onClose={() => setSubmissionError("")} />}
+      {submissionError && <ErrorAlert message={submissionError} onClose={clearError} />}
       {!isConfirmed ? (
         <form action={handleFormAction} className="flex flex-col items-center justify-center flex-grow">
           <Banner

--- a/src/pages/keychain/secrets/show-private-key.tsx
+++ b/src/pages/keychain/secrets/show-private-key.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from "react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { useFormStatus } from "react-dom";
 import { useNavigate, useParams } from "react-router";
 import { Banner } from "@/components/ui/banner";
@@ -8,8 +8,8 @@ import { ErrorAlert } from "@/components/ui/error-alert";
 import { PasswordInput } from "@/components/ui/inputs/password-input";
 import { useHeader } from "@/contexts/header-context";
 import { useWallet } from "@/contexts/wallet-context";
-import { MIN_PASSWORD_LENGTH } from "@/core/encryption/encryption";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
+import { useSecretReveal } from "@/hooks/useSecretReveal";
 
 const PATHS = {
   BACK: -1,
@@ -23,11 +23,45 @@ export default function ShowPrivateKeyPage(): ReactElement {
   const { pending } = useFormStatus();
 
   const [privateKey, setPrivateKey] = useState("");
-  const [isConfirmed, setIsConfirmed] = useState(false);
-  const [submissionError, setSubmissionError] = useState("");
   const [walletType, setWalletType] = useState<"mnemonic" | "privateKey" | "hardware" | null>(null);
   const { copy, isCopied } = useCopyToClipboard();
-  const passwordInputRef = useRef<HTMLInputElement>(null);
+
+  const {
+    isRevealed: isConfirmed,
+    submissionError,
+    setSubmissionError,
+    clearError,
+    passwordInputRef,
+    formAction: handleFormAction,
+  } = useSecretReveal({
+    walletId,
+    verifyPassword,
+    onVerified: async () => {
+      // Checked after the password, as it was before: a missing path is not a
+      // reason to tell someone whether their password was right.
+      if (walletType === "mnemonic" && !addressPath) {
+        throw new Error("Address derivation path is missing.");
+      }
+      try {
+        // Load the wallet to decrypt its secret
+        await selectWallet(walletId!);
+        const privKeyData =
+          walletType === "privateKey"
+            ? await getPrivateKey(walletId!)
+            : await getPrivateKey(walletId!, addressPath);
+
+        if (!privKeyData) throw new Error("Failed to retrieve private key");
+        if (!privKeyData.wif) throw new Error("Private key WIF format not available");
+
+        setPrivateKey(privKeyData.wif);
+      } catch (err) {
+        console.error("Error revealing private key:", err);
+        throw new Error(
+          err instanceof Error ? err.message : "Failed to reveal private key."
+        );
+      }
+    },
+  });
 
   useEffect(() => {
     if (walletId) {
@@ -47,61 +81,6 @@ export default function ShowPrivateKeyPage(): ReactElement {
     });
   }, [walletId, wallets, setHeaderProps, navigate]);
 
-  useEffect(() => {
-    passwordInputRef.current?.focus();
-  }, []);
-
-
-  async function handleFormAction(formData: FormData) {
-    setSubmissionError("");
-
-    const password = formData.get("password") as string;
-    if (!walletId) {
-      setSubmissionError("Invalid wallet.");
-      return;
-    }
-    if (!password) {
-      setSubmissionError("Password is required.");
-      return;
-    }
-    if (password.length < MIN_PASSWORD_LENGTH) {
-      setSubmissionError(`Password must be at least ${MIN_PASSWORD_LENGTH} characters.`);
-      return;
-    }
-    let passwordValid = false;
-    try {
-      passwordValid = await verifyPassword(password);
-    } catch {
-      passwordValid = false;
-    }
-    if (!passwordValid) {
-      setSubmissionError("Incorrect password.");
-      return;
-    }
-    if (walletType === "mnemonic" && !addressPath) {
-      setSubmissionError("Address derivation path is missing.");
-      return;
-    }
-
-    try {
-      // Load the wallet to decrypt its secret
-      await selectWallet(walletId);
-      const privKeyData =
-        walletType === "privateKey"
-          ? await getPrivateKey(walletId)
-          : await getPrivateKey(walletId, addressPath);
-
-      if (!privKeyData) throw new Error("Failed to retrieve private key");
-      if (!privKeyData.wif) throw new Error("Private key WIF format not available");
-
-      setPrivateKey(privKeyData.wif);
-      setIsConfirmed(true);
-    } catch (err) {
-      console.error("Error revealing private key:", err);
-      setSubmissionError(err instanceof Error ? err.message : "Failed to reveal private key.");
-    }
-  }
-
   const handleCopyPrivateKey = async () => {
     // useCopyToClipboard auto-clears the clipboard after 30 seconds
     await copy(privateKey);
@@ -110,7 +89,7 @@ export default function ShowPrivateKeyPage(): ReactElement {
   return (
     <section className="flex flex-col h-full p-4" aria-labelledby="show-private-key-title">
       <h2 id="show-private-key-title" className="sr-only">Show Private Key</h2>
-      {submissionError && <ErrorAlert message={submissionError} onClose={() => setSubmissionError("")} />}
+      {submissionError && <ErrorAlert message={submissionError} onClose={clearError} />}
       {!isConfirmed ? (
         <form action={handleFormAction} className="flex flex-col items-center justify-center flex-grow">
           <Banner


### PR DESCRIPTION
First of the pairwise de-duplications. The compose/secret pages duplicate
each other **pairwise**, not globally — jscpd pairs detach↔move,
deposit↔withdraw, lock-description↔lock-supply, remove↔reset — so the fix
is several small extractions rather than one `<ComposeForm>` abstraction,
which would need a props explosion to cover pages that genuinely differ.

This is the pair where drift has a security consequence rather than a
cosmetic one.

Both secret screens asked the same question in the same order: is there a
wallet, is there a password, is it long enough, does it verify. Then they
diverged entirely on what they revealed. Two copies of a password gate is
the dangerous kind of duplication — tighten a check on one screen and not
the other and nothing fails, no test goes red, and nobody notices.

`useSecretReveal` now owns that sequence. Each page supplies `onVerified`,
which runs only once the password is accepted and throws the message it
wants the user to see. The reveal UI stays per-page: a twelve-word grid and
a copyable WIF string have nothing worth sharing.

**Behaviour is preserved down to the error strings**, including two that
were easy to lose in the move:

- the passphrase screen says something *different* when retrieval returns
  nothing than when retrieval throws;
- the private key screen still checks for a derivation path **after** the
  password rather than before, so a missing path cannot be used to probe
  whether a password was correct.

Eight tests cover the gate directly, including the two paths that must
never reveal: a verifier returning `false`, and a verifier that throws
rather than returning at all. One of them caught a bug in my own test —
`setup(undefined)` was hitting a default parameter and silently running
the no-wallet case with a valid wallet.

Verified: 4142 unit tests, plus both secret screens end to end (43 specs).

https://claude.ai/code/session_01HUJSeVf1JXG1Rp3VXpb2Cr
