### PR TITLE
Fix the four hooks that were reading a stale value, document the rest

### DIFF
--- a/src/components/domain/asset/fairminter-select-input.tsx
+++ b/src/components/domain/asset/fairminter-select-input.tsx
@@ -50,6 +50,8 @@ export function FairminterSelectInput({
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // Load the open fairminters once, at mount. The fetch calls onChange(selectedAsset, ...), so
+  // listing either would refetch the whole list on every selection change.
   useEffect(() => {
     const fetchFairminters = async () => {
       setIsLoading(true);

--- a/src/components/ui/inputs/hash-input.tsx
+++ b/src/components/ui/inputs/hash-input.tsx
@@ -110,7 +110,8 @@ export function HashInput({
     setLocalValue(value);
   }, [value]);
 
-  // Validate on change
+  // Validate on change. The deps name the values validateHash reads rather than the function,
+  // which is redefined every render.
   useEffect(() => {
     const valid = validateHash(localValue);
     setIsValid(valid);

--- a/src/components/ui/inputs/memo-input.tsx
+++ b/src/components/ui/inputs/memo-input.tsx
@@ -54,7 +54,8 @@ export function MemoInput({
     onValidationChange?.(valid);
   };
 
-  // Sync with external value changes
+  // Sync with external value changes. `memo` is deliberately not a dep — listing it would re-run
+  // this on every keystroke and setMemo(value) would discard what the user just typed.
   useEffect(() => {
     if (value !== memo) {
       setMemo(value);
@@ -64,7 +65,8 @@ export function MemoInput({
     }
   }, [value]);
 
-  // Initial validation
+  // Initial validation, mount only. Later changes report through handleMemoChange and the sync
+  // effect above.
   useEffect(() => {
     const valid = checkMemoValidity(memo);
     setIsValid(valid);

--- a/src/components/ui/inputs/textarea-input.tsx
+++ b/src/components/ui/inputs/textarea-input.tsx
@@ -91,7 +91,8 @@ export function TextAreaInput({
     return true;
   };
 
-  // Validate on change
+  // Validate on change. The deps name the values validate reads rather than the function, which
+  // is redefined every render.
   useEffect(() => {
     const valid = validate(localValue);
     setIsValid(valid);

--- a/src/hooks/__tests__/useAssetBalance.test.ts
+++ b/src/hooks/__tests__/useAssetBalance.test.ts
@@ -22,9 +22,13 @@ vi.mock('@/contexts/wallet-context', () => ({
   })
 }));
 
+// The balance cache is shared app-wide, so the mock has to be mutable: a test needs to be able to
+// write into it the way a second mounted component would.
+const headerCache = vi.hoisted(() => ({ balances: {} as Record<string, any> }));
+
 vi.mock('@/contexts/header-context', () => ({
   useHeader: () => ({
-    subheadings: { balances: {} },
+    subheadings: { balances: headerCache.balances },
     setBalanceHeader: vi.fn(),
     clearBalances: vi.fn()
   })
@@ -45,6 +49,64 @@ describe('useAssetBalance', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    headerCache.balances = {};
+  });
+
+  // A compose form reads the spendable balance from this hook. When another mounted component
+  // refreshes the same asset it writes the new balance into the shared header cache — this hook
+  // has to notice, or the form goes on showing the number it read when it mounted.
+  it('picks up a balance another component wrote into the shared cache', async () => {
+    headerCache.balances = {
+      XCP: {
+        asset: 'XCP',
+        quantity_normalized: asDisplayUnits('10.00000000'),
+        asset_info: { divisible: true },
+      },
+    };
+
+    const { result, rerender } = renderHook(() => useAssetBalance('XCP'));
+
+    await waitFor(() => expect(result.current.balance).toBe('10.00000000'));
+    expect(fetchAssetDetailsAndBalance).not.toHaveBeenCalled();
+
+    // Someone else refreshes XCP and writes the fresher figure into the shared cache.
+    headerCache.balances = {
+      XCP: {
+        asset: 'XCP',
+        quantity_normalized: asDisplayUnits('42.00000000'),
+        asset_info: { divisible: true },
+      },
+    };
+    rerender();
+
+    await waitFor(() => expect(result.current.balance).toBe('42.00000000'));
+    // Reading the cache must not trigger a network fetch.
+    expect(fetchAssetDetailsAndBalance).not.toHaveBeenCalled();
+  });
+
+  it('picks up a divisibility correction from the shared cache', async () => {
+    headerCache.balances = {
+      RAREPEPE: {
+        asset: 'RAREPEPE',
+        quantity_normalized: asDisplayUnits('5'),
+        asset_info: { divisible: true },
+      },
+    };
+
+    const { result, rerender } = renderHook(() => useAssetBalance('RAREPEPE'));
+
+    await waitFor(() => expect(result.current.isDivisible).toBe(true));
+
+    headerCache.balances = {
+      RAREPEPE: {
+        asset: 'RAREPEPE',
+        quantity_normalized: asDisplayUnits('5'),
+        asset_info: { divisible: false },
+      },
+    };
+    rerender();
+
+    await waitFor(() => expect(result.current.isDivisible).toBe(false));
   });
 
   it('should fetch BTC balance successfully', async () => {

--- a/src/hooks/__tests__/useSignTransactionRequest.test.ts
+++ b/src/hooks/__tests__/useSignTransactionRequest.test.ts
@@ -1,0 +1,104 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { analyzeSignRequest } from '@/core/counterparty/signRequestAnalysis';
+import { getSignFlow } from '@/platform/provider/signFlow';
+import { useSignTransactionRequest } from '../useSignTransactionRequest';
+
+vi.mock('react-router', () => ({
+  useSearchParams: () => [new URLSearchParams('requestId=req-1')],
+}));
+
+vi.mock('@/platform/provider/signFlow', () => ({
+  getSignFlow: vi.fn(),
+  recordSignOutcome: vi.fn(),
+}));
+
+vi.mock('@/platform/provider/emitToBackground', () => ({
+  emitToBackground: vi.fn(),
+}));
+
+vi.mock('@/core/bitcoin/localTransactionParse', () => ({
+  parseRawTransactionLocally: () => ({
+    txid: 'tx-1',
+    inputs: [{ txid: 'prev-1', vout: 0 }],
+    outputs: [{ index: 0, value: 10_000, type: 'p2wpkh', address: 'bc1qmine' }],
+    vsize: 110,
+    hasOpReturn: false,
+  }),
+}));
+
+vi.mock('@/core/counterparty/inputAssets', () => ({
+  fetchInputsAttachedAssets: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('@/core/counterparty/transaction', () => ({
+  fetchInputPrevouts: vi.fn().mockResolvedValue(new Map()),
+}));
+
+vi.mock('@/core/counterparty/unpack/opReturn', () => ({
+  extractCounterpartyPayload: () => undefined,
+}));
+
+vi.mock('@/core/counterparty/signRequestAnalysis', () => ({
+  analyzeSignRequest: vi.fn(),
+}));
+
+/** The signer addresses each `analyzeSignRequest` call was made with, in order. */
+function signerAddressesPerCall(): string[][] {
+  return vi.mocked(analyzeSignRequest).mock.calls.map(([input]) => input.signerAddresses);
+}
+
+describe('useSignTransactionRequest', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getSignFlow).mockResolvedValue({
+      id: 'req-1',
+      rawTxHex: '0100000000',
+    } as any);
+    vi.mocked(analyzeSignRequest).mockResolvedValue({
+      counterpartyMessage: undefined,
+      verification: {} as any,
+      safety: { blocked: false, warnings: [] } as any,
+      attachedAssets: [],
+      mpmaRecipients: [],
+      structureFindings: [],
+      protocolContext: {} as any,
+      attachedAssetDestination: null,
+    });
+  });
+
+  // The approval screen passes `activeAddress?.address`, which is null until the wallet context
+  // hydrates. If the analysis is not recomputed once the address arrives, the screen decides
+  // whose outputs are whose with an empty signer list — every output back to the user reads as
+  // leaving the wallet.
+  it('re-analyzes with the signer address once the wallet context hydrates', async () => {
+    const { result, rerender } = renderHook(
+      ({ signer }: { signer?: string }) => useSignTransactionRequest(signer),
+      { initialProps: { signer: undefined } as { signer?: string } }
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(signerAddressesPerCall()).toEqual([[]]);
+
+    rerender({ signer: 'bc1qmine' });
+
+    await waitFor(() => {
+      expect(signerAddressesPerCall()).toContainEqual(['bc1qmine']);
+    });
+  });
+
+  it('does not re-analyze when the signer address is unchanged', async () => {
+    const { result, rerender } = renderHook(
+      ({ signer }: { signer?: string }) => useSignTransactionRequest(signer),
+      { initialProps: { signer: 'bc1qmine' } as { signer?: string } }
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(signerAddressesPerCall()).toEqual([['bc1qmine']]);
+
+    rerender({ signer: 'bc1qmine' });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(signerAddressesPerCall()).toEqual([['bc1qmine']]);
+  });
+});

--- a/src/hooks/useAssetBalance.ts
+++ b/src/hooks/useAssetBalance.ts
@@ -200,10 +200,14 @@ export function useAssetBalance(asset: string) {
         abortControllerRef.current = null;
       }
     };
+    // The header cache is shared, so another component can refresh this asset; re-running copies
+    // the newer value out of the cache without re-fetching.
   }, [
     asset,
     activeAddress?.address,
     activeWallet?.id,
+    cachedBalance?.quantity_normalized,
+    cachedBalance?.asset_info?.divisible,
   ]);
 
   return state;

--- a/src/hooks/useAssetInfo.ts
+++ b/src/hooks/useAssetInfo.ts
@@ -147,7 +147,7 @@ export function useAssetInfo(asset: string) {
         abortControllerRef.current = null;
       }
     };
-  }, [asset, activeAddress?.address, state.data]);
+  }, [asset, activeAddress?.address, state.data, isBTC]);
 
   return state;
 }

--- a/src/hooks/useAssetOwnerLookup.ts
+++ b/src/hooks/useAssetOwnerLookup.ts
@@ -83,7 +83,7 @@ export function useMultiAssetOwnerLookup(options: UseMultiAssetOwnerLookupOption
 
   useEffect(() => {
     return cleanupAll;
-  }, []);
+  }, [cleanupAll]);
 
   const performLookup = useCallback(
     async (destinationId: number, assetName: string) => {
@@ -142,7 +142,7 @@ export function useMultiAssetOwnerLookup(options: UseMultiAssetOwnerLookupOption
         }
       }, debounceMs);
     },
-    [debounceMs, onResolve]
+    [debounceMs, onResolve, cleanupDestination]
   );
 
   const clearLookup = useCallback((destinationId: number) => {
@@ -152,7 +152,7 @@ export function useMultiAssetOwnerLookup(options: UseMultiAssetOwnerLookupOption
       delete newState[destinationId];
       return newState;
     });
-  }, []);
+  }, [cleanupDestination]);
 
   const getLookupState = useCallback(
     (destinationId: number) => {

--- a/src/hooks/useAssetUtxos.ts
+++ b/src/hooks/useAssetUtxos.ts
@@ -130,6 +130,8 @@ export function useAssetUtxos(asset: string) {
         abortControllerRef.current = null;
       }
     };
+    // state.utxos is deliberately not a dep: the BTC branch above assigns a fresh [] each run, so
+    // the identity check always sees a change and listing it here spins forever.
   }, [asset, activeAddress?.address]);
 
   return state;

--- a/src/hooks/useBlockHeight.ts
+++ b/src/hooks/useBlockHeight.ts
@@ -59,7 +59,8 @@ export function useBlockHeight(options: UseBlockHeightOptions = {}) {
     }
   }, [blockHeight]);
 
