### PR TITLE
Run the skipped tests, and fix what they were hiding

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -26,12 +26,23 @@
         "useKeyWithClickEvents": "error",
         "useSemanticElements": "error"
       },
+      "complexity": {
+        "noUselessCatch": "error"
+      },
       "correctness": {
         "noUnusedImports": "error",
-        "noUnusedVariables": "warn"
+        "noUnusedVariables": "warn",
+        "useParseIntRadix": "error"
       },
       "style": {
         "useImportType": "error"
+      },
+      "suspicious": {
+        "noExportsInTest": "error",
+        "noGlobalIsNan": "error",
+        "noNonNullAssertedOptionalChain": "error",
+        "noSkippedTests": "error",
+        "useArraySortCompare": "error"
       }
     }
   }

--- a/knip.json
+++ b/knip.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://unpkg.com/knip@5/schema.json",
+  "entry": [
+    "src/entrypoints/**/*.{ts,tsx}",
+    "e2e/**/*.spec.ts",
+    "*.config.ts",
+    "vitest.setup.ts"
+  ],
+  "project": [
+    "src/**/*.{ts,tsx}",
+    "e2e/**/*.{ts,js}"
+  ],
+  "ignore": [
+    "src/core/qr-code/qrcodegen.ts"
+  ],
+  "ignoreUnresolved": [
+    "#imports"
+  ]
+}

--- a/src/components/domain/address/destinations-input.test.tsx
+++ b/src/components/domain/address/destinations-input.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import '@testing-library/jest-dom/vitest';
+import { DESTINATION_WARNING_THRESHOLD, MAX_DESTINATIONS } from '@/core/validation/destinations';
 import { DestinationsInput } from './destinations-input';
 
 // Mock the bitcoin validation
@@ -365,11 +366,8 @@ describe('DestinationsInput', () => {
     expect(screen.getByText(/Paste multiple addresses/)).toBeInTheDocument();
   });
 
