### PR TITLE
Offer XCP-69 as a mint model, and scale the pool quantity on the way out

### DIFF
--- a/src/core/counterparty/__tests__/normalize.test.ts
+++ b/src/core/counterparty/__tests__/normalize.test.ts
@@ -186,6 +186,24 @@ describe('normalize.ts', () => {
         expect(mockToSatoshis).toHaveBeenCalledWith('0.01');
         expect(result.normalizedData.lot_price).toBe('1000000');
       });
+
+      it('scales fairminter pool_quantity to base units', async () => {
+        // Same omission as lot_price, one field over: pool_quantity was not in quantityFields, so
+        // an XCP-69 launch would have reserved 0.31 tokens instead of 31,000,000. Core compares it
+        // against the hard cap in base units (supply + premint + pool >= hard_cap), so an unscaled
+        // figure is not rejected — it just reserves a hundred-millionth of the intended pool.
+        const formData = new FormData();
+        formData.set('pool_quantity', '31000000');
+        formData.set('asset', 'LAUNCHCOIN');
+        formData.set('divisible', 'true');
+
+        mockToSatoshis.mockReturnValue('3100000000000000');
+
+        const result = await normalizeFormData(formData, 'fairminter');
+
+        expect(mockToSatoshis).toHaveBeenCalledWith('31000000');
+        expect(result.normalizedData.pool_quantity).toBe('3100000000000000');
+      });
     });
 
     describe('Divisible asset normalization', () => {

--- a/src/core/counterparty/__tests__/xcp69.test.ts
+++ b/src/core/counterparty/__tests__/xcp69.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+import { isNumericAsset } from "@/core/validation/asset";
+import {
+  checkXcp69Conformance,
+  deriveXcp69Blocks,
+  describeXcp69LeadRisk,
+  generateXcp69LpAsset,
+  XCP69_BASE,
+  XCP69_DEFAULT_LEAD_BLOCKS,
+  XCP69_DISPLAY,
+  XCP69_WINDOW_BLOCKS,
+} from "../xcp69";
+
+/** A conforming launch, in the base units core stores. */
+const conforming = {
+  asset: "LAUNCHCOIN",
+  hard_cap: 10000000000000000,
+  soft_cap: 6900000000000000,
+  pool_quantity: 3100000000000000,
+  quantity_by_price: 100000000000,
+  price: 1000000,
+  max_mint_per_address: 100000000000000,
+  max_mint_per_tx: 100000000000000,
+  premint_quantity: 0,
+  minted_asset_commission_int: 0,
+  start_block: 961518,
+  soft_cap_deadline_block: 962518,
+  end_block: 0,
+  burn_payment: false,
+  lock_quantity: true,
+  lock_description: true,
+  divisible: true,
+  lp_asset: "A690210627902342169",
+};
+
+describe("XCP69 constants", () => {
+  it("splits the supply exactly between the sale and the pool", () => {
+    // The invariant the spec uses to rule out pre-existing supply.
+    expect(XCP69_BASE.soft_cap + XCP69_BASE.pool_quantity).toBe(XCP69_BASE.hard_cap);
+  });
+
+  it("raises exactly 690 XCP on a full sale", () => {
+    // 69,000,000 tokens / 1,000 per lot * 0.01 XCP = 690 XCP.
+    const lots = XCP69_BASE.soft_cap / XCP69_BASE.quantity_by_price;
+    expect(lots).toBe(69000n);
+    expect((lots * XCP69_BASE.price) / 100000000n).toBe(690n);
+  });
+
+  it("opens the pool at 69/31 of the mint price", () => {
+    // 690 XCP against 31,000,000 tokens, versus 0.01 per 1,000 minted.
+    const poolTokens = XCP69_BASE.pool_quantity / 100000000n;
+    expect(poolTokens).toBe(31000000n);
+  });
+
+  it("states the display figures the form collects, consistent with the base units", () => {
+    // normalize.ts scales these by 1e8 for a divisible asset, so they must agree exactly.
+    expect(BigInt(XCP69_DISPLAY.hard_cap) * 100000000n).toBe(XCP69_BASE.hard_cap);
+    expect(BigInt(XCP69_DISPLAY.soft_cap) * 100000000n).toBe(XCP69_BASE.soft_cap);
+    expect(BigInt(XCP69_DISPLAY.pool_quantity) * 100000000n).toBe(XCP69_BASE.pool_quantity);
+    expect(BigInt(XCP69_DISPLAY.lot_size) * 100000000n).toBe(XCP69_BASE.quantity_by_price);
+    expect(BigInt(XCP69_DISPLAY.max_mint_per_address) * 100000000n).toBe(XCP69_BASE.max_mint_per_address);
+    // 0.01 XCP, which is divisible, so it scales the same way.
+    expect(Math.round(Number(XCP69_DISPLAY.lot_price) * 1e8)).toBe(Number(XCP69_BASE.price));
+  });
+});
+
+describe("deriveXcp69Blocks", () => {
+  it("opens after the lead and runs exactly the window", () => {
+    const blocks = deriveXcp69Blocks(961512, XCP69_DEFAULT_LEAD_BLOCKS);
+    expect(blocks.start_block).toBe(961518);
+    expect(blocks.soft_cap_deadline_block - blocks.start_block).toBe(XCP69_WINDOW_BLOCKS);
+    expect(blocks.end_block).toBe(0);
+  });
+});
+
+describe("generateXcp69LpAsset", () => {
+  it("produces a valid numeric asset carrying the A69 convention", () => {
+    for (let i = 0; i < 50; i++) {
+      const name = generateXcp69LpAsset();
+      expect(name.startsWith("A69")).toBe(true);
+      // The range check is the point: a shorter tail falls below 26^12 and is not a numeric asset.
+      expect(isNumericAsset(name)).toBe(true);
+    }
+  });
+
+  it("does not repeat itself", () => {
+    // A predictable name could be issued first by someone watching the mempool.
+    const names = new Set(Array.from({ length: 50 }, () => generateXcp69LpAsset()));
+    expect(names.size).toBe(50);
+  });
+});
+
+describe("checkXcp69Conformance", () => {
+  it("accepts a conforming launch", () => {
+    expect(checkXcp69Conformance(conforming)).toEqual({ conformant: true, failures: [] });
+  });
+
+  it.each([
+    // Strings, not numbers: 10000000000000001 is past Number.MAX_SAFE_INTEGER and rounds straight
+    // back to the conforming value, so as a number this case silently tested nothing.
+    ["hard_cap", "10000000000000001", "Hard cap must be 100,000,000"],
+    ["soft_cap", "6900000000000001", "Soft cap must be 69,000,000"],
+    ["pool_quantity", 0, "Pool reserve must be 31,000,000"],
+    ["quantity_by_price", 1, "Lot size must be 1,000"],
+    ["price", 0, "Price must be 0.01 XCP per lot"],
+    ["max_mint_per_address", 0, "Per-address cap must be 1,000,000"],
+    ["max_mint_per_tx", 0, "Per-transaction cap must be 1,000,000"],
+    ["premint_quantity", 1, "Premint must be 0"],
+    // The clause naive checks miss: the protocol allows up to a 99% skim per mint, which is a
+    // premine with extra steps.
+    ["minted_asset_commission_int", 1, "Commission must be 0"],
+  ])("rejects a wrong %s", (field, value, message) => {
+    const result = checkXcp69Conformance({ ...conforming, [field]: value });
+    expect(result.conformant).toBe(false);
+    expect(result.failures).toContain(message);
+  });
+
+  it("rejects a numeric asset", () => {
+    const result = checkXcp69Conformance({ ...conforming, asset: "A690210627902342169" });
+    expect(result.failures).toContain("Asset must be a named asset, not numeric");
+  });
+
+  it("rejects a burned payment, which would leave nothing to seed the pool", () => {
+    const result = checkXcp69Conformance({ ...conforming, burn_payment: true });
+    expect(result.failures).toContain("Payment must not be burned; it seeds the pool");
+  });
+
+  it.each([
+    ["lock_quantity", "Supply must be locked"],
+    ["lock_description", "Description must be locked"],
+  ])("rejects an unlocked %s", (field, message) => {
+    const result = checkXcp69Conformance({ ...conforming, [field]: false });
+    expect(result.failures).toContain(message);
+  });
+
+  it("rejects an indivisible asset", () => {
+    expect(checkXcp69Conformance({ ...conforming, divisible: false }).failures)
+      .toContain("Asset must be divisible");
+  });
+
+  it("rejects a shortened mint window", () => {
+    // The clause that stops a creator running a fast insider mint behind 1,000-block metadata.
+    const result = checkXcp69Conformance({ ...conforming, soft_cap_deadline_block: 961520 });
+    expect(result.failures).toContain("Mint window must be exactly 1000 blocks");
+  });
+
+  it("rejects a set end block", () => {
+    expect(checkXcp69Conformance({ ...conforming, end_block: 962518 }).failures)
+      .toContain("End block must be unset; pool fairminters close at the deadline");
+  });
+
+  it("rejects a missing LP asset", () => {
+    expect(checkXcp69Conformance({ ...conforming, lp_asset: null }).failures)
+      .toContain("An LP asset is required");
+  });
+
+  it("reads a display-unit figure in a base-unit field as a failure, not as a rounding", () => {
+    // "100000000.00000000" reaching hard_cap means normalize.ts did not scale it. Treating that as
+    // near-enough would let a launch through that is off by 1e8.
+    const result = checkXcp69Conformance({ ...conforming, hard_cap: "100000000.00000000" });
+    expect(result.failures).toContain("Hard cap must be 100,000,000");
+  });
+
+  it("reports every failure at once, not just the first", () => {
+    const result = checkXcp69Conformance({});
+    expect(result.conformant).toBe(false);
+    expect(result.failures.length).toBeGreaterThan(10);
+  });
+});
+
+describe("describeXcp69LeadRisk", () => {
+  it("says nothing when the lead is comfortable", () => {
+    expect(describeXcp69LeadRisk(XCP69_DEFAULT_LEAD_BLOCKS)).toBeNull();
+    expect(describeXcp69LeadRisk(50)).toBeNull();
+  });
+
+  it("warns on a short lead", () => {
+    expect(describeXcp69LeadRisk(3)).toContain("not XCP-69");
+  });
+
+  it("warns hardest on a lead that cannot be corrected afterwards", () => {
+    expect(describeXcp69LeadRisk(1)).toContain("cannot be corrected");
+    expect(describeXcp69LeadRisk(0)).toContain("cannot be corrected");
+  });
+});

--- a/src/core/counterparty/normalize.ts
+++ b/src/core/counterparty/normalize.ts
@@ -101,7 +101,11 @@ const NORMALIZATION_CONFIG: Record<string, {
     // a base-unit balance), so "1" composed a price of 0.00000001 XCP and offered the whole
     // supply for a hundred-millionth of what was intended. Byte-equality verification cannot
     // catch this, because the packer packs the same wrong number the form produced.
-    quantityFields: ['premint_quantity', 'lot_size', 'lot_price', 'max_mint_per_tx', 'max_mint_per_address', 'hard_cap', 'soft_cap'],
+    // `pool_quantity` belongs here for the same reason `lot_price` does. It is denominated in the
+    // asset being minted — core checks `supply + premint_quantity + pool_quantity >= hard_cap`
+    // against base units in messages/fairminter.py — so leaving it out sends the form's figure
+    // through untouched and reserves a hundred-millionth of the intended pool.
+    quantityFields: ['premint_quantity', 'lot_size', 'lot_price', 'max_mint_per_tx', 'max_mint_per_address', 'hard_cap', 'soft_cap', 'pool_quantity'],
     assetFields: {
       premint_quantity: 'asset',
       lot_size: 'asset',
@@ -109,7 +113,8 @@ const NORMALIZATION_CONFIG: Record<string, {
       max_mint_per_tx: 'asset',
       max_mint_per_address: 'asset',
       hard_cap: 'asset',
-      soft_cap: 'asset'
+      soft_cap: 'asset',
+      pool_quantity: 'asset'
     },
     booleanFields: ['burn_payment', 'lock_description', 'lock_quantity', 'divisible']
   },

--- a/src/core/counterparty/xcp69.ts
+++ b/src/core/counterparty/xcp69.ts
@@ -1,0 +1,232 @@
+/**
+ * XCP-69: a fully-specified pooled fairminter.
+ *
+ * Every parameter is fixed by the standard except the asset name, the description, and when the
+ * sale opens. That is what separates it from the other three mint models in the form: those are
+ * modifiers on a form the user fills in, this one *is* the form.
+ *
+ * The standard is xcp.fun's, not Counterparty's — core has no marker for it, so the predicate
+ * below is the whole of the enforcement. A launch that misses it is still a valid fairminter; it
+ * simply is not XCP-69, and nothing on-chain will say so afterwards. That asymmetry is why
+ * `checkXcp69Conformance` runs before signing rather than being left to the launchpad to notice.
+ *
+ * Spec: `docs/xcp-69.md` in the launchpad repo.
+ */
+
+import { isNamedAsset } from "@/core/validation/asset";
+
+/**
+ * The fixed parameters, in the base units core stores and the predicate reads.
+ *
+ * The spec is explicit that conformance is checked against raw integer fields and never against
+ * `*_normalized` — partly because two of these quantities have no normalized spelling at all.
+ */
+export const XCP69_BASE = {
+  /** 100,000,000 total supply. */
+  hard_cap: 10000000000000000n,
+  /** 69,000,000 sold to the public. The 69 in the name. */
+  soft_cap: 6900000000000000n,
+  /** 31,000,000 reserved to seed the pool. soft_cap + pool_quantity === hard_cap. */
+  pool_quantity: 3100000000000000n,
+  /** 1,000 tokens per lot. */
+  quantity_by_price: 100000000000n,
+  /** 0.01 XCP per lot, so a full sale raises exactly 690 XCP. */
+  price: 1000000n,
+  /** 1,000,000 tokens — 10 XCP — per address, and the same per transaction. */
+  max_mint_per_address: 100000000000000n,
+  max_mint_per_tx: 100000000000000n,
+  premint_quantity: 0n,
+  minted_asset_commission_int: 0n,
+} as const;
+
+/** The same figures in the display units the form collects, before `normalize.ts` scales them. */
+export const XCP69_DISPLAY = {
+  hard_cap: "100000000",
+  soft_cap: "69000000",
+  pool_quantity: "31000000",
+  lot_size: "1000",
+  lot_price: "0.01",
+  max_mint_per_address: "1000000",
+  max_mint_per_tx: "1000000",
+  premint_quantity: "0",
+} as const;
+
+/** The sale runs for exactly this many blocks, about a week. */
+export const XCP69_WINDOW_BLOCKS = 1000;
+
+/**
+ * Default announcement lead, in blocks.
+ *
+ * Consensus does not require any lead — a fairminter confirming at or past its start simply opens
+ * at once. The requirement is the standard's: `start_block` must be strictly greater than the
+ * block the launch confirms in, so the announcement window is provably mint-proof. Nobody can know
+ * their confirmation block in advance, so this is a wager on confirmation time and the user can
+ * move it. Six blocks is roughly an hour.
+ */
+export const XCP69_DEFAULT_LEAD_BLOCKS = 6;
+
+/** A lead the standard cannot tolerate: the launch would very likely confirm past its own start. */
+export const XCP69_MIN_SAFE_LEAD_BLOCKS = 2;
+
+export interface Xcp69Blocks {
+  start_block: number;
+  soft_cap_deadline_block: number;
+  /** Pool fairminters close at the soft-cap deadline, so an end block is dead weight. */
+  end_block: 0;
+}
+
+/**
+ * When the sale opens and closes, from the current height and a chosen lead.
+ *
+ * The window is exact: `soft_cap_deadline_block - start_block === 1000`. A creator cannot shorten
+ * it to run a fast insider mint behind thousand-block metadata, because the launchpad reads the
+ * clock from the chain rather than from the composed values.
+ */
+export function deriveXcp69Blocks(currentHeight: number, leadBlocks: number): Xcp69Blocks {
+  const start = currentHeight + leadBlocks;
+  return {
+    start_block: start,
+    soft_cap_deadline_block: start + XCP69_WINDOW_BLOCKS,
+    end_block: 0,
+  };
+}
+
+/** Numeric assets run from 26^12 + 1 up to 2^64 - 1. */
+const NUMERIC_ASSET_MIN = 26n ** 12n + 1n;
+const NUMERIC_ASSET_MAX = 2n ** 64n - 1n;
+
+/**
+ * An LP asset name of the form `A69…`, which is the standard's branding convention.
+ *
+ * The tail is random rather than derived: two launches must not collide, and a predictable name
+ * could be front-run by issuing it first. Sixteen digits after the `69` puts the value between
+ * 6.9e17 and 7.0e17, comfortably inside the numeric range — a shorter tail would fall *below*
+ * 26^12 (9.54e16) and not be a valid numeric asset at all.
+ *
+ * Conformance requires only a valid, unissued numeric asset; the `A69` prefix is convention.
+ */
+export function generateXcp69LpAsset(): string {
+  const digits = new Uint32Array(16);
+  crypto.getRandomValues(digits);
+  const tail = Array.from(digits, (d) => (d % 10).toString()).join("");
+  const name = `A69${tail}`;
+  const value = BigInt(`69${tail}`);
+  /* c8 ignore next */
+  if (value < NUMERIC_ASSET_MIN || value > NUMERIC_ASSET_MAX) {
+    throw new Error(`Generated LP asset out of numeric range: ${name}`);
+  }
+  return name;
+}
+
+/** The composed fairminter parameters, in base units, as the predicate reads them. */
+export interface Xcp69Candidate {
+  asset?: string;
+  hard_cap?: string | number | bigint | null;
+  soft_cap?: string | number | bigint | null;
+  pool_quantity?: string | number | bigint | null;
+  quantity_by_price?: string | number | bigint | null;
+  price?: string | number | bigint | null;
+  max_mint_per_address?: string | number | bigint | null;
+  max_mint_per_tx?: string | number | bigint | null;
+  premint_quantity?: string | number | bigint | null;
+  minted_asset_commission_int?: string | number | bigint | null;
+  start_block?: number | null;
+  soft_cap_deadline_block?: number | null;
+  end_block?: number | null;
+  burn_payment?: boolean | null;
+  lock_quantity?: boolean | null;
+  lock_description?: boolean | null;
+  divisible?: boolean | null;
+  lp_asset?: string | null;
+}
+
+export interface Xcp69Conformance {
+  conformant: boolean;
+  /** One sentence per failed clause, in the order the spec states them. */
+  failures: string[];
+}
+
+/** Reads a quantity as an integer, or null when it is absent or not one. */
+function asInteger(value: string | number | bigint | null | undefined): bigint | null {
+  if (value === undefined || value === null || value === "") return null;
+  try {
+    if (typeof value === "bigint") return value;
+    const text = typeof value === "number" ? value.toString() : value.trim();
+    // A decimal point here means display units reached a base-unit field, which is a unit error
+    // rather than a value that happens to miss the constant — worth failing rather than rounding.
+    if (!/^\d+$/.test(text)) return null;
+    return BigInt(text);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Whether a composed launch conforms to XCP-69, and what fails if not.
+ *
+ * Deliberately exhaustive rather than short-circuiting: a creator fixing one clause should not
+ * have to re-run to discover the next.
+ */
+export function checkXcp69Conformance(candidate: Xcp69Candidate): Xcp69Conformance {
+  const failures: string[] = [];
+
+  const fixed: Array<[keyof typeof XCP69_BASE, string]> = [
+    ["hard_cap", "Hard cap must be 100,000,000"],
+    ["soft_cap", "Soft cap must be 69,000,000"],
+    ["pool_quantity", "Pool reserve must be 31,000,000"],
+    ["quantity_by_price", "Lot size must be 1,000"],
+    ["price", "Price must be 0.01 XCP per lot"],
+    ["max_mint_per_address", "Per-address cap must be 1,000,000"],
+    ["max_mint_per_tx", "Per-transaction cap must be 1,000,000"],
+    ["premint_quantity", "Premint must be 0"],
+    ["minted_asset_commission_int", "Commission must be 0"],
+  ];
+  for (const [field, message] of fixed) {
+    if (asInteger(candidate[field]) !== XCP69_BASE[field]) failures.push(message);
+  }
+
+  // A numeric asset can be issued by anyone holding the name; XCP-69 launches are named assets so
+  // the ticker is the thing being launched.
+  if (!candidate.asset || !isNamedAsset(candidate.asset)) {
+    failures.push("Asset must be a named asset, not numeric");
+  }
+
+  if (candidate.divisible !== true) failures.push("Asset must be divisible");
+  if (candidate.burn_payment === true) failures.push("Payment must not be burned; it seeds the pool");
+  if (!candidate.lock_quantity) failures.push("Supply must be locked");
+  if (!candidate.lock_description) failures.push("Description must be locked");
+
+  const start = candidate.start_block ?? 0;
+  const deadline = candidate.soft_cap_deadline_block ?? 0;
+  if (deadline - start !== XCP69_WINDOW_BLOCKS) {
+    failures.push(`Mint window must be exactly ${XCP69_WINDOW_BLOCKS} blocks`);
+  }
+  if ((candidate.end_block ?? 0) !== 0) {
+    failures.push("End block must be unset; pool fairminters close at the deadline");
+  }
+
+  // Checked against the composed start block only. Whether the launch actually confirms before it
+  // is unknowable here — see `describeXcp69LeadRisk`.
+  if (start <= 0) failures.push("Start block must be set, and in the future");
+
+  if (!candidate.lp_asset) failures.push("An LP asset is required");
+
+  return { conformant: failures.length === 0, failures };
+}
+
+/**
+ * The one clause this wallet cannot verify, stated plainly for the creator.
+ *
+ * `start_block > block_index` is measured at the confirming block, so a launch broadcast with too
+ * little lead confirms late and is valid to core but not XCP-69 — permanently, with nothing
+ * on-chain recording the near miss. Returns null when the lead is comfortable.
+ */
+export function describeXcp69LeadRisk(leadBlocks: number): string | null {
+  if (leadBlocks < XCP69_MIN_SAFE_LEAD_BLOCKS) {
+    return "Too short. This launch will very likely confirm at or after its own start block, which is valid to Counterparty but is not XCP-69, and cannot be corrected afterwards.";
+  }
+  if (leadBlocks < XCP69_DEFAULT_LEAD_BLOCKS) {
+    return "Short. If the transaction confirms at or after the start block the launch is still valid, but it is not XCP-69.";
+  }
+  return null;
+}

--- a/src/pages/compose/fairminter/__tests__/form.xcp69.test.tsx
+++ b/src/pages/compose/fairminter/__tests__/form.xcp69.test.tsx
@@ -1,0 +1,259 @@
+/**
+ * XCP-69 is not a fourth peer of the other three mint models. The other three decide where the
+ * payment goes and leave every number to the creator; this one fixes every number, so what is
+ * worth testing is that the fields disappear, that the values submitted are the standard's rather
+ * than the form's, and that a launch which would miss the standard cannot be signed.
+ *
+ * The last of those is the one that matters most. A non-conforming launch is a perfectly valid
+ * fairminter forever, and nothing on-chain records that it meant to be XCP-69.
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ComposerProvider } from '@/contexts/composer-context';
+import { XCP69_BASE, XCP69_WINDOW_BLOCKS } from '@/core/counterparty/xcp69';
+import { FairminterForm } from '../form';
+
+vi.mock('@/core/bitcoin/feeRate', () => ({
+  getFeeRates: vi.fn().mockResolvedValue({
+    fastestFee: 10, halfHourFee: 5, hourFee: 3, economyFee: 1, minimumFee: 1,
+  }),
+}));
+
+vi.mock('@/contexts/wallet-context', () => ({
+  useWallet: () => ({
+    activeWallet: { id: 'test-wallet', name: 'Test Wallet' },
+    activeAddress: { address: 'bc1qtest', walletId: 'test-wallet' },
+    authState: 'unlocked',
+    signTransaction: vi.fn(),
+    broadcastTransaction: vi.fn(),
+    unlockWallet: vi.fn(),
+    isKeychainLocked: vi.fn().mockResolvedValue(false),
+  }),
+}));
+
+vi.mock('@/contexts/settings-context', () => ({
+  useSettings: () => ({
+    settings: { showHelpText: false, counterpartyApiBase: 'https://api.test' },
+    updateSettings: vi.fn(),
+    isLoading: false,
+  }),
+}));
+
+vi.mock('@/contexts/header-context', () => ({
+  useHeader: () => ({
+    setHeaderProps: vi.fn(),
+    setTitle: vi.fn(),
+    setAddressHeader: vi.fn(),
+    setBalanceHeader: vi.fn(),
+    subheadings: { addresses: {} },
+  }),
+}));
+
+vi.mock('@/contexts/loading-context', () => ({
+  useLoading: () => ({
+    showLoading: vi.fn(() => 'loading-id'), hideLoading: vi.fn(), loading: false, setLoading: vi.fn(),
+  }),
+}));
+
+const CURRENT_HEIGHT = 961512;
+vi.mock('@/hooks/useBlockHeight', () => ({
+  useBlockHeight: () => ({ blockHeight: 961512, isLoading: false, error: null }),
+}));
+
+vi.mock('@/hooks/useAssetInfo', () => ({
+  useAssetInfo: () => ({ data: null, error: null, isLoading: false }),
+}));
+
+// AssetNameInput debounces, then asks whether the name is already issued, and only reports the
+// name valid when it is not. Null means unissued, so Continue can enable.
+vi.mock('@/core/counterparty/api', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/core/counterparty/api')>()),
+  fetchAssetDetails: vi.fn().mockResolvedValue(null),
+}));
+
+global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ result: [] }) });
+
+describe('FairminterForm — XCP-69', () => {
+  const mockFormAction = vi.fn();
+
+  const renderForm = () =>
+    render(
+      <MemoryRouter>
+        <ComposerProvider
+          composeApi={vi.fn().mockResolvedValue({ result: { tx_hash: 'test' } })}
+          initialTitle="Fairminter"
+          composeType="fairminter"
+        >
+          <FairminterForm formAction={mockFormAction} initialFormData={null} asset="" />
+        </ComposerProvider>
+      </MemoryRouter>
+    );
+
+  /** Open the Mint Method listbox and take the XCP-69 entry. */
+  const selectXcp69 = async () => {
+    fireEvent.click(await screen.findByText('XCP Fee Model (To You)'));
+    fireEvent.click(await screen.findByText('XCP-69 Model (Pooled)'));
+    await waitFor(() => expect(screen.getByText(/Pool reserve/i)).toBeInTheDocument());
+  };
+
+  const continueButton = () => screen.getByRole('button', { name: /continue/i });
+
+  /** Type a name and wait for the debounced availability check, which gates the submit button. */
+  const typeAssetName = async (name: string) => {
+    const input = await screen.findByLabelText(/Asset Name/i);
+    fireEvent.change(input, { target: { value: name } });
+    await waitFor(() => expect(input).toHaveValue(name));
+  };
+
+  /** Type a conforming name and wait until the form will actually submit. */
+  const typeValidAssetName = async (name = 'LAUNCHCOIN') => {
+    await typeAssetName(name);
+    await waitFor(() => expect(continueButton()).not.toBeDisabled(), { timeout: 5000 });
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('offers the model as the last option, after the three protocol-level ones', async () => {
+    renderForm();
+    fireEvent.click(await screen.findByText('XCP Fee Model (To You)'));
+
+    // By document order rather than by role: this Headless UI version does not put role="option"
+    // on the entries, so a role query finds nothing even with the list open.
+    const xcp69 = await screen.findByText('XCP-69 Model (Pooled)');
+    for (const label of ['BTC Fee Model (Miners)', 'XCP Fee Model (Burned)']) {
+      const other = screen.getByText(label);
+      // DOCUMENT_POSITION_PRECEDING === 2: the other option comes before XCP-69.
+      expect(xcp69.compareDocumentPosition(other) & Node.DOCUMENT_POSITION_PRECEDING).toBeTruthy();
+    }
+  });
+
+  it('removes the fields the standard fixes', async () => {
+    renderForm();
+    await selectXcp69();
+
+    // Selecting it should shrink the form, not extend it.
+    for (const label of [/Hard Cap/i, /Mint per Address/i, /Tokens per Mint/i, /XCP Cost per Mint/i, /Lock Quantity/i, /Lock Description/i]) {
+      expect(screen.queryByLabelText(label)).not.toBeInTheDocument();
+    }
+    expect(screen.queryByText(/Advanced Options/i)).not.toBeInTheDocument();
+    // What is left: the name, the description, and the one parameter the standard leaves open.
+    expect(screen.getByLabelText(/Announcement Lead/i)).toBeInTheDocument();
+  });
+
+  it('submits the standard\'s figures, not the form\'s', async () => {
+    renderForm();
+    await selectXcp69();
+    await typeValidAssetName();
+
+    fireEvent.click(continueButton());
+    await waitFor(() => expect(mockFormAction).toHaveBeenCalled());
+
+    const submitted = mockFormAction.mock.calls[0]![0] as FormData;
+    // Display units — normalize.ts scales these by 1e8 before they reach core.
+    expect(submitted.get('hard_cap')).toBe('100000000');
+    expect(submitted.get('soft_cap')).toBe('69000000');
+    expect(submitted.get('pool_quantity')).toBe('31000000');
+    expect(submitted.get('lot_size')).toBe('1000');
+    expect(submitted.get('lot_price')).toBe('0.01');
+    expect(submitted.get('max_mint_per_address')).toBe('1000000');
+    expect(submitted.get('max_mint_per_tx')).toBe('1000000');
+    expect(submitted.get('premint_quantity')).toBe('0');
+    expect(submitted.get('minted_asset_commission')).toBe('0');
+    expect(submitted.get('divisible')).toBe('true');
+    expect(submitted.get('lock_quantity')).toBe('true');
+    expect(submitted.get('lock_description')).toBe('true');
+    expect(submitted.get('burn_payment')).toBe('false');
+    expect(submitted.get('end_block')).toBe('0');
+  });
+
+  it('submits a sale window of exactly the standard length, offset by the chosen lead', async () => {
+    renderForm();
+    await selectXcp69();
+    await typeValidAssetName();
+    fireEvent.change(screen.getByLabelText(/Announcement Lead/i), { target: { value: '10' } });
+
+    fireEvent.click(continueButton());
+    await waitFor(() => expect(mockFormAction).toHaveBeenCalled());
+
+    const submitted = mockFormAction.mock.calls[0]![0] as FormData;
+    const start = Number(submitted.get('start_block'));
+    const deadline = Number(submitted.get('soft_cap_deadline_block'));
+    expect(start).toBe(CURRENT_HEIGHT + 10);
+    expect(deadline - start).toBe(XCP69_WINDOW_BLOCKS);
+  });
+
+  it('generates an A69 LP asset and submits that same one', async () => {
+    renderForm();
+    await selectXcp69();
+    await typeValidAssetName();
+
+    // Shown before signing, so the creator sees the name the launch will carry.
+    const shown = screen.getByText(/^A69\d+$/);
+    fireEvent.click(continueButton());
+    await waitFor(() => expect(mockFormAction).toHaveBeenCalled());
+
+    const submitted = mockFormAction.mock.calls[0]![0] as FormData;
+    expect(submitted.get('lp_asset')).toBe(shown.textContent);
+  });
+
+  /**
+   * The gate that matters, isolated from the name-validity gate beside it.
+   *
+   * `submitDisabled` also refuses an invalid asset name, so asserting "disabled" against a numeric
+   * name proves nothing on its own — the first version of this test passed with the conformance
+   * check deleted. Switching mint method afterwards is what separates them: the same name enables
+   * the button under a model that has no standard to miss, so only conformance was holding it.
+   */
+  /**
+   * The gate that matters, isolated from the name-validity gate beside it.
+   *
+   * Order is load-bearing. `submitDisabled` also refuses an invalid asset name, and the name check
+   * is debounced and asynchronous — so selecting XCP-69 first and asserting "disabled" only proves
+   * the debounce had not finished yet. Written that way round, this test passed with the
+   * conformance check replaced by `false`. Enabling the button *before* switching model is what
+   * makes the disabling afterwards attributable to conformance and nothing else.
+   */
+  it('blocks signing a launch that would not conform, and only for that reason', async () => {
+    renderForm();
+    // A numeric asset is a perfectly valid fairminter, and is not XCP-69. Under the default model
+    // it submits happily, which is the baseline this test needs.
+    await typeValidAssetName('A12309771814620297401');
+
+    await selectXcp69();
+
+    await waitFor(() =>
+      expect(screen.getByText(/would not be XCP-69/i)).toBeInTheDocument()
+    );
+    expect(screen.getByText(/Asset must be a named asset/i)).toBeInTheDocument();
+    expect(continueButton()).toBeDisabled();
+  });
+
+  it('warns about a lead too short to be relied on, without blocking it', async () => {
+    // The one clause the wallet cannot verify: whether the launch confirms before its start block.
+    // Unknowable here, so it is a warning rather than a refusal.
+    renderForm();
+    await selectXcp69();
+    await typeValidAssetName();
+    fireEvent.change(screen.getByLabelText(/Announcement Lead/i), { target: { value: '1' } });
+
+    await waitFor(() => expect(screen.getByText(/cannot be corrected/i)).toBeInTheDocument());
+    expect(continueButton()).not.toBeDisabled();
+  });
+
+  it('leaves the other three models alone', async () => {
+    renderForm();
+    // The default model still shows the fields XCP-69 removes.
+    expect(await screen.findByLabelText(/Hard Cap/i)).toBeInTheDocument();
+    expect(screen.queryByLabelText(/Announcement Lead/i)).not.toBeInTheDocument();
+  });
+
+  it('keeps the display figures in step with the base units the predicate reads', () => {
+    // Guards the pair the form depends on: it submits XCP69_DISPLAY, and conformance is judged
+    // against XCP69_BASE. If they ever drift, the form would submit a launch it just approved.
+    expect(XCP69_BASE.soft_cap + XCP69_BASE.pool_quantity).toBe(XCP69_BASE.hard_cap);
+  });
+});

--- a/src/pages/compose/fairminter/form.tsx
+++ b/src/pages/compose/fairminter/form.tsx
@@ -24,21 +24,39 @@ import { TextField } from "@/components/ui/inputs/text-field";
 import { useComposer } from "@/contexts/composer-context-object";
 import { isSegwitFormat } from '@/core/bitcoin/address';
 import type { FairminterOptions } from "@/core/counterparty/compose";
+import {
+  checkXcp69Conformance,
+  deriveXcp69Blocks,
+  describeXcp69LeadRisk,
+  generateXcp69LpAsset,
+  XCP69_BASE,
+  XCP69_DEFAULT_LEAD_BLOCKS,
+  XCP69_DISPLAY,
+  XCP69_WINDOW_BLOCKS,
+} from "@/core/counterparty/xcp69";
 import { asDisplayUnits } from '@/core/numeric';
 import { useAssetInfo } from "@/hooks/useAssetInfo";
+import { useBlockHeight } from "@/hooks/useBlockHeight";
 
 const FAIRMINTER_MODELS = {
   MINER_FEE_ONLY: "MINER_FEE_ONLY",
   XCP_FEE_TO_ISSUER: "XCP_FEE_TO_ISSUER",
   XCP_FEE_BURNED: "XCP_FEE_BURNED",
+  XCP_69_POOLED: "XCP_69_POOLED",
 } as const;
 
 type FairminterModel = typeof FAIRMINTER_MODELS[keyof typeof FAIRMINTER_MODELS];
 
+/**
+ * The first three are modifiers: each decides where the payment goes and leaves the numbers to the
+ * creator. XCP-69 is not one of those — it fixes every number, so selecting it removes the fields
+ * rather than adding any. See `core/counterparty/xcp69.ts`.
+ */
 const FAIRMINTER_MODEL_OPTIONS = [
   { value: FAIRMINTER_MODELS.MINER_FEE_ONLY, label: "BTC Fee Model (Miners)" },
   { value: FAIRMINTER_MODELS.XCP_FEE_TO_ISSUER, label: "XCP Fee Model (To You)" },
   { value: FAIRMINTER_MODELS.XCP_FEE_BURNED, label: "XCP Fee Model (Burned)" },
+  { value: FAIRMINTER_MODELS.XCP_69_POOLED, label: "XCP-69 Model (Pooled)" },
 ];
 
 /**
@@ -108,7 +126,47 @@ export function FairminterForm({
     ? FAIRMINTER_MODELS.XCP_FEE_BURNED
     : FAIRMINTER_MODELS.XCP_FEE_TO_ISSUER;
   const [selectedMintMethod, setSelectedMintMethod] = useState<FairminterModel>(initialMintMethod);
-  
+
+  // XCP-69 state. The lead is the only parameter the standard leaves open, and the LP asset is
+  // generated once per form so the review screen and the composed transaction name the same one.
+  const isXcp69 = selectedMintMethod === FAIRMINTER_MODELS.XCP_69_POOLED;
+  const [leadBlocks, setLeadBlocks] = useState<string>(String(XCP69_DEFAULT_LEAD_BLOCKS));
+  const [lpAsset] = useState<string>(() => generateXcp69LpAsset());
+  const { blockHeight } = useBlockHeight({ autoFetch: isXcp69 });
+
+  const leadNumber = Number.parseInt(leadBlocks, 10);
+  const hasLead = Number.isFinite(leadNumber) && leadNumber >= 0;
+  const xcp69Blocks = isXcp69 && blockHeight !== null && hasLead
+    ? deriveXcp69Blocks(blockHeight, leadNumber)
+    : null;
+  const leadRisk = isXcp69 && hasLead ? describeXcp69LeadRisk(leadNumber) : null;
+
+  /**
+   * The clauses that can actually vary here.
+   *
+   * The fixed quantities are supplied from `XCP69_DISPLAY` on submit, and that they scale to
+   * `XCP69_BASE` is pinned by a unit test rather than re-derived on every keystroke — checking
+   * constants against themselves in the UI would assert nothing. What is worth checking is
+   * everything the creator or the network can change: the asset name, the sale window, and whether
+   * a block height was available to compute it from.
+   */
+  const xcp69Conformance = isXcp69
+    ? checkXcp69Conformance({
+        ...Object.fromEntries(
+          Object.entries(XCP69_BASE).map(([key, value]) => [key, value.toString()])
+        ),
+        asset: assetName,
+        divisible: true,
+        burn_payment: false,
+        lock_quantity: true,
+        lock_description: true,
+        lp_asset: lpAsset,
+        start_block: xcp69Blocks?.start_block ?? 0,
+        soft_cap_deadline_block: xcp69Blocks?.soft_cap_deadline_block ?? 0,
+        end_block: 0,
+      })
+    : null;
+
   // Helper function to get input step based on divisibility
   const getInputStep = () => isDivisible ? "0.00000001" : "1";
   const getInputPlaceholder = () => isDivisible ? "0.00000000" : "0";
@@ -162,13 +220,35 @@ export function FairminterForm({
     // Add divisible value
     processedFormData.set('divisible', isDivisible.toString());
 
-    // Set controlled quantity fields from state
-    if (maxMintPerTx) processedFormData.set('max_mint_per_tx', maxMintPerTx);
-    if (maxMintPerAddress) processedFormData.set('max_mint_per_address', maxMintPerAddress);
-    if (lotSize) processedFormData.set('lot_size', lotSize);
-    if (hardCap) processedFormData.set('hard_cap', hardCap);
-    if (premintQuantity) processedFormData.set('premint_quantity', premintQuantity);
-    if (softCap) processedFormData.set('soft_cap', softCap);
+    if (isXcp69) {
+      // Every quantity is the standard's, in the display units normalize.ts scales by 1e8 for a
+      // divisible asset. Nothing here is read from the fields above, because none of them render.
+      processedFormData.set('max_mint_per_tx', XCP69_DISPLAY.max_mint_per_tx);
+      processedFormData.set('max_mint_per_address', XCP69_DISPLAY.max_mint_per_address);
+      processedFormData.set('lot_size', XCP69_DISPLAY.lot_size);
+      processedFormData.set('lot_price', XCP69_DISPLAY.lot_price);
+      processedFormData.set('hard_cap', XCP69_DISPLAY.hard_cap);
+      processedFormData.set('soft_cap', XCP69_DISPLAY.soft_cap);
+      processedFormData.set('pool_quantity', XCP69_DISPLAY.pool_quantity);
+      processedFormData.set('premint_quantity', XCP69_DISPLAY.premint_quantity);
+      processedFormData.set('minted_asset_commission', '0');
+      processedFormData.set('lp_asset', lpAsset);
+      processedFormData.set('divisible', 'true');
+      processedFormData.set('lock_quantity', 'true');
+      processedFormData.set('lock_description', 'true');
+      processedFormData.set('burn_payment', 'false');
+      processedFormData.set('start_block', String(xcp69Blocks?.start_block ?? 0));
+      processedFormData.set('soft_cap_deadline_block', String(xcp69Blocks?.soft_cap_deadline_block ?? 0));
+      processedFormData.set('end_block', '0');
+    } else {
+      // Set controlled quantity fields from state
+      if (maxMintPerTx) processedFormData.set('max_mint_per_tx', maxMintPerTx);
+      if (maxMintPerAddress) processedFormData.set('max_mint_per_address', maxMintPerAddress);
+      if (lotSize) processedFormData.set('lot_size', lotSize);
+      if (hardCap) processedFormData.set('hard_cap', hardCap);
+      if (premintQuantity) processedFormData.set('premint_quantity', premintQuantity);
+      if (softCap) processedFormData.set('soft_cap', softCap);
+    }
 
     // Call the original formAction with the processed FormData
     formAction(processedFormData);
@@ -203,7 +283,13 @@ export function FairminterForm({
         </div>
       }
       submitText="Continue"
-      submitDisabled={pending || (!isExistingAsset && !isAssetNameValid)}
+      submitDisabled={
+        pending ||
+        (!isExistingAsset && !isAssetNameValid) ||
+        // Blocked, not warned. A non-conforming launch is a valid fairminter forever, and nothing
+        // on-chain records that it meant to be XCP-69, so there is no correcting it afterwards.
+        (isXcp69 && !xcp69Conformance?.conformant)
+      }
     >
           {localError && (
             <div className="mb-4">
@@ -264,6 +350,80 @@ export function FairminterForm({
             />
           )}
           
+          {isXcp69 && (
+            <>
+              <TextField
+                label="Announcement Lead"
+                id="xcp69_lead"
+                name="xcp69_lead"
+                type="text"
+                inputMode="numeric"
+                value={leadBlocks}
+                onChange={(e) => setLeadBlocks(e.target.value.replace(/[^\d]/g, ''))}
+                placeholder={String(XCP69_DEFAULT_LEAD_BLOCKS)}
+                required
+                disabled={pending}
+                showHelpText={showHelpText}
+                description="Blocks between now and the sale opening. The launch must confirm before the start block."
+              />
+
+              {leadRisk && (
+                <div className="text-xs text-yellow-800 bg-yellow-50 border border-yellow-200 rounded p-2">
+                  {leadRisk}
+                </div>
+              )}
+
+              <div className="rounded-lg border border-gray-200 bg-white p-3 space-y-1 text-sm">
+                <div className="flex justify-between">
+                  <span className="text-gray-500">Supply</span>
+                  <span className="font-medium">100,000,000</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-gray-500">Public sale</span>
+                  <span className="font-medium">69,000,000 · 0.01 XCP per 1,000</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-gray-500">Pool reserve</span>
+                  <span className="font-medium">31,000,000</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-gray-500">Per address</span>
+                  <span className="font-medium">1,000,000 · 10 XCP</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-gray-500">Sale window</span>
+                  <span className="font-medium">
+                    {xcp69Blocks
+                      ? `${xcp69Blocks.start_block.toLocaleString()} → ${xcp69Blocks.soft_cap_deadline_block.toLocaleString()}`
+                      : "—"}
+                    {` (${XCP69_WINDOW_BLOCKS} blocks)`}
+                  </span>
+                </div>
+                <div className="flex justify-between gap-3">
+                  <span className="text-gray-500 flex-shrink-0">LP asset</span>
+                  <span className="font-medium text-right break-all">{lpAsset}</span>
+                </div>
+                <p className="pt-1 text-xs text-gray-500">
+                  Raises exactly 690 XCP. Nothing is credited until the soft cap is reached, and
+                  every payment is refunded if it is missed by the deadline.
+                </p>
+              </div>
+
+              {xcp69Conformance && !xcp69Conformance.conformant && (
+                // Blocking rather than warning: a launch that misses the standard is a valid
+                // fairminter forever, and nothing on-chain records the near miss afterwards.
+                <div className="text-xs text-red-800 bg-red-50 border border-red-200 rounded p-2">
+                  <p className="font-medium">This launch would not be XCP-69</p>
+                  <ul className="mt-1 list-disc list-inside space-y-0.5">
+                    {xcp69Conformance.failures.map((failure) => (
+                      <li key={failure}>{failure}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </>
+          )}
+
           {selectedMintMethod === FAIRMINTER_MODELS.MINER_FEE_ONLY && (
             <TextField
               label="Mint per TX"
@@ -282,21 +442,23 @@ export function FairminterForm({
             />
           )}
 
-          <TextField
-            label="Mint per Address"
-            id="max_mint_per_address"
-            name="max_mint_per_address"
-            type="text"
-            inputMode="decimal"
-            value={maxMintPerAddress}
-            onChange={handleQuantityChange(setMaxMintPerAddress)}
-            step={getInputStep()}
-            placeholder="No limit"
-            disabled={pending}
-            showHelpText={showHelpText}
-            description="Optional maximum amount each address can mint. Leave blank for no per-address limit."
-          />
-          {selectedMintMethod !== FAIRMINTER_MODELS.MINER_FEE_ONLY && (
+          {!isXcp69 && (
+            <TextField
+              label="Mint per Address"
+              id="max_mint_per_address"
+              name="max_mint_per_address"
+              type="text"
+              inputMode="decimal"
+              value={maxMintPerAddress}
+              onChange={handleQuantityChange(setMaxMintPerAddress)}
+              step={getInputStep()}
+              placeholder="No limit"
+              disabled={pending}
+              showHelpText={showHelpText}
+              description="Optional maximum amount each address can mint. Leave blank for no per-address limit."
+            />
+          )}
+          {selectedMintMethod !== FAIRMINTER_MODELS.MINER_FEE_ONLY && !isXcp69 && (
             <>
               <TextField
                 label="Tokens per Mint"
@@ -330,7 +492,7 @@ export function FairminterForm({
             </>
           )}
           
-          {!isInitializing && !isExistingAsset && (
+          {!isInitializing && !isExistingAsset && !isXcp69 && (
             <CheckboxInput
               name="divisible"
               label="Divisible"
@@ -370,33 +532,38 @@ export function FairminterForm({
             />
           )}
           
-          <CheckboxInput
-            name="lock_description"
-            label="Lock Description"
-            defaultChecked={initialFormData?.lock_description || false}
-            disabled={pending}
-          />
-          <TextField
-            label="Hard Cap"
-            id="hard_cap"
-            name="hard_cap"
-            type="text"
-            inputMode="decimal"
-            value={hardCap}
-            onChange={handleQuantityChange(setHardCap)}
-            step={getInputStep()}
-            placeholder={getInputPlaceholder()}
-            disabled={pending}
-            showHelpText={showHelpText}
-            description="Maximum total supply that can be minted."
-          />
-          <CheckboxInput
-            name="lock_quantity"
-            label="Lock Quantity"
-            defaultChecked={initialFormData?.lock_quantity || false}
-            disabled={pending}
-          />
-          
+          {!isXcp69 && (
+            <>
+              <CheckboxInput
+                name="lock_description"
+                label="Lock Description"
+                defaultChecked={initialFormData?.lock_description || false}
+                disabled={pending}
+              />
+              <TextField
+                label="Hard Cap"
+                id="hard_cap"
+                name="hard_cap"
+                type="text"
+                inputMode="decimal"
+                value={hardCap}
+                onChange={handleQuantityChange(setHardCap)}
+                step={getInputStep()}
+                placeholder={getInputPlaceholder()}
+                disabled={pending}
+                showHelpText={showHelpText}
+                description="Maximum total supply that can be minted."
+              />
+              <CheckboxInput
+                name="lock_quantity"
+                label="Lock Quantity"
+                defaultChecked={initialFormData?.lock_quantity || false}
+                disabled={pending}
+              />
+            </>
+          )}
+
+          {!isXcp69 && (
           <Collapsible title="Advanced Options">
                   <BlockHeightInput
                     name="start_block"
@@ -471,6 +638,7 @@ export function FairminterForm({
                     </>
                   )}
           </Collapsible>
+          )}
     </ComposerForm>
   );
 }


### PR DESCRIPTION
XCP-69 is [xcp.fun's](https://xcp.fun) pooled launch standard: 100,000,000 supply, 69,000,000 sold
to the public at 0.01 XCP per 1,000, 31,000,000 held back to seed a liquidity pool, a 1,000-block
window, and a full refund if the soft cap is missed. A full sale raises exactly 690 XCP and opens
the pool at 69/31 ≈ 2.23× the mint price.

## It is not a fourth peer of the other three

The existing models are modifiers: each decides where the payment goes and leaves ten numbers to the
creator. XCP-69 fixes all ten, so selecting it **removes** fields rather than adding any.

What is left is the asset name, the description, and the one parameter the standard leaves open —
the announcement lead — plus a summary of everything decided for you and the generated `A69…` LP
asset the launch will carry.

## Two decisions worth reviewing

**The lead is the creator's, because it cannot be derived.** Conformance requires
`start_block > block_index` at the *confirming* block, and consensus does not enforce it — a
fairminter that confirms past its start simply opens at once. Nobody can know their confirmation
block in advance, so the form defaults to six blocks and escalates its warning below that. A launch
that confirms late is a valid fairminter forever, and nothing on-chain records that it meant to be
XCP-69.

**Non-conformance blocks signing rather than warning,** for the same reason: there is no correcting
it afterwards. Every failing clause is listed at once, so fixing one does not reveal the next.

## A bug this turned up, which is not XCP-69-specific

`pool_quantity` was missing from `normalize.ts`'s fairminter config — the same omission as
`lot_price`, one field over, and the comment already sitting there describes the consequence. Core
compares the pool against the hard cap in base units, so `31000000` would have reached it as `0.31`
tokens and reserved a hundred-millionth of the intended pool **without being rejected**.

No pooled fairminter could have worked before this, XCP-69 or otherwise. If we ever prefer a plain
user-set pool field instead of this preset, that fix is the part to keep.

## Testing

40 new tests. Three mutants, each caught: dropping the conformance gate, omitting `pool_quantity`
from the submission, and unregistering it in `normalize`. Full suite 4342 passed, `tsc` and `lint`
clean.

Two of the tests were wrong first, both toward passing for free, and both now carry a comment
saying why:

- The blocking test **passed with the conformance check deleted**. `submitDisabled` also refuses an
  invalid asset name, and that check is debounced, so asserting "disabled" straight after selecting
  the model only proved the debounce had not finished. It now enables the button under the default
  model first, which makes the disabling afterwards attributable to conformance alone.
- A unit test asserted rejection of `hard_cap: 10000000000000001`, which is past
  `Number.MAX_SAFE_INTEGER` and rounds straight back to the conforming value. It is a string now.

Conformance is judged against `XCP69_BASE` while the form submits `XCP69_DISPLAY`, and a unit test
pins that the two agree. Checking constants against themselves in the component would assert
nothing, and those two drifting is the one way the form could approve a launch and then submit a
different one.

## The coupling a maintainer should be aware of

**This ships a third-party standard as a wallet primitive.** Core has no XCP-69 marker — as the spec
itself says, the predicate *is* the enforcement. If xcp.fun changes the numbers this goes stale
silently, and launches created here stop conforming with nothing in the wallet noticing. It is
labelled "XCP-69 Model (Pooled)" and placed last, after the three protocol-level models, so it at
least reads as the odd one out, but the coupling is real and worth an explicit decision.

https://claude.ai/code/session_01HUJSeVf1JXG1Rp3VXpb2Cr
