### PR TITLE
Promote the two clean lint rules to error

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -6,8 +6,8 @@
     "oxc/const-comparisons": "error",
 
     "react-hooks/exhaustive-deps": "warn",
-    "no-useless-escape": "warn",
-    "unicorn/no-useless-fallback-in-spread": "warn",
+    "no-useless-escape": "error",
+    "unicorn/no-useless-fallback-in-spread": "error",
 
     "no-unused-vars": "off",
     "no-control-regex": "off",

--- a/src/core/__tests__/format.test.ts
+++ b/src/core/__tests__/format.test.ts
@@ -17,7 +17,7 @@ describe('format utilities', () => {
       });
       // Currency formatting can vary by locale, so check for key components
       expect(result).toContain('1,234.57');
-      expect(result).toMatch(/[\$]|USD/); // Should contain $ or USD
+      expect(result).toMatch(/[$]|USD/); // Should contain $ or USD
     });
 
     it('should format percentage amounts', () => {

--- a/src/core/__tests__/numeric.test.ts
+++ b/src/core/__tests__/numeric.test.ts
@@ -83,6 +83,19 @@ describe('numeric utilities', () => {
       expect(isValidPositiveNumber('999999999.99999999')).toBe(true);
     });
 
+    // A value starting with =, @, + or - is a spreadsheet formula once exported to CSV, so the
+    // formula-injection guard rejects it before BigNumber sees it.
+    //
+    // Only '+' actually exercises that guard here: '=' and '@' are NaN to BigNumber and '-' is
+    // not positive, so those three are rejected either way and asserting them proves nothing
+    // about the guard. They are kept as the caller-visible contract, not as evidence.
+    it.each(['=', '@', '+', '-'])('rejects a value starting with %s', (prefix) => {
+      expect(isValidPositiveNumber(`${prefix}1234`)).toBe(false);
+      expect(isValidPositiveNumber(`${prefix}cmd|' /c calc'!A0`)).toBe(false);
+      // Leading whitespace is trimmed before the check, so it cannot be used to slip past it.
+      expect(isValidPositiveNumber(`  ${prefix}1234`)).toBe(false);
+    });
+
     it('should reject zero by default', () => {
       expect(isValidPositiveNumber('0')).toBe(false);
       expect(isValidPositiveNumber('0.0')).toBe(false);

--- a/src/core/numeric.ts
+++ b/src/core/numeric.ts
@@ -112,7 +112,7 @@ export const isValidPositiveNumber = (
 
   try {
     // Check for formula injection attempts
-    if (/^[=@+\-]/.test(value.trim())) {
+    if (/^[-=@+]/.test(value.trim())) {
       return false;
     }
 

--- a/src/core/validation/privateKey.ts
+++ b/src/core/validation/privateKey.ts
@@ -26,7 +26,7 @@ export function validatePrivateKeyFormat(privateKey: string): PrivateKeyValidati
   }
   
   // Check for formula injection attempts
-  if (/^[=@+\-]/.test(trimmed)) {
+  if (/^[-=@+]/.test(trimmed)) {
     return { isValid: false, error: 'Invalid private key format' };
   }
 

--- a/src/platform/walletManager.ts
+++ b/src/platform/walletManager.ts
@@ -836,7 +836,7 @@ export class WalletManager {
     if (!this.keychain) {
       return {
         ...DEFAULT_SETTINGS,
-        providerCapabilities: { ...(DEFAULT_SETTINGS.providerCapabilities ?? {}) },
+        providerCapabilities: { ...DEFAULT_SETTINGS.providerCapabilities },
       };
     }
     // DEFAULT_SETTINGS first backfills fields missing from keychains created

--- a/src/services/connectionService.ts
+++ b/src/services/connectionService.ts
@@ -230,7 +230,7 @@ export class ConnectionService extends BaseService {
   ): Promise<void> {
     const walletService = getWalletService();
     const settings = await walletService.getSettings();
-    const capabilities = { ...(settings.providerCapabilities ?? {}) };
+    const capabilities = { ...settings.providerCapabilities };
     capabilities[origin] = { pairedAddresses: true, walletId, address };
     await walletService.updateSettings({ providerCapabilities: capabilities });
   }

--- a/src/services/walletService.ts
+++ b/src/services/walletService.ts
@@ -119,7 +119,7 @@ function createWalletService(): WalletService {
     },
     removeConnectedWebsite: async (origin) => {
       const settings = walletManager.getSettings();
-      const providerCapabilities = { ...(settings.providerCapabilities ?? {}) };
+      const providerCapabilities = { ...settings.providerCapabilities };
       delete providerCapabilities[origin];
       await walletManager.updateSettings({
         connectedWebsites: settings.connectedWebsites.filter((site) => site !== origin),


### PR DESCRIPTION
Follow-on to #291. Clears the six remaining oxlint findings and ratchets both rules to `error`, so they can't regress.

## The six

**3× `unicorn/no-useless-fallback-in-spread`** — `{ ...(settings.providerCapabilities ?? {}) }` in `connectionService`, `walletService`, `walletManager`. Spreading `undefined` into an object literal is already a no-op, so the fallback never did anything. Now `{ ...settings.providerCapabilities }`.

**1× `no-useless-escape`** — `/[\$]|USD/` in `format.test.ts`. `$` isn't special inside a character class.

**2× `no-useless-escape`** — `/^[=@+\-]/`, the formula-injection guards in `core/numeric.ts` and `core/validation/privateKey.ts`. The escape was redundant *only* because `-` sat last in the class. Rather than just deleting the backslash and leaving `[=@+-]` one appended character away from becoming an accidental range, I moved the hyphen to the front: `/^[-=@+]/`. Same character set, range-safe under future edits.

## Coverage for the guards

These two are security checks, so I checked they were actually tested. `isValidPositiveNumber` **was not** — the existing injection test in `amount.fuzz.test.ts` uses payloads like `<script>` and `../../etc/passwd`, none of which start with `=@+-`. (It's also a fuzz test, so it only runs nightly.)

Added a case to `numeric.test.ts`, and mutation-tested it — which caught my own first attempt being a tautology:

- Narrowing the class to `[=@+]` (dropping `-`) → **still passed.** `-1234` isn't positive, so it's rejected either way.
- Disabling the guard entirely → **only the `+` case failed.** `=1234` and `@1234` are NaN to BigNumber and rejected regardless.

So `+` is the only character that isolates this guard. The test asserts all four as the caller-visible contract but says plainly in a comment that only `+` is evidence — rather than implying four characters' worth of proof it doesn't have.

`validatePrivateKeyFormat` already had a test that goes red when its guard is disabled, so I added nothing there and removed the redundant block I'd drafted.

## Not included

`react-hooks/exhaustive-deps` stays at `"warn"` — oxlint 1.77.0 ignores line-level disables for it, so the 17 intentional omissions can't be silenced individually. Reasoning is in #291.

## Verification

- `npm run lint` exits 0 with both rules at `error`
- `npx tsc --noEmit` clean
- `numeric.test.ts` 83 passing · `privateKey.test.ts` 28 passing (run individually per CLAUDE.md)

https://claude.ai/code/session_01HUJSeVf1JXG1Rp3VXpb2Cr