### PR TITLE
Give the lockfile a check that runs before CI does

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,21 @@ We intentionally minimized runtime dependencies—most wallets ship dozens, we s
 ## Development
 
 ```bash
-npm install
+npm install        # plain install — never --legacy-peer-deps, it prunes @testing-library/dom
 npm run dev        # Chrome
 npm run dev:firefox
 ```
+
+After changing `package.json` or `package-lock.json`, run:
+
+```bash
+npm run check:lockfile
+```
+
+CI installs with `npm ci`, which builds from the lockfile alone and fails if it
+does not record everything the tree needs. `lint`, `compile` and the test suite
+all run against your existing `node_modules`, so they pass either way — this is
+the only local check that catches a lockfile drift before CI does.
 
 ## Build
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "test:emulator": "vitest run --config vitest.emulator.config.ts",
     "compile": "tsc --noEmit",
     "lint": "biome check src && oxlint src",
+    "check:lockfile": "npm ci --dry-run",
     "lint:fix": "biome check src --write && oxlint src --fix",
     "postinstall": "wxt prepare"
   },


### PR DESCRIPTION
Closes the gap that made #289 fail on all four checks at once.

## What happened

Every job in #289 died at the install step in under 12 seconds, before running a single lint rule or test:

```
npm error `npm ci` can only install packages when your package.json and
package-lock.json ... are in sync.
npm error Missing: @emnapi/wasi-threads@1.2.3 from lock file
```

The local verification beforehand had been genuinely clean — `npm run lint`, `tsc --noEmit`, and vitest all passed. They couldn't have caught it. All three run against the `node_modules` already on disk, so they pass whether or not the lockfile records what that tree needs. `npm ci` builds from the lockfile alone.

## Demonstrated, not assumed

Deleted the `@emnapi/wasi-threads` entry from `package-lock.json` again and re-ran everything:

| check | result with a broken lockfile |
|---|---|
| `npm run lint` | exit 0 |
| `npx tsc --noEmit` | exit 0 |
| `npx vitest run src/core/__tests__/numeric.test.ts` | 79 passed |
| **`npm run check:lockfile`** | **exit 1, exact CI error** |

Three green, one red. That's the blind spot, reproduced.

## The change

- `package.json`: `"check:lockfile": "npm ci --dry-run"` — one line, no new dependency, and `--dry-run` writes nothing.
- `README.md`: what to run after touching `package.json`/`package-lock.json`, and why the other three checks can't substitute. Also notes plain `npm install` — `--legacy-peer-deps` prunes `@testing-library/dom` and breaks the suite.

The README rather than `CLAUDE.md`, because `CLAUDE.md` is gitignored (`.gitignore:41`) and guidance written there reaches nobody else.

## Deliberately not done

No husky / pre-push hook — that adds a dependency and a commit-time tax for something that bites only on dependency changes. And no extra CI step: CI already fails on this correctly and loudly. The gap was purely local, so the fix is local.

https://claude.ai/code/session_01HUJSeVf1JXG1Rp3VXpb2Cr