-  // Initial fetch on mount if autoFetch is true
+  // Initial fetch on mount if autoFetch is true. fetchBlockHeight is omitted deliberately: it
+  // depends on blockHeight, so listing it would poll forever.
   useEffect(() => {
     if (autoFetch) {
       fetchBlockHeight();

--- a/src/hooks/useMarketPrices.ts
+++ b/src/hooks/useMarketPrices.ts
@@ -76,7 +76,8 @@ export const useMarketPrices = (currency: FiatCurrency = 'usd') => {
     }
   };
 
-  // Fetch prices on mount and when currency changes
+  // Fetch prices on mount and when currency changes. fetchPrices is redefined every render and
+  // closes over nothing but currency, so listing it would re-fetch on every render.
   useEffect(() => {
     fetchPrices();
   }, [currency]);

--- a/src/hooks/useSignTransactionRequest.ts
+++ b/src/hooks/useSignTransactionRequest.ts
@@ -188,7 +188,9 @@ export function useSignTransactionRequest(signerAddress?: string) {
     };
 
     loadRequest();
-  }, [requestId, decodeTransaction]);
+    // signerAddress is null until the wallet context hydrates; without it the analysis is
+    // computed once with no signer and never revisited.
+  }, [requestId, decodeTransaction, signerAddress]);
 
   // Listen for navigation messages from background
   useEffect(() => {
@@ -211,7 +213,7 @@ export function useSignTransactionRequest(signerAddress?: string) {
     return () => {
       chrome.runtime.onMessage.removeListener(handleMessage);
     };
-  }, [decodeTransaction]);
+  }, [decodeTransaction, signerAddress]);
 
   // Handle completion - called when user approves and signs
   const handleSuccess = useCallback(async (signedTxHex: string) => {

--- a/src/pages/actions/consolidate/index.tsx
+++ b/src/pages/actions/consolidate/index.tsx
@@ -30,7 +30,8 @@ function ConsolidatePage() {
     setLocalShowHelpText(prev => prev === null ? !settings?.showHelpText : !prev);
   }, [settings?.showHelpText]);
 
-  // Mark the recover bitcoin page as visited
+  // Mark the recover bitcoin page as visited. One-shot: listing the flag would re-run the effect
+  // on the write it just made.
   useEffect(() => {
     if (!settings?.hasVisitedRecoverBitcoin) {
       updateSettings({ hasVisitedRecoverBitcoin: true });

--- a/src/pages/actions/consolidate/status.tsx
+++ b/src/pages/actions/consolidate/status.tsx
@@ -40,6 +40,8 @@ function ConsolidateStatusPage() {
     }
   };
 
+  // fetchStatus is redefined every render; listing it would recreate the interval each time and
+  // the 30s auto-refresh would never fire.
   useEffect(() => {
     fetchStatus();
     

--- a/src/pages/addresses/history.tsx
+++ b/src/pages/addresses/history.tsx
@@ -88,12 +88,14 @@ export default function AddressHistoryPage(): ReactElement {
     }
   }, [searchParams, setSearchParams]);
 
-  // Fetch transactions when page or address changes
+  // Fetch transactions when page or address changes. loadTransactions is redefined every render,
+  // so it is omitted here and in the two effects below; its inputs are listed instead.
   useEffect(() => {
     loadTransactions();
   }, [currentPage, activeAddress]);
 
-  // Auto-refresh for unconfirmed transactions
+  // Auto-refresh for unconfirmed transactions. Listing loadTransactions would recreate the
+  // interval every render, so the 30s timer would never fire.
   useEffect(() => {
     // Check if there are any unconfirmed transactions
     const hasUnconfirmed = transactions.some(tx => tx.confirmed === false);
@@ -108,7 +110,7 @@ export default function AddressHistoryPage(): ReactElement {
     }
   }, [transactions]);
 
-  // Configure header
+  // Configure header. loadTransactions omitted (see above).
   useEffect(() => {
     setHeaderProps({
       title: "History",

--- a/src/pages/assets/[asset]/index.tsx
+++ b/src/pages/assets/[asset]/index.tsx
@@ -83,7 +83,9 @@ export default function AssetPage(): ReactElement {
     }
   };
 
-  // Load dividends when section is expanded
+  // Load dividends when the section is first expanded. The guard is a one-shot latch: an asset
+  // with no dividends still reads as empty and idle afterwards, so making it reactive refetches
+  // forever.
   useEffect(() => {
     if (showDividends && dividends.length === 0 && !dividendsLoading) {
       loadDividends();

--- a/src/pages/assets/index.tsx
+++ b/src/pages/assets/index.tsx
@@ -117,7 +117,7 @@ export default function AssetsPage(): ReactElement {
   // Sync pinned assets from wallet
   useEffect(() => {
     if (settings) setPinnedAssets(settings.pinnedAssets || []);
-  }, [settings?.pinnedAssets]);
+  }, [settings, settings?.pinnedAssets]);
 
   /**
    * Handles search input changes and updates URL params.

--- a/src/pages/assets/utxos/[txHash].tsx
+++ b/src/pages/assets/utxos/[txHash].tsx
@@ -57,7 +57,8 @@ export default function UtxoPage(): ReactElement {
     }
   };
 
-  // Configure header
+  // Configure header. handleCopyUtxo is redefined every render; listing it would call
+  // setHeaderProps on every render and re-trigger this effect.
   useEffect(() => {
     setHeaderProps({
       title: "UTXO Details",

--- a/src/pages/compose/dispenser/dispense/__tests__/form.test.tsx
+++ b/src/pages/compose/dispenser/dispense/__tests__/form.test.tsx
@@ -1,8 +1,9 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ComposerProvider } from '@/contexts/composer-context';
+import { useComposer } from '@/contexts/composer-context-object';
 import * as counterpartyApi from '@/core/counterparty/api';
 import * as utxoSelection from '@/core/counterparty/utxoSelection';
 import { asBaseUnits, asDisplayUnits } from '@/core/numeric';
@@ -336,6 +337,73 @@ describe('DispenseForm', () => {
     // Should show insufficient balance error
     await waitFor(() => {
       expect(screen.getByText(/Insufficient BTC balance/i)).toBeInTheDocument();
+    });
+  });
+
+  // The shortfall message quotes a fee computed from the composer's fee rate, which is refreshed
+  // while the form is open. `maxDispenses` recomputes from the live rate on every render, so if
+  // the Max handler holds an older one the two disagree and the user is quoted a fee at a rate
+  // that is no longer in effect.
+  it('quotes the shortfall at the current fee rate, not the one in effect when Max was built', async () => {
+    const mockDispensers = [createMockDispenser({
+      asset: 'EXPENSIVE',
+      satoshirate: asBaseUnits(100000000), // 1 BTC per dispense, far above the balance below
+      satoshirate_normalized: asDisplayUnits('1.00000000'),
+    })];
+
+    mockFetchAddressDispensers.mockResolvedValue({
+      result: mockDispensers,
+      result_count: 1,
+    });
+
+    mockSelectUtxosForTransaction.mockResolvedValue({
+      utxos: [
+        { txid: 'abc123', vout: 0, value: 100000, status: { confirmed: true, block_height: 800000, block_hash: 'hash', block_time: 1234567890 } }
+      ],
+      inputsSet: 'abc123:0',
+      totalValue: 100000,
+      excludedWithAssets: 0,
+      excludedValue: 0,
+    });
+
+    let setFeeRate!: (rate: number) => void;
+    function FeeRateDriver() {
+      setFeeRate = useComposer().setFeeRate;
+      return null;
+    }
+
+    render(
+      <MemoryRouter>
+        <ComposerProvider composeApi={vi.fn()} initialTitle="Dispense" composeType="dispense">
+          <FeeRateDriver />
+          <DispenseForm formAction={mockFormAction} initialFormData={null} />
+        </ComposerProvider>
+      </MemoryRouter>
+    );
+
+    await userEvent.type(screen.getByLabelText(/Dispenser Address/i), '1CounterpartyXXXXXXXXXXXXXXXUWLpVr');
+    await waitFor(() => expect(screen.getByText('EXPENSIVE')).toBeInTheDocument());
+
+    const quotedFee = () => {
+      const message = screen.getByText(/Insufficient BTC balance/i).textContent ?? '';
+      const match = message.match(/~(\d+) sats fee/);
+      if (!match) throw new Error(`No fee in shortfall message: ${message}`);
+      return Number(match[1]);
+    };
+
+    await act(async () => { setFeeRate(1); });
+    await userEvent.click(screen.getByText('Max'));
+    await waitFor(() => expect(screen.getByText(/Insufficient BTC balance/i)).toBeInTheDocument());
+    const feeAtRate1 = quotedFee();
+
+    // Fees spike; the form's fee rate is updated underneath the mounted component.
+    await act(async () => { setFeeRate(100); });
+    await userEvent.click(screen.getByText('Max'));
+
+    await waitFor(() => {
+      // 100× the rate over the same transaction means ~100× the fee. A handler holding the old
+      // rate keeps quoting feeAtRate1.
+      expect(quotedFee()).toBeGreaterThan(feeAtRate1 * 50);
     });
   });
 

--- a/src/pages/compose/dispenser/dispense/form.tsx
+++ b/src/pages/compose/dispenser/dispense/form.tsx
@@ -317,7 +317,9 @@ export function DispenseForm({
 
     setNumberOfDispenses(maxDispenses.toString());
     setValidationError(null);
-  }, [selectedDispenser, maxDispenses, spendableBtc]);
+    // feeRate and the address feed the shortfall figure above, and feeRate refreshes while the
+    // form is open.
+  }, [selectedDispenser, maxDispenses, spendableBtc, feeRate, activeAddress?.address]);
 
   // Handle dispenser selection change
   const handleDispenserSelectionChange = useCallback((index: number | null, option: DispenserOption | null) => {

--- a/src/pages/compose/issuance/update-description/form.tsx
+++ b/src/pages/compose/issuance/update-description/form.tsx
@@ -58,7 +58,8 @@ export function UpdateDescriptionForm({
   };
 
 
-  // Focus description textarea on mount
+  // Focus description textarea on mount. Listing inscribeEnabled would steal focus back every
+  // time the user toggles inscribe.
   useEffect(() => {
     if (!inscribeEnabled) {
       descriptionRef.current?.focus();

--- a/src/pages/compose/order/form.tsx
+++ b/src/pages/compose/order/form.tsx
@@ -109,8 +109,10 @@ export function OrderForm({
   // Trading state - restore from initialFormData if present
   const [isPairFlipped, setIsPairFlipped] = useState(initialFormData?.is_pair_flipped === "true");
 
-  // Sync URL params when they arrive after initial render (e.g., page.goto() in tests or direct URL entry)
-  // Only applies if no initialFormData (user wasn't editing a form)
+  // Sync URL params when they arrive after initial render (e.g., page.goto() in tests or direct URL
+  // entry). Only applies if no initialFormData (user wasn't editing a form).
+  // The form fields are read as "has the user set this yet?" guards and are deliberately not
+  // deps: listing them would re-run on the user's own edits and force each field back to the URL.
   useEffect(() => {
     if (initialFormData) return; // Don't override persisted form state
 

--- a/src/pages/keychain/secrets/show-private-key.tsx
+++ b/src/pages/keychain/secrets/show-private-key.tsx
@@ -79,7 +79,7 @@ export default function ShowPrivateKeyPage(): ReactElement {
       title: "Private Key",
       onBack: () => navigate(PATHS.BACK),
     });
-  }, [walletId, wallets, setHeaderProps, navigate]);
+  }, [walletId, wallets, setHeaderProps, navigate, setSubmissionError]);
 
   const handleCopyPrivateKey = async () => {
     // useCopyToClipboard auto-clears the clipboard after 30 seconds

--- a/src/pages/keychain/setup/create-mnemonic.tsx
+++ b/src/pages/keychain/setup/create-mnemonic.tsx
@@ -80,7 +80,7 @@ function CreateMnemonicPage() {
         disabled: isPending,
       },
     });
-  }, [navigate, setHeaderProps, keychainExists, isPending]);
+  }, [navigate, setHeaderProps, keychainExists, isPending, PATHS.BACK]);
 
   function handleGenerateWallet() {
     const newMnemonic = generateNewMnemonic();

--- a/src/pages/keychain/setup/import-mnemonic.tsx
+++ b/src/pages/keychain/setup/import-mnemonic.tsx
@@ -115,7 +115,7 @@ function ImportMnemonicPage() {
         ariaLabel: showMnemonic ? "Hide recovery phrase" : "Show recovery phrase",
       },
     });
-  }, [navigate, setHeaderProps, showMnemonic, keychainExists]);
+  }, [navigate, setHeaderProps, showMnemonic, keychainExists, PATHS.BACK]);
 
   useEffect(() => {
     inputRefs.current[0]?.focus();

--- a/src/pages/keychain/wallets/index.tsx
+++ b/src/pages/keychain/wallets/index.tsx
@@ -12,6 +12,13 @@ import type { Wallet } from '@/types/wallet';
 /** Check if we're running in the sidepanel (vs popup) */
 const isSidepanel = () => document.body.dataset.context === 'sidepanel';
 
+/** Route constants, at module scope so their identity is stable across renders. */
+const PATHS = {
+  BACK: '/',
+  ADD_WALLET: '/keychain/wallets/add',
+  INDEX: '/index',
+} as const;
+
 /**
  * SelectWallet component allows users to choose an active wallet or add a new one.
  *
@@ -26,13 +33,6 @@ function WalletsPage() {
   const { wallets, activeWallet, activeAddress, selectWallet } = useWallet();
   const [error, setError] = useState<string | null>(null);
   const canUseHardwareWallet = isSidepanel();
-
-  // Constants for paths
-  const PATHS = {
-    BACK: '/',
-    ADD_WALLET: '/keychain/wallets/add',
-    INDEX: '/index',
-  } as const;
 
   const handleAddWallet = useCallback(() => {
     if (wallets.length >= MAX_WALLETS) {

--- a/src/pages/market/orders/[baseAsset]/[quoteAsset].tsx
+++ b/src/pages/market/orders/[baseAsset]/[quoteAsset].tsx
@@ -32,6 +32,8 @@ import { useInView } from "@/hooks/useInView";
 // Constants
 const FETCH_LIMIT = 20;
 const REFRESH_COOLDOWN_MS = 5000; // 5 second cooldown between refreshes
+/** Stable empty result, so the order memos below do not recompute on every render. */
+const NO_ORDERS: Order[] = [];
 
 /**
  * Format price in raw quote asset units
@@ -245,7 +247,7 @@ export default function AssetOrdersPage(): ReactElement {
   }, [loading, orders.length, buyOrders.length, sellOrders.length]);
 
   // Get current orders based on tab
-  const currentOrders = tab === "buy" ? buyOrders : tab === "sell" ? sellOrders : [];
+  const currentOrders = tab === "buy" ? buyOrders : tab === "sell" ? sellOrders : NO_ORDERS;
 
   // Aggregate orders into price levels (like an exchange order book)
   const priceLevels = useMemo(() => {


### PR DESCRIPTION
Audit of the 33 `react-hooks/exhaustive-deps` findings oxlint surfaced in #289 (now merged).

Supersedes #290, which GitHub auto-closed when its base branch was deleted on merge. Same commit,
rebased onto `main`.

**Split: 4 real staleness (a) · 17 intentional (b) · 12 cosmetic (c)**

## Priority tier: compose, approval, and signing flows

Three of the four (a) fixes are in this tier, and it's where a stale closure stops being cosmetic.

### `useSignTransactionRequest.ts` — both effects (a)

The approval screen calls `useSignTransactionRequest(activeAddress?.address)`. `activeAddress` starts `null` in the wallet context and hydrates asynchronously, but both effects listed only `[requestId, decodeTransaction]` — and `decodeTransaction` is a `useCallback([])`, so they ran exactly once, capturing `signerAddress === undefined`.

`signerAddress` is what `analyzeSignRequest` uses to decide whose outputs are whose. With an empty signer list:

- `analyzeTransactionSafety` can't match any output to the user, so the change output back to their own address is reported as `BTC Sent to External Address … not yours` (severity `danger`)
- `resolveAttachedAssetDestination` reports `leavesWallet: true` for assets that stay put

Both fail loud rather than silent, so this is a false-alarm bug, not a false-safe one — but a spurious `danger` banner on a signing screen is how users learn to click through the real ones.

**Mutation:** removed `signerAddress` from the loader's deps → `re-analyzes with the signer address once the wallet context hydrates` fails with `expected [ [] ] to contain ['bc1qmine']`.

### `useAssetBalance.ts` (a)

Deps were `[asset, activeAddress?.address, activeWallet?.id]`, but the effect reads `cachedBalance` from the shared header context. When another mounted component refreshes the same asset and writes the cache, this hook never re-ran — it kept returning the balance it read at mount. That's the spendable figure a compose form shows. Re-running takes the `!needsFetch` branch and copies the cache into state; it does not re-fetch (asserted).

**Mutation:** removed both cache deps → the two new tests fail, balance stuck at `10.00000000` instead of `42.00000000`.

### `compose/dispenser/dispense/form.tsx` — `handleMaxClick` (a)

The `maxDispenses` IIFE recomputes from the live `feeRate` on every render; `handleMaxClick`, sitting right next to it and computing a fee the same way, had frozen it. The two disagreed, and the "you need at least N BTC (including ~Y sats fee)" message quoted a rate no longer in effect.

**Mutation:** removed `feeRate` → test fails with `expected 1100 to be greater than 55000` — exactly the stale rate-1 fee where the rate-100 fee belonged.

### `useAssetInfo.ts` (c)

`isBTC` is `asset === 'BTC'` and `asset` was already a dep, so it could never go stale. Added.

## The one that bit

`useAssetUtxos.ts` looked cosmetic — `state.utxos` guards a branch the existing deps already make unreachable — so I added it. **The test suite hung.**

Its early-return branch does `const targetUtxos = asset === 'BTC' ? [] : null`, minting a fresh array each run, so `prev.utxos !== targetUtxos` is always true by identity. With `state.utxos` as a dep that's an unbounded loop. Reverted and reclassified (b). This is the failure mode the brief warned about, and it was two characters from shipping.

## Intentional omissions (17)

Behavior unchanged; each has a one-line comment saying why. The recurring shapes:

- **Interval resets** — `consolidate/status.tsx`, `history.tsx` auto-refresh. The handler is redefined every render, so listing it recreates the `setInterval` each time and the 30s timer never fires.
- **Refetch loops** — `useBlockHeight` (`fetchBlockHeight` depends on `blockHeight`), `useMarketPrices`, `fairminter-select-input` (its fetch calls `onChange(selectedAsset, …)`, so listing either refetches the whole list per selection).
- **Discarding user input** — `memo-input`'s sync effect: listing `memo` makes it fire per keystroke, where `setMemo(value)` throws away what was just typed. `order/form.tsx` likewise would force fields back to the URL params on every edit.
- **One-shot latches** — `assets/[asset]/index.tsx` dividends (an asset with no dividends still reads empty+idle afterwards, so a reactive guard refetches forever), `consolidate/index.tsx` visited flag, `update-description` mount focus.
- **Primitive dep lists** — `hash-input`, `textarea-input` deliberately list the values the validator reads rather than the validator itself. That idiom is fine and now says so.

## Cosmetic (12)

Stable `useCallback([])` identities in `useAssetOwnerLookup`; `setSubmissionError` (a raw `useState` setter); `settings` in `assets/index.tsx`; `PATHS.BACK` in the two mnemonic pages. Two hoists that remove the finding at the source rather than appeasing it: `PATHS` in `keychain/wallets` and a `NO_ORDERS` constant replacing the `[]` literal that made both market-order memos recompute every render.

## Can exhaustive-deps be promoted to "error"? No — leave it at "warn"

This was the goal, and it isn't reachable. **oxlint 1.77.0 ignores line-level disable directives for this rule.** Verified four placements — `eslint-disable-next-line`, `oxlint-disable-next-line`, a bare `eslint-disable-next-line` with no rule name, and a trailing `eslint-disable-line` — none suppress it. It isn't a general directive failure: the same `eslint-disable-next-line` suppresses `no-useless-escape` fine, and a file-level `// oxlint-disable react-hooks/exhaustive-deps` works.

So the 17 (b) findings can't be silenced individually. Promoting to "error" would require file-level disables on `history.tsx`, `memo-input.tsx`, `order/form.tsx` and the rest — blanket-suppressing the files with the most hook-heavy, staleness-prone code, so a genuinely stale effect added there later would never be reported. That trades a real future signal for a clean lint run.

Recommendation: keep `"warn"`, revisit if oxlint fixes line-level suppression. The 17 remaining warnings are all documented in code, so the next reader has the reasoning without needing the linter to carry it.

## Verification

- `npx tsc --noEmit` clean
- `npm run lint` — 17 exhaustive-deps warnings (all (b)), down from 33; unrelated `no-useless-escape` / `no-useless-fallback-in-spread` untouched
- Test files run individually per CLAUDE.md: `useSignTransactionRequest` (2, new) · `useAssetBalance` (7, +2) · `useAssetInfo` (10) · `useAssetUtxos` (5) · `useBlockHeight` (11) · `memo-input` (9) · `dispense/form` (9, +1)
- Every (a) fix mutation-tested: broke the fix, watched the test go red, restored

https://claude.ai/code/session_01HUJSeVf1JXG1Rp3VXpb2Cr

