### PR TITLE
Let the fairmint form be a form, not a worse copy of the review screen

### DIFF
--- a/src/components/domain/asset/fairmint-summary.tsx
+++ b/src/components/domain/asset/fairmint-summary.tsx
@@ -1,15 +1,19 @@
 /**
- * What a fairmint costs and where the payment goes.
+ * What a fairmint costs per lot, and where the payment goes.
  *
  * The form's only price text lived in the amount field's help text, which renders only when
  * showHelpText is on — off by default. This is shown unconditionally.
+ *
+ * Deliberately not a review screen. The running total and the issuer's address both used to appear
+ * here, and between them they turned the form into a worse copy of the screen that follows it —
+ * the total in particular rendered as a bare "— XCP" until something was typed. Both are on the
+ * review screen, which is where the figures being signed for belong.
  */
 
 import type { ReactElement } from "react";
 import type { FairminterDetails } from "@/core/counterparty/api";
 import {
   describeFairminterPaymentModel,
-  getFairmintCost,
   getFairminterLotCost,
   isPaidFairminter,
   readFairminterPaymentModel,
@@ -40,7 +44,6 @@ export function FairmintSummary({
   const hasQuantity = isGreaterThan(quantity || 0, 0);
   const decimals = fairminter.divisible === false ? 0 : 8;
 
-  const totalCost = paid ? getFairmintCost(fairminter, quantity || 0) : "0";
   const hasSoftCap = isGreaterThan(fairminter.soft_cap_normalized ?? fairminter.soft_cap ?? 0, 0);
 
   return (
@@ -57,22 +60,13 @@ export function FairmintSummary({
       )}
 
       {paid ? (
-        <>
-          <Row label="Price" value={`${getFairminterLotCost(fairminter)} XCP per lot`} />
-          {totalCost !== null && (
-            <Row label="You pay" value={hasQuantity ? `${totalCost} XCP` : "— XCP"} />
-          )}
-        </>
+        <Row label="Price" value={`${getFairminterLotCost(fairminter)} XCP per lot`} />
       ) : (
         // A free mint's whole cost is the miner fee, and its amount is set by the fairminter.
-        <Row label="You pay" value="Bitcoin network fee only" />
+        <Row label="Price" value="Bitcoin network fee only" />
       )}
 
       <Row label="Payment" value={describeFairminterPaymentModel(model)} />
-
-      {model === "issuer" && fairminter.source && (
-        <Row label="Paid to" value={fairminter.source} />
-      )}
 
       {hasSoftCap && (
         // Core sends both the payment and the assets to UNSPENDABLE until the soft cap is met.

--- a/src/pages/compose/fairminter/fairmint/__tests__/form.test.tsx
+++ b/src/pages/compose/fairminter/fairmint/__tests__/form.test.tsx
@@ -169,13 +169,26 @@ describe('FairmintForm', () => {
     // Unconditionally, not behind showHelpText — which is false in these tests.
     expect(await screen.findByText(/1 XCP per lot/i)).toBeInTheDocument();
     expect(screen.getByText(/XCP Fee \(to issuer\)/i)).toBeInTheDocument();
-    expect(screen.getByText('bc1qissuer')).toBeInTheDocument();
+  });
+
+  /**
+   * The form says what a lot costs and where the money goes; it does not total the order or name
+   * the issuer. Both belong to the review screen, and carrying them here made the form a worse
+   * copy of it — the running total in particular read as a bare "— XCP" until something was typed.
+   */
+  it('leaves the running total and the issuer address to the review screen', async () => {
+    renderForm();
+    await selectFairminter();
+    await screen.findByText(/1 XCP per lot/i);
+
+    expect(screen.queryByText('bc1qissuer')).not.toBeInTheDocument();
+    expect(screen.queryByText(/^— XCP$/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/You pay/i)).not.toBeInTheDocument();
   });
 
   // A fairminter that seeds a liquidity pool pays the pool, not the address that opened it. This
-  // screen read only price and burn_payment, so it called a pool mint "XCP Fee (to issuer)" and
-  // printed the issuer's address under "Paid to" — naming an address that receives none of it.
-  it('names the pool, and no address, when the payment seeds one', async () => {
+  // screen read only price and burn_payment, so it called a pool mint "XCP Fee (to issuer)".
+  it('names the pool when the payment seeds one', async () => {
     mockFairmintersResponse([
       createMockFairminter({ pool_quantity: asBaseUnits(3100000000000000) }),
     ]);
@@ -184,7 +197,6 @@ describe('FairmintForm', () => {
 
     expect(await screen.findByText(/XCP Fee \(to liquidity pool\)/i)).toBeInTheDocument();
     expect(screen.queryByText(/XCP Fee \(to issuer\)/i)).not.toBeInTheDocument();
-    expect(screen.queryByText('bc1qissuer')).not.toBeInTheDocument();
   });
 
   it('submits the quantity the lot count implies, not the lot count', async () => {


### PR DESCRIPTION
`FairmintSummary` had grown a running total and the issuer's address. Between them they answered the
questions the *next* screen exists to answer, and the total in particular rendered as a bare
`— XCP` until a quantity was typed — so the first thing the form said about cost was a dash.

Both are already on the review screen, which is where a figure being signed for belongs.

**Before**

```
You receive   1,000,000 LAUNCHCOIN
Price         0.01 XCP per lot
You pay       — XCP                     ← before you type anything
Payment       XCP Fee (to issuer)
Paid to       16aZDCvD6w1x25qYNWDrXLUswEXiUU9ttr
```

**After**

```
You receive   1,000,000 LAUNCHCOIN
Price         0.01 XCP per lot
Payment       XCP Fee (to issuer)
```

What is left is what helps you fill the field in: what a lot costs, and where the payment goes. The
free-mint branch keeps its line under `Price` rather than `You pay`, since the row is now about the
rate rather than about the order.

## Tests

The test asserting the issuer address is replaced by one asserting its absence, along with the
absence of the em-dash total.

The pool test loses its "and no address" clause. That clause was there to catch a pool fairminter
naming the issuer under "Paid to" — with the address gone for every model it no longer distinguishes
a pool fairminter from an issuer one, so keeping it would have looked like coverage without being
any. The payment-model label still carries that distinction and is still asserted.

## Related, and deliberately not done here

The review screen only shows `Paid To` for the issuer model — correctly, since a pool or burned
fairminter does not pay that address. But that means for those two models the launcher's address now
appears **nowhere**, on either screen. If it is worth showing, it wants its own row labelled as what
it is (who created the fairminter) rather than as the payee. Happy to add that; it seemed like a
separate call from trimming the form.