-  it.skip('should show warning when approaching destination limit', async () => {
-    // Skip: This test renders 950 destinations which is too slow for CI
-    // Use a smaller number near the warning threshold for faster testing
-    // The warning typically shows at 950+ destinations
-    const destinations = Array.from({ length: 950 }, (_, i) => ({
+  it('should show warning when approaching destination limit', async () => {
+    const destinations = Array.from({ length: DESTINATION_WARNING_THRESHOLD }, (_, i) => ({
       id: i,
       address: `addr${i}` // Use very short addresses for speed
     }));
@@ -385,15 +383,14 @@ describe('DestinationsInput', () => {
 
     // Wait for the warning text to appear
     await waitFor(() => {
-      expect(screen.getByText(/Approaching destination limit: 950\/1000/)).toBeInTheDocument();
+      expect(
+        screen.getByText(`Approaching destination limit: ${DESTINATION_WARNING_THRESHOLD}/${MAX_DESTINATIONS}`)
+      ).toBeInTheDocument();
     }, { timeout: 5000 });
   }, 60000);
 
-  it.skip('should show error when at destination limit', () => {
-    // Skip: This test renders 1000 destinations which is too slow for CI
-    // Test with exactly 1000 destinations to verify limit message appears
-    // Use minimal addresses for performance
-    const destinations = Array.from({ length: 1000 }, (_, i) => ({
+  it('should show error when at destination limit', () => {
+    const destinations = Array.from({ length: MAX_DESTINATIONS }, (_, i) => ({
       id: i,
       address: `${i}` // Minimal string for performance
     }));
@@ -410,13 +407,11 @@ describe('DestinationsInput', () => {
     // Look for the limit message using more specific selector
     const limitMessage = container.querySelector('p.text-red-600');
     expect(limitMessage).toBeInTheDocument();
-    expect(limitMessage?.textContent).toBe('Maximum destination limit reached: 1000');
+    expect(limitMessage?.textContent).toBe(`Maximum destination limit reached: ${MAX_DESTINATIONS}`);
   }, 30000); // Increase timeout to 30 seconds for safety
 
-  it.skip('should not show add button at 1000 limit', async () => {
-    // Skip: This test renders 1000 destinations which is too slow for CI
-    // The limit behavior is tested in the previous test with 999 destinations
-    const destinations = Array.from({ length: 1000 }, (_, i) => ({
+  it('should not show add button at the destination limit', async () => {
+    const destinations = Array.from({ length: MAX_DESTINATIONS }, (_, i) => ({
       id: i,
       address: `${i}` // Simplified addresses for performance
     }));
@@ -432,7 +427,7 @@ describe('DestinationsInput', () => {
 
     // Wait for the component to render with limit message
     await waitFor(() => {
-      expect(screen.getByText('Maximum destination limit reached: 1000')).toBeInTheDocument();
+      expect(screen.getByText(`Maximum destination limit reached: ${MAX_DESTINATIONS}`)).toBeInTheDocument();
     }, { timeout: 5000 });
 
     // Should not show add button when at max limit

--- a/src/components/domain/address/destinations-input.tsx
+++ b/src/components/domain/address/destinations-input.tsx
@@ -3,7 +3,7 @@ import { type ReactElement, useEffect, useRef, useState } from "react";
 import { FiMinus, FiPlus } from "@/components/icons";
 import { lookupAssetOwner, shouldTriggerAssetLookup } from "@/core/validation/assetOwner";
 import { validateBitcoinAddress } from "@/core/validation/bitcoin";
-import { type Destination, isMPMASupported, parseMultiLineDestinations, validateDestinations } from "@/core/validation/destinations";
+import { type Destination, getDestinationLimitState, isMPMASupported, MAX_DESTINATIONS, parseMultiLineDestinations, validateDestinations } from "@/core/validation/destinations";
 import { useMultiAssetOwnerLookup } from "@/hooks/useAssetOwnerLookup";
 
 interface DestinationsInputProps {
@@ -78,7 +78,7 @@ export function DestinationsInput({
   };
 
   const addDestination = () => {
-    if (destinations.length >= 1000) {
+    if (getDestinationLimitState(destinations.length) === 'at-limit') {
       return; // Hard protocol limit
     }
     onChange([...destinations, { id: Date.now(), address: "" }]);
@@ -134,8 +134,8 @@ export function DestinationsInput({
       const updatedDestinations = [...destinations];
       updatedDestinations[currentIndex] = { ...updatedDestinations[currentIndex]!, address: resolvedLines[0]! };
       
-      // Add remaining addresses as new destinations (respect 1000 limit)
-      const remainingSlots = 1000 - updatedDestinations.length;
+      // Add remaining addresses as new destinations (respect the protocol limit)
+      const remainingSlots = MAX_DESTINATIONS - updatedDestinations.length;
       const linesToAdd = resolvedLines.slice(1, Math.min(resolvedLines.length, remainingSlots + 1));
       const newDestinations = linesToAdd.map(address => ({
         id: Date.now() + Math.random(),
@@ -146,7 +146,8 @@ export function DestinationsInput({
     }
   };
 
-  const showAddButton = isMPMASupported(asset) && enableMPMA && destinations.length < 1000;
+  const limitState = getDestinationLimitState(destinations.length);
+  const showAddButton = isMPMASupported(asset) && enableMPMA && limitState !== 'at-limit';
   const canRemove = destinations.length > 1;
 
   return (
@@ -217,21 +218,21 @@ export function DestinationsInput({
       
       {showHelpText && (
         <Description className="mt-2 text-sm text-gray-500">
-          {destinations.length > 1 
-            ? `Enter the addresses to send to. Each destination will receive the same amount. Duplicate addresses are not allowed. (${destinations.length}/1000 destinations)`
+          {destinations.length > 1
+            ? `Enter the addresses to send to. Each destination will receive the same amount. Duplicate addresses are not allowed. (${destinations.length}/${MAX_DESTINATIONS} destinations)`
             : enableMPMA && asset !== "BTC"
-              ? "Enter the address to send to. Paste multiple addresses (one per line) to send to multiple destinations. (Max: 1000)"
+              ? `Enter the address to send to. Paste multiple addresses (one per line) to send to multiple destinations. (Max: ${MAX_DESTINATIONS})`
               : "Enter recipient's address."}
         </Description>
       )}
-      {destinations.length >= 900 && destinations.length < 1000 && (
+      {limitState === 'approaching' && (
         <p className="mt-1 text-sm text-orange-600">
-          Approaching destination limit: {destinations.length}/1000
+          Approaching destination limit: {destinations.length}/{MAX_DESTINATIONS}
         </p>
       )}
-      {destinations.length >= 1000 && (
+      {limitState === 'at-limit' && (
         <p className="mt-1 text-sm text-red-600">
-          Maximum destination limit reached: 1000
+          Maximum destination limit reached: {MAX_DESTINATIONS}
         </p>
       )}
     </Field>

--- a/src/components/domain/approval/__tests__/approval-warnings.test.ts
+++ b/src/components/domain/approval/__tests__/approval-warnings.test.ts
@@ -1,0 +1,166 @@
+/**
+ * The warning list both approval screens render before the user signs.
+ *
+ * These assertions are deliberately about the text and the severity, not just the count: the
+ * severity decides whether the row reads as caution or as danger, and the description is the only
+ * place the screen says where the assets actually go.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { buildApprovalWarnings } from '../approval-warnings';
+import type { ApprovalWarningInput } from '../approval-warnings';
+
+const EMPTY: ApprovalWarningInput = {
+  safetyWarnings: [],
+  attachedAssetDestination: null,
+  structureFindings: [],
+  signedInputsWithAssets: [],
+  signedInputsUnknownStatus: [],
+};
+
+const destination = (over: Record<string, unknown>) =>
+  ({
+    detaches: false,
+    leavesWallet: false,
+    sourceInputs: [0],
+    destinationVout: 1,
+    destinationAddress: null,
+    ...over,
+  }) as ApprovalWarningInput['attachedAssetDestination'];
+
+describe('buildApprovalWarnings', () => {
+  it('returns nothing when there is nothing to warn about', () => {
+    expect(buildApprovalWarnings(EMPTY)).toEqual([]);
+  });
+
+  it('maps a blocking safety warning down to danger', () => {
+    // WarningStack has no 'block' severity; unmapped, a blocking warning would render as
+    // whatever the component does with an unknown severity.
+    const [item] = buildApprovalWarnings({
+      ...EMPTY,
+      safetyWarnings: [{ severity: 'block', title: 'Sweep', message: 'Drains the address.' }],
+    });
+
+    expect(item).toMatchObject({ severity: 'danger', title: 'Sweep', description: 'Drains the address.' });
+  });
+
+  it.each([
+    ['warning', 'info'],
+    ['warning', 'warning'],
+    ['danger', 'danger'],
+  ])('passes severity %s through unchanged', (_out, severity) => {
+    const [item] = buildApprovalWarnings({
+      ...EMPTY,
+      safetyWarnings: [{ severity: severity as 'info', title: 't', message: 'm' }],
+    });
+
+    expect(item?.severity).toBe(severity);
+  });
+
+  describe('attached asset destination', () => {
+    it('is danger when the assets leave the wallet, and names the output', () => {
+      const [item] = buildApprovalWarnings({
+        ...EMPTY,
+        attachedAssetDestination: destination({
+          leavesWallet: true,
+          destinationVout: 2,
+          destinationAddress: 'bc1qexample',
+        }),
+      });
+
+      expect(item?.severity).toBe('danger');
+      expect(item?.title).toBe('Attached assets leave your wallet');
+      expect(item?.description).toContain('output #2');
+      expect(item?.description).toContain('bc1qexample');
+      expect(item?.description).toContain('not an address you control');
+    });
+
+    it('is a warning when they land on your own output', () => {
+      const [item] = buildApprovalWarnings({
+        ...EMPTY,
+        attachedAssetDestination: destination({}),
+      });
+
+      expect(item?.severity).toBe('warning');
+      expect(item?.title).toBe('Attached assets move to your own output');
+      expect(item?.description).not.toContain('not an address you control');
+    });
+
+    it('describes a detach without inventing an output', () => {
+      const [item] = buildApprovalWarnings({
+        ...EMPTY,
+        attachedAssetDestination: destination({ detaches: true }),
+      });
+
+      expect(item?.title).toBe('Attached assets are detached to your address');
+      expect(item?.description).toContain('credited back to your address');
+      expect(item?.description).not.toContain('output #');
+    });
+
+    it('pluralises the source inputs', () => {
+      const one = buildApprovalWarnings({
+        ...EMPTY,
+        attachedAssetDestination: destination({ sourceInputs: [3] }),
+      })[0];
+      const many = buildApprovalWarnings({
+        ...EMPTY,
+        attachedAssetDestination: destination({ sourceInputs: [3, 4] }),
+      })[0];
+
+      expect(one?.description).toContain('input #3');
+      expect(many?.description).toContain('inputs #3, #4');
+    });
+  });
+
+  it('lists every structure finding', () => {
+    const items = buildApprovalWarnings({
+      ...EMPTY,
+      structureFindings: [
+        { title: 'Bad ref', message: 'Points at a missing input.' },
+        { title: 'Bad vout', message: 'Points past the end.' },
+      ] as ApprovalWarningInput['structureFindings'],
+    });
+
+    expect(items).toHaveLength(2);
+    expect(items.map((i) => i.key)).toEqual(['structure-0', 'structure-1']);
+    expect(items.every((i) => i.severity === 'warning')).toBe(true);
+  });
+
+  it('separates inputs carrying assets from inputs whose status is unknown', () => {
+    const items = buildApprovalWarnings({
+      ...EMPTY,
+      signedInputsWithAssets: [
+        { inputIndex: 0, utxo: 'a:0', assets: [{ asset: 'XCP', quantity_normalized: '1.5' }] },
+      ] as unknown as ApprovalWarningInput['signedInputsWithAssets'],
+      signedInputsUnknownStatus: [
+        { inputIndex: 1, utxo: 'b:1', assets: [] },
+      ] as unknown as ApprovalWarningInput['signedInputsUnknownStatus'],
+    });
+
+    // A failed lookup must never be presented as "no assets" — it gets its own row.
+    expect(items.map((i) => i.key)).toEqual(['attached-assets', 'unknown-status']);
+    expect(items[1]?.title).toBe("Couldn't verify asset status");
+  });
+
+  it('orders safety warnings ahead of the structural ones', () => {
+    const items = buildApprovalWarnings({
+      safetyWarnings: [{ severity: 'danger', title: 'S', message: 'm' }],
+      attachedAssetDestination: destination({}),
+      structureFindings: [{ title: 'F', message: 'm' }] as ApprovalWarningInput['structureFindings'],
+      signedInputsWithAssets: [
+        { inputIndex: 0, utxo: 'a:0', assets: [{ asset: 'XCP', quantity_normalized: '1' }] },
+      ] as unknown as ApprovalWarningInput['signedInputsWithAssets'],
+      signedInputsUnknownStatus: [
+        { inputIndex: 1, utxo: 'b:1', assets: [] },
+      ] as unknown as ApprovalWarningInput['signedInputsUnknownStatus'],
+    });
+
+    expect(items.map((i) => i.key)).toEqual([
+      'safety-0',
+      'attached-destination',
+      'structure-0',
+      'attached-assets',
+      'unknown-status',
+    ]);
+  });
+});

--- a/src/components/domain/approval/__tests__/approval-warnings.test.ts
+++ b/src/components/domain/approval/__tests__/approval-warnings.test.ts
@@ -7,8 +7,8 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { buildApprovalWarnings } from '../approval-warnings';
 import type { ApprovalWarningInput } from '../approval-warnings';
+import { buildApprovalWarnings } from '../approval-warnings';
 
 const EMPTY: ApprovalWarningInput = {
   safetyWarnings: [],
@@ -24,7 +24,7 @@ const destination = (over: Record<string, unknown>) =>
     leavesWallet: false,
     sourceInputs: [0],
     destinationVout: 1,
-    destinationAddress: null,
+    destinationAddress: undefined,
     ...over,
   }) as ApprovalWarningInput['attachedAssetDestination'];
 

--- a/src/components/domain/approval/approval-warnings.tsx
+++ b/src/components/domain/approval/approval-warnings.tsx
@@ -1,0 +1,120 @@
+/**
+ * The warnings both approval screens raise about a transaction they are asked to sign.
+ *
+ * The PSBT screen and the raw-transaction screen answer the same questions about attached assets
+ * and message structure, and they used to answer them in two identical copies of this code. That is
+ * the wrong thing to duplicate: these strings are the whole of what the user is told before they
+ * sign, so a fix applied to one copy and not the other means one route silently keeps warning
+ * about the wrong thing.
+ *
+ * Warnings specific to one route stay on that route. The PSBT screen appends its own
+ * ANYONECANPAY warning after calling this, because a raw transaction is signed SIGHASH_ALL
+ * throughout and cannot be modified after signing.
+ */
+
+import type { WarningItem } from '@/components/ui/warning-stack';
+import type { AttachedAssetDestination } from '@/core/counterparty/attachedAssetMovement';
+import type { InputAttachedAssets } from '@/core/counterparty/inputAssets';
+import type { StructureFinding } from '@/core/counterparty/messageStructure';
+import type { SecurityWarning } from '@/core/counterparty/transactionSafety';
+
+export interface ApprovalWarningInput {
+  /** Safety analysis warnings, already sorted by severity. */
+  safetyWarnings: SecurityWarning[];
+  /** Where assets attached to the signed inputs end up, when that could be resolved. */
+  attachedAssetDestination: AttachedAssetDestination | null;
+  /** Message fields that reference this transaction and do not resolve against it. */
+  structureFindings: StructureFinding[];
+  /** Signed inputs whose UTXOs carry assets — signing moves them. */
+  signedInputsWithAssets: InputAttachedAssets[];
+  /** Signed inputs whose asset lookup failed, so status is unknown rather than clean. */
+  signedInputsUnknownStatus: InputAttachedAssets[];
+}
+
+export function buildApprovalWarnings({
+  safetyWarnings,
+  attachedAssetDestination,
+  structureFindings,
+  signedInputsWithAssets,
+  signedInputsUnknownStatus,
+}: ApprovalWarningInput): WarningItem[] {
+  const warningItems: WarningItem[] = safetyWarnings.map((warning, idx) => ({
+    key: `safety-${idx}`,
+    severity: warning.severity === 'block' ? 'danger' : warning.severity,
+    title: warning.title,
+    description: warning.message,
+  }));
+
+  // Where the attached assets land. Spending an attached UTXO moves its balances with no
+  // Counterparty message, so without this the screen can say only that assets move, never where —
+  // and for an atomic swap that is the whole question.
+  if (attachedAssetDestination) {
+    const dest = attachedAssetDestination;
+    warningItems.push({
+      key: 'attached-destination',
+      severity: dest.leavesWallet ? 'danger' : 'warning',
+      title: dest.detaches
+        ? 'Attached assets are detached to your address'
+        : dest.leavesWallet
+          ? 'Attached assets leave your wallet'
+          : 'Attached assets move to your own output',
+      description: dest.detaches
+        ? 'This transaction has no ordinary output, so every asset attached to the inputs you are ' +
+          'signing is credited back to your address.'
+        : `Every asset attached to input${dest.sourceInputs.length === 1 ? '' : 's'} ` +
+          `${dest.sourceInputs.map((i) => `#${i}`).join(', ')} is credited to output ` +
+          `#${dest.destinationVout}${dest.destinationAddress ? ` (${dest.destinationAddress})` : ''}` +
+          `${dest.leavesWallet ? ', which is not an address you control.' : '.'}`,
+    });
+  }
+
+  // The message's own references to this transaction, where they do not resolve against it. A
+  // warning rather than a block: core rejects such a transaction, so it is ineffective rather than
+  // dangerous — but the screen cannot describe what it claims to do.
+  for (const [idx, finding] of structureFindings.entries()) {
+    warningItems.push({
+      key: `structure-${idx}`,
+      severity: 'warning',
+      title: finding.title,
+      description: finding.message,
+    });
+  }
+
+  if (signedInputsWithAssets.length > 0) {
+    warningItems.push({
+      key: 'attached-assets',
+      severity: 'warning',
+      title: 'Spends UTXOs holding Counterparty assets',
+      description: 'Inputs you are signing carry attached assets. Signing moves them, not just BTC.',
+      children: (
+        <ul className="mt-2 space-y-1 text-xs font-medium">
+          {signedInputsWithAssets.flatMap(entry =>
+            entry.assets.map(asset => (
+              <li key={`${entry.inputIndex}-${asset.asset}`}>
+                Input #{entry.inputIndex}: {asset.quantity_normalized} {asset.asset_longname ?? asset.asset}
+              </li>
+            ))
+          )}
+        </ul>
+      ),
+    });
+  }
+
+  if (signedInputsUnknownStatus.length > 0) {
+    warningItems.push({
+      key: 'unknown-status',
+      severity: 'warning',
+      title: "Couldn't verify asset status",
+      description: `The balance lookup failed for ${signedInputsUnknownStatus.length === 1 ? 'an input' : 'some inputs'} you are signing, so attached Counterparty assets can't be confirmed either way. Proceed only if you trust this transaction.`,
+      children: (
+        <ul className="mt-2 space-y-1 text-xs font-medium">
+          {signedInputsUnknownStatus.map(entry => (
+            <li key={entry.inputIndex}>Input #{entry.inputIndex}: status unknown</li>
+          ))}
+        </ul>
+      ),
+    });
+  }
+
+  return warningItems;
+}

--- a/src/components/domain/approval/counterparty-details-card.tsx
+++ b/src/components/domain/approval/counterparty-details-card.tsx
@@ -1,0 +1,42 @@
+/**
+ * What the Counterparty message itself says, kept apart from the Bitcoin view around it.
+ *
+ * The headline is one line and loses most of it — a fairminter's headline is its asset name, while
+ * the thing being agreed to is a set of caps, a price and a deadline. Both approval screens show
+ * this, so it lives here rather than in two copies that can drift.
+ */
+
+import type { ProtocolField } from '@/core/counterparty/describe';
+
+/**
+ * Values longer than this get their own line instead of sharing a row with their label.
+ * A hash or an outpoint right-aligned beside a label wrapped into three ragged lines that
+ * nobody can read across.
+ */
+const OWN_LINE_LENGTH = 32;
+
+export function CounterpartyDetailsCard({ fields }: { fields: ProtocolField[] }) {
+  if (fields.length === 0) return null;
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm p-4">
+      <h3 className="text-xs font-medium text-gray-500 uppercase mb-2">Counterparty Details</h3>
+      <div className="space-y-1.5">
+        {fields.map((field) =>
+          field.value.length > OWN_LINE_LENGTH ? (
+            // Monospace on its own line, where the digits line up and can be compared.
+            <div key={field.label} className="text-sm">
+              <div className="text-gray-500">{field.label}</div>
+              <div className="text-gray-900 font-mono text-xs break-all mt-0.5">{field.value}</div>
+            </div>
+          ) : (
+            <div key={field.label} className="flex justify-between gap-3 text-sm">
+              <span className="text-gray-500 flex-shrink-0">{field.label}</span>
+              <span className="text-gray-900 font-medium text-right break-all">{field.value}</span>
+            </div>
+          )
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/domain/asset/asset-header.test.tsx
+++ b/src/components/domain/asset/asset-header.test.tsx
@@ -41,7 +41,7 @@ vi.mock('@/core/numeric', async (importOriginal) => ({
   asBaseUnits: (v: unknown) => v,
   asDisplayUnits: (v: unknown) => v,
   fromSatoshis: vi.fn((value, options) => {
-    const numValue = typeof value === 'string' ? parseInt(value) : value;
+    const numValue = typeof value === 'string' ? parseInt(value, 10) : value;
     const result = numValue / 100000000;
     return options?.asNumber ? result : result.toString();
   })

--- a/src/components/domain/asset/fairmint-summary.tsx
+++ b/src/components/domain/asset/fairmint-summary.tsx
@@ -1,0 +1,100 @@
+/**
+ * What a fairmint costs and where the payment goes.
+ *
+ * The form's only price text lived in the amount field's help text, which renders only when
+ * showHelpText is on — off by default. This is shown unconditionally.
+ */
+
+import type { ReactElement } from "react";
+import {
+  describeFairminterPaymentModel,
+  getFairmintCost,
+  getFairminterLotCost,
+  getFairminterPaymentModel,
+  isPaidFairminter,
+} from "@/core/counterparty/fairminterModel";
+import { formatAmount } from "@/core/format";
+import { isGreaterThan } from "@/core/numeric";
+
+export interface FairmintSummaryFairminter {
+  asset: string;
+  source?: string;
+  price?: number | string | null;
+  price_normalized?: string | null;
+  quantity_by_price_normalized?: string | null;
+  burn_payment?: boolean;
+  soft_cap?: number;
+  soft_cap_normalized?: string;
+  divisible?: boolean;
+}
+
+function Row({ label, value }: { label: string; value: string }): ReactElement {
+  return (
+    <div className="flex justify-between gap-3 text-sm">
+      <span className="text-gray-500 flex-shrink-0">{label}</span>
+      <span className="text-gray-900 font-medium text-right break-all">{value}</span>
+    </div>
+  );
+}
+
+export function FairmintSummary({
+  fairminter,
+  quantity,
+}: {
+  fairminter: FairmintSummaryFairminter;
+  /** What the user has asked to mint, in display units. Blank until they type. */
+  quantity: string;
+}): ReactElement {
+  const model = getFairminterPaymentModel({
+    price: fairminter.price ?? fairminter.price_normalized,
+    burnPayment: fairminter.burn_payment,
+  });
+  const paid = isPaidFairminter(model);
+  const hasQuantity = isGreaterThan(quantity || 0, 0);
+  const decimals = fairminter.divisible === false ? 0 : 8;
+
+  const totalCost = paid ? getFairmintCost(fairminter, quantity || 0) : "0";
+  const hasSoftCap = isGreaterThan(fairminter.soft_cap_normalized ?? fairminter.soft_cap ?? 0, 0);
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-3 space-y-1.5">
+      {hasQuantity && (
+        <Row
+          label="You receive"
+          value={`${formatAmount({
+            value: quantity,
+            maximumFractionDigits: decimals,
+            minimumFractionDigits: 0,
+          })} ${fairminter.asset}`}
+        />
+      )}
+
+      {paid ? (
+        <>
+          <Row label="Price" value={`${getFairminterLotCost(fairminter)} XCP per lot`} />
+          {totalCost !== null && (
+            <Row label="You pay" value={hasQuantity ? `${totalCost} XCP` : "— XCP"} />
+          )}
+        </>
+      ) : (
+        // A free mint's whole cost is the miner fee, and its amount is set by the fairminter.
+        <Row label="You pay" value="Bitcoin network fee only" />
+      )}
+
+      <Row label="Payment" value={describeFairminterPaymentModel(model)} />
+
+      {model === "issuer" && fairminter.source && (
+        <Row label="Paid to" value={fairminter.source} />
+      )}
+
+      {hasSoftCap && (
+        // Core sends both the payment and the assets to UNSPENDABLE until the soft cap is met.
+        <p className="pt-1 text-xs text-yellow-800 bg-yellow-50 border border-yellow-200 rounded p-2">
+          This fairminter has a soft cap. Until it is reached, your payment and the tokens are both
+          held in escrow — nothing is credited when this transaction confirms, and your XCP is
+          refunded if the cap is missed by its deadline.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/domain/asset/fairminter-select-input.tsx
+++ b/src/components/domain/asset/fairminter-select-input.tsx
@@ -9,20 +9,43 @@ import {
 import { type ReactElement, useEffect, useState } from "react";
 import { FaCheck, FiChevronDown } from "@/components/icons";
 import { useSettings } from "@/contexts/settings-context";
-import { formatAmount } from "@/core/format";
+import { describeFairminterLot } from "@/core/counterparty/fairminterModel";
 import { isGreaterThan } from "@/core/numeric";
 
+/**
+ * A fairminter as `/v2/fairminters?verbose=true` returns it.
+ *
+ * The endpoint returns every column of core's fairminters table; this interface used to declare
+ * nine fields and drop the rest, which is why the mint screens could not say where a payment goes
+ * or how close the asset is to its cap. The fields below are read by the mint form and review, so
+ * they are declared here rather than re-fetched.
+ */
 export interface Fairminter {
   tx_hash: string;
+  /** Where the XCP goes when burn_payment is false — the address that opened the fairminter. */
   source: string;
   asset: string;
   description: string;
+  /** XCP charged per lot, in base units. */
+  price?: number;
+  /** XCP per whole unit; core derives it as price / quantity_by_price. */
   price_normalized: string;
+  /** Assets released per lot paid for, i.e. the lot size. */
   quantity_by_price_normalized: string;
   status: string;
   divisible: boolean;
   max_mint_per_tx?: number;
   max_mint_per_tx_normalized?: string;
+  /** True burns the payment; false sends it to `source`. Says nothing about whether it is free. */
+  burn_payment?: boolean;
+  hard_cap?: number;
+  hard_cap_normalized?: string;
+  /** Until this is reached, both the payment and the minted assets sit in escrow. */
+  soft_cap?: number;
+  soft_cap_normalized?: string;
+  soft_cap_deadline_block?: number;
+  max_mint_per_address?: number;
+  max_mint_per_address_normalized?: string;
 }
 
 interface FairminterSelectInputProps {
@@ -225,9 +248,9 @@ export function FairminterSelectInput({
                           <span
                             className={`text-xs ${active ? "text-blue-100" : "text-gray-500"}`}
                           >
-                            {!isGreaterThan(fairminter.price_normalized, 0)
-                              ? "Free mint (BTC fees only)"
-                              : `Price: ${formatAmount({ value: fairminter.price_normalized, maximumFractionDigits: 8 })} XCP`}
+                            {/* Cost of a whole lot, not of one token. The per-token figure read
+                                as "the price of a mint" while being a fraction of it. */}
+                            {describeFairminterLot(fairminter)}
                           </span>
                         </div>
                         {selected && (

--- a/src/components/domain/balance/amount-with-max-input.test.tsx
+++ b/src/components/domain/balance/amount-with-max-input.test.tsx
@@ -18,7 +18,7 @@ vi.mock('@/core/numeric', async (importOriginal) => ({
   // Brands are compile-time only; at runtime they are identity.
   asBaseUnits: (v: unknown) => v,
   asDisplayUnits: (v: unknown) => v,
-  fromSatoshis: vi.fn((sats) => (parseInt(sats) / 100000000).toFixed(8)),
+  fromSatoshis: vi.fn((sats) => (parseInt(sats, 10) / 100000000).toFixed(8)),
 }));
 
 describe('AmountWithMaxInput', () => {

--- a/src/components/domain/utxo/utxo-source-field.tsx
+++ b/src/components/domain/utxo/utxo-source-field.tsx
@@ -1,0 +1,60 @@
+import type { ReactElement } from "react";
+import { useNavigate } from "react-router";
+import { FaSpinner } from "@/components/icons";
+import { ErrorAlert } from "@/components/ui/error-alert";
+import { formatTxid } from "@/core/format";
+import type { UtxoSource } from "@/hooks/useUtxoSource";
+
+/**
+ * Shows which UTXO a compose form is spending from, what it holds, and any
+ * failure to load that. Also carries the hidden sourceUtxo field that the
+ * form action reads.
+ *
+ * @param props - The component props
+ * @returns A ReactElement for the source UTXO section of a compose form
+ */
+export function UtxoSourceField({ source }: { source: UtxoSource }): ReactElement {
+  const navigate = useNavigate();
+  const { utxo, balances, isLoadingBalances, error, dismissError } = source;
+
+  return (
+    <>
+      {error && (
+        <div className="mb-4">
+          <ErrorAlert message={error} onClose={dismissError} />
+        </div>
+      )}
+
+      {/* Hidden UTXO input - always passed to formAction */}
+      <input type="hidden" name="sourceUtxo" value={utxo} />
+
+      {/* UTXO Display - styled like an input */}
+      {utxo && (
+        <div>
+          <span className="block text-sm font-medium text-gray-700">
+            Output <span className="text-red-500">*</span>
+          </span>
+          <button
+            type="button"
+            onClick={() => navigate(`/assets/utxos/${utxo}`)}
+            className="text-left mt-1 block w-full p-2.5 rounded-md border border-gray-300 bg-gray-50 hover:bg-gray-100 cursor-pointer flex justify-between items-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+          >
+            <span className="text-sm font-mono text-blue-600 hover:text-blue-800">
+              {formatTxid(utxo)}
+            </span>
+            <span className="text-sm text-gray-500">
+              {isLoadingBalances ? (
+                <span className="flex items-center gap-1">
+                  <FaSpinner className="animate-spin size-4" aria-hidden="true" />
+                  Loading…
+                </span>
+              ) : (
+                `${balances.length} ${balances.length === 1 ? "Balance" : "Balances"}`
+              )}
+            </span>
+          </button>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/ui/cards/pool-card.tsx
+++ b/src/components/ui/cards/pool-card.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from "react";
 import { AssetIcon } from "@/components/domain/asset/asset-icon";
 import type { Pool, PoolPosition } from "@/core/counterparty/api";
-import { getCanonicalPoolAssets } from "@/core/counterparty/pool";
+import { getPoolDisplayAssets } from "@/core/counterparty/pool";
 import { formatAmount } from "@/core/format";
 
 interface PoolCardProps {
@@ -20,7 +20,7 @@ export function PoolCard({
   className = "",
 }: PoolCardProps): ReactElement {
   // Show icons and reserves in the same canonical order as the pair title
-  const [assetA, assetB] = getCanonicalPoolAssets(pool.asset_a, pool.asset_b);
+  const [assetA, assetB] = getPoolDisplayAssets(pool.asset_a, pool.asset_b);
   const swapped = assetA !== pool.asset_a;
   const reserveA = Number(
     swapped

--- a/src/components/ui/headers/pool-header.tsx
+++ b/src/components/ui/headers/pool-header.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from "react";
 import { AssetIcon } from "@/components/domain/asset/asset-icon";
 import type { Pool, PoolPosition } from "@/core/counterparty/api";
-import { getCanonicalPoolPair } from "@/core/counterparty/pool";
+import { getPoolDisplayPair } from "@/core/counterparty/pool";
 import { formatAmount } from "@/core/format";
 
 interface PoolHeaderProps {
@@ -10,7 +10,7 @@ interface PoolHeaderProps {
 }
 
 export function PoolHeader({ pool, className = "" }: PoolHeaderProps): ReactElement {
-  const pair = getCanonicalPoolPair(pool.asset_a, pool.asset_b);
+  const pair = getPoolDisplayPair(pool.asset_a, pool.asset_b);
   const quantity = "quantity_normalized" in pool
     ? (pool.quantity_normalized as string | undefined)
     : undefined;

--- a/src/components/ui/inputs/price-with-suggest-input.test.tsx
+++ b/src/components/ui/inputs/price-with-suggest-input.test.tsx
@@ -18,7 +18,7 @@ vi.mock('@/core/numeric', async (importOriginal) => ({
   isValidPositiveNumber: vi.fn((value, options) => {
     if (value === '') return true;
     const num = parseFloat(value);
-    if (isNaN(num)) return false;
+    if (Number.isNaN(num)) return false;
     if (num < 0) return false;
     if (!options?.allowZero && num === 0) return false;
     return true;

--- a/src/core/__tests__/numeric.fuzz.test.ts
+++ b/src/core/__tests__/numeric.fuzz.test.ts
@@ -207,7 +207,7 @@ describe('Numeric Utilities Fuzz Tests', () => {
         (btcAmount) => {
           const satoshis = toSatoshis(btcAmount);
           const expectedSatoshis = Math.floor(btcAmount * 1e8);
-          expect(parseInt(satoshis)).toBe(expectedSatoshis);
+          expect(parseInt(satoshis, 10)).toBe(expectedSatoshis);
         }
       ), { numRuns: 500 });
     });
@@ -277,7 +277,7 @@ describe('Numeric Utilities Fuzz Tests', () => {
         (minuend, subtrahend) => {
           const result = subtractSatoshis(minuend, subtrahend);
           const expected = minuend - subtrahend;
-          expect(parseInt(result)).toBe(expected);
+          expect(parseInt(result, 10)).toBe(expected);
         }
       ), { numRuns: 200 });
     });
@@ -289,7 +289,7 @@ describe('Numeric Utilities Fuzz Tests', () => {
         (dividend, divisor) => {
           const result = divideSatoshis(dividend, divisor);
           const expected = Math.floor(dividend / divisor);
-          expect(parseInt(result)).toBe(expected);
+          expect(parseInt(result, 10)).toBe(expected);
         }
       ), { numRuns: 200 });
     });

--- a/src/core/__tests__/numeric.test.ts
+++ b/src/core/__tests__/numeric.test.ts
@@ -222,10 +222,42 @@ describe('numeric utilities', () => {
     });
   });
 
+  describe('isFiniteNumber', () => {
+    it('accepts finite numbers, as strings or numbers', () => {
+      expect(isFiniteNumber('1.25')).toBe(true);
+      expect(isFiniteNumber(1.25)).toBe(true);
+      expect(isFiniteNumber(0)).toBe(true);
+      expect(isFiniteNumber('-3')).toBe(true);
+      // Same comma and space tolerance as toBigNumber.
+      expect(isFiniteNumber('1,234.5')).toBe(true);
+    });
+
+    it('rejects the infinities', () => {
+      expect(isFiniteNumber('Infinity')).toBe(false);
+      expect(isFiniteNumber(Number.POSITIVE_INFINITY)).toBe(false);
+      expect(isFiniteNumber(Number.NEGATIVE_INFINITY)).toBe(false);
+    });
+
+    // Each of these used to return true. Routing through toBigNumber replaced anything
+    // unparseable with its default of 0, and 0 is finite — so the predicate reported junk as a
+    // number and only ever rejected Infinity.
+    it('rejects what is not a number at all', () => {
+      expect(isFiniteNumber(Number.NaN)).toBe(false);
+      expect(isFiniteNumber('NaN')).toBe(false);
+      expect(isFiniteNumber('abc')).toBe(false);
+      expect(isFiniteNumber('')).toBe(false);
+      expect(isFiniteNumber('   ')).toBe(false);
+      expect(isFiniteNumber(null)).toBe(false);
+      expect(isFiniteNumber(undefined)).toBe(false);
+    });
+
+    it('does not treat a lone decimal point as a number', () => {
+      expect(isFiniteNumber('.')).toBe(false);
+    });
+  });
+
   describe('generic comparisons', () => {
     it('compares mixed numeric inputs safely', () => {
-      expect(isFiniteNumber('1.25')).toBe(true);
-      expect(isFiniteNumber('Infinity')).toBe(false);
       expect(isEqualTo('100', 100)).toBe(true);
       expect(isLessThan('99.99999999', 100)).toBe(true);
       expect(isLessThanOrEqualTo('100', 100)).toBe(true);

--- a/src/core/__tests__/numericDiscipline.test.ts
+++ b/src/core/__tests__/numericDiscipline.test.ts
@@ -70,7 +70,7 @@ function sourceFiles(dir: string): string[] {
  * code, and a comment mentioning `Number()` scored as a violation. It also made the count differ
  * between a Windows working copy and CI's Linux one.
  */
-export function violationsIn(source: string): number {
+function violationsIn(source: string): number {
   let count = 0;
   for (const line of source.split(/\r?\n/)) {
     const code = line.replace(/\/\/.*$/, '').replace(/^\s*\*.*$/, '');

--- a/src/core/__tests__/settings.test.ts
+++ b/src/core/__tests__/settings.test.ts
@@ -68,8 +68,10 @@ describe('VALID_AUTO_LOCK_TIMERS', () => {
   });
 
   it('matches AUTO_LOCK_TIMEOUT_MS keys', () => {
-    expect(VALID_AUTO_LOCK_TIMERS.sort()).toEqual(
-      Object.keys(AUTO_LOCK_TIMEOUT_MS).sort()
+    // Compare as sets: sorting in place would mutate the exported constant and
+    // reorder it for every test that runs after this one.
+    expect(new Set(VALID_AUTO_LOCK_TIMERS)).toEqual(
+      new Set(Object.keys(AUTO_LOCK_TIMEOUT_MS))
     );
   });
 });

--- a/src/core/bitcoin/__tests__/address.test.ts
+++ b/src/core/bitcoin/__tests__/address.test.ts
@@ -40,52 +40,47 @@ describe('Bitcoin Address Utilities', () => {
   });
 
   describe('encodeAddress', () => {
-    // Known test vector: compressed public key
+    // secp256k1's generator point G, i.e. the public key for private key 1.
+    // Its addresses are published, so the expectations below are independent of
+    // this codebase rather than recordings of whatever it happens to produce.
     const testPubKey = hexToBytes('0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798');
-    
+    const uncompressedPubKey = hexToBytes('0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8');
+
+    // These used to assert only `typeof address === 'string'`, a prefix and a
+    // length band. Every wrong-but-well-formed address passes that: the wrong
+    // hash, the wrong key encoding, the wrong network byte within a prefix
+    // class. The compressed and uncompressed cases below are the same key and
+    // differ only in encoding, and both satisfy startsWith('1').
     it('should encode P2PKH address correctly', () => {
-      const address = encodeAddress(testPubKey, AddressFormat.P2PKH);
-      expect(typeof address).toBe('string');
-      expect(address.startsWith('1')).toBe(true);
-      expect(address.length).toBeGreaterThan(25);
-      expect(address.length).toBeLessThan(36);
+      expect(encodeAddress(testPubKey, AddressFormat.P2PKH))
+        .toBe('1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH');
     });
 
     it('should encode P2SH_P2WPKH address correctly', () => {
-      const address = encodeAddress(testPubKey, AddressFormat.P2SH_P2WPKH);
-      expect(typeof address).toBe('string');
-      expect(address.startsWith('3')).toBe(true);
-      expect(address.length).toBeGreaterThan(25);
-      expect(address.length).toBeLessThan(36);
+      expect(encodeAddress(testPubKey, AddressFormat.P2SH_P2WPKH))
+        .toBe('3JvL6Ymt8MVWiCNHC7oWU6nLeHNJKLZGLN');
     });
 
     it('should encode P2WPKH address correctly', () => {
-      const address = encodeAddress(testPubKey, AddressFormat.P2WPKH);
-      expect(typeof address).toBe('string');
-      expect(address.startsWith('bc1')).toBe(true);
-      expect(address.length).toBe(42); // bech32 P2WPKH is always 42 chars
+      // BIP-173 test vector.
+      expect(encodeAddress(testPubKey, AddressFormat.P2WPKH))
+        .toBe('bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4');
     });
 
     it('should encode P2TR address correctly', () => {
-      const address = encodeAddress(testPubKey, AddressFormat.P2TR);
-      expect(typeof address).toBe('string');
-      expect(address.startsWith('bc1p')).toBe(true);
-      expect(address.length).toBe(62); // bech32m P2TR is always 62 chars
+      // BIP-350 test vector.
+      expect(encodeAddress(testPubKey, AddressFormat.P2TR))
+        .toBe('bc1pmfr3p9j00pfxjh0zmgp99y8zftmd3s5pmedqhyptwy6lm87hf5sspknck9');
     });
 
-    it('should encode Counterwallet address correctly', () => {
-      const address = encodeAddress(testPubKey, AddressFormat.Counterwallet);
-      expect(typeof address).toBe('string');
-      expect(address.startsWith('1')).toBe(true);
-      expect(address.length).toBeGreaterThan(25);
-      expect(address.length).toBeLessThan(36);
+    it('should encode Counterwallet address as P2PKH', () => {
+      expect(encodeAddress(testPubKey, AddressFormat.Counterwallet))
+        .toBe('1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH');
     });
 
-    it('should encode CounterwalletSegwit address correctly', () => {
-      const address = encodeAddress(testPubKey, AddressFormat.CounterwalletSegwit);
-      expect(typeof address).toBe('string');
-      expect(address.startsWith('bc1')).toBe(true);
-      expect(address.length).toBe(42); // bech32 P2WPKH is always 42 chars
+    it('should encode CounterwalletSegwit address as P2WPKH', () => {
+      expect(encodeAddress(testPubKey, AddressFormat.CounterwalletSegwit))
+        .toBe('bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4');
     });
 
     it('should throw error for unsupported address type', () => {
@@ -94,10 +89,20 @@ describe('Bitcoin Address Utilities', () => {
     });
 
     it('should handle uncompressed public key', () => {
-      const uncompressedPubKey = hexToBytes('0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8');
-      const address = encodeAddress(uncompressedPubKey, AddressFormat.P2PKH);
-      expect(typeof address).toBe('string');
-      expect(address.startsWith('1')).toBe(true);
+      expect(encodeAddress(uncompressedPubKey, AddressFormat.P2PKH))
+        .toBe('1EHNa6Q4Jz2uvNExL497mE43ikXhwF6kZm');
+    });
+
+    it('should not conflate the two encodings of one key', () => {
+      // Same point, two serialisations, two different addresses. A prefix or
+      // length check cannot tell these apart, which is how an encoding bug
+      // hides.
+      const compressed = encodeAddress(testPubKey, AddressFormat.P2PKH);
+      const uncompressed = encodeAddress(uncompressedPubKey, AddressFormat.P2PKH);
+
+      expect(compressed).not.toBe(uncompressed);
+      expect(compressed.startsWith('1')).toBe(true);
+      expect(uncompressed.startsWith('1')).toBe(true);
     });
 
     it('should generate different addresses for different public keys', () => {
@@ -133,48 +138,53 @@ describe('Bitcoin Address Utilities', () => {
     const testMnemonic = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
     const testPath = "m/84'/0'/0'/0/0";
 
+    // testMnemonic is the BIP-39 "abandon ... about" vector, so the first
+    // receiving address of each standard account is published in the BIP that
+    // defines the path. Asserting the address rather than its shape is what
+    // makes these tests able to catch a derivation change.
     it('should derive P2PKH address from mnemonic', () => {
-      const address = getAddressFromMnemonic(testMnemonic, "m/44'/0'/0'/0/0", AddressFormat.P2PKH);
-      expect(typeof address).toBe('string');
-      expect(address.startsWith('1')).toBe(true);
+      // BIP-44 m/44'/0'/0'/0/0
+      expect(getAddressFromMnemonic(testMnemonic, "m/44'/0'/0'/0/0", AddressFormat.P2PKH))
+        .toBe('1LqBGSKuX5yYUonjxT5qGfpUsXKYYWeabA');
     });
 
     it('should derive P2WPKH address from mnemonic', () => {
-      const address = getAddressFromMnemonic(testMnemonic, testPath, AddressFormat.P2WPKH);
-      expect(typeof address).toBe('string');
-      expect(address.startsWith('bc1')).toBe(true);
+      // BIP-84 m/84'/0'/0'/0/0, given verbatim in the BIP.
+      expect(getAddressFromMnemonic(testMnemonic, testPath, AddressFormat.P2WPKH))
+        .toBe('bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu');
     });
 
     it('should derive P2SH_P2WPKH address from mnemonic', () => {
-      const address = getAddressFromMnemonic(testMnemonic, "m/49'/0'/0'/0/0", AddressFormat.P2SH_P2WPKH);
-      expect(typeof address).toBe('string');
-      expect(address.startsWith('3')).toBe(true);
+      // BIP-49 m/49'/0'/0'/0/0
+      expect(getAddressFromMnemonic(testMnemonic, "m/49'/0'/0'/0/0", AddressFormat.P2SH_P2WPKH))
+        .toBe('37VucYSaXLCAsxYyAPfbSi9eh4iEcbShgf');
     });
 
     it('should derive P2TR address from mnemonic', () => {
-      const address = getAddressFromMnemonic(testMnemonic, "m/86'/0'/0'/0/0", AddressFormat.P2TR);
-      expect(typeof address).toBe('string');
-      expect(address.startsWith('bc1p')).toBe(true);
+      // BIP-86 m/86'/0'/0'/0/0, given verbatim in the BIP.
+      expect(getAddressFromMnemonic(testMnemonic, "m/86'/0'/0'/0/0", AddressFormat.P2TR))
+        .toBe('bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr');
     });
 
+    // Counterwallet has no BIP to cite and derives from the seed mocked at the
+    // top of this file, so these two pin current behaviour rather than an
+    // external standard. They still fail if the derivation changes.
     it('should derive Counterwallet address from mnemonic', () => {
-      const address = getAddressFromMnemonic(testMnemonic, "m/0'/0", AddressFormat.Counterwallet);
-      expect(typeof address).toBe('string');
-      expect(address.startsWith('1')).toBe(true);
+      expect(getAddressFromMnemonic(testMnemonic, "m/0'/0", AddressFormat.Counterwallet))
+        .toBe('1537tphrFkmJcxsmGqXprqpsKEUcSU5NHV');
     });
 
     it('should derive CounterwalletSegwit address from mnemonic', () => {
-      const address = getAddressFromMnemonic(testMnemonic, "m/0'/0", AddressFormat.CounterwalletSegwit);
-      expect(typeof address).toBe('string');
-      expect(address.startsWith('bc1')).toBe(true);
-      expect(address.length).toBe(42); // bech32 P2WPKH is always 42 chars
+      expect(getAddressFromMnemonic(testMnemonic, "m/0'/0", AddressFormat.CounterwalletSegwit))
+        .toBe('bc1q93r3de5tt6ks8qjuj2e3zd5r2p6rcmluzteug4');
     });
 
     it('should generate different addresses for different paths', () => {
-      const address1 = getAddressFromMnemonic(testMnemonic, "m/84'/0'/0'/0/0", AddressFormat.P2WPKH);
-      const address2 = getAddressFromMnemonic(testMnemonic, "m/84'/0'/0'/0/1", AddressFormat.P2WPKH);
-      
-      expect(address1).not.toBe(address2);
+      // BIP-84's second receiving address, m/84'/0'/0'/0/1.
+      expect(getAddressFromMnemonic(testMnemonic, "m/84'/0'/0'/0/0", AddressFormat.P2WPKH))
+        .toBe('bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu');
+      expect(getAddressFromMnemonic(testMnemonic, "m/84'/0'/0'/0/1", AddressFormat.P2WPKH))
+        .toBe('bc1qnjg0jd8228aq7egyzacy8cys3knf9xvrerkf9g');
     });
 
     it('should generate same address for same inputs', () => {
@@ -185,12 +195,14 @@ describe('Bitcoin Address Utilities', () => {
     });
 
     it('should handle different mnemonic lengths', () => {
-      // 24-word mnemonic
+      // The 24-word "abandon ... art" BIP-39 vector. Asserting the address is
+      // what distinguishes "a 24-word phrase derives its own key" from "a
+      // 24-word phrase silently derives the 12-word one".
       const longMnemonic = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art';
       const address = getAddressFromMnemonic(longMnemonic, testPath, AddressFormat.P2WPKH);
-      
-      expect(typeof address).toBe('string');
-      expect(address.startsWith('bc1')).toBe(true);
+
+      expect(address).toBe('bc1qzmtrqsfuaf6l6kkcsseumq26ukaphfj9skkug6');
+      expect(address).not.toBe(getAddressFromMnemonic(testMnemonic, testPath, AddressFormat.P2WPKH));
     });
 
     it('should throw error for invalid mnemonic', () => {
@@ -205,19 +217,19 @@ describe('Bitcoin Address Utilities', () => {
     });
 
     it('should handle hardened derivation paths', () => {
-      const hardenedPath = "m/84'/0'/0'/0'/0'";
-      const address = getAddressFromMnemonic(testMnemonic, hardenedPath, AddressFormat.P2WPKH);
-      
-      expect(typeof address).toBe('string');
-      expect(address.startsWith('bc1')).toBe(true);
+      // Hardened child indices take a different derivation branch, so this
+      // must not land on the unhardened m/84'/0'/0'/0/0 address.
+      const address = getAddressFromMnemonic(testMnemonic, "m/84'/0'/0'/0'/0'", AddressFormat.P2WPKH);
+
+      expect(address).toBe('bc1q8d2x9494zdyx6ka8pp4p94xe8jpsef77pzl7td');
+      expect(address).not.toBe(getAddressFromMnemonic(testMnemonic, testPath, AddressFormat.P2WPKH));
     });
 
     it('should handle deep derivation paths', () => {
-      const deepPath = "m/84'/0'/0'/0/0/1/2/3";
-      const address = getAddressFromMnemonic(testMnemonic, deepPath, AddressFormat.P2WPKH);
-      
-      expect(typeof address).toBe('string');
-      expect(address.startsWith('bc1')).toBe(true);
+      const address = getAddressFromMnemonic(testMnemonic, "m/84'/0'/0'/0/0/1/2/3", AddressFormat.P2WPKH);
+
+      expect(address).toBe('bc1qd7kpfv598fstjzu6p4c9rkc4eqt4p9v0vysyd8');
+      expect(address).not.toBe(getAddressFromMnemonic(testMnemonic, testPath, AddressFormat.P2WPKH));
     });
   });
 
@@ -375,14 +387,19 @@ describe('Bitcoin Address Utilities', () => {
 
       const testMnemonic = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
       
-      addressFormats.forEach(addressFormat => {
-        const path = getDerivationPathForAddressFormat(addressFormat);
-        const fullPath = path + '/0';
-        const address = getAddressFromMnemonic(testMnemonic, fullPath, addressFormat);
-        
-        expect(typeof address).toBe('string');
-        expect(address.length).toBeGreaterThan(0);
+      // Every format must produce an address that validates, and no two
+      // formats may collide. `typeof address === 'string'` and a non-zero
+      // length were true of any return value at all, including one format
+      // silently falling back to another.
+      const derived = addressFormats.map(addressFormat => {
+        const fullPath = `${getDerivationPathForAddressFormat(addressFormat)}/0`;
+        return getAddressFromMnemonic(testMnemonic, fullPath, addressFormat);
       });
+
+      for (const address of derived) {
+        expect(isValidBitcoinAddress(address)).toBe(true);
+      }
+      expect(new Set(derived).size).toBe(addressFormats.length);
     });
   });
 });

--- a/src/core/bitcoin/__tests__/psbt.test.ts
+++ b/src/core/bitcoin/__tests__/psbt.test.ts
@@ -440,7 +440,7 @@ describe('signPSBT', () => {
 
     expect(input.sighashType).toBe(0x83);
     expect(input.partialSig).toHaveLength(1);
-    expect(input.partialSig?.[0]![1].at(-1)).toBe(0x83);
+    expect(input.partialSig![0]![1].at(-1)).toBe(0x83);
   });
 
   it('should throw on invalid private key', () => {

--- a/src/core/bitcoin/__tests__/wallet-fixtures.test.ts
+++ b/src/core/bitcoin/__tests__/wallet-fixtures.test.ts
@@ -1,10 +1,44 @@
 /**
  * Wallet Test Fixtures
  * Test signatures from various wallet implementations to ensure cross-platform compatibility
+ *
+ * Reference material, kept as documentation rather than as tests. It used to
+ * live in it() blocks that only console.log-ed it, which inflated the passing
+ * count with five checks that asserted nothing.
+ *
+ * What each wallet does:
+ * - Our extension: signs BIP-322 only; verifies BIP-322, BIP-137 (loose and
+ *   strict) and legacy, for P2PKH, P2WPKH, P2SH-P2WPKH and P2TR.
+ * - Bitcore: BIP-137/legacy. P2PKH verifies; P2TR unsupported.
+ * - FreeWallet: BIP-137, and BIP-322 over legacy addresses - see the fixture
+ *   below, whose witness-stack signature only the BIP-322 path can accept.
+ * - Electrum: BIP-137. Flags 27-30 uncompressed, 31-34 compressed, 35-42 SegWit.
+ * - Bitcoin Core: strict BIP-137, correct flags per address type, and does not
+ *   sign P2TR with BIP-137 at all.
+ * - Ledger/Sparrow: BIP-137 including for Taproot, so P2TR needs loose verification.
+ * - Trezor: BIP-137 for all address types; Taproot is firmware dependent.
+ *
+ * Known gaps, unchanged by this file:
+ * - Testnet addresses are not supported alongside mainnet.
+ * - P2SH multisig and P2WSH are not supported; that would need full script
+ *   evaluation.
+ *
+ * Wallets with no fixtures yet (Electrum, Bitcoin Core, Trezor) simply have no
+ * tests here. An empty it() that prints their expected format is not coverage.
+ *
+ * One former fixture is deliberately gone. It paired address
+ * 1HnhWpkMHMjgt167kvgcPyurMmsCQ2WPgg with a "Hello World" signature, and no
+ * key can satisfy that pair: recovering the signature over that message across
+ * every recovery id, in both point encodings, and deriving P2PKH, P2WPKH and
+ * P2SH-P2WPKH from each, never produces that address. The signature itself is
+ * sound - it recovers to 1QDZfWJTVXqHFmJFRkyrnidvHyPyG5bynY - so the fixture
+ * was a real signature filed under the wrong address. Correcting it to the
+ * address we derived ourselves would only assert that our recovery agrees with
+ * our recovery, which is why it was dropped rather than patched.
  */
 
 import { describe, expect, it } from 'vitest';
-import { verifyMessage, verifyMessageWithMethod } from '../messageVerifier';
+import { verifyLooseBIP137, verifyMessage, verifyMessageWithMethod } from '../messageVerifier';
 
 describe('Wallet Implementation Test Fixtures', () => {
   describe('Bitcore/FreeWallet Fixtures', () => {
@@ -14,13 +48,6 @@ describe('Wallet Implementation Test Fixtures', () => {
         address: '1F3sAm6ZtwLAUnj7d38pGFxtP3RVEvtsbV',
         message: 'This is an example of a signed message.',
         signature: 'H9L5yLFjti0QTHhPyFrZCT1V/MMnBtXKmoiKDZ78NDBjERki6ZTQZdSMCtkgoNmp17By9ItJr8o7ChX0XxY91nk=',
-        wallet: 'bitcore',
-        expected: true
-      },
-      {
-        address: '1HnhWpkMHMjgt167kvgcPyurMmsCQ2WPgg',
-        message: 'Hello World',
-        signature: 'IAtVrymJqo43BCt9f7Dhl6ET4Gg3SmhyvdlW6wn9iWc9PweD7tNM5+qw7xE9/bzlw/Et789AQ2F59YKEnSzQudo=',
         wallet: 'bitcore',
         expected: true
       }
@@ -34,222 +61,87 @@ describe('Wallet Implementation Test Fixtures', () => {
           fixture.address
         );
 
-        console.log(`${fixture.wallet} verification:`, result);
-
-        // For known issues, we'll just check it doesn't throw
-        if (fixture.expected) {
-          expect(result.valid || typeof result.valid === 'boolean').toBe(true);
-        }
+        // This used to read `result.valid || typeof result.valid === 'boolean'`,
+        // which is true for any boolean and so could never fail.
+        expect(result.valid).toBe(fixture.expected);
       });
     }
   });
 
-  describe('Electrum Fixtures', () => {
-    // Electrum uses standard BIP-137 for P2PKH addresses
-    // TODO: Add real Electrum fixtures when available
+  describe('FreeWallet Fixtures', () => {
+    // A BIP-322 signature over a legacy address, which is the combination the
+    // BIP-137 fixtures above cannot reach. The 108-byte witness-stack encoding
+    // is rejected outright by every BIP-137 and legacy path on signature
+    // length, so a pass here can only have come from the BIP-322 verifier.
+    const fixture = {
+      address: '19QWXpMXeLkoEKEJv2xo9rn8wkPCyxACSX',
+      message: 'Hello World',
+      signature:
+        'AkgwRQIhAKwLGWnYM9idetpSZLcZ3AQyycuyxuBUUYi1jr2+HozyAiB42v9dg03JyrEDJzRrGbmXMNlM+NJM1dLHBwU1WaNzVwEhAy7800wgcNj8nqpNtZnrdyxygC5U1XWnsFpLK+/B9+dv'
+    };
 
-    it('should handle Electrum signature format', async () => {
-      // Document Electrum's expected behavior
-      console.log('Electrum signature format:');
-      console.log('- Uses BIP-137 for P2PKH addresses');
-      console.log('- Flag 31-34 for compressed keys');
-      console.log('- Flag 27-30 for uncompressed keys');
-      console.log('- Supports SegWit with flags 35-42');
+    it('should verify a FreeWallet BIP-322 signature for a P2PKH address', async () => {
+      const result = await verifyMessageWithMethod(
+        fixture.message,
+        fixture.signature,
+        fixture.address
+      );
+
+      expect(result.valid).toBe(true);
+      expect(result.method).toContain('BIP-322');
+    });
+
+    it('should reject that signature against a different message', async () => {
+      const result = await verifyMessageWithMethod(
+        'Goodbye World',
+        fixture.signature,
+        fixture.address
+      );
+
+      expect(result.valid).toBe(false);
+    });
+
+    it('should reject that signature against a different address', async () => {
+      const result = await verifyMessageWithMethod(
+        fixture.message,
+        fixture.signature,
+        '1F3sAm6ZtwLAUnj7d38pGFxtP3RVEvtsbV'
+      );
+
+      expect(result.valid).toBe(false);
     });
   });
 
   describe('Ledger/Sparrow Fixtures', () => {
-    // From bip322-js issue #1
-    const ledgerFixtures = [
-      {
-        taprootAddress: 'bc1ps5pt865e77nr9t9z7fdefryx27lsz0ced875lxcc68lszvc7x3qsxx25fy',
-        p2pkhAddress: '19C7EwHP5FN32YPrMRfW7mkFKg3FYwyAzr',
-        message: 'bitcheckdiuq5gh179v9r5vwmw58ijtkea1vb4idr92khiu',
-        signature: 'HxOxevYmNjW58m/TBcewrpLbOC0NXjwnWO+jccW9tq8JbdtjI8modbmYbJNVO6PpE9MATfiZeU/S/GbmozNhV4Y=',
-        wallet: 'Ledger/Sparrow',
-        note: 'BIP-137 signature for Taproot address'
-      }
-    ];
+    // From bip322-js issue #1. One signature, one key, two address encodings:
+    // Ledger and Sparrow sign Taproot addresses with BIP-137, which the spec
+    // does not cover, so P2TR only verifies through loose verification.
+    const fixture = {
+      taprootAddress: 'bc1ps5pt865e77nr9t9z7fdefryx27lsz0ced875lxcc68lszvc7x3qsxx25fy',
+      p2pkhAddress: '19C7EwHP5FN32YPrMRfW7mkFKg3FYwyAzr',
+      message: 'bitcheckdiuq5gh179v9r5vwmw58ijtkea1vb4idr92khiu',
+      signature: 'HxOxevYmNjW58m/TBcewrpLbOC0NXjwnWO+jccW9tq8JbdtjI8modbmYbJNVO6PpE9MATfiZeU/S/GbmozNhV4Y=',
+      wallet: 'Ledger/Sparrow'
+    };
 
-    for (const fixture of ledgerFixtures) {
-      it(`should handle ${fixture.wallet} Taproot signatures`, async () => {
-        // Test with P2PKH address (should work)
-        const p2pkhResult = await verifyMessage(
-          fixture.message,
-          fixture.signature,
-          fixture.p2pkhAddress
-        );
+    it(`should verify ${fixture.wallet} signatures against the P2PKH form of the key`, async () => {
+      const result = await verifyMessage(
+        fixture.message,
+        fixture.signature,
+        fixture.p2pkhAddress
+      );
 
-        console.log(`${fixture.wallet} P2PKH verification:`, p2pkhResult);
-
-        // Test with Taproot address using loose verification
-        const { verifyLooseBIP137 } = await import('../messageVerifier');
-        const taprootResult = await verifyLooseBIP137(
-          fixture.message,
-          fixture.signature,
-          fixture.taprootAddress
-        );
-
-        console.log(`${fixture.wallet} Taproot verification (loose):`, taprootResult);
-        console.log(`Note: ${fixture.note}`);
-      });
-    }
-  });
-
-  describe('Bitcoin Core Fixtures', () => {
-    // Bitcoin Core uses standard BIP-137
-    // TODO: Add actual Bitcoin Core test fixtures when available
-    // Expected format:
-    // - address: Bitcoin address
-    // - message: Message that was signed
-    // - signature: Base64 encoded signature from Bitcoin Core
-    // - Uses strict BIP-137 implementation with correct header flags
-
-    it('should document Bitcoin Core signature format', async () => {
-      console.log('Bitcoin Core signature format:');
-      console.log('- Strict BIP-137 implementation');
-      console.log('- Correct header flags for address types');
-      console.log('- P2PKH: flags 27-34');
-      console.log('- P2SH-P2WPKH: flags 35-38');
-      console.log('- P2WPKH: flags 39-42');
-      console.log('- Does not sign for P2TR addresses with BIP-137');
+      expect(result.valid).toBe(true);
     });
-  });
 
-  describe('Trezor Fixtures', () => {
-    // TODO: Add actual Trezor hardware wallet test fixtures when available
-    // Expected format:
-    // - address: Bitcoin address (including segwit)
-    // - message: Message that was signed
-    // - signature: Base64 encoded signature from Trezor
-    // - Uses BIP-137 format for all address types
+    it(`should verify ${fixture.wallet} Taproot signatures only loosely`, async () => {
+      const loose = await verifyLooseBIP137(
+        fixture.message,
+        fixture.signature,
+        fixture.taprootAddress
+      );
 
-    it('should document Trezor signature format', async () => {
-      console.log('Trezor signature format:');
-      console.log('- Uses BIP-137 for all address types');
-      console.log('- Proper header flags for address types');
-      console.log('- Supports P2PKH, P2SH-P2WPKH, P2WPKH');
-      console.log('- May not support Taproot signing yet');
-    });
-  });
-
-  describe('Cross-Wallet Compatibility Matrix', () => {
-    it('should document wallet compatibility', () => {
-      const compatibilityMatrix = {
-        'Our Extension': {
-          signing: 'BIP-322 only',
-          verification: 'BIP-322, BIP-137 (loose & strict), Legacy',
-          P2PKH: '✅ Sign & Verify',
-          P2WPKH: '✅ Sign & Verify',
-          'P2SH-P2WPKH': '✅ Sign & Verify',
-          P2TR: '✅ Sign & Verify'
-        },
-        'Bitcore/FreeWallet': {
-          signing: 'BIP-137/Legacy',
-          verification: 'BIP-137/Legacy',
-          P2PKH: '✅ Verify',
-          P2WPKH: '❓ May not support',
-          'P2SH-P2WPKH': '❓ May not support',
-          P2TR: '❌ Not supported'
-        },
-        'Electrum': {
-          signing: 'BIP-137',
-          verification: 'BIP-137',
-          P2PKH: '✅ Verify',
-          P2WPKH: '✅ Verify',
-          'P2SH-P2WPKH': '✅ Verify',
-          P2TR: '❓ Version dependent'
-        },
-        'Ledger': {
-          signing: 'BIP-137 (including for Taproot)',
-          verification: 'BIP-137',
-          P2PKH: '✅ Verify',
-          P2WPKH: '✅ Verify',
-          'P2SH-P2WPKH': '✅ Verify',
-          P2TR: '⚠️ Verify with loose BIP-137'
-        },
-        'Sparrow': {
-          signing: 'BIP-137 (including for Taproot)',
-          verification: 'BIP-137',
-          P2PKH: '✅ Verify',
-          P2WPKH: '✅ Verify',
-          'P2SH-P2WPKH': '✅ Verify',
-          P2TR: '⚠️ Verify with loose BIP-137'
-        },
-        'Bitcoin Core': {
-          signing: 'BIP-137 (strict)',
-          verification: 'BIP-137 (strict)',
-          P2PKH: '✅ Verify',
-          P2WPKH: '✅ Verify',
-          'P2SH-P2WPKH': '✅ Verify',
-          P2TR: '❌ Not BIP-137 compatible'
-        },
-        'Trezor': {
-          signing: 'BIP-137',
-          verification: 'BIP-137',
-          P2PKH: '✅ Verify',
-          P2WPKH: '✅ Verify',
-          'P2SH-P2WPKH': '✅ Verify',
-          P2TR: '❓ Firmware dependent'
-        }
-      };
-
-      console.log('\n=== Wallet Compatibility Matrix ===\n');
-
-      for (const [wallet, details] of Object.entries(compatibilityMatrix)) {
-        console.log(`${wallet}:`);
-        for (const [key, value] of Object.entries(details)) {
-          console.log(`  ${key}: ${value}`);
-        }
-        console.log('');
-      }
-
-      console.log('Legend:');
-      console.log('✅ = Fully supported');
-      console.log('⚠️ = Supported with caveats');
-      console.log('❓ = Unknown/Version dependent');
-      console.log('❌ = Not supported');
-    });
-  });
-
-  describe('Known Issues and Workarounds', () => {
-    it('should document known compatibility issues', () => {
-      const knownIssues = [
-        {
-          issue: 'Ledger/Sparrow Taproot signatures',
-          description: 'These wallets sign Taproot addresses using BIP-137 format instead of BIP-322',
-          workaround: 'Use loose BIP-137 verification to check if recovered pubkey can derive the Taproot address',
-          implemented: true
-        },
-        {
-          issue: 'Header flag mismatches',
-          description: 'Some wallets use incorrect header flags (e.g., P2PKH flag for SegWit address)',
-          workaround: 'Loose verification ignores flag type and checks pubkey match',
-          implemented: true
-        },
-        {
-          issue: 'Testnet addresses',
-          description: 'Some test vectors use testnet addresses which may not verify on mainnet',
-          workaround: 'Support both mainnet and testnet address formats',
-          implemented: false
-        },
-        {
-          issue: 'Multi-signature addresses',
-          description: 'P2SH multisig and P2WSH are not supported',
-          workaround: 'Not implemented - would require full script evaluation',
-          implemented: false
-        }
-      ];
-
-      console.log('\n=== Known Issues and Workarounds ===\n');
-
-      for (const issue of knownIssues) {
-        console.log(`Issue: ${issue.issue}`);
-        console.log(`Description: ${issue.description}`);
-        console.log(`Workaround: ${issue.workaround}`);
-        console.log(`Implemented: ${issue.implemented ? '✅ Yes' : '❌ No'}`);
-        console.log('');
-      }
+      expect(loose.valid).toBe(true);
     });
   });
 });

--- a/src/core/bitcoin/blockHeight.ts
+++ b/src/core/bitcoin/blockHeight.ts
@@ -83,14 +83,7 @@ const blockHeightFetchers: Array<() => Promise<number>> = [
  * @throws {DataFetchError} If all sources fail
  */
 export async function fetchBlockHeightRace(): Promise<number> {
-  const fetchPromises = blockHeightFetchers.map(async (fetcher) => {
-    try {
-      return await fetcher();
-    } catch (error) {
-      // Convert rejections to a special rejected value so we can track failures
-      throw error;
-    }
-  });
+  const fetchPromises = blockHeightFetchers.map((fetcher) => fetcher());
 
   try {
     // Use Promise.any which returns the first fulfilled promise, ignoring rejections until all reject

--- a/src/core/bitcoin/messageVerifier/__tests__/secp-recovery.test.ts
+++ b/src/core/bitcoin/messageVerifier/__tests__/secp-recovery.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Public key recovery, specifically the compressed/uncompressed distinction.
+ *
+ * BIP-137 header flags 27-30 mean "P2PKH, uncompressed key" and 31-34 mean
+ * "P2PKH, compressed key". The two encodings of the same point hash to
+ * different addresses, so recovery has to honour the request: returning a
+ * compressed key when the caller asked for an uncompressed one silently
+ * derives the wrong address and fails every otherwise-valid signature.
+ *
+ * These tests build signatures from a known key rather than using wallet
+ * fixtures, because the point is the encoding, not any wallet's behaviour.
+ */
+
+import * as secp from '@noble/secp256k1';
+import { base64 } from '@scure/base';
+import * as btc from '@scure/btc-signer';
+import { describe, expect, it } from 'vitest';
+import { verifyLooseBIP137 } from '../compatibility/loose-bip137';
+import { verifyBIP137 } from '../specs/bip137';
+import { hashMessage, recoverPublicKey } from '../utils';
+import { verifyMessage } from '../verifier';
+
+const PRIVATE_KEY = new Uint8Array(32).fill(7);
+const MESSAGE = 'Hello World';
+
+function signBIP137(baseFlag: number) {
+  const hash = hashMessage(MESSAGE);
+  const recovered = secp.sign(hash, PRIVATE_KEY, { prehash: false, format: 'recovered' });
+  const recoveryId = recovered[0]!;
+  const raw = recovered.slice(1);
+
+  const signature = new Uint8Array(65);
+  signature[0] = baseFlag + recoveryId;
+  signature.set(raw, 1);
+
+  return { raw, recoveryId, signature: base64.encode(signature), hash };
+}
+
+describe('recoverPublicKey encoding', () => {
+  const point = secp.Point.fromBytes(secp.getPublicKey(PRIVATE_KEY, true));
+  const compressedKey = point.toBytes(true);
+  const uncompressedKey = point.toBytes(false);
+
+  it('returns 33 bytes when a compressed key is requested', () => {
+    const { raw, recoveryId, hash } = signBIP137(31);
+
+    const key = recoverPublicKey({ raw, recoveryId, compressed: true }, hash);
+
+    expect(key).toEqual(compressedKey);
+    expect(key).toHaveLength(33);
+  });
+
+  it('returns 65 bytes when an uncompressed key is requested', () => {
+    const { raw, recoveryId, hash } = signBIP137(27);
+
+    const key = recoverPublicKey({ raw, recoveryId, compressed: false }, hash);
+
+    // Regression: this used to return the 33-byte compressed key regardless,
+    // so uncompressed signatures derived the compressed address and never
+    // verified. Truncating 65 bytes to 33 is not compression either.
+    expect(key).toEqual(uncompressedKey);
+    expect(key).toHaveLength(65);
+  });
+
+  it('derives different addresses from the two encodings', () => {
+    expect(btc.p2pkh(uncompressedKey).address).not.toBe(btc.p2pkh(compressedKey).address);
+  });
+});
+
+describe('BIP-137 uncompressed signatures', () => {
+  const point = secp.Point.fromBytes(secp.getPublicKey(PRIVATE_KEY, true));
+
+  it('verifies a flag 27-30 signature against its uncompressed address', async () => {
+    const { signature } = signBIP137(27);
+    const address = btc.p2pkh(point.toBytes(false)).address!;
+
+    const result = await verifyMessage(MESSAGE, signature, address);
+
+    expect(result.valid).toBe(true);
+  });
+
+  it('verifies a flag 31-34 signature against its compressed address', async () => {
+    const { signature } = signBIP137(31);
+    const address = btc.p2pkh(point.toBytes(true)).address!;
+
+    const result = await verifyMessage(MESSAGE, signature, address);
+
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects an uncompressed-flag signature against the compressed address under strict BIP-137', async () => {
+    const { signature } = signBIP137(27);
+    const address = btc.p2pkh(point.toBytes(true)).address!;
+
+    // Strict BIP-137 honours the flag, so the uncompressed flag must derive
+    // the uncompressed address and therefore miss this one.
+    const strict = await verifyBIP137(MESSAGE, signature, address);
+
+    expect(strict.valid).toBe(false);
+  });
+
+  it('accepts that same pair loosely, because loose verification ignores the flag', async () => {
+    const { signature } = signBIP137(27);
+    const address = btc.p2pkh(point.toBytes(true)).address!;
+
+    // The loose layer tries both point encodings. That branch only does
+    // anything now that recovery honours the compressed flag - before the fix
+    // both iterations produced the same compressed key.
+    const loose = await verifyLooseBIP137(MESSAGE, signature, address);
+
+    expect(loose.valid).toBe(true);
+  });
+});

--- a/src/core/bitcoin/messageVerifier/__tests__/verifier.test.ts
+++ b/src/core/bitcoin/messageVerifier/__tests__/verifier.test.ts
@@ -6,59 +6,65 @@ import { describe, expect, it } from 'vitest';
 import { getVerificationReport, isSpecCompliant, verifyMessage } from '../verifier';
 
 describe('Clean Architecture Verifier', () => {
-  // FreeWallet signature - we know this works with bitcoinjs-message
+  // FreeWallet signature - header 31 over a P2PKH address, which is textbook
+  // BIP-137, so it verifies against the spec with no compatibility layer.
   const freewalletFixture = {
     address: '19QWXpMXeLkoEKEJv2xo9rn8wkPCyxACSX',
     message: 'test',
     signature: 'H+MnkbI81kkWRUys5B6j/svR3I5rQCdjkCH6/Jv88/Q+BoIX6n7hP9Tj/kRqmnfdwLLYv27/pM1hlsWISMVwuBs='
   };
 
+  // Ledger signs Taproot with BIP-137, which the spec does not cover. This is
+  // the signature that actually needs the compatibility layer.
+  const taprootFixture = {
+    address: 'bc1ps5pt865e77nr9t9z7fdefryx27lsz0ced875lxcc68lszvc7x3qsxx25fy',
+    message: 'bitcheckdiuq5gh179v9r5vwmw58ijtkea1vb4idr92khiu',
+    signature: 'HxOxevYmNjW58m/TBcewrpLbOC0NXjwnWO+jccW9tq8JbdtjI8modbmYbJNVO6PpE9MATfiZeU/S/GbmozNhV4Y='
+  };
+
   describe('Spec Compliance vs Compatibility', () => {
     it('should distinguish between spec-compliant and compatibility mode', async () => {
-      const report = await getVerificationReport(
+      const specReport = await getVerificationReport(
         freewalletFixture.message,
         freewalletFixture.signature,
         freewalletFixture.address
       );
 
-      console.log('\n=== VERIFICATION REPORT ===');
-      console.log('Spec Compliant:', report.specCompliant ? '✅' : '❌');
-      console.log('Compatibility Mode:', report.compatibilityMode ? '✅' : '❌');
-      console.log('Method:', report.method || 'None');
-      console.log('Details:', report.details || 'Success');
+      const compatReport = await getVerificationReport(
+        taprootFixture.message,
+        taprootFixture.signature,
+        taprootFixture.address
+      );
 
-      // We expect FreeWallet to fail spec but work in compatibility
-      if (!report.specCompliant && report.compatibilityMode) {
-        console.log('\n✅ Correctly handled as compatibility mode');
-      } else if (report.specCompliant) {
-        console.log('\n✅ Signature is spec-compliant');
-      } else {
-        console.log('\n❌ Signature failed both spec and compatibility');
-      }
+      // The distinction this module exists to draw: one signature satisfies the
+      // spec outright, the other only verifies through the compatibility layer.
+      expect(specReport.specCompliant).toBe(true);
+      expect(compatReport.specCompliant).toBe(false);
+      expect(compatReport.compatibilityMode).toBe(true);
     });
 
     it('should verify in strict mode only if spec-compliant', async () => {
       // Strict mode - spec only
       const strictResult = await verifyMessage(
-        freewalletFixture.message,
-        freewalletFixture.signature,
-        freewalletFixture.address,
+        taprootFixture.message,
+        taprootFixture.signature,
+        taprootFixture.address,
         { strict: true }
       );
 
-      console.log('\nStrict Mode:', strictResult.valid ? '✅' : '❌');
-      console.log('Details:', strictResult.details);
-
       // Non-strict mode - includes compatibility
       const compatResult = await verifyMessage(
-        freewalletFixture.message,
-        freewalletFixture.signature,
-        freewalletFixture.address,
+        taprootFixture.message,
+        taprootFixture.signature,
+        taprootFixture.address,
         { strict: false }
       );
 
-      console.log('\nCompatibility Mode:', compatResult.valid ? '✅' : '❌');
-      console.log('Method:', compatResult.method);
+      // This is the whole point of strict mode: the same signature is refused
+      // by the spec and accepted by the compatibility layer. Asserted against
+      // the Taproot fixture, since the P2PKH one passes the spec either way.
+      expect(strictResult.valid).toBe(false);
+      expect(compatResult.valid).toBe(true);
     });
   });
 
@@ -69,7 +75,7 @@ describe('Clean Architecture Verifier', () => {
         address: '19QWXpMXeLkoEKEJv2xo9rn8wkPCyxACSX',
         message: 'test',
         signature: 'H+MnkbI81kkWRUys5B6j/svR3I5rQCdjkCH6/Jv88/Q+BoIX6n7hP9Tj/kRqmnfdwLLYv27/pM1hlsWISMVwuBs=',
-        expectSpec: false,
+        expectSpec: true,
         expectCompat: true
       },
       {
@@ -97,28 +103,12 @@ describe('Clean Architecture Verifier', () => {
           { strict: false }
         );
 
-        console.log(`\n${testCase.name}:`);
-        console.log(`  Spec Compliant: ${specCompliant ? '✅' : '❌'} (expected: ${testCase.expectSpec ? '✅' : '❌'})`);
-        console.log(`  Compatibility: ${compatResult.valid ? '✅' : '❌'} (expected: ${testCase.expectCompat ? '✅' : '❌'})`);
-
-        if (testCase.expectSpec) {
-          expect(specCompliant).toBe(true);
-        }
-        if (testCase.expectCompat) {
-          expect(compatResult.valid).toBe(true);
-        }
+        // Assert both directions. Guarding these behind `if (expected)` meant
+        // every false expectation went unchecked, and both fixtures expect
+        // false for spec compliance -- so that half was never tested at all.
+        expect(specCompliant).toBe(testCase.expectSpec);
+        expect(compatResult.valid).toBe(testCase.expectCompat);
       });
     }
-  });
-
-  describe('Architecture Benefits', () => {
-    it('should demonstrate clean separation of concerns', () => {
-      console.log('\n=== ARCHITECTURE BENEFITS ===');
-      console.log('✅ Spec implementations remain pure');
-      console.log('✅ Compatibility layer is separate');
-      console.log('✅ Can audit spec compliance');
-      console.log('✅ Can disable compatibility with strict mode');
-      console.log('✅ Clear distinction between "correct" and "workaround"');
-    });
   });
 });

--- a/src/core/bitcoin/messageVerifier/secp-recovery.ts
+++ b/src/core/bitcoin/messageVerifier/secp-recovery.ts
@@ -45,18 +45,11 @@ export function recoverPublicKeyFromSignature(
       { prehash: false }      // don't hash again - we already hashed
     );
 
-    // Noble returns the public key bytes directly
-    // If we need uncompressed and got compressed (or vice versa), convert
-    if (compressed && publicKeyBytes.length === 65) {
-      // Convert uncompressed to compressed
-      return publicKeyBytes.slice(0, 33);
-    } else if (!compressed && publicKeyBytes.length === 33) {
-      // For uncompressed we'd need to reconstruct - for now just return what we have
-      // Most Bitcoin signatures use compressed anyway
-      return publicKeyBytes;
-    }
-
-    return publicKeyBytes;
+    // Noble returns a compressed key. Re-encode through the curve point so that
+    // asking for an uncompressed key actually yields all 65 bytes: the two
+    // encodings hash to different addresses, and BIP-137 flags 27-30 mean
+    // uncompressed. Truncating a 65-byte key to 33 does NOT compress it.
+    return secp256k1.Point.fromBytes(publicKeyBytes).toBytes(compressed);
   } catch (_error) {
     return null;
   }

--- a/src/core/counterparty/__tests__/fairminterModel.test.ts
+++ b/src/core/counterparty/__tests__/fairminterModel.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+  describeFairminterPaymentModel,
+  getFairminterPaymentModel,
+  isPaidFairminter,
+} from "../fairminterModel";
+
+describe("getFairminterPaymentModel", () => {
+  it("calls a zero price free, whatever burn_payment says", () => {
+    expect(getFairminterPaymentModel({ price: 0, burnPayment: false })).toBe("free");
+    expect(getFairminterPaymentModel({ price: "0", burnPayment: true })).toBe("free");
+    expect(getFairminterPaymentModel({ price: "0.00000000" })).toBe("free");
+  });
+
+  // The regression this exists for. burn_payment says where a payment goes, not whether there is
+  // one, so a false value used to be read as "free" — and every pay-the-issuer fairminter created
+  // outside this extension reported itself as costing nothing but miner fees.
+  it("does not call a priced fairminter free just because burn_payment is false", () => {
+    expect(getFairminterPaymentModel({ price: "1.5", burnPayment: false })).toBe("issuer");
+    expect(getFairminterPaymentModel({ price: 100, burnPayment: false })).toBe("issuer");
+  });
+
+  it("reads a missing burn_payment as payment to the issuer", () => {
+    // Core's default branch: xcp_destination = fairminter["source"].
+    expect(getFairminterPaymentModel({ price: "1" })).toBe("issuer");
+    expect(getFairminterPaymentModel({ price: "1", burnPayment: null })).toBe("issuer");
+  });
+
+  it("reports a burn when burn_payment is set on a priced fairminter", () => {
+    expect(getFairminterPaymentModel({ price: "1", burnPayment: true })).toBe("burned");
+  });
+
+  it("puts a pool ahead of a burn, the way core orders the branches", () => {
+    // perform_fairmint_soft_cap_operations checks pool_quantity before burn_payment.
+    expect(getFairminterPaymentModel({ price: "1", burnPayment: true, poolQuantity: "500" }))
+      .toBe("pool");
+    expect(getFairminterPaymentModel({ price: "1", poolQuantity: 500 })).toBe("pool");
+  });
+
+  it("ignores a pool quantity of zero", () => {
+    expect(getFairminterPaymentModel({ price: "1", poolQuantity: 0 })).toBe("issuer");
+    expect(getFairminterPaymentModel({ price: "1", poolQuantity: "0" })).toBe("issuer");
+  });
+
+  // An absent price is not evidence of a free mint, so it must not produce one. Falling through to
+  // the destination questions is the honest answer: we still know where a payment would go.
+  it("does not invent a free mint from a missing price", () => {
+    expect(getFairminterPaymentModel({})).toBe("issuer");
+    expect(getFairminterPaymentModel({ price: undefined, burnPayment: true })).toBe("burned");
+    expect(getFairminterPaymentModel({ price: null })).toBe("issuer");
+    expect(getFairminterPaymentModel({ price: "" })).toBe("issuer");
+  });
+});
+
+describe("describeFairminterPaymentModel", () => {
+  it("labels every model", () => {
+    expect(describeFairminterPaymentModel("free")).toBe("BTC Fee Only (to miners)");
+    expect(describeFairminterPaymentModel("burned")).toBe("XCP Fee (burned)");
+    expect(describeFairminterPaymentModel("pool")).toBe("XCP Fee (to liquidity pool)");
+    expect(describeFairminterPaymentModel("issuer")).toBe("XCP Fee (to issuer)");
+  });
+});
+
+describe("isPaidFairminter", () => {
+  it("is true for everything that charges XCP", () => {
+    expect(isPaidFairminter("free")).toBe(false);
+    expect(isPaidFairminter("burned")).toBe(true);
+    expect(isPaidFairminter("pool")).toBe(true);
+    expect(isPaidFairminter("issuer")).toBe(true);
+  });
+});

--- a/src/core/counterparty/__tests__/fairminterModel.test.ts
+++ b/src/core/counterparty/__tests__/fairminterModel.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
+  describeFairminterLot,
   describeFairminterPaymentModel,
+  getFairmintCost,
+  getFairminterLotCost,
   getFairminterPaymentModel,
   isPaidFairminter,
 } from "../fairminterModel";
@@ -58,6 +61,71 @@ describe("describeFairminterPaymentModel", () => {
     expect(describeFairminterPaymentModel("burned")).toBe("XCP Fee (burned)");
     expect(describeFairminterPaymentModel("pool")).toBe("XCP Fee (to liquidity pool)");
     expect(describeFairminterPaymentModel("issuer")).toBe("XCP Fee (to issuer)");
+  });
+});
+
+describe("getFairminterLotCost", () => {
+  it("uses core's per-lot price when it is available", () => {
+    // price is base units: 100000000 = 1 XCP for the whole lot.
+    expect(getFairminterLotCost({ price: 100000000, quantity_by_price_normalized: "1000" }))
+      .toBe("1");
+  });
+
+  it("avoids the round trip through the per-unit price", () => {
+    // A lot of 3 at 1 XCP gives price_normalized 0.33333333, whose product with 3 is 0.99999999.
+    // Reading core's own per-lot figure keeps it exactly 1.
+    const fairminter = {
+      price: 100000000,
+      price_normalized: "0.33333333",
+      quantity_by_price_normalized: "3",
+    };
+    expect(getFairminterLotCost(fairminter)).toBe("1");
+    // Without the raw price there is nothing better to do, and the drift is visible.
+    expect(getFairminterLotCost({ ...fairminter, price: undefined })).toBe("0.99999999");
+  });
+});
+
+describe("getFairmintCost", () => {
+  it("charges per lot, not per token", () => {
+    const fairminter = { price: 100000000, quantity_by_price_normalized: "1000" };
+    expect(getFairmintCost(fairminter, "1000")).toBe("1");
+    expect(getFairmintCost(fairminter, "3000")).toBe("3");
+  });
+
+  it("is zero for a zero or empty quantity", () => {
+    const fairminter = { price: 100000000, quantity_by_price_normalized: "1000" };
+    expect(getFairmintCost(fairminter, 0)).toBe("0");
+    expect(getFairmintCost(fairminter, "")).toBe("0");
+  });
+
+  // Assuming a lot size of 1 would multiply the cost by the real lot size, so a signing screen
+  // would show a payment wrong by a factor. Absent is the only safe answer.
+  it("returns null rather than guessing a missing lot size", () => {
+    expect(getFairmintCost({ price: 100000000 }, "1000")).toBeNull();
+    expect(getFairmintCost({ price: 1, quantity_by_price_normalized: "0" }, "10")).toBeNull();
+    expect(getFairmintCost({ price: 1, quantity_by_price_normalized: null }, "10")).toBeNull();
+  });
+
+  it("matches the total a whole number of lots implies", () => {
+    // 250 XCP per lot of 5,000 tokens; 4 lots is 20,000 tokens for 1,000 XCP.
+    const fairminter = { price: 25000000000, quantity_by_price_normalized: "5000" };
+    expect(getFairminterLotCost(fairminter)).toBe("250");
+    expect(getFairmintCost(fairminter, "20000")).toBe("1000");
+  });
+});
+
+describe("describeFairminterLot", () => {
+  it("quotes the cost of a lot rather than of one token", () => {
+    expect(describeFairminterLot({
+      price: 100000000,
+      quantity_by_price_normalized: "1000",
+      asset: "TESTASSET",
+    })).toBe("1 XCP per 1000 TESTASSET");
+  });
+
+  it("names a free mint", () => {
+    expect(describeFairminterLot({ price: 0, quantity_by_price_normalized: "1" }))
+      .toBe("Free mint (BTC fees only)");
   });
 });
 

--- a/src/core/counterparty/__tests__/pool.fuzz.test.ts
+++ b/src/core/counterparty/__tests__/pool.fuzz.test.ts
@@ -5,8 +5,9 @@ import {
   applyPoolSlippage,
   calculateInitialLpEstimate,
   calculateLimitingLpEstimate,
-  getCanonicalPoolAssets,
-  getCanonicalPoolPair,
+  getAutoSlippage,
+  getPoolDisplayAssets,
+  getPoolDisplayPair,
 } from '../pool';
 
 // 21,000,000 BTC expressed in satoshis — an upper bound on any on-chain quantity.
@@ -23,14 +24,48 @@ const slippageReachesSigning = (s: string) =>
   isValidPositiveNumber(s, { allowZero: true, maxDecimals: 2 }) && isLessThanOrEqualTo(s, 50);
 
 describe('Pool Math Fuzz Tests', () => {
-  describe('getCanonicalPoolAssets / Pair', () => {
-    it('returns a sorted pair, independent of argument order', () => {
+  describe('getPoolDisplayAssets / Pair', () => {
+    // No longer sorted — display order is the base/quote rule, not the protocol's alphabetical
+    // storage order. What must still hold is that a pool reads identically whichever way round its
+    // two assets arrive, or the same pool would render one way from the market and another from a
+    // balance.
+    it('is independent of argument order', () => {
       fc.assert(fc.property(assetName, assetName, (a, b) => {
-        const [x, y] = getCanonicalPoolAssets(a, b);
-        expect(x <= y).toBe(true);
-        expect(getCanonicalPoolAssets(a, b)).toEqual(getCanonicalPoolAssets(b, a));
-        expect(getCanonicalPoolPair(a, b)).toBe(getCanonicalPoolPair(b, a));
+        expect(getPoolDisplayAssets(a, b)).toEqual(getPoolDisplayAssets(b, a));
+        expect(getPoolDisplayPair(a, b)).toBe(getPoolDisplayPair(b, a));
       }), { numRuns: 500 });
+    });
+
+    it('shows both assets and invents neither', () => {
+      fc.assert(fc.property(assetName, assetName, (a, b) => {
+        expect([...getPoolDisplayAssets(a, b)].sort()).toEqual([a, b].sort());
+      }), { numRuns: 500 });
+    });
+  });
+
+  describe('getAutoSlippage', () => {
+    it('stays within the 0.5%..5% band for any impact, and is always submittable', () => {
+      fc.assert(fc.property(
+        fc.double({ min: -1000, max: 1000, noNaN: true, noDefaultInfinity: true }),
+        (impact) => {
+          const slippage = getAutoSlippage(impact);
+          expect(Number(slippage)).toBeGreaterThanOrEqual(0.5);
+          expect(Number(slippage)).toBeLessThanOrEqual(5);
+          // Auto must never produce a value the form would then reject.
+          expect(slippageReachesSigning(slippage)).toBe(true);
+        }
+      ), { numRuns: 500 });
+    });
+
+    it('never tolerates less than the impact the quote already reported', () => {
+      fc.assert(fc.property(
+        fc.double({ min: 0.5, max: 5, noNaN: true, noDefaultInfinity: true }),
+        (impact) => {
+          // Inside the band, rounding up a tenth must not land under the impact itself, or Auto
+          // would quote a tolerance the trade is already known to breach.
+          expect(Number(getAutoSlippage(impact))).toBeGreaterThanOrEqual(impact);
+        }
+      ), { numRuns: 500 });
     });
   });
 

--- a/src/core/counterparty/__tests__/pool.test.ts
+++ b/src/core/counterparty/__tests__/pool.test.ts
@@ -1,19 +1,86 @@
 import { describe, expect, it } from "vitest";
-import { asBaseUnits, asDisplayUnits } from '@/core/numeric';
+import { asBaseUnits, asDisplayUnits } from "@/core/numeric";
+import { POOL_SLIPPAGE_AUTO } from "@/core/settings";
 import {
   applyPoolSlippage,
   calculateInitialLpEstimate,
   calculateLimitingLpEstimate,
-  getCanonicalPoolAssets,
-  getCanonicalPoolPair,
+  getAutoSlippage,
+  getPoolDisplayAssets,
+  getPoolDisplayPair,
+  isAutoPoolSlippage,
   normalizePoolPosition,
+  resolvePoolSlippage,
 } from "../pool";
 
 describe("counterparty pool utilities", () => {
-  it("formats pool pairs in canonical Counterparty asset order", () => {
-    expect(getCanonicalPoolAssets("XCP", "PEPECASH")).toEqual(["PEPECASH", "XCP"]);
-    expect(getCanonicalPoolPair("XCP", "PEPECASH")).toBe("PEPECASH / XCP");
-    expect(getCanonicalPoolPair("A111111111111111111", "XCP")).toBe("A111111111111111111 / XCP");
+  it("formats pool pairs with the quote asset second", () => {
+    expect(getPoolDisplayAssets("XCP", "PEPECASH")).toEqual(["PEPECASH", "XCP"]);
+    expect(getPoolDisplayPair("XCP", "PEPECASH")).toBe("PEPECASH / XCP");
+    expect(getPoolDisplayPair("A111111111111111111", "XCP")).toBe("A111111111111111111 / XCP");
+  });
+
+  it("orders by quote asset rather than alphabetically", () => {
+    // The cases alphabetical order gets backwards. BTC outranks everything, and a quote asset
+    // that sorts after its pair still belongs on the right.
+    expect(getPoolDisplayPair("BTC", "PEPECASH")).toBe("PEPECASH / BTC");
+    expect(getPoolDisplayPair("PEPECASH", "BTC")).toBe("PEPECASH / BTC");
+    expect(getPoolDisplayPair("XCP", "ZZZCOIN")).toBe("ZZZCOIN / XCP");
+    // BTC outranks XCP, so an XCP pair against BTC prices in BTC.
+    expect(getPoolDisplayPair("XCP", "BTC")).toBe("XCP / BTC");
+  });
+
+  it("derives Auto slippage from the quote's price impact", () => {
+    // Rounded up to a tenth, so the tolerance covers the impact rather than sitting under it.
+    expect(getAutoSlippage(1.23)).toBe("1.3");
+    expect(getAutoSlippage(2)).toBe("2");
+    // Floored at 0.5% (pool-fee territory) and capped at 5%.
+    expect(getAutoSlippage(0)).toBe("0.5");
+    expect(getAutoSlippage(0.11)).toBe("0.5");
+    expect(getAutoSlippage(42)).toBe("5");
+    // A negative impact means the trade improves the price; it still needs the floor.
+    expect(getAutoSlippage(-3)).toBe("0.5");
+  });
+
+  it("falls back to the standing default when there is no quote to read", () => {
+    expect(getAutoSlippage(null)).toBe("1");
+    expect(getAutoSlippage(undefined)).toBe("1");
+    expect(getAutoSlippage(Number.NaN)).toBe("1");
+    expect(getAutoSlippage(Number.POSITIVE_INFINITY)).toBe("1");
+  });
+
+  describe("resolvePoolSlippage", () => {
+    it("uses a stored percent verbatim, impact or no impact", () => {
+      expect(resolvePoolSlippage("2.5", 4)).toBe("2.5");
+      expect(resolvePoolSlippage("0", 4)).toBe("0");
+      expect(resolvePoolSlippage("3")).toBe("3");
+    });
+
+    it("derives from the impact when the setting is auto", () => {
+      expect(resolvePoolSlippage(POOL_SLIPPAGE_AUTO, 2.2)).toBe("2.2");
+      expect(resolvePoolSlippage(POOL_SLIPPAGE_AUTO, 0.05)).toBe("0.5");
+    });
+
+    it("gives deposit and withdraw a real percent even when the setting says auto", () => {
+      // They pass no impact because neither quotes one — but they still need a tolerance, so this
+      // must never hand "auto" back to a form that will put it through applyPoolSlippage.
+      expect(resolvePoolSlippage(POOL_SLIPPAGE_AUTO)).toBe("1");
+      expect(resolvePoolSlippage(undefined)).toBe("1");
+      expect(resolvePoolSlippage("")).toBe("1");
+    });
+
+    it("never returns the literal auto sentinel", () => {
+      for (const setting of [POOL_SLIPPAGE_AUTO, undefined, "", "1.5"]) {
+        expect(resolvePoolSlippage(setting, 3)).not.toBe(POOL_SLIPPAGE_AUTO);
+      }
+    });
+  });
+
+  it("identifies which stored settings mean auto", () => {
+    expect(isAutoPoolSlippage(POOL_SLIPPAGE_AUTO)).toBe(true);
+    expect(isAutoPoolSlippage(undefined)).toBe(true);
+    expect(isAutoPoolSlippage("")).toBe(true);
+    expect(isAutoPoolSlippage("1")).toBe(false);
   });
 
   it("applies pool slippage to raw integer quantities", () => {

--- a/src/core/counterparty/api.ts
+++ b/src/core/counterparty/api.ts
@@ -834,12 +834,19 @@ export interface FairminterDetails {
   tx_hash: string;
   asset: string;
   status: string;
+  /** The address that opened the fairminter, and where the payment goes unless it is burned. */
+  source?: string;
   /** XCP charged per lot, in base units. */
   price: ApiQuantity;
   price_normalized?: DisplayUnits;
   /** Assets released per lot paid for. */
   quantity_by_price: ApiQuantity;
   quantity_by_price_normalized?: DisplayUnits;
+  /** True burns the payment, false sends it to `source`. Not whether the mint is free. */
+  burn_payment?: boolean;
+  /** While this is unmet, core escrows both the payment and the minted assets. */
+  soft_cap?: ApiQuantity;
+  soft_cap_normalized?: DisplayUnits;
 }
 
 /**

--- a/src/core/counterparty/fairminterModel.ts
+++ b/src/core/counterparty/fairminterModel.ts
@@ -11,7 +11,7 @@
  * costing nothing but miner fees. Price is therefore the first question asked here, not the last.
  */
 
-import { isGreaterThan } from "@/core/numeric";
+import { divide, fromSatoshis, isGreaterThan, multiply } from "@/core/numeric";
 
 export type FairminterPaymentModel =
   /** price 0: the miner fee is the whole cost. */
@@ -61,4 +61,63 @@ export function describeFairminterPaymentModel(model: FairminterPaymentModel): s
 /** Whether this model charges XCP at all, i.e. whether a price and lot size are worth showing. */
 export function isPaidFairminter(model: FairminterPaymentModel): boolean {
   return model !== "free";
+}
+
+export interface FairminterLot {
+  /** XCP charged per lot, in base units — core's own figure. */
+  price?: number | string | null;
+  /** XCP per whole unit, which core derives as price / quantity_by_price. */
+  price_normalized?: string | null;
+  /** Assets released per lot paid for. */
+  quantity_by_price_normalized?: string | null;
+  asset?: string;
+}
+
+/**
+ * What one lot costs, in XCP.
+ *
+ * Prefers core's `price`, which is already per-lot: `price_normalized` is that figure divided by
+ * the lot size, so multiplying it back up is a round trip through a division that does not always
+ * terminate. A lot size of 3 at 1 XCP gives a per-unit price of 0.333…, and the product of the
+ * rounded value is not 1 again.
+ */
+export function getFairminterLotCost(fairminter: FairminterLot): string {
+  if (fairminter.price !== undefined && fairminter.price !== null && fairminter.price !== "") {
+    return fromSatoshis(fairminter.price, { removeTrailingZeros: true });
+  }
+  return multiply(
+    fairminter.price_normalized ?? 0,
+    fairminter.quantity_by_price_normalized ?? 0
+  ).toString();
+}
+
+/**
+ * What minting `quantity` of the asset costs, in XCP, or null if it cannot be known.
+ *
+ * Core charges `ceil(quantity / quantity_by_price * price)` — a whole number of lots, since it
+ * rejects any quantity that is not a multiple of the lot size. Computed the same way round here,
+ * as lots first, so the figure shown is the figure charged.
+ *
+ * Returns null rather than assuming a lot size of 1 when the field is absent: that assumption
+ * multiplies the cost by the real lot size, and a payment figure that is wrong by a factor is
+ * worse on a signing screen than no figure at all.
+ */
+export function getFairmintCost(
+  fairminter: FairminterLot,
+  quantity: string | number
+): string | null {
+  const lotSize = fairminter.quantity_by_price_normalized;
+  if (lotSize === undefined || lotSize === null || !isGreaterThan(lotSize, 0)) return null;
+  if (!isGreaterThan(quantity, 0)) return "0";
+  return multiply(divide(quantity, lotSize), getFairminterLotCost(fairminter)).toString();
+}
+
+/** One line naming what a single mint costs and yields, for a list row. */
+export function describeFairminterLot(fairminter: FairminterLot): string {
+  if (!isGreaterThan(getFairminterLotCost(fairminter), 0)) {
+    return "Free mint (BTC fees only)";
+  }
+  const lotSize = fairminter.quantity_by_price_normalized ?? "1";
+  const asset = fairminter.asset ?? "";
+  return `${getFairminterLotCost(fairminter)} XCP per ${lotSize}${asset ? ` ${asset}` : ""}`;
 }

--- a/src/core/counterparty/fairminterModel.ts
+++ b/src/core/counterparty/fairminterModel.ts
@@ -1,0 +1,64 @@
+/**
+ * Where the XCP paid for a fairmint ends up, and what to call it.
+ *
+ * The rule is core's, from `perform_fairmint_soft_cap_operations` in messages/fairminter.py, which
+ * picks the destination in this order: refund if the soft cap was missed, else a liquidity pool if
+ * one was requested, else burned if burn_payment is set, else the fairminter's issuer.
+ *
+ * `burn_payment` is a plain boolean in core — burned versus paid to the issuer — and being free is
+ * `price == 0`, independent of it. Reading a false `burn_payment` as "free" is wrong for every
+ * fairminter not created by this extension: an ordinary pay-the-issuer mint reports itself as
+ * costing nothing but miner fees. Price is therefore the first question asked here, not the last.
+ */
+
+import { isGreaterThan } from "@/core/numeric";
+
+export type FairminterPaymentModel =
+  /** price 0: the miner fee is the whole cost. */
+  | "free"
+  /** XCP is destroyed. */
+  | "burned"
+  /** XCP seeds a liquidity pool for the asset. */
+  | "pool"
+  /** XCP goes to the address that opened the fairminter. */
+  | "issuer";
+
+export interface FairminterPaymentInput {
+  /** Price per lot. Either the normalized or the base-unit figure; only zero-ness is read. */
+  price?: string | number | null;
+  burnPayment?: boolean | null;
+  /** XCP set aside to open a pool once the soft cap is reached. */
+  poolQuantity?: string | number | null;
+}
+
+export function getFairminterPaymentModel({
+  price,
+  burnPayment,
+  poolQuantity,
+}: FairminterPaymentInput): FairminterPaymentModel {
+  // Only a price we can actually read as zero makes this free. An absent price is not evidence of
+  // one, so it falls through to the destination questions rather than claiming the mint is free.
+  if (price !== undefined && price !== null && price !== "" && !isGreaterThan(price, 0)) {
+    return "free";
+  }
+  if (poolQuantity !== undefined && poolQuantity !== null && isGreaterThan(poolQuantity, 0)) {
+    return "pool";
+  }
+  return burnPayment ? "burned" : "issuer";
+}
+
+const LABELS: Record<FairminterPaymentModel, string> = {
+  free: "BTC Fee Only (to miners)",
+  burned: "XCP Fee (burned)",
+  pool: "XCP Fee (to liquidity pool)",
+  issuer: "XCP Fee (to issuer)",
+};
+
+export function describeFairminterPaymentModel(model: FairminterPaymentModel): string {
+  return LABELS[model];
+}
+
+/** Whether this model charges XCP at all, i.e. whether a price and lot size are worth showing. */
+export function isPaidFairminter(model: FairminterPaymentModel): boolean {
+  return model !== "free";
+}

--- a/src/core/counterparty/pool.ts
+++ b/src/core/counterparty/pool.ts
@@ -1,5 +1,18 @@
 import type { PoolPosition } from "@/core/counterparty/api";
-import { asDisplayUnits, BigNumber, fromSatoshis, toBigNumber } from '@/core/numeric';
+import {
+  asDisplayUnits,
+  BigNumber,
+  divide,
+  fromSatoshis,
+  isFiniteNumber,
+  maximum,
+  minimum,
+  multiply,
+  roundUp,
+  toBigNumber,
+} from '@/core/numeric';
+import { DEFAULT_POOL_SLIPPAGE, POOL_SLIPPAGE_AUTO } from "@/core/settings";
+import { getTradingPair } from "@/core/tradingPair";
 
 /**
  * verbose=true does not normalize the LP `quantity` on the address pools
@@ -21,12 +34,70 @@ export function normalizePoolPosition(position: PoolPosition): PoolPosition {
   };
 }
 
-export function getCanonicalPoolAssets(assetA: string, assetB: string): [string, string] {
-  return assetA <= assetB ? [assetA, assetB] : [assetB, assetA];
+/**
+ * The order a pool's two assets are shown in, as [base, quote].
+ *
+ * The protocol stores a pool's assets alphabetically, and displaying them that way makes prices
+ * read backwards whenever the quote asset happens to sort second: BTC/PEPECASH implies a price
+ * denominated in PEPECASH, and XCP/ZZZCOIN implies one denominated in ZZZCOIN. Pools therefore use
+ * the same base/quote rule as DEX orders and the market pages, so one pair reads the same way
+ * everywhere in the app.
+ *
+ * Display only. Nothing here decides what is sent to core — compose calls and the pool endpoints
+ * take `pool.asset_a`/`pool.asset_b` as the API returned them.
+ */
+export function getPoolDisplayAssets(assetA: string, assetB: string): [string, string] {
+  return getTradingPair(assetA, assetB);
 }
 
-export function getCanonicalPoolPair(assetA: string, assetB: string): string {
-  return getCanonicalPoolAssets(assetA, assetB).join(" / ");
+export function getPoolDisplayPair(assetA: string, assetB: string): string {
+  return getPoolDisplayAssets(assetA, assetB).join(" / ");
+}
+
+/** Below the pool fee a swap mostly just fails; above 5% the tolerance stops protecting anything. */
+const MIN_AUTO_SLIPPAGE = "0.5";
+const MAX_AUTO_SLIPPAGE = "5";
+
+/**
+ * Slippage tolerance Auto picks for a swap, as a percent string.
+ *
+ * A trade's own price impact is what another taker of the same size would move the price by, so
+ * Auto tolerates roughly that and no more: rounded up to a tenth, floored at 0.5% (pool-fee
+ * territory, below which a swap mostly just fails) and capped at 5%. With no quote yet there is
+ * nothing to derive it from, so it falls back to the standing default.
+ */
+export function getAutoSlippage(priceImpact: number | null | undefined): string {
+  // price_impact arrives as a raw JSON number, so NaN and the infinities are all reachable.
+  if (typeof priceImpact !== "number" || !isFiniteNumber(priceImpact)) {
+    return DEFAULT_POOL_SLIPPAGE;
+  }
+  // Rounded through BigNumber rather than Math.ceil: the impact arrives as a float, and an impact
+  // of exactly 2 can reach here as 2.0000000000000004, which raw arithmetic rounds up to 2.1.
+  const toTenth = divide(roundUp(multiply(priceImpact, 10)), 10);
+  return minimum(MAX_AUTO_SLIPPAGE, maximum(MIN_AUTO_SLIPPAGE, toTenth)).toString();
+}
+
+/**
+ * The slippage percent to actually use, from the stored setting.
+ *
+ * Auto is a value the one slippage setting can hold, not a second setting beside it, so every
+ * screen resolves it the same way.
+ *
+ * Deposit and withdraw pass no impact and so land on the numeric default. That is not because they
+ * are safe from slippage — another deposit, withdrawal or trade confirming first moves the ratio
+ * and changes what they return, which is exactly what their tolerance guards against. It is that
+ * neither quotes a price impact, so there is no per-transaction figure for Auto to size against.
+ */
+export function resolvePoolSlippage(
+  setting: string | undefined,
+  priceImpact?: number | null
+): string {
+  if (!setting || setting === POOL_SLIPPAGE_AUTO) return getAutoSlippage(priceImpact);
+  return setting;
+}
+
+export function isAutoPoolSlippage(setting: string | undefined): boolean {
+  return !setting || setting === POOL_SLIPPAGE_AUTO;
 }
 
 export function applyPoolSlippage(value: number | string | null | undefined, slippagePercent: string): string {

--- a/src/core/counterparty/unpack/__tests__/integration.test.ts
+++ b/src/core/counterparty/unpack/__tests__/integration.test.ts
@@ -5,11 +5,12 @@ import { asBaseUnits } from '@/core/numeric';
  * These tests call the real Counterparty API with validate=0 to get composed
  * transactions, then verify that our local unpacker correctly extracts the data.
  *
- * These tests require network access and may be slow. They're marked with
- * .skip() by default and can be enabled by removing the skip.
+ * These tests require network access and may be slow, so they do not run by
+ * default -- CI stays offline and deterministic. They are gated on an env var
+ * rather than .skip() so that they remain runnable on demand.
  *
  * To run integration tests:
- *   npm test -- --run integration.test.ts
+ *   RUN_INTEGRATION_TESTS=1 npx vitest run src/core/counterparty/unpack/__tests__/integration.test.ts
  */
 
 import { beforeAll, describe, expect, it } from 'vitest';
@@ -81,7 +82,9 @@ function getDataFromCompose(composeResult: { data: string }): string {
   return composeResult.data;
 }
 
-describe.skip('Integration: Counterparty API Compose & Unpack', () => {
+const runIntegrationTests = Boolean(process.env.RUN_INTEGRATION_TESTS);
+
+describe.runIf(runIntegrationTests)('Integration: Counterparty API Compose & Unpack', () => {
   // Increase timeout for API calls
   beforeAll(() => {
     // Warm up the connection

--- a/src/core/numeric.ts
+++ b/src/core/numeric.ts
@@ -248,13 +248,30 @@ export const isLessThanOrEqualToSatoshis = (value: string | number, threshold: s
 };
 
 /**
- * Checks if a numeric value is finite.
+ * Checks if a value is a finite number.
+ *
+ * Deliberately does NOT route through toBigNumber. That helper substitutes its default of 0 for
+ * anything it cannot read — NaN, "", "abc", null, undefined — and 0 is finite, so asking it made
+ * this predicate answer true for every one of them. It rejected only Infinity, which made it a
+ * test for "not infinite" wearing the name of a test for "is a number".
  *
  * @param value - The value to check
- * @returns Boolean indicating if the value is finite
+ * @returns Whether the value is a number, and finite
  */
 export const isFiniteNumber = (value: string | number | BigNumber | null | undefined): boolean => {
-  return toBigNumber(value).isFinite();
+  if (value === null || value === undefined) return false;
+  if (BigNumber.isBigNumber(value)) return value.isFinite();
+  if (typeof value === "number") return Number.isFinite(value);
+
+  // Strings get the same comma/space tolerance as toBigNumber, then are parsed directly: this
+  // BigNumber build throws on unparseable input rather than returning NaN.
+  const cleaned = value.replace(/[,\s]/g, "");
+  if (cleaned === "") return false;
+  try {
+    return new BigNumber(cleaned).isFinite();
+  } catch {
+    return false;
+  }
 };
 
 /**

--- a/src/core/replayPrevention.ts
+++ b/src/core/replayPrevention.ts
@@ -525,34 +525,26 @@ export async function withReplayPrevention<T>(
     }
   }
   
-  try {
-    // Execute the handler
-    const result = await handler();
-    
-    // Store the nonce after successful execution (only if we generated it)
-    if (nonceWasGenerated && nonce !== undefined && address) {
-      store.setNonce(origin, address, nonce);
-    }
-    
-    // Record successful idempotency response if applicable
-    if (idempotencyKey) {
-      recordIdempotencyResponse(
-        idempotencyKey,
-        origin,
-        method,
-        result,
-        idempotencyTtlMinutes
-      );
-    }
-    
-    return result;
-    
-  } catch (error) {
-    // Track failed requests
-    // Analytics: request_failed
-    
-    throw error;
+  // Execute the handler
+  const result = await handler();
+
+  // Store the nonce after successful execution (only if we generated it)
+  if (nonceWasGenerated && nonce !== undefined && address) {
+    store.setNonce(origin, address, nonce);
   }
+
+  // Record successful idempotency response if applicable
+  if (idempotencyKey) {
+    recordIdempotencyResponse(
+      idempotencyKey,
+      origin,
+      method,
+      result,
+      idempotencyTtlMinutes
+    );
+  }
+
+  return result;
 }
 
 // Export the store for testing purposes

--- a/src/core/settings.ts
+++ b/src/core/settings.ts
@@ -50,9 +50,15 @@ export const LEGACY_MAX_ORDER_EXPIRATION = 8064;
 export const MAX_ORDER_EXPIRATION = 2 ** 16 - 1;
 export const DEFAULT_ORDER_EXPIRATION = LEGACY_MAX_ORDER_EXPIRATION;
 
-/** Default pool slippage tolerance, as a percent string. 1% sits one notch above
- *  fast-chain DEX defaults to absorb pool drift over Counterparty's ~10-min blocks. */
+/** Slippage tolerance sits one notch above fast-chain DEX defaults to absorb pool drift over
+ *  Counterparty's ~10-min blocks. 1% is what Auto falls back to with no quote to read, and what
+ *  deposit and withdraw use: they are exposed to the pool moving under them just as a swap is —
+ *  another deposit, withdrawal or trade confirming first changes what comes back — but neither
+ *  quotes a price impact, so there is no per-transaction number to size the tolerance from. */
 export const DEFAULT_POOL_SLIPPAGE = '1';
+
+/** The slippage setting's non-numeric value: derive the tolerance per-quote. See getAutoSlippage. */
+export const POOL_SLIPPAGE_AUTO = 'auto';
 
 /**
  * Application settings - stored encrypted inside the keychain.
@@ -105,7 +111,10 @@ export interface AppSettings {
   counterpartyApiBase: string;
   /** Default order expiration in blocks */
   defaultOrderExpiration: number;
-  /** Default pool slippage tolerance, percent (e.g. "2.5"); falls back to DEFAULT_POOL_SLIPPAGE */
+  /**
+   * Default pool slippage tolerance: a percent (e.g. "2.5"), or POOL_SLIPPAGE_AUTO to let a swap
+   * derive it from that quote's price impact. Falls back to DEFAULT_POOL_SLIPPAGE.
+   */
   defaultPoolSlippage?: string;
   /** Block signing if local verification fails */
   strictTransactionVerification: boolean;
@@ -141,7 +150,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   transactionDryRun: false,
   counterpartyApiBase: 'https://api.counterparty.io:4000',
   defaultOrderExpiration: DEFAULT_ORDER_EXPIRATION,
-  defaultPoolSlippage: DEFAULT_POOL_SLIPPAGE,
+  defaultPoolSlippage: POOL_SLIPPAGE_AUTO,
   strictTransactionVerification: true,
   connectedWebsites: [],
   providerCapabilities: {},

--- a/src/core/validation/__tests__/amount.fuzz.test.ts
+++ b/src/core/validation/__tests__/amount.fuzz.test.ts
@@ -233,7 +233,7 @@ describe('Amount Validation Fuzz Tests', () => {
     it('should reject non-numeric strings', () => {
       fc.assert(
         fc.property(
-          fc.string().filter(s => isNaN(Number(s)) || s.trim() === ''),
+          fc.string().filter(s => Number.isNaN(Number(s)) || s.trim() === ''),
           (str) => {
             const result = isValidNumber(str);
             expect(result).toBe(false);

--- a/src/core/validation/__tests__/destinations.test.ts
+++ b/src/core/validation/__tests__/destinations.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DESTINATION_WARNING_THRESHOLD,
+  getDestinationLimitState,
+  MAX_DESTINATIONS,
+  validateDestinationCount,
+} from '@/core/validation/destinations';
+
+describe('getDestinationLimitState', () => {
+  it('reports ok below the warning threshold', () => {
+    expect(getDestinationLimitState(0)).toBe('ok');
+    expect(getDestinationLimitState(1)).toBe('ok');
+    expect(getDestinationLimitState(DESTINATION_WARNING_THRESHOLD - 1)).toBe('ok');
+  });
+
+  it('starts warning exactly at the threshold, not after it', () => {
+    expect(getDestinationLimitState(DESTINATION_WARNING_THRESHOLD)).toBe('approaching');
+    expect(getDestinationLimitState(DESTINATION_WARNING_THRESHOLD + 1)).toBe('approaching');
+    expect(getDestinationLimitState(MAX_DESTINATIONS - 1)).toBe('approaching');
+  });
+
+  it('reports at-limit exactly at the maximum, and stays there beyond it', () => {
+    expect(getDestinationLimitState(MAX_DESTINATIONS)).toBe('at-limit');
+    expect(getDestinationLimitState(MAX_DESTINATIONS + 1)).toBe('at-limit');
+  });
+
+  it('leaves a warning band between the threshold and the limit', () => {
+    // Guards against the two thresholds being collapsed into one, which would
+    // mean the user jumps straight from no warning to a hard stop.
+    expect(DESTINATION_WARNING_THRESHOLD).toBeLessThan(MAX_DESTINATIONS);
+  });
+});
+
+describe('validateDestinationCount', () => {
+  it('requires at least one destination', () => {
+    expect(validateDestinationCount(0).isValid).toBe(false);
+    expect(validateDestinationCount(1).isValid).toBe(true);
+  });
+
+  it('accepts exactly the maximum and rejects one past it', () => {
+    expect(validateDestinationCount(MAX_DESTINATIONS).isValid).toBe(true);
+
+    const overLimit = validateDestinationCount(MAX_DESTINATIONS + 1);
+    expect(overLimit.isValid).toBe(false);
+    expect(overLimit.error).toBe(`Maximum ${MAX_DESTINATIONS} destinations allowed`);
+  });
+
+  it('agrees with getDestinationLimitState at the boundary', () => {
+    // The count that blocks the add button must still be a valid count to submit.
+    expect(getDestinationLimitState(MAX_DESTINATIONS)).toBe('at-limit');
+    expect(validateDestinationCount(MAX_DESTINATIONS).isValid).toBe(true);
+  });
+});

--- a/src/core/validation/destinations.ts
+++ b/src/core/validation/destinations.ts
@@ -67,17 +67,48 @@ export function areDestinationsComplete(destinations: Destination[]): boolean {
 }
 
 /**
+ * Hard protocol limit on the number of MPMA destinations in one transaction.
+ */
+export const MAX_DESTINATIONS = 1000;
+
+/**
+ * Count at which the UI starts warning that the limit is close.
+ */
+export const DESTINATION_WARNING_THRESHOLD = 900;
+
+/**
+ * Where a destination count sits relative to the protocol limit.
+ * 'approaching' only warns; 'at-limit' blocks adding more destinations.
+ */
+export type DestinationLimitState = 'ok' | 'approaching' | 'at-limit';
+
+/**
+ * Classify a destination count against the protocol limit.
+ */
+export function getDestinationLimitState(count: number): DestinationLimitState {
+  if (count >= MAX_DESTINATIONS) {
+    return 'at-limit';
+  }
+
+  if (count >= DESTINATION_WARNING_THRESHOLD) {
+    return 'approaching';
+  }
+
+  return 'ok';
+}
+
+/**
  * Validate destination count limits
  */
 export function validateDestinationCount(count: number): { isValid: boolean; error?: string } {
   if (count < 1) {
     return { isValid: false, error: 'At least one destination is required' };
   }
-  
-  if (count > 1000) {
-    return { isValid: false, error: 'Maximum 1000 destinations allowed' };
+
+  if (count > MAX_DESTINATIONS) {
+    return { isValid: false, error: `Maximum ${MAX_DESTINATIONS} destinations allowed` };
   }
-  
+
   return { isValid: true };
 }
 

--- a/src/hooks/useAssetOwnerLookup.ts
+++ b/src/hooks/useAssetOwnerLookup.ts
@@ -72,7 +72,7 @@ export function useMultiAssetOwnerLookup(options: UseMultiAssetOwnerLookupOption
 
   const cleanupAll = useCallback(() => {
     Object.keys(debounceTimeouts.current).forEach((id) => {
-      clearTimeout(debounceTimeouts.current[parseInt(id)]);
+      clearTimeout(debounceTimeouts.current[Number(id)]);
     });
     Object.values(abortControllers.current).forEach((controller) => {
       controller.abort();

--- a/src/hooks/useUtxoSource.ts
+++ b/src/hooks/useUtxoSource.ts
@@ -1,0 +1,63 @@
+import { useEffect, useState } from "react";
+import { fetchUtxoBalances, type UtxoBalance } from "@/core/counterparty/api";
+
+/**
+ * The UTXO a compose form spends from, and what it holds.
+ */
+export interface UtxoSource {
+  /** The resolved UTXO, or "" when the form was opened without one. */
+  utxo: string;
+  balances: UtxoBalance[];
+  isLoadingBalances: boolean;
+  /** Set when the balance lookup failed, so the form can say so rather than showing zero. */
+  error: string | null;
+  dismissError: () => void;
+}
+
+/**
+ * Resolve the source UTXO for a compose form and load the balances it holds.
+ *
+ * Shared by the detach and move forms: both spend from a UTXO chosen on an
+ * earlier screen and show what it holds before the user commits.
+ *
+ * @param initialUtxo - UTXO passed in by the route
+ * @param formDataUtxo - UTXO carried on restored form data, used when the route has none
+ */
+export function useUtxoSource(
+  initialUtxo: string | undefined,
+  formDataUtxo: string | undefined,
+): UtxoSource {
+  const utxo = initialUtxo || formDataUtxo || "";
+
+  const [balances, setBalances] = useState<UtxoBalance[]>([]);
+  const [isLoadingBalances, setIsLoadingBalances] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!utxo) return;
+
+    setIsLoadingBalances(true);
+    fetchUtxoBalances(utxo)
+      .then((response) => {
+        setBalances(response.result || []);
+      })
+      .catch((err) => {
+        console.error("Failed to fetch UTXO balances:", err);
+        // Without this the form silently shows "0 Balances", which reads as an
+        // empty UTXO rather than as a lookup that failed.
+        setError("Could not load balances for this UTXO.");
+        setBalances([]);
+      })
+      .finally(() => {
+        setIsLoadingBalances(false);
+      });
+  }, [utxo]);
+
+  return {
+    utxo,
+    balances,
+    isLoadingBalances,
+    error,
+    dismissError: () => setError(null),
+  };
+}

--- a/src/pages/assets/[asset]/balance.tsx
+++ b/src/pages/assets/[asset]/balance.tsx
@@ -7,7 +7,7 @@ import { ActionList } from "@/components/ui/lists/action-list";
 import { Spinner } from "@/components/ui/spinner";
 import { useHeader } from "@/contexts/header-context";
 import type { TokenBalance } from "@/core/counterparty/api";
-import { getCanonicalPoolPair } from "@/core/counterparty/pool";
+import { getPoolDisplayPair } from "@/core/counterparty/pool";
 import { asDisplayUnits, divide, formatDecimal, isGreaterThan, multiply, toBigNumber } from '@/core/numeric';
 import { useAssetDetails } from "@/hooks/useAssetDetails";
 import { useLpAssetPool } from "@/hooks/useLpAssetPool";
@@ -187,7 +187,7 @@ export default function AssetBalancePage(): ReactElement {
       ? divide(lpBalance, lpSupply)
       : null;
     return {
-      pair: getCanonicalPoolPair(lpPool.asset_a, lpPool.asset_b),
+      pair: getPoolDisplayPair(lpPool.asset_a, lpPool.asset_b),
       sharePercent: poolShare ? formatDecimal(multiply(poolShare, 100), 4) : null,
       underlying: poolShare
         ? [

--- a/src/pages/compose/dispenser/dispense/form.tsx
+++ b/src/pages/compose/dispenser/dispense/form.tsx
@@ -250,7 +250,7 @@ export function DispenseForm({
       selectedDispenserIndex !== previousIndexRef.current &&
       selectedDispenser
     ) {
-      const currentNumber = parseInt(numberOfDispenses) || 1;
+      const currentNumber = parseInt(numberOfDispenses, 10) || 1;
       
       // Check against new max
       if (currentNumber > maxDispenses && maxDispenses > 0) {

--- a/src/pages/compose/fairminter/fairmint/form.tsx
+++ b/src/pages/compose/fairminter/fairmint/form.tsx
@@ -1,6 +1,7 @@
 import { startTransition, useCallback, useEffect, useRef, useState } from "react";
 import { useFormStatus } from "react-dom";
 import { ComposerForm } from "@/components/composer/composer-form";
+import { FairmintSummary } from "@/components/domain/asset/fairmint-summary";
 import { type Fairminter, FairminterSelectInput } from "@/components/domain/asset/fairminter-select-input";
 import { AmountWithMaxInput } from "@/components/domain/balance/amount-with-max-input";
 import { BalanceHeader } from "@/components/domain/balance/balance-header";
@@ -255,17 +256,22 @@ export function FairmintForm({
             label="Fairminter Asset"
             required
             showHelpText={showHelpText}
-            description={`Select an available fairminter asset${currencyType ? ` that uses ${currencyType}` : ""}`}
+            description={currencyType === "BTC" ? "Select a free fairminter — these cost only the Bitcoin network fee" : currencyType === "XCP" ? "Select a fairminter that charges XCP" : "Select an available fairminter"}
             currencyFilter={currencyType}
           />
 
-          {/* Show info message for free mints */}
+          {/* What this mint costs and where the payment goes, stated whether or not help text is
+              on. Free mints have no amount field, so this is the only account of them. */}
+          {formData.asset && selectedFairminter && (
+            <FairmintSummary fairminter={selectedFairminter} quantity={formData.quantity} />
+          )}
+
           {formData.asset && isFreeMint && selectedFairminter && (
             <div className="bg-blue-50 border border-blue-200 rounded-lg p-3">
               <p className="text-sm text-blue-800">
-                <strong>Free Mint</strong> - You'll receive{" "}
-                {selectedFairminter.max_mint_per_tx_normalized || "the maximum allowed"} {formData.asset} tokens.
-                Only BTC transaction fees apply.
+                <strong>Free mint.</strong> The fairminter decides the amount — up to{" "}
+                {selectedFairminter.max_mint_per_tx_normalized || "the maximum allowed"}{" "}
+                {formData.asset} per transaction, and less if that would pass the hard cap.
               </p>
             </div>
           )}
@@ -285,9 +291,11 @@ export function FairmintForm({
               showHelpText={showHelpText}
               sourceAddress={activeAddress}
               maxAmount={calculateMaxQuantity()}
-              label="Amount"
+              label={`Amount to Mint${formData.asset ? ` (${formData.asset})` : ""}`}
               name="amount"
-              description={`Enter the amount to mint${selectedFairminter?.divisible ? " (up to 8 decimal places)" : " (whole numbers only)"}. ${selectedFairminter && isGreaterThan(selectedFairminter.quantity_by_price_normalized, 1) ? `Amount must be a multiple of ${selectedFairminter.quantity_by_price_normalized} (lot size). ` : ""}${selectedFairminter ? `Price: ${multiply(selectedFairminter.price_normalized, selectedFairminter.quantity_by_price_normalized)} ${currencyType || 'XCP'} per ${selectedFairminter.quantity_by_price_normalized} ${formData.asset}` : ""}`}
+              // The price used to live here too, where it only rendered with help text on. It is
+              // in the summary above instead; this keeps the rules for the field itself.
+              description={`Enter the amount to mint${selectedFairminter?.divisible ? " (up to 8 decimal places)" : " (whole numbers only)"}.${selectedFairminter && isGreaterThan(selectedFairminter.quantity_by_price_normalized, 1) ? ` Must be a multiple of ${selectedFairminter.quantity_by_price_normalized} (lot size).` : ""}`}
               disableMaxButton={false}
               onMaxClick={() => {
                 const maxQty = calculateMaxQuantity();

--- a/src/pages/compose/fairminter/fairmint/review.tsx
+++ b/src/pages/compose/fairminter/fairmint/review.tsx
@@ -1,4 +1,13 @@
+import { useEffect, useState } from "react";
 import { ReviewScreen } from "@/components/screens/review-screen";
+import { type FairminterDetails, fetchAssetFairminter } from "@/core/counterparty/api";
+import {
+  describeFairminterPaymentModel,
+  getFairmintCost,
+  getFairminterPaymentModel,
+  isPaidFairminter,
+} from "@/core/counterparty/fairminterModel";
+import { isGreaterThan } from "@/core/numeric";
 
 /**
  * Props for the ReviewFairmint component.
@@ -12,9 +21,12 @@ interface ReviewFairmintProps {
 }
 
 /**
- * Displays a review screen for fairmint transactions.
- * @param {ReviewFairmintProps} props - Component props
- * @returns {ReactElement} Review UI for fairmint transaction
+ * Review screen for fairmint transactions.
+ *
+ * This showed the asset and the quantity and nothing else, so the one number the screen existed to
+ * confirm — what leaves your wallet — never appeared on it. The compose response carries only the
+ * asset and quantity, so the price is fetched here, the way the dispense review re-fetches its
+ * dispenser rather than trusting the compose params.
  */
 export function ReviewFairmint({
   apiResponse,
@@ -24,14 +36,78 @@ export function ReviewFairmint({
   isSigning
 }: ReviewFairmintProps) {
   const { result } = apiResponse;
+  const asset = result.params.asset;
 
   // Use normalized quantity from verbose API response (handles divisibility correctly)
   const quantityDisplay = result.params.quantity_normalized ?? result.params.quantity;
 
-  const customFields = [
-    { label: "Asset", value: result.params.asset },
-    { label: "Quantity", value: quantityDisplay },
+  const [fairminter, setFairminter] = useState<FairminterDetails | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!asset) return;
+
+    fetchAssetFairminter(asset)
+      .then((found) => {
+        if (!cancelled) setFairminter(found);
+      })
+      .catch((err) => {
+        // A failed lookup must not block signing, but it must not invent a cost either: the cost
+        // rows are simply absent rather than shown as zero.
+        console.error("Failed to fetch fairminter for review:", err);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [asset]);
+
+  const customFields: Array<{ label: string; value: string }> = [
+    { label: "Asset", value: asset },
   ];
+
+  if (fairminter) {
+    const model = getFairminterPaymentModel({
+      price: fairminter.price ?? fairminter.price_normalized,
+      burnPayment: fairminter.burn_payment,
+    });
+    const escrowed = isGreaterThan(fairminter.soft_cap_normalized ?? fairminter.soft_cap ?? 0, 0);
+
+    if (isPaidFairminter(model)) {
+      const cost = getFairmintCost(fairminter, quantityDisplay);
+      customFields.push({
+        // Core escrows the assets until the soft cap is met, so they do not arrive on confirmation.
+        label: escrowed ? "You Receive (after soft cap)" : "You Receive",
+        value: `${quantityDisplay} ${asset}`,
+      });
+      // Absent when the lot size is unknown: see getFairmintCost.
+      if (cost !== null) {
+        customFields.push({ label: "You Pay", value: `${cost} XCP` });
+      }
+    } else {
+      // A free mint's quantity is set by the fairminter, so the composed quantity is 0 and
+      // reporting it as what you receive would read as receiving nothing.
+      customFields.push({ label: "You Pay", value: "Bitcoin network fee only" });
+    }
+
+    customFields.push({ label: "Payment", value: describeFairminterPaymentModel(model) });
+
+    if (model === "issuer" && fairminter.source) {
+      customFields.push({ label: "Paid To", value: fairminter.source });
+    }
+    if (escrowed) {
+      customFields.push({
+        label: "⚠️ Soft Cap",
+        value:
+          "Your payment and the tokens are held in escrow until the soft cap is reached. " +
+          "Nothing is credited when this transaction confirms, and the XCP is refunded if the " +
+          "cap is missed by its deadline.",
+      });
+    }
+  } else {
+    // Pre-fetch, or after a failed lookup: say what was composed without claiming a price.
+    customFields.push({ label: "Quantity", value: quantityDisplay });
+  }
 
   return (
     <ReviewScreen

--- a/src/pages/compose/pool/deposit/form.tsx
+++ b/src/pages/compose/pool/deposit/form.tsx
@@ -17,6 +17,7 @@ import {
   applyPoolSlippage,
   calculateInitialLpEstimate,
   calculateLimitingLpEstimate,
+  resolvePoolSlippage,
 } from "@/core/counterparty/pool";
 import {
   fromSatoshis,
@@ -28,7 +29,6 @@ import {
   roundDown,
   toSatoshis,
 } from "@/core/numeric";
-import { DEFAULT_POOL_SLIPPAGE } from "@/core/settings";
 import { useAssetDetails } from "@/hooks/useAssetDetails";
 import { usePool } from "@/hooks/usePool";
 import { usePoolDepositQuote } from "@/hooks/usePoolQuotes";
@@ -56,7 +56,7 @@ export function PoolDepositForm({
   const [quantityB, setQuantityB] = useState(initialFormData?.quantity_b?.toString() || "");
   const [lpAsset, setLpAsset] = useState(initialFormData?.lp_asset || "");
   const [isLpAssetValid, setIsLpAssetValid] = useState(false);
-  const [slippage, setSlippage] = useState((initialFormData as PoolDepositOptions & { slippage?: string })?.slippage || settings?.defaultPoolSlippage || DEFAULT_POOL_SLIPPAGE);
+  const [slippage, setSlippage] = useState((initialFormData as PoolDepositOptions & { slippage?: string })?.slippage || resolvePoolSlippage(settings?.defaultPoolSlippage));
   const [showSettings, setShowSettings] = useState(false);
   const [localError, setLocalError] = useState<string | null>(null);
 

--- a/src/pages/compose/pool/deposit/review.tsx
+++ b/src/pages/compose/pool/deposit/review.tsx
@@ -1,6 +1,6 @@
 import { ReviewScreen } from "@/components/screens/review-screen";
 import { useComposerOptional } from "@/contexts/composer-context-object";
-import { getCanonicalPoolPair } from "@/core/counterparty/pool";
+import { getPoolDisplayPair } from "@/core/counterparty/pool";
 import { fromSatoshis } from "@/core/numeric";
 
 interface ReviewPoolDepositProps {
@@ -36,7 +36,7 @@ export function ReviewPoolDeposit({
   const customFields = [
     {
       label: "Pool",
-      value: getCanonicalPoolPair(assetA, assetB),
+      value: getPoolDisplayPair(assetA, assetB),
     },
     {
       label: "Deposit",

--- a/src/pages/compose/pool/slippage-input.tsx
+++ b/src/pages/compose/pool/slippage-input.tsx
@@ -2,6 +2,8 @@ import { Description, Field, Input, Label } from "@headlessui/react";
 import type { ReactElement } from "react";
 import { isFiniteNumber, isGreaterThan, isLessThan } from "@/core/numeric";
 
+import { POOL_SLIPPAGE_AUTO } from "@/core/settings";
+
 export { DEFAULT_POOL_SLIPPAGE } from "@/core/settings";
 
 // Presets skew slightly above fast-chain DEXs: Counterparty's ~10-min blocks leave
@@ -12,19 +14,33 @@ const LOW_SLIPPAGE_THRESHOLD = "0.5";
 const HIGH_SLIPPAGE_THRESHOLD = "5";
 
 interface SlippageInputProps {
+  /** The stored setting: a percent, or POOL_SLIPPAGE_AUTO. */
   value: string;
   onChange: (value: string) => void;
   showHelpText?: boolean;
+  /**
+   * Offer Auto as a fourth preset, where a quote reports the price impact to size it against.
+   * Deposit and withdraw leave this off and render as before — they still need a tolerance, since
+   * the pool can move under them before they confirm, but they have no impact figure to derive one
+   * from and so use a flat percent.
+   */
+  offerAuto?: boolean;
+  /** The percent Auto resolved to for the current quote; shown so the number is never hidden. */
+  resolvedValue?: string;
 }
 
 export function SlippageInput({
   value,
   onChange,
   showHelpText = false,
+  offerAuto = false,
+  resolvedValue,
 }: SlippageInputProps): ReactElement {
+  const autoOn = value === POOL_SLIPPAGE_AUTO;
   const isPreset = (PRESETS as readonly string[]).includes(value);
+  const displayValue = autoOn ? (resolvedValue ?? "") : value;
 
-  const showWarning = value.trim() !== "" && isFiniteNumber(value);
+  const showWarning = !autoOn && value.trim() !== "" && isFiniteNumber(value);
   const isLow = showWarning && isLessThan(value, LOW_SLIPPAGE_THRESHOLD);
   const isHigh = showWarning && isGreaterThan(value, HIGH_SLIPPAGE_THRESHOLD);
 
@@ -41,11 +57,24 @@ export function SlippageInput({
         <Label className="text-sm font-medium text-gray-700">
           Slippage Tolerance <span className="text-red-500">*</span>
         </Label>
-        <span className="text-sm text-gray-500 tabular-nums">{value || "0"}%</span>
+        <span className="text-sm text-gray-500 tabular-nums">
+          {displayValue || "0"}%{autoOn && <span className="text-gray-400"> · auto</span>}
+        </span>
       </div>
 
-      {/* Preset buttons */}
-      <div className="grid grid-cols-3 gap-2 mb-3">
+      {/* Presets. Auto is one of them, so picking a number is how you leave it. */}
+      <div className={`grid gap-2 mb-3 ${offerAuto ? "grid-cols-4" : "grid-cols-3"}`}>
+        {offerAuto && (
+          <button
+            type="button"
+            onClick={() => onChange(POOL_SLIPPAGE_AUTO)}
+            className={`px-3 py-2 text-sm rounded-md transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
+              autoOn ? "bg-blue-500 text-white" : "bg-gray-100 hover:bg-gray-200 text-gray-700"
+            }`}
+          >
+            Auto
+          </button>
+        )}
         {PRESETS.map((preset) => (
           <button
             key={preset}
@@ -67,16 +96,24 @@ export function SlippageInput({
         <Input
           type="text"
           inputMode="decimal"
-          value={isPreset ? "" : value}
+          value={autoOn || isPreset ? "" : value}
           onChange={handleCustomChange}
           placeholder="Custom %"
           aria-label="Custom slippage percent"
           className={`w-full px-3 py-2.5 pr-8 text-sm border rounded-md outline-none focus:border-blue-500 focus-visible:ring-2 focus-visible:ring-blue-500 ${
-            isPreset ? "border-gray-300" : "border-blue-500"
+            autoOn || isPreset ? "border-gray-300" : "border-blue-500"
           }`}
         />
         <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-sm text-gray-500">%</span>
       </div>
+
+      {autoOn && (
+        <Description className="mt-2 text-sm text-gray-500">
+          {resolvedValue
+            ? `Using ${resolvedValue}%, matched to this trade's price impact.`
+            : "Set from the quote's price impact once you enter an amount."}
+        </Description>
+      )}
 
       {showHelpText && (
         <Description className="mt-2 text-sm text-gray-500">

--- a/src/pages/compose/pool/withdraw/form.tsx
+++ b/src/pages/compose/pool/withdraw/form.tsx
@@ -9,9 +9,8 @@ import { PoolHeader } from "@/components/ui/headers/pool-header";
 import { Spinner } from "@/components/ui/spinner";
 import { useComposer } from "@/contexts/composer-context-object";
 import type { PoolWithdrawOptions } from "@/core/counterparty/compose";
-import { applyPoolSlippage } from "@/core/counterparty/pool";
+import { applyPoolSlippage, resolvePoolSlippage } from "@/core/counterparty/pool";
 import { fromSatoshis, isGreaterThan, isLessThanOrEqualTo, isValidPositiveNumber } from "@/core/numeric";
-import { DEFAULT_POOL_SLIPPAGE } from "@/core/settings";
 import { useAssetDetails } from "@/hooks/useAssetDetails";
 import { useLpAssetPool } from "@/hooks/useLpAssetPool";
 import { usePoolWithdrawQuote } from "@/hooks/usePoolQuotes";
@@ -35,7 +34,7 @@ export function PoolWithdrawForm({
   const { data: assetADetails } = useAssetDetails(pool?.asset_a || "");
   const { data: assetBDetails } = useAssetDetails(pool?.asset_b || "");
   const [quantity, setQuantity] = useState(initialFormData?.quantity?.toString() || "");
-  const [slippage, setSlippage] = useState((initialFormData as PoolWithdrawOptions & { slippage?: string })?.slippage || settings?.defaultPoolSlippage || DEFAULT_POOL_SLIPPAGE);
+  const [slippage, setSlippage] = useState((initialFormData as PoolWithdrawOptions & { slippage?: string })?.slippage || resolvePoolSlippage(settings?.defaultPoolSlippage));
   const [showSettings, setShowSettings] = useState(false);
   const [localError, setLocalError] = useState<string | null>(null);
 

--- a/src/pages/compose/pool/withdraw/review.tsx
+++ b/src/pages/compose/pool/withdraw/review.tsx
@@ -1,6 +1,6 @@
 import { ReviewScreen } from "@/components/screens/review-screen";
 import { useComposerOptional } from "@/contexts/composer-context-object";
-import { getCanonicalPoolPair } from "@/core/counterparty/pool";
+import { getPoolDisplayPair } from "@/core/counterparty/pool";
 import { fromSatoshis } from "@/core/numeric";
 import { useAssetInfo } from "@/hooks/useAssetInfo";
 
@@ -51,7 +51,7 @@ export function ReviewPoolWithdraw({
   const customFields = [
     {
       label: "Pool",
-      value: assetA && assetB ? getCanonicalPoolPair(assetA, assetB) : params.lp_asset,
+      value: assetA && assetB ? getPoolDisplayPair(assetA, assetB) : params.lp_asset,
     },
     {
       label: "Withdraw",

--- a/src/pages/compose/swap/form.tsx
+++ b/src/pages/compose/swap/form.tsx
@@ -11,7 +11,7 @@ import { useComposer } from "@/contexts/composer-context-object";
 import { useSettings } from "@/contexts/settings-context";
 import type { PoolQuote } from "@/core/counterparty/api";
 import type { OrderOptions } from "@/core/counterparty/compose";
-import { applyPoolSlippage } from "@/core/counterparty/pool";
+import { applyPoolSlippage, resolvePoolSlippage } from "@/core/counterparty/pool";
 import { formatAmount } from "@/core/format";
 import {
   fromSatoshis,
@@ -20,7 +20,7 @@ import {
   isValidPositiveNumber,
   toBigNumber,
 } from "@/core/numeric";
-import { DEFAULT_POOL_SLIPPAGE } from "@/core/settings";
+import { POOL_SLIPPAGE_AUTO } from "@/core/settings";
 import { useAssetDetails } from "@/hooks/useAssetDetails";
 import { usePool } from "@/hooks/usePool";
 import { usePoolSwapQuote } from "@/hooks/usePoolQuotes";
@@ -112,10 +112,12 @@ export function SwapForm({
     initialFormData?.get_asset || initialGetAsset || "XCP",
   );
   const [amount, setAmount] = useState(initialFormData?.give_quantity?.toString() || "");
-  const [slippage, setSlippage] = useState(
+  // The stored setting, which is either a percent or "auto" — not two settings. Resolved against
+  // the live quote below.
+  const [slippageSetting, setSlippageSetting] = useState(
     (initialFormData as (OrderOptions & { slippage?: string }) | null)?.slippage
       || settings?.defaultPoolSlippage
-      || DEFAULT_POOL_SLIPPAGE,
+      || POOL_SLIPPAGE_AUTO,
   );
   const [showDetails, setShowDetails] = useState(false);
   const [validationError, setValidationError] = useState<string | null>(null);
@@ -150,6 +152,9 @@ export function SwapForm({
   // Compared as a BigNumber: give_remaining is a 64-bit asset quantity, so it can arrive as a
   // string, and "0" > 0 is false but "10" > 0 compares as text rather than as a number.
   const unfilled = toBigNumber(quote?.give_remaining ?? 0).gt(0);
+
+  // Auto reads the tolerance off this quote's own price impact; a stored percent is used as-is.
+  const slippage = resolvePoolSlippage(slippageSetting, quote?.price_impact);
 
   // Null until the quote produces actual output; all values in display units.
   const quoteView = useMemo<QuoteView | null>(() => {
@@ -220,7 +225,7 @@ export function SwapForm({
   // Edits apply to this swap immediately and persist as the user's default,
   // same as the pool deposit/withdraw settings panel.
   const handleSlippageChange = (next: string) => {
-    setSlippage(next);
+    setSlippageSetting(next);
     void updateSettings({ defaultPoolSlippage: next });
   };
 
@@ -393,9 +398,11 @@ export function SwapForm({
             )}
             <div className="border-t border-gray-200 pt-3">
               <SlippageInput
-                value={slippage}
+                value={slippageSetting}
                 onChange={handleSlippageChange}
                 showHelpText={showHelpText}
+                offerAuto
+                resolvedValue={slippage}
               />
             </div>
           </div>

--- a/src/pages/compose/utxo/attach/__tests__/form.test.tsx
+++ b/src/pages/compose/utxo/attach/__tests__/form.test.tsx
@@ -84,15 +84,10 @@ vi.mock('@/contexts/header-context', () => ({
   })
 }));
 
-vi.mock('@/contexts/loading-context', () => ({
-  useLoading: () => ({
-    setLoading: vi.fn(),
-    loading: false
-  })
-}));
-
 vi.mock('@/hooks/useAssetDetails', () => ({
-  useAssetDetails: () => ({
+  // vi.fn so individual tests can override it with a failed load.
+  useAssetDetails: vi.fn(() => ({
+    error: null,
     data: {
       assetInfo: {
         asset_longname: null,
@@ -104,7 +99,7 @@ vi.mock('@/hooks/useAssetDetails', () => ({
       },
       availableBalance: asDisplayUnits('100')
     }
-  })
+  }))
 }));
 
 // Mock compose API for ComposerProvider
@@ -214,15 +209,40 @@ describe('UtxoAttachForm', () => {
     expect(continueButton).toBeDisabled();
   });
 
-  it('should display error message when composer context has error', () => {
-    // This test should verify that errors from the composer context are displayed
-    // For now, we'll skip this test since the forms handle errors through the composer context
-    // and it requires more complex mocking setup
+  it('should show an error when the asset details fail to load', async () => {
+    const { useAssetDetails } = await import('@/hooks/useAssetDetails');
+    (useAssetDetails as any).mockReturnValueOnce({ error: new Error('API Error'), data: null });
+
+    render(
+      <TestWrapper>
+        <UtxoAttachForm {...defaultProps} />
+      </TestWrapper>
+    );
+
+    // Otherwise a failed load renders as an asset that simply has no balance.
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('Could not load details for this asset.');
+    });
   });
 
-  it('should have dismiss button for error message', async () => {
-    // This test should verify that error messages can be dismissed
-    // For now, we'll skip this test since it requires mocking the composer context error state
+  it('should dismiss the asset details error when closed', async () => {
+    const user = userEvent.setup();
+    const { useAssetDetails } = await import('@/hooks/useAssetDetails');
+    (useAssetDetails as any).mockReturnValueOnce({ error: new Error('API Error'), data: null });
+
+    render(
+      <TestWrapper>
+        <UtxoAttachForm {...defaultProps} />
+      </TestWrapper>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Dismiss error message' }));
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   });
 
   it('should populate max amount when Max button is clicked', async () => {

--- a/src/pages/compose/utxo/attach/form.tsx
+++ b/src/pages/compose/utxo/attach/form.tsx
@@ -31,7 +31,7 @@ export function UtxoAttachForm({
   
   // Data fetching hooks
   const asset = initialAsset || initialFormData?.asset || "";
-  const { data: assetDetails } = useAssetDetails(asset);
+  const { data: assetDetails, error: assetError } = useAssetDetails(asset);
   
   // Local error state management
   const [validationError, setValidationError] = useState<string | null>(null);
@@ -49,6 +49,14 @@ export function UtxoAttachForm({
     const quantityInput = document.querySelector("input[name='quantity']") as HTMLInputElement;
     quantityInput?.focus();
   }, []);
+
+  // Surface a failed asset load instead of rendering the form as if the asset
+  // simply had no balance. Seeded into local state so it stays dismissible.
+  useEffect(() => {
+    if (assetError) {
+      setValidationError('Could not load details for this asset.');
+    }
+  }, [assetError]);
 
   return (
     <ComposerForm

--- a/src/pages/compose/utxo/detach/__tests__/form.test.tsx
+++ b/src/pages/compose/utxo/detach/__tests__/form.test.tsx
@@ -54,13 +54,6 @@ vi.mock('@/contexts/header-context', () => ({
   })
 }));
 
-vi.mock('@/contexts/loading-context', () => ({
-  useLoading: () => ({
-    setLoading: vi.fn(),
-    loading: false
-  })
-}));
-
 // Mock API call
 vi.mock('@/core/counterparty/api', () => ({
   fetchUtxoBalances: vi.fn().mockResolvedValue({
@@ -68,24 +61,6 @@ vi.mock('@/core/counterparty/api', () => ({
       { asset: 'TESTTOKEN', quantity_normalized: '100' as DisplayUnits }
     ]
   })
-}));
-
-// Mock address validation and fee rates
-vi.mock('@/core/bitcoin', () => ({
-  isValidBitcoinAddress: vi.fn((address) => {
-    // Allow test addresses
-    return address.startsWith('bc1q') || address.startsWith('1') || address.startsWith('3');
-  })
-}));
-
-// Mock validation utilities to prevent async issues
-vi.mock('@/core/validation', () => ({
-  isValidBitcoinAddress: vi.fn((address) => {
-    // Allow test addresses - same logic as the bitcoin mock
-    return address.startsWith('bc1q') || address.startsWith('1') || address.startsWith('3');
-  }),
-  lookupAssetOwner: vi.fn().mockResolvedValue({ isValid: false, ownerAddress: null, error: null }),
-  shouldTriggerAssetLookup: vi.fn().mockReturnValue(false)
 }));
 
 // Mock the asset owner lookup hook to prevent async issues
@@ -263,15 +238,41 @@ describe('UtxoDetachForm', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/assets/utxos/def456abc123:1');
   });
 
-  it('should display error message when composer context has error', () => {
-    // This test should verify that errors from the composer context are displayed
-    // For now, we'll skip this test since the forms handle errors through the composer context
-    // and it requires more complex mocking setup
+  it('should show an error when the UTXO balance lookup fails', async () => {
+    const { fetchUtxoBalances } = await import('@/core/counterparty/api');
+    (fetchUtxoBalances as any).mockRejectedValueOnce(new Error('API Error'));
+
+    render(
+      <TestWrapper>
+        <UtxoDetachForm {...defaultProps} />
+      </TestWrapper>
+    );
+
+    // Without the alert the form just reads "0 Balances", which looks like an
+    // empty UTXO rather than a lookup that failed.
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('Could not load balances for this UTXO.');
+    });
   });
 
-  it('should have dismiss button for error message', async () => {
-    // This test should verify that error messages can be dismissed
-    // For now, we'll skip this test since it requires mocking the composer context error state
+  it('should dismiss the balance lookup error when closed', async () => {
+    const user = userEvent.setup();
+    const { fetchUtxoBalances } = await import('@/core/counterparty/api');
+    (fetchUtxoBalances as any).mockRejectedValueOnce(new Error('API Error'));
+
+    render(
+      <TestWrapper>
+        <UtxoDetachForm {...defaultProps} />
+      </TestWrapper>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Dismiss error message' }));
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   });
 
   it('should handle multiple balances correctly', async () => {

--- a/src/pages/compose/utxo/detach/form.tsx
+++ b/src/pages/compose/utxo/detach/form.tsx
@@ -1,15 +1,12 @@
 import type { ReactElement } from "react";
 import { useEffect, useRef, useState } from "react";
-import { useNavigate } from "react-router";
 import { ComposerForm } from "@/components/composer/composer-form";
 import { AddressHeader } from "@/components/domain/address/address-header";
-import { FaSpinner } from "@/components/icons";
-import { ErrorAlert } from "@/components/ui/error-alert";
+import { UtxoSourceField } from "@/components/domain/utxo/utxo-source-field";
 import { DestinationInput } from "@/components/ui/inputs/destination-input";
 import { useComposer } from "@/contexts/composer-context-object";
-import { fetchUtxoBalances, type UtxoBalance } from "@/core/counterparty/api";
 import type { DetachOptions } from "@/core/counterparty/compose";
-import { formatTxid } from "@/core/format";
+import { useUtxoSource } from "@/hooks/useUtxoSource";
 
 /**
  * Props for the UtxoDetachForm component, aligned with Composer's formAction.
@@ -30,43 +27,23 @@ export function UtxoDetachForm({
 }: UtxoDetachFormProps): ReactElement {
   // Context hooks
   const { activeAddress, activeWallet, showHelpText } = useComposer();
-  const navigate = useNavigate();
-  
-  // Local error state management
-  const [validationError, setValidationError] = useState<string | null>(null);
-  
+
+  // Source UTXO and the balances it holds
+  const source = useUtxoSource(initialUtxo, initialFormData?.sourceUtxo);
+
   // Form state
   const [destination, setDestination] = useState(initialFormData?.destination || "");
   const [destinationValid, setDestinationValid] = useState(true); // Optional field, so default to true
-  const [utxoBalances, setUtxoBalances] = useState<UtxoBalance[]>([]);
-  const [isLoadingBalances, setIsLoadingBalances] = useState(false);
-  
+
   // Refs
   const destinationRef = useRef<HTMLInputElement>(null);
 
   // Effects
 
-  // Focus destination input on mount and fetch UTXO balances
+  // Focus destination input on mount
   useEffect(() => {
     destinationRef.current?.focus();
-    
-    // Fetch UTXO balances if we have a UTXO
-    const utxo = initialUtxo || initialFormData?.sourceUtxo;
-    if (utxo) {
-      setIsLoadingBalances(true);
-      fetchUtxoBalances(utxo).then(response => {
-        setUtxoBalances(response.result || []);
-      }).catch(err => {
-        console.error('Failed to fetch UTXO balances:', err);
-        // Without this the form silently shows "0 Balances", which reads as an
-        // empty UTXO rather than as a failed lookup.
-        setValidationError('Could not load balances for this UTXO.');
-        setUtxoBalances([]);
-      }).finally(() => {
-        setIsLoadingBalances(false);
-      });
-    }
-  }, [initialUtxo, initialFormData?.sourceUtxo]);
+  }, []);
 
   return (
     <ComposerForm
@@ -78,61 +55,22 @@ export function UtxoDetachForm({
       }
       submitDisabled={!destinationValid}
     >
-      {validationError && (
-        <div className="mb-4">
-          <ErrorAlert
-            message={validationError}
-            onClose={() => setValidationError(null)}
-          />
-        </div>
-      )}
-          {/* Hidden UTXO input - always passed to formAction */}
-          <input 
-            type="hidden" 
-            name="sourceUtxo" 
-            value={initialUtxo || initialFormData?.sourceUtxo || ""}
-          />
-          
-          {/* UTXO Display - styled like an input */}
-          {(initialUtxo || initialFormData?.sourceUtxo) && (
-            <div>
-              <span className="block text-sm font-medium text-gray-700">Output <span className="text-red-500">*</span></span>
-              <button type="button"
-                onClick={() => navigate(`/assets/utxos/${initialUtxo || initialFormData?.sourceUtxo}`)}
-                className="text-left mt-1 block w-full p-2.5 rounded-md border border-gray-300 bg-gray-50 hover:bg-gray-100 cursor-pointer flex justify-between items-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
-              >
-                <span className="text-sm font-mono text-blue-600 hover:text-blue-800">
-                  {formatTxid(initialUtxo || initialFormData?.sourceUtxo || '')}
-                </span>
-                <span className="text-sm text-gray-500">
-                  {isLoadingBalances ? (
-                    <span className="flex items-center gap-1">
-                      <FaSpinner className="animate-spin size-4" aria-hidden="true" />
-                      Loading…
-                    </span>
-                  ) : (
-                    `${utxoBalances.length} ${utxoBalances.length === 1 ? 'Balance' : 'Balances'}`
-                  )}
-                </span>
-              </button>
-            </div>
-          )}
-          
-          <input type="hidden" name="destination" value={destination} />
-          <DestinationInput
-            ref={destinationRef}
-            value={destination}
-            onChange={setDestination}
-            onValidationChange={setDestinationValid}
-            placeholder="Leave empty to use UTXO's address"
-            required={false}
-            disabled={false}
-            showHelpText={showHelpText}
-            name="destination_display"
-            label="Destination (Optional)"
-            helpText="The address to detach assets to. If not provided, assets will be detached to the UTXO's owner address."
-          />
+      <UtxoSourceField source={source} />
 
+      <input type="hidden" name="destination" value={destination} />
+      <DestinationInput
+        ref={destinationRef}
+        value={destination}
+        onChange={setDestination}
+        onValidationChange={setDestinationValid}
+        placeholder="Leave empty to use UTXO's address"
+        required={false}
+        disabled={false}
+        showHelpText={showHelpText}
+        name="destination_display"
+        label="Destination (Optional)"
+        helpText="The address to detach assets to. If not provided, assets will be detached to the UTXO's owner address."
+      />
     </ComposerForm>
   );
 }

--- a/src/pages/compose/utxo/detach/form.tsx
+++ b/src/pages/compose/utxo/detach/form.tsx
@@ -58,6 +58,9 @@ export function UtxoDetachForm({
         setUtxoBalances(response.result || []);
       }).catch(err => {
         console.error('Failed to fetch UTXO balances:', err);
+        // Without this the form silently shows "0 Balances", which reads as an
+        // empty UTXO rather than as a failed lookup.
+        setValidationError('Could not load balances for this UTXO.');
         setUtxoBalances([]);
       }).finally(() => {
         setIsLoadingBalances(false);

--- a/src/pages/compose/utxo/move/__tests__/form.test.tsx
+++ b/src/pages/compose/utxo/move/__tests__/form.test.tsx
@@ -54,13 +54,6 @@ vi.mock('@/contexts/header-context', () => ({
   })
 }));
 
-vi.mock('@/contexts/loading-context', () => ({
-  useLoading: () => ({
-    setLoading: vi.fn(),
-    loading: false
-  })
-}));
-
 // Mock API call
 vi.mock('@/core/counterparty/api', () => ({
   fetchUtxoBalances: vi.fn().mockResolvedValue({
@@ -69,24 +62,6 @@ vi.mock('@/core/counterparty/api', () => ({
       { asset: 'XCP', quantity_normalized: '50' as DisplayUnits }
     ]
   })
-}));
-
-// Mock address validation and fee rates
-vi.mock('@/core/bitcoin', () => ({
-  isValidBitcoinAddress: vi.fn((address) => {
-    // Allow test addresses
-    return address.startsWith('bc1q') || address.startsWith('1') || address.startsWith('3');
-  })
-}));
-
-// Mock validation utilities to prevent async issues
-vi.mock('@/core/validation', () => ({
-  isValidBitcoinAddress: vi.fn((address) => {
-    // Allow test addresses - same logic as the bitcoin mock
-    return address.startsWith('bc1q') || address.startsWith('1') || address.startsWith('3');
-  }),
-  lookupAssetOwner: vi.fn().mockResolvedValue({ isValid: false, ownerAddress: null, error: null }),
-  shouldTriggerAssetLookup: vi.fn().mockReturnValue(false)
 }));
 
 // Mock the asset owner lookup hook to prevent async issues
@@ -271,10 +246,41 @@ describe('UtxoMoveForm', () => {
     });
   });
 
-  it('should display error message when composer context has error', () => {
-    // This test should verify that errors from the composer context are displayed
-    // For now, we'll skip this test since the forms handle errors through the composer context
-    // and it requires more complex mocking setup
+  it('should show an error when the UTXO balance lookup fails', async () => {
+    const { fetchUtxoBalances } = await import('@/core/counterparty/api');
+    (fetchUtxoBalances as any).mockRejectedValueOnce(new Error('API Error'));
+
+    render(
+      <TestWrapper>
+        <UtxoMoveForm {...defaultProps} />
+      </TestWrapper>
+    );
+
+    // Without the alert the form just reads "0 Balances", which looks like an
+    // empty UTXO rather than a lookup that failed.
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('Could not load balances for this UTXO.');
+    });
+  });
+
+  it('should dismiss the balance lookup error when closed', async () => {
+    const user = userEvent.setup();
+    const { fetchUtxoBalances } = await import('@/core/counterparty/api');
+    (fetchUtxoBalances as any).mockRejectedValueOnce(new Error('API Error'));
+
+    render(
+      <TestWrapper>
+        <UtxoMoveForm {...defaultProps} />
+      </TestWrapper>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Dismiss error message' }));
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   });
 
   it('should handle single balance correctly', async () => {

--- a/src/pages/compose/utxo/move/form.tsx
+++ b/src/pages/compose/utxo/move/form.tsx
@@ -1,15 +1,12 @@
 import type { ReactElement } from "react";
 import { useEffect, useRef, useState } from "react";
-import { useNavigate } from "react-router";
 import { ComposerForm } from "@/components/composer/composer-form";
 import { AddressHeader } from "@/components/domain/address/address-header";
-import { FaSpinner } from "@/components/icons";
-import { ErrorAlert } from "@/components/ui/error-alert";
+import { UtxoSourceField } from "@/components/domain/utxo/utxo-source-field";
 import { DestinationInput } from "@/components/ui/inputs/destination-input";
 import { useComposer } from "@/contexts/composer-context-object";
-import { fetchUtxoBalances, type UtxoBalance } from "@/core/counterparty/api";
 import type { MoveOptions } from "@/core/counterparty/compose";
-import { formatTxid } from "@/core/format";
+import { useUtxoSource } from "@/hooks/useUtxoSource";
 
 /**
  * Props for the UtxoMoveForm component, aligned with Composer's formAction.
@@ -28,38 +25,25 @@ export function UtxoMoveForm({
   initialFormData,
   initialUtxo,
 }: UtxoMoveFormProps): ReactElement {
-  const navigate = useNavigate();
+  // Context hooks
   const { activeAddress, activeWallet, showHelpText } = useComposer();
-  const [validationError, setValidationError] = useState<string | null>(null);
+
+  // Source UTXO and the balances it holds
+  const source = useUtxoSource(initialUtxo, initialFormData?.sourceUtxo);
+
+  // Form state
   const [destination, setDestination] = useState(initialFormData?.destination || "");
-  const [destinationValid, setDestinationValid] = useState(false);
-  const [utxoBalances, setUtxoBalances] = useState<UtxoBalance[]>([]);
-  const [isLoadingBalances, setIsLoadingBalances] = useState(false);
+  const [destinationValid, setDestinationValid] = useState(false); // Required field, so invalid until entered
+
+  // Refs
   const destinationRef = useRef<HTMLInputElement>(null);
 
   // Effects
 
-  // Focus destination input on mount and fetch UTXO balances
+  // Focus destination input on mount
   useEffect(() => {
     destinationRef.current?.focus();
-    
-    // Fetch UTXO balances if we have a UTXO
-    const utxo = initialUtxo || initialFormData?.sourceUtxo;
-    if (utxo) {
-      setIsLoadingBalances(true);
-      fetchUtxoBalances(utxo).then(response => {
-        setUtxoBalances(response.result || []);
-      }).catch(err => {
-        console.error('Failed to fetch UTXO balances:', err);
-        // Without this the form silently shows "0 Balances", which reads as an
-        // empty UTXO rather than as a failed lookup.
-        setValidationError('Could not load balances for this UTXO.');
-        setUtxoBalances([]);
-      }).finally(() => {
-        setIsLoadingBalances(false);
-      });
-    }
-  }, [initialUtxo, initialFormData?.sourceUtxo]);
+  }, []);
 
   return (
     <ComposerForm
@@ -75,59 +59,20 @@ export function UtxoMoveForm({
       }
       submitDisabled={!destinationValid}
     >
-      {validationError && (
-        <div className="mb-4">
-          <ErrorAlert
-            message={validationError}
-            onClose={() => setValidationError(null)}
-          />
-        </div>
-      )}
-          {/* Hidden UTXO input - always passed to formAction */}
-          <input 
-            type="hidden" 
-            name="sourceUtxo" 
-            value={initialUtxo || initialFormData?.sourceUtxo || ""}
-          />
-          
-          {/* UTXO Display - styled like an input */}
-          {(initialUtxo || initialFormData?.sourceUtxo) && (
-            <div>
-              <span className="block text-sm font-medium text-gray-700">Output <span className="text-red-500">*</span></span>
-              <button type="button"
-                onClick={() => navigate(`/assets/utxos/${initialUtxo || initialFormData?.sourceUtxo}`)}
-                className="text-left mt-1 block w-full p-2.5 rounded-md border border-gray-300 bg-gray-50 hover:bg-gray-100 cursor-pointer flex justify-between items-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
-              >
-                <span className="text-sm font-mono text-blue-600 hover:text-blue-800">
-                  {formatTxid(initialUtxo || initialFormData?.sourceUtxo || '')}
-                </span>
-                <span className="text-sm text-gray-500">
-                  {isLoadingBalances ? (
-                    <span className="flex items-center gap-1">
-                      <FaSpinner className="animate-spin size-4" aria-hidden="true" />
-                      Loading…
-                    </span>
-                  ) : (
-                    `${utxoBalances.length} ${utxoBalances.length === 1 ? 'Balance' : 'Balances'}`
-                  )}
-                </span>
-              </button>
-            </div>
-          )}
-          
-          <input type="hidden" name="destination" value={destination} />
-          <DestinationInput
-            ref={destinationRef}
-            value={destination}
-            onChange={setDestination}
-            onValidationChange={setDestinationValid}
-            placeholder="Enter destination address"
-            required
-            disabled={false}
-            showHelpText={showHelpText}
-            name="destination_display"
-          />
+      <UtxoSourceField source={source} />
 
+      <input type="hidden" name="destination" value={destination} />
+      <DestinationInput
+        ref={destinationRef}
+        value={destination}
+        onChange={setDestination}
+        onValidationChange={setDestinationValid}
+        placeholder="Enter destination address"
+        required
+        disabled={false}
+        showHelpText={showHelpText}
+        name="destination_display"
+      />
     </ComposerForm>
   );
 }

--- a/src/pages/compose/utxo/move/form.tsx
+++ b/src/pages/compose/utxo/move/form.tsx
@@ -51,6 +51,9 @@ export function UtxoMoveForm({
         setUtxoBalances(response.result || []);
       }).catch(err => {
         console.error('Failed to fetch UTXO balances:', err);
+        // Without this the form silently shows "0 Balances", which reads as an
+        // empty UTXO rather than as a failed lookup.
+        setValidationError('Could not load balances for this UTXO.');
         setUtxoBalances([]);
       }).finally(() => {
         setIsLoadingBalances(false);

--- a/src/pages/pools/[assetA]/[assetB].tsx
+++ b/src/pages/pools/[assetA]/[assetB].tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui/button";
 import { ErrorAlert } from "@/components/ui/error-alert";
 import { Spinner } from "@/components/ui/spinner";
 import { useHeader } from "@/contexts/header-context";
-import { getCanonicalPoolPair } from "@/core/counterparty/pool";
+import { getPoolDisplayPair } from "@/core/counterparty/pool";
 import { useLpAssetPool } from "@/hooks/useLpAssetPool";
 import { usePool } from "@/hooks/usePool";
 import { PoolOverview } from "@/pages/pools/pool-overview";
@@ -21,7 +21,7 @@ export default function PoolPage(): ReactElement {
   // pool share, underlying, and Withdraw on the shared overview.
   const { data: position } = useLpAssetPool(pool?.lp_asset);
   const pair = decodedAssetA && decodedAssetB
-    ? getCanonicalPoolPair(decodedAssetA, decodedAssetB)
+    ? getPoolDisplayPair(decodedAssetA, decodedAssetB)
     : "Pool";
 
   useEffect(() => {

--- a/src/pages/pools/pool-overview.tsx
+++ b/src/pages/pools/pool-overview.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import { PoolHeader } from "@/components/ui/headers/pool-header";
 import { ActionList } from "@/components/ui/lists/action-list";
 import type { Pool, PoolPosition } from "@/core/counterparty/api";
-import { getCanonicalPoolAssets, getCanonicalPoolPair } from "@/core/counterparty/pool";
+import { getPoolDisplayAssets, getPoolDisplayPair } from "@/core/counterparty/pool";
 import { divide, formatDecimal, isGreaterThan, multiply, toBigNumber } from "@/core/numeric";
 import { useAssetInfo } from "@/hooks/useAssetInfo";
 
@@ -22,8 +22,8 @@ interface PoolOverviewProps {
  */
 export function PoolOverview({ pool, position }: PoolOverviewProps): ReactElement {
   const navigate = useNavigate();
-  const pair = getCanonicalPoolPair(pool.asset_a, pool.asset_b);
-  const [firstReserveAsset, secondReserveAsset] = getCanonicalPoolAssets(pool.asset_a, pool.asset_b);
+  const pair = getPoolDisplayPair(pool.asset_a, pool.asset_b);
+  const [firstReserveAsset, secondReserveAsset] = getPoolDisplayAssets(pool.asset_a, pool.asset_b);
   const { data: lpAssetInfo } = useAssetInfo(position ? pool.lp_asset : "");
 
   const reserveByAsset = {

--- a/src/pages/requests/psbt/approve.tsx
+++ b/src/pages/requests/psbt/approve.tsx
@@ -4,6 +4,8 @@ import {ApprovalExpired, ApprovalFooter,
   ApprovalWalletHeader, 
 } from '@/components/domain/approval/approval-chrome';
 import { ApprovalSummaryCard } from '@/components/domain/approval/approval-summary-card';
+import { buildApprovalWarnings } from '@/components/domain/approval/approval-warnings';
+import { CounterpartyDetailsCard } from '@/components/domain/approval/counterparty-details-card';
 import { computeMoneyMovement } from '@/components/domain/approval/money-movement';
 import { buildOrderAction } from '@/components/domain/approval/order-card';
 import { getTxActionInfo } from '@/components/domain/tx/tx-action-info';
@@ -214,79 +216,15 @@ export default function ApprovePsbtPage() {
     committedOutputs,
   });
 
-  const warningItems: WarningItem[] = safetyWarnings.map((warning, idx) => ({
-    key: `safety-${idx}`,
-    severity: warning.severity === 'block' ? 'danger' : warning.severity,
-    title: warning.title,
-    description: warning.message,
-  }));
-  // Where the attached assets land. Spending an attached UTXO moves its balances with no
-  // Counterparty message, so without this the screen can say only that assets move, never where —
-  // and for an atomic swap that is the whole question.
-  if (decodedInfo.attachedAssetDestination) {
-    const dest = decodedInfo.attachedAssetDestination;
-    warningItems.push({
-      key: 'attached-destination',
-      severity: dest.leavesWallet ? 'danger' : 'warning',
-      title: dest.detaches
-        ? 'Attached assets are detached to your address'
-        : dest.leavesWallet
-          ? 'Attached assets leave your wallet'
-          : 'Attached assets move to your own output',
-      description: dest.detaches
-        ? 'This transaction has no ordinary output, so every asset attached to the inputs you are ' +
-          'signing is credited back to your address.'
-        : `Every asset attached to input${dest.sourceInputs.length === 1 ? '' : 's'} ` +
-          `${dest.sourceInputs.map((i) => `#${i}`).join(', ')} is credited to output ` +
-          `#${dest.destinationVout}${dest.destinationAddress ? ` (${dest.destinationAddress})` : ''}` +
-          `${dest.leavesWallet ? ', which is not an address you control.' : '.'}`,
-    });
-  }
+  const warningItems: WarningItem[] = buildApprovalWarnings({
+    safetyWarnings,
+    attachedAssetDestination: decodedInfo.attachedAssetDestination,
+    structureFindings: decodedInfo.structureFindings ?? [],
+    signedInputsWithAssets,
+    signedInputsUnknownStatus,
+  });
 
-  // Message fields that reference this transaction and do not resolve against it.
-  for (const [idx, finding] of (decodedInfo.structureFindings ?? []).entries()) {
-    warningItems.push({
-      key: `structure-${idx}`,
-      severity: 'warning',
-      title: finding.title,
-      description: finding.message,
-    });
-  }
-
-  if (signedInputsWithAssets.length > 0) {
-    warningItems.push({
-      key: 'attached-assets',
-      severity: 'warning',
-      title: 'Spends UTXOs holding Counterparty assets',
-      description: 'Inputs you are signing carry attached assets. Signing moves them, not just BTC.',
-      children: (
-        <ul className="mt-2 space-y-1 text-xs font-medium">
-          {signedInputsWithAssets.flatMap(entry =>
-            entry.assets.map(asset => (
-              <li key={`${entry.inputIndex}-${asset.asset}`}>
-                Input #{entry.inputIndex}: {asset.quantity_normalized} {asset.asset_longname ?? asset.asset}
-              </li>
-            ))
-          )}
-        </ul>
-      ),
-    });
-  }
-  if (signedInputsUnknownStatus.length > 0) {
-    warningItems.push({
-      key: 'unknown-status',
-      severity: 'warning',
-      title: "Couldn't verify asset status",
-      description: `The balance lookup failed for ${signedInputsUnknownStatus.length === 1 ? 'an input' : 'some inputs'} you are signing, so attached Counterparty assets can't be confirmed either way. Proceed only if you trust this transaction.`,
-      children: (
-        <ul className="mt-2 space-y-1 text-xs font-medium">
-          {signedInputsUnknownStatus.map(entry => (
-            <li key={entry.inputIndex}>Input #{entry.inputIndex}: status unknown</li>
-          ))}
-        </ul>
-      ),
-    });
-  }
+  // PSBT-only: a raw transaction is signed SIGHASH_ALL throughout and cannot change after signing.
   if (userSignsWithAnyoneCanPay) {
     // Money the signature leaves redirectable is a different order of risk from a transaction that
     // can merely gain inputs, so it reads as danger rather than caution.
@@ -361,36 +299,8 @@ export default function ApprovePsbtPage() {
 
           {/* Transaction Details (expandable) */}
 
-          {/* What the Counterparty message itself says, kept apart from the Bitcoin view below.
-              The headline is one line and loses most of it — a fairminter's headline is its asset
-              name, while the thing being agreed to is a set of caps, a price and a deadline. */}
-          {txAction && 'protocol' in txAction && txAction.protocol.length > 0 && (
-            <div className="bg-white rounded-lg shadow-sm p-4">
-              <h3 className="text-xs font-medium text-gray-500 uppercase mb-2">Counterparty Details</h3>
-              <div className="space-y-1.5">
-                {txAction.protocol.map((field) => {
-                  /* A hash or an outpoint does not fit on a row beside its label: right-aligned it
-                     wrapped into three ragged lines that nobody can read across. Long values get
-                     their own line in monospace, where the digits line up and can be compared. */
-                  const isLong = field.value.length > 32;
-                  return isLong ? (
-                    <div key={field.label} className="text-sm">
-                      <div className="text-gray-500">{field.label}</div>
-                      <div className="text-gray-900 font-mono text-xs break-all mt-0.5">
-                        {field.value}
-                      </div>
-                    </div>
-                  ) : (
-                    <div key={field.label} className="flex justify-between gap-3 text-sm">
-                      <span className="text-gray-500 flex-shrink-0">{field.label}</span>
-                      <span className="text-gray-900 font-medium text-right break-all">
-                        {field.value}
-                      </span>
-                    </div>
-                  );
-                })}
-              </div>
-            </div>
+          {txAction && 'protocol' in txAction && (
+            <CounterpartyDetailsCard fields={txAction.protocol} />
           )}
           <Collapsible variant="card" title="Transaction Details">
                 {/* TX Hash */}

--- a/src/pages/requests/transaction/approve.tsx
+++ b/src/pages/requests/transaction/approve.tsx
@@ -4,6 +4,8 @@ import {ApprovalExpired, ApprovalFooter,
   ApprovalWalletHeader, 
 } from '@/components/domain/approval/approval-chrome';
 import { splitTrailingAddress } from '@/components/domain/approval/approval-summary-card';
+import { buildApprovalWarnings } from '@/components/domain/approval/approval-warnings';
+import { CounterpartyDetailsCard } from '@/components/domain/approval/counterparty-details-card';
 import { computeMoneyMovement } from '@/components/domain/approval/money-movement';
 import { MoneyMovementView } from '@/components/domain/approval/money-movement-view';
 import { buildOrderAction, type OrderAction, OrderCard } from '@/components/domain/approval/order-card';
@@ -170,81 +172,13 @@ export default function ApproveTransactionPage() {
     committedOutputs: null,
   });
 
-  const warningItems: WarningItem[] = safetyWarnings.map((warning, idx) => ({
-    key: `safety-${idx}`,
-    severity: warning.severity === 'block' ? 'danger' : warning.severity,
-    title: warning.title,
-    description: warning.message,
-  }));
-  // Where the attached assets land. Spending an attached UTXO moves its balances with no
-  // Counterparty message, so without this the screen can say only that assets move, never where —
-  // and for an atomic swap that is the whole question.
-  if (decodedInfo.attachedAssetDestination) {
-    const dest = decodedInfo.attachedAssetDestination;
-    warningItems.push({
-      key: 'attached-destination',
-      severity: dest.leavesWallet ? 'danger' : 'warning',
-      title: dest.detaches
-        ? 'Attached assets are detached to your address'
-        : dest.leavesWallet
-          ? 'Attached assets leave your wallet'
-          : 'Attached assets move to your own output',
-      description: dest.detaches
-        ? 'This transaction has no ordinary output, so every asset attached to the inputs you are ' +
-          'signing is credited back to your address.'
-        : `Every asset attached to input${dest.sourceInputs.length === 1 ? '' : 's'} ` +
-          `${dest.sourceInputs.map((i) => `#${i}`).join(', ')} is credited to output ` +
-          `#${dest.destinationVout}${dest.destinationAddress ? ` (${dest.destinationAddress})` : ''}` +
-          `${dest.leavesWallet ? ', which is not an address you control.' : '.'}`,
-    });
-  }
-
-  // The message's own references to this transaction, where they do not resolve against it. A
-  // warning rather than a block: core rejects such a transaction, so it is ineffective rather than
-  // dangerous — but the screen cannot describe what it claims to do.
-  for (const [idx, finding] of (decodedInfo.structureFindings ?? []).entries()) {
-    warningItems.push({
-      key: `structure-${idx}`,
-      severity: 'warning',
-      title: finding.title,
-      description: finding.message,
-    });
-  }
-
-  if (signedInputsWithAssets.length > 0) {
-    warningItems.push({
-      key: 'attached-assets',
-      severity: 'warning',
-      title: 'Spends UTXOs holding Counterparty assets',
-      description: 'Inputs you are signing carry attached assets. Signing moves them, not just BTC.',
-      children: (
-        <ul className="mt-2 space-y-1 text-xs font-medium">
-          {signedInputsWithAssets.flatMap(entry =>
-            entry.assets.map(asset => (
-              <li key={`${entry.inputIndex}-${asset.asset}`}>
-                Input #{entry.inputIndex}: {asset.quantity_normalized} {asset.asset_longname ?? asset.asset}
-              </li>
-            ))
-          )}
-        </ul>
-      ),
-    });
-  }
-  if (signedInputsUnknownStatus.length > 0) {
-    warningItems.push({
-      key: 'unknown-status',
-      severity: 'warning',
-      title: "Couldn't verify asset status",
-      description: `The balance lookup failed for ${signedInputsUnknownStatus.length === 1 ? 'an input' : 'some inputs'} you are signing, so attached Counterparty assets can't be confirmed either way. Proceed only if you trust this transaction.`,
-      children: (
-        <ul className="mt-2 space-y-1 text-xs font-medium">
-          {signedInputsUnknownStatus.map(entry => (
-            <li key={entry.inputIndex}>Input #{entry.inputIndex}: status unknown</li>
-          ))}
-        </ul>
-      ),
-    });
-  }
+  const warningItems: WarningItem[] = buildApprovalWarnings({
+    safetyWarnings,
+    attachedAssetDestination: decodedInfo.attachedAssetDestination,
+    structureFindings: decodedInfo.structureFindings ?? [],
+    signedInputsWithAssets,
+    signedInputsUnknownStatus,
+  });
 
   return (
     <div className="flex flex-col h-full bg-gray-50">
@@ -306,36 +240,8 @@ export default function ApproveTransactionPage() {
             )}
           </div>
 
-          {/* What the Counterparty message itself says, kept apart from the Bitcoin view below.
-              The headline is one line and loses most of it — a fairminter's headline is its asset
-              name, while the thing being agreed to is a set of caps, a price and a deadline. */}
-          {txAction && 'protocol' in txAction && txAction.protocol.length > 0 && (
-            <div className="bg-white rounded-lg shadow-sm p-4">
-              <h3 className="text-xs font-medium text-gray-500 uppercase mb-2">Counterparty Details</h3>
-              <div className="space-y-1.5">
-                {txAction.protocol.map((field) => {
-                  /* A hash or an outpoint does not fit on a row beside its label: right-aligned it
-                     wrapped into three ragged lines that nobody can read across. Long values get
-                     their own line in monospace, where the digits line up and can be compared. */
-                  const isLong = field.value.length > 32;
-                  return isLong ? (
-                    <div key={field.label} className="text-sm">
-                      <div className="text-gray-500">{field.label}</div>
-                      <div className="text-gray-900 font-mono text-xs break-all mt-0.5">
-                        {field.value}
-                      </div>
-                    </div>
-                  ) : (
-                    <div key={field.label} className="flex justify-between gap-3 text-sm">
-                      <span className="text-gray-500 flex-shrink-0">{field.label}</span>
-                      <span className="text-gray-900 font-medium text-right break-all">
-                        {field.value}
-                      </span>
-                    </div>
-                  );
-                })}
-              </div>
-            </div>
+          {txAction && 'protocol' in txAction && (
+            <CounterpartyDetailsCard fields={txAction.protocol} />
           )}
           {/* Transaction Details (expandable) */}
           <Collapsible variant="card" title="Transaction Details">

--- a/src/pages/transactions/_messages/fairminter.tsx
+++ b/src/pages/transactions/_messages/fairminter.tsx
@@ -1,5 +1,10 @@
 import type { ReactNode } from "react";
 import type { Transaction } from "@/core/counterparty/api";
+import {
+  describeFairminterPaymentModel,
+  getFairminterPaymentModel,
+  isPaidFairminter,
+} from "@/core/counterparty/fairminterModel";
 import { formatAmount } from "@/core/format";
 import { isGreaterThan } from "@/core/numeric";
 
@@ -29,29 +34,33 @@ export function fairminter(tx: Transaction): Array<{ label: string; value: strin
     },
   ];
 
-  // Mint model (use API-provided normalized values)
-  if (params.burn_payment === false) {
-    fields.push({
-      label: "Mint Model",
-      value: "BTC Fee Only (to miners)",
-    });
+  // Mint model. Derived from the price first: burn_payment says where a payment goes, not whether
+  // there is one, so reading it alone reported ordinary pay-the-issuer fairminters as free.
+  const paymentModel = getFairminterPaymentModel({
+    price: params.price_normalized ?? params.price,
+    burnPayment: params.burn_payment,
+    poolQuantity: params.pool_quantity_normalized ?? params.pool_quantity,
+  });
 
-    if (params.max_mint_per_tx_normalized !== undefined) {
-      fields.push({
-        label: "Max Mint per TX",
-        value: formatAmount({
-          value: Number(params.max_mint_per_tx_normalized),
-          minimumFractionDigits: isDivisible ? 8 : 0,
-          maximumFractionDigits: isDivisible ? 8 : 0,
-        }),
-      });
-    }
-  } else {
-    fields.push({
-      label: "Mint Model",
-      value: params.burn_payment ? "XCP Fee (burned)" : "XCP Fee (to issuer)",
-    });
+  fields.push({
+    label: "Mint Model",
+    value: describeFairminterPaymentModel(paymentModel),
+  });
 
+  // Bounds a paid mint as well as a free one — core rejects any quantity above it either way —
+  // so it is not part of the free-mint branch.
+  if (params.max_mint_per_tx_normalized !== undefined) {
+    fields.push({
+      label: "Max Mint per TX",
+      value: formatAmount({
+        value: Number(params.max_mint_per_tx_normalized),
+        minimumFractionDigits: isDivisible ? 8 : 0,
+        maximumFractionDigits: isDivisible ? 8 : 0,
+      }),
+    });
+  }
+
+  if (isPaidFairminter(paymentModel)) {
     // Price per mint (normalized)
     if (params.price_normalized !== undefined) {
       fields.push({


### PR DESCRIPTION
Thirteen commits. The thread through all of them: tests that looked like coverage but could not fail, and the defects they hid.

## Tests that could not fail, and the bugs behind them

- **The four skipped tests.** Three claimed "too slow for CI" at 30–60s timeouts; they cost 1.25s. Behind them: the 1000-destination limit hardcoded in nine places, now `MAX_DESTINATIONS` / `getDestinationLimitState()`. Enabled 7 biome rules.
- **`verifier.test.ts` made able to fail** — which proved the file's premise backwards.
- **A wallet fixture no key could satisfy.** `expect(result.valid || typeof result.valid === 'boolean')` is true for any boolean. Asserting the real expectation turned one bitcore fixture red: its signature recovers cleanly, but never to the address it was filed under. Replaced with a verified FreeWallet BIP-322 fixture over a legacy address.
- **BIP-137 uncompressed recovery was broken.** `recoverPublicKeyFromSignature` took a `compressed` flag and ignored it, so **no uncompressed-key signature could ever verify** — strict, legacy and loose alike. The loose layer's `[true, false]` loop was dead on one side.
- **`address.test.ts` asserted `typeof address === 'string'`** above a comment reading "Known test vector". Now asserts the published BIP-173/350/44/49/84/86 addresses. Verified by mutation: swapping hash160 for a double-sha still yields a valid `1…` address, so every old assertion passed it.
- **`isFiniteNumber` returned true for `NaN`, `""`, `"abc"`, `null` and `undefined`** — it routed through `toBigNumber`, which substitutes 0. It rejected only Infinity.

## Duplication on security-critical surfaces

- **Approval screens** shared 110 duplicated lines of warning construction — the entire text a user is shown before signing. Now `buildApprovalWarnings()` + `<CounterpartyDetailsCard>`, with the tests the inline copies could not have.
- **detach ↔ move** deduped via `useUtxoSource()`.

## Pools, swap, and fairmint

- **Pool pairs** now use the same base/quote rule as DEX orders. Alphabetical order rendered `BTC / PEPECASH`, implying a price denominated in PEPECASH.
- **Auto slippage** on swaps, after Uniswap v4 and the launchpad: sized to the quote's own price impact, floored at 0.5%, capped at 5%. One setting, Auto as a fourth preset.
- **Fairmint** now states what it costs. The form showed a bare "Amount" field under an XCP balance header with no price on it at all (the price text only rendered with help text on, off by default), and the review screen showed no cost whatsoever. Payment model is now read from the price rather than `burn_payment`, which had been reporting ordinary pay-the-issuer fairminters as free.

## Also

`knip.json` — without config it called 186 files unused, including `background.ts`.

## Verification

4191 unit tests and 399 fuzz tests pass; typecheck and lint clean. The only local failure is `trezorAdapter.emulator.test.ts`, which needs a service on `localhost:9001`.

**E2E has not been run** — it is CI-only here, and these changes touch the approval, pool, swap and fairmint screens.