### PR TITLE
Fix closing a dispenser, and the packers that were never checked

### DIFF
--- a/e2e/pages/compose/dispenser/close.spec.ts
+++ b/e2e/pages/compose/dispenser/close.spec.ts
@@ -16,8 +16,9 @@ import { enableValidationBypass } from '../../../compose-test-helpers';
 walletTest.describe('Compose Dispenser Close Page (/compose/dispenser/close)', () => {
   walletTest.beforeEach(async ({ page }) => {
     await enableValidationBypass(page);
-    // Route requires asset parameter: /compose/dispenser/close/:asset?
-    await page.goto(page.url().replace(/\/index.*/, '/compose/dispenser/close/XCP'));
+    // The asset is optional: this is the bare route the Actions page links to, and
+    // the asset comes from the dispenser picked in the dropdown.
+    await page.goto(page.url().replace(/\/index.*/, '/compose/dispenser/close'));
     await page.waitForLoadState('networkidle');
   });
 

--- a/src/core/counterparty/pack/__tests__/coreOracle.test.ts
+++ b/src/core/counterparty/pack/__tests__/coreOracle.test.ts
@@ -37,6 +37,13 @@ const API_URL = process.env.COUNTERPARTY_API_URL;
 /** A funded mainnet address is only needed to satisfy the endpoint's shape; nothing is broadcast. */
 const SOURCE = process.env.COUNTERPARTY_ORACLE_SOURCE
   ?? '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa';
+/**
+ * Any real UTXO satisfies the `/v2/utxos/...` route's shape. A detach message carries only the
+ * destination, so which UTXO this is does not reach the bytes; `validate=false` keeps it from
+ * needing a balance.
+ */
+const DETACH_UTXO = process.env.COUNTERPARTY_ORACLE_UTXO
+  ?? '8691695cef015590229d0e9a9502865f64d9aa8e96dad2a4186542912daab774:1';
 
 interface OracleCase {
   label: string;
@@ -52,6 +59,8 @@ interface OracleCase {
    * numeric asset id core draws for a new subasset. Equality then proves every *other* byte.
    */
   observedFromResponse?: boolean;
+  /** Compose from this UTXO instead of an address, for the types core routes under `/v2/utxos`. */
+  sourceUtxo?: string;
 }
 
 const CASES: OracleCase[] = [
@@ -238,6 +247,121 @@ const CASES: OracleCase[] = [
       expiration: '5000', fee_required: '0',
     },
   },
+  // Dispensers, whose trailing addresses core packs only for particular statuses. These cases are
+  // here because the type had no oracle coverage and shipped a divergence: the packer appended
+  // `open_address` whenever the request carried one, so closing a dispenser held on the signing
+  // address composed 21 bytes core never emits, and byte equality blocked the close.
+  // `dispenserGating.test.ts` pins the same expectations offline; this asks a live node.
+  {
+    label: 'dispenser close',
+    composeType: 'dispenser',
+    params: { asset: 'XCP', status: 10, sourceAddress: SOURCE },
+    query: {
+      asset: 'XCP', status: '10',
+      give_quantity: '0', escrow_quantity: '0', mainchainrate: '0',
+    },
+  },
+  {
+    label: 'dispenser close naming the signing address (core drops open_address)',
+    composeType: 'dispenser',
+    params: { asset: 'XCP', status: 10, open_address: SOURCE, sourceAddress: SOURCE },
+    query: {
+      asset: 'XCP', status: '10', open_address: SOURCE,
+      give_quantity: '0', escrow_quantity: '0', mainchainrate: '0',
+    },
+  },
+  {
+    label: 'dispenser close on another address (core keeps open_address)',
+    composeType: 'dispenser',
+    params: {
+      asset: 'XCP', status: 10,
+      open_address: '1CounterpartyXXXXXXXXXXXXXXXUWLpVr', sourceAddress: SOURCE,
+    },
+    query: {
+      asset: 'XCP', status: '10', open_address: '1CounterpartyXXXXXXXXXXXXXXXUWLpVr',
+      give_quantity: '0', escrow_quantity: '0', mainchainrate: '0',
+    },
+  },
+  {
+    label: 'dispenser open',
+    composeType: 'dispenser',
+    params: {
+      asset: 'XCP', give_quantity: 1, escrow_quantity: 10, mainchainrate: 100,
+      sourceAddress: SOURCE,
+    },
+    query: {
+      asset: 'XCP', status: '0',
+      give_quantity: '1', escrow_quantity: '10', mainchainrate: '100',
+    },
+  },
+  // The remaining types that compose against an arbitrary address. Each had no oracle coverage.
+  {
+    label: 'UTXO attach',
+    composeType: 'attach',
+    params: { asset: 'XCP', quantity: 100 },
+    query: { asset: 'XCP', quantity: '100' },
+  },
+  {
+    label: 'dispense',
+    composeType: 'dispense',
+    params: { dispenser: '1CounterpartyXXXXXXXXXXXXXXXUWLpVr', quantity: 1000 },
+    query: { dispenser: '1CounterpartyXXXXXXXXXXXXXXXUWLpVr', quantity: '1000' },
+  },
+  {
+    label: 'UTXO detach',
+    composeType: 'detach',
+    sourceUtxo: DETACH_UTXO,
+    params: { destination: SOURCE },
+    query: { destination: SOURCE },
+  },
+  {
+    label: 'fairmint',
+    composeType: 'fairmint',
+    params: { asset: 'PEPECASH', quantity: 1 },
+    query: { asset: 'PEPECASH', quantity: '1' },
+  },
+  {
+    label: 'pool withdraw',
+    composeType: 'poolwithdraw',
+    params: {
+      asset_a: 'XCP', asset_b: 'PEPECASH',
+      quantity: 100, min_quantity_a: 1, min_quantity_b: 2,
+    },
+    query: {
+      asset_a: 'XCP', asset_b: 'PEPECASH',
+      quantity: '100', min_quantity_a: '1', min_quantity_b: '2',
+    },
+  },
+  // The LP asset id is 0 for a pool that already exists, and a value the request cannot predict
+  // for one that does not — core draws a random numeric asset when the deposit names none. Both
+  // are here because packing 0 for the second case blocked every first deposit into a new pool.
+  {
+    label: 'pool deposit into an existing pool',
+    composeType: 'pooldeposit',
+    params: { asset_a: 'XCP', asset_b: 'PEPECASH', quantity_a: 100, quantity_b: 200 },
+    query: { asset_a: 'XCP', asset_b: 'PEPECASH', quantity_a: '100', quantity_b: '200' },
+  },
+  {
+    label: 'pool deposit naming its own LP asset',
+    composeType: 'pooldeposit',
+    params: {
+      asset_a: 'XCP', asset_b: 'RAREPEPE',
+      quantity_a: 100, quantity_b: 200, lp_asset: 'A95428956661682177',
+    },
+    query: {
+      asset_a: 'XCP', asset_b: 'RAREPEPE',
+      quantity_a: '100', quantity_b: '200', lp_asset: 'A95428956661682177',
+    },
+  },
+  {
+    // No LP asset named and no pool for the pair: core invents one, and the packer has to borrow
+    // the id it drew. Every other byte still has to match.
+    label: 'first pool deposit, LP asset drawn by core',
+    composeType: 'pooldeposit',
+    params: { asset_a: 'XCP', asset_b: 'RAREPEPE', quantity_a: 100, quantity_b: 200 },
+    query: { asset_a: 'XCP', asset_b: 'RAREPEPE', quantity_a: '100', quantity_b: '200' },
+    observedFromResponse: true,
+  },
 ];
 
 async function composeDataFromCore(testCase: OracleCase): Promise<string> {
@@ -247,7 +371,12 @@ async function composeDataFromCore(testCase: OracleCase): Promise<string> {
       query.append(key, entry);
     }
   }
-  const url = `${API_URL}/v2/addresses/${SOURCE}/compose/${testCase.composeType}?${query}`;
+  // Detach and move spend a UTXO rather than an address balance, and core routes them under
+  // `/v2/utxos/...` accordingly — the wallet calls them the same way (`composeUtxoTransaction`).
+  const from = testCase.sourceUtxo
+    ? `utxos/${testCase.sourceUtxo}`
+    : `addresses/${SOURCE}`;
+  const url = `${API_URL}/v2/${from}/compose/${testCase.composeType}?${query}`;
   const response = await fetch(url);
   if (!response.ok) {
     throw new Error(`core returned ${response.status} for ${testCase.label}: ${await response.text()}`);

--- a/src/core/counterparty/pack/__tests__/dispenserGating.test.ts
+++ b/src/core/counterparty/pack/__tests__/dispenserGating.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Dispenser packing, against bytes counterparty-core actually composed.
+ *
+ * Which trailing addresses a dispenser message carries depends on its status, and core decides
+ * that in `dispenser.py`:
+ *
+ *     is_empty_address = status == STATUS_OPEN_EMPTY_ADDRESS and open_address
+ *     if is_empty_address or (... status == STATUS_CLOSED and open_address and open_address != source):
+ *         data += address_pack(open_address)
+ *     if oracle_address is not None and is_oracle_fee_status and ...:
+ *         data += address_pack(oracle_address)
+ *
+ * The packer appended whichever address the request carried, regardless of status. Byte equality
+ * is fail-closed, so the extra 21 bytes did not read as a curiosity — they blocked the compose.
+ * That is the shape that shipped: closing a dispenser named its own address, core packed nothing,
+ * and the wallet refused to sign a transaction that was perfectly correct.
+ *
+ * The expectations below are not derived from our own packer. Each was returned by
+ * api.counterparty.io for the same parameters via `return_only_data=true` (the mechanism
+ * `coreOracle.test.ts` uses live); pinning them here keeps the check offline and deterministic.
+ * `coreOracle.test.ts` re-asks a live node on the nightly run, so drift is still caught.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { bytesToHex } from '../../unpack/binary';
+import { packComposeMessage } from '../messages';
+
+const SOURCE = '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa';
+const OTHER = '1CounterpartyXXXXXXXXXXXXXXXUWLpVr';
+
+/** `CNTRPRTY` + type 0x0c + asset id 1 (XCP) + give/escrow/rate + status byte. */
+const CLOSE_XCP = '434e5452505254590c'
+  + '0000000000000001' + '0000000000000000' + '0000000000000000' + '0000000000000000' + '0a';
+const OPEN_XCP = '434e5452505254590c'
+  + '0000000000000001' + '0000000000000001' + '000000000000000a' + '0000000000000064' + '00';
+/** Legacy 21-byte packing of OTHER: base58 version 0x00 + hash160. */
+const OTHER_PACKED = '00818895f3dc2c178629d3d2d8fa3ec4a3f8179821';
+
+const pack = (params: Record<string, unknown>) => {
+  const packed = packComposeMessage('dispenser', { sourceAddress: SOURCE, ...params });
+  return packed ? bytesToHex(packed.bytes) : null;
+};
+
+const close = { asset: 'XCP', status: '10', give_quantity: '0', escrow_quantity: '0', mainchainrate: '0' };
+const open = { asset: 'XCP', status: '0', give_quantity: '1', escrow_quantity: '10', mainchainrate: '100' };
+
+describe('dispenser packing matches core byte for byte', () => {
+  it('packs a plain close', () => {
+    expect(pack(close)).toBe(CLOSE_XCP);
+  });
+
+  // The reported bug: core drops an open_address equal to the source, so the extra bytes made
+  // byte equality reject the close.
+  it('omits open_address when closing a dispenser on the signing address', () => {
+    expect(pack({ ...close, open_address: SOURCE })).toBe(CLOSE_XCP);
+  });
+
+  it('carries open_address when closing a dispenser on another address', () => {
+    expect(pack({ ...close, open_address: OTHER })).toBe(CLOSE_XCP + OTHER_PACKED);
+  });
+
+  it('omits oracle_address on a close, which core never packs there', () => {
+    expect(pack({ ...close, oracle_address: OTHER })).toBe(CLOSE_XCP);
+  });
+
+  it('packs a plain open', () => {
+    expect(pack(open)).toBe(OPEN_XCP);
+  });
+
+  // Core's open_address branch requires STATUS_OPEN_EMPTY_ADDRESS; a plain open drops it.
+  it('omits open_address on a plain open', () => {
+    expect(pack({ ...open, open_address: OTHER })).toBe(OPEN_XCP);
+  });
+
+  it('carries open_address when opening on an empty address', () => {
+    const openEmpty = OPEN_XCP.slice(0, -2) + '01';
+    expect(pack({ ...open, status: '1', open_address: OTHER })).toBe(openEmpty + OTHER_PACKED);
+  });
+
+  // Both flows omit fields that `composeDispenser` fills with 0 before calling the API. While the
+  // packer required them it returned null for every real request, and each dispenser quietly took
+  // the weaker field-comparison path instead of byte equality.
+  it('packs the fields each flow actually submits', () => {
+    expect(pack({ asset: 'XCP', status: '10' }), 'close: no quantities submitted').toBe(CLOSE_XCP);
+    expect(
+      pack({ asset: 'XCP', give_quantity: '1', escrow_quantity: '10', mainchainrate: '100' }),
+      'open: no status submitted'
+    ).toBe(OPEN_XCP);
+  });
+});

--- a/src/core/counterparty/pack/__tests__/onchainRoundTrip.test.ts
+++ b/src/core/counterparty/pack/__tests__/onchainRoundTrip.test.ts
@@ -71,6 +71,14 @@ const PARAMS_FROM_DECODED: Record<string, (data: Record<string, any>) => Record<
   }),
   destroy: (data) => ({ asset: data.asset, quantity: data.quantity, tag: data.tag ?? '' }),
   cancel: (data) => ({ offer_hash: data.offerHash }),
+  // btcpay is here rather than in the compose oracle because core cannot compose one on request:
+  // it needs a *pending* order match in the ledger, so a synthetic id is refused ("no such order
+  // match"). On-chain samples need no such arrangement.
+  btcpay: (data) => ({ order_match_id: data.orderMatchId }),
+  // The decoder reports core's literal "0" — its stand-in for "no destination, use the sender's
+  // address" — as an empty string, and `packDetach` writes that byte back. Passing it through
+  // unchanged is what makes the round trip test that pair rather than skip it.
+  detach: (data) => ({ destination: data.destination }),
   order: (data) => ({
     give_asset: data.giveAsset,
     give_quantity: data.giveQuantity,
@@ -183,6 +191,8 @@ const COMPOSE_TYPE_FOR: Record<string, string> = {
   fairminter: 'fairminter',
   broadcast: 'broadcast',
   mpma: 'mpma',
+  btcpay: 'btcpay',
+  detach: 'detach',
 };
 
 async function recentTransactions(type: string): Promise<OnChainTransaction[]> {

--- a/src/core/counterparty/pack/__tests__/poolLpAsset.test.ts
+++ b/src/core/counterparty/pack/__tests__/poolLpAsset.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Pool deposit packing, against bytes counterparty-core actually composed.
+ *
+ * The LP asset id is the one field of a pool deposit that the request does not determine
+ * (`pooldeposit.py`):
+ *
+ *     if existing_pool is None and lp_asset is None:
+ *         lp_asset = assetnames.generate_random_asset(f"{sorted_a}:{sorted_b}")
+ *     ...
+ *     lp_asset_id = generate_asset_id(lp_asset) if existing_pool is None and lp_asset else 0
+ *
+ * so it is 0 into an existing pool, the named asset's id when one is named, and a random draw for
+ * the first deposit into a new pool that names none. The packer wrote 0 for that last case, and
+ * byte equality is fail-closed — so the first deposit into any new pool was refused, which is the
+ * ordinary path given the LP name is optional and only offered on a new pool.
+ *
+ * Expectations are core's own output for these params (`return_only_data=true`), pinned here so
+ * the check stays offline; `coreOracle.test.ts` re-asks a live node nightly.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { bytesToHex } from '../../unpack/binary';
+import { packComposeMessage } from '../messages';
+
+/** `CNTRPRTY` + type 0x78 (120). */
+const DEPOSIT = '434e5452505254597800000000000000010000001c61620c4b'
+  + '000000000000006400000000000000c8' + '0000000000000000';
+/** XCP/PEPECASH, quantities 100 and 200, min LP 0 — then the LP asset id. */
+const EXISTING_POOL = `${DEPOSIT}0000000000000000`;
+
+const deposit = (extra: Record<string, unknown>, observed?: Record<string, unknown>) => {
+  const packed = packComposeMessage(
+    'pooldeposit',
+    { asset_a: 'XCP', asset_b: 'PEPECASH', quantity_a: 100, quantity_b: 200, ...extra },
+    observed
+  );
+  return packed ? bytesToHex(packed.bytes) : null;
+};
+
+describe('pool deposit LP asset id matches core', () => {
+  it('packs 0 for a deposit into an existing pool', () => {
+    expect(deposit({})).toBe(EXISTING_POOL);
+  });
+
+  it('packs the id of an LP asset the request names', () => {
+    // A95428956661682177 -> 0x01530821671b1001, as core composed it.
+    expect(deposit({ lp_asset: 'A95428956661682177' })).toBe(`${DEPOSIT}01530821671b1001`);
+  });
+
+  // The reported failure: core draws the id, so 0 could never match.
+  it('borrows the id core drew when the request names no LP asset', () => {
+    expect(deposit({}, { lpAssetId: 0x43ab252b336104e7n })).toBe(`${DEPOSIT}43ab252b336104e7`);
+  });
+
+  it('prefers a named LP asset over the composed one, so a substitution still fails', () => {
+    expect(deposit({ lp_asset: 'A95428956661682177' }, { lpAssetId: 0x43ab252b336104e7n }))
+      .toBe(`${DEPOSIT}01530821671b1001`);
+  });
+
+  // Only a draw from the numeric-asset range is one core could have generated. A named asset's id
+  // appearing where the request named nothing is declined rather than blessed by borrowing it.
+  it('declines an LP asset id outside the range core draws from', () => {
+    expect(deposit({}, { lpAssetId: 1n })).toBeNull();
+    expect(deposit({}, { lpAssetId: 26n ** 12n })).toBeNull();
+  });
+});

--- a/src/core/counterparty/pack/messages.ts
+++ b/src/core/counterparty/pack/messages.ts
@@ -868,16 +868,27 @@ function packBtcPay(params: Params): PackedMessage | null {
 }
 
 /**
+ * Dispenser statuses, as core names them (`dispenser.py`). Which trailing addresses a message
+ * carries depends entirely on these.
+ */
+const DISPENSER_STATUS = { OPEN: 0n, OPEN_EMPTY_ADDRESS: 1n, CLOSED: 10n } as const;
+
+/**
  * dispenser: `">QQQQB"` — asset_id, give_quantity, escrow_quantity, mainchainrate, status —
  * optionally followed by a 21-byte action address and a 21-byte oracle address (dispenser.py).
  */
 function packDispenser(params: Params): PackedMessage | null {
   const asset = requireString(params, 'asset');
-  const give = requireQuantity(params, 'give_quantity');
-  const escrow = requireQuantity(params, 'escrow_quantity');
-  const rate = requireQuantity(params, 'mainchainrate');
-  const status = requireQuantity(params, 'status');
-  if (!asset || give === null || escrow === null || rate === null || status === null) return null;
+  if (!asset) return null;
+
+  // Defaults mirror `composeDispenser`, which is what actually reaches the API: an open omits
+  // `status` and a close omits the three quantities, and it sends 0 for each. Requiring them here
+  // meant no dispenser request could be packed at all, so byte equality — the strongest check —
+  // silently never ran for this type and every dispenser fell back to field comparison.
+  const give = requireQuantity(params, 'give_quantity') ?? 0n;
+  const escrow = requireQuantity(params, 'escrow_quantity') ?? 0n;
+  const rate = requireQuantity(params, 'mainchainrate') ?? 0n;
+  const status = requireQuantity(params, 'status') ?? 0n;
   if (status > 255n) return null;
 
   let assetId: bigint;
@@ -895,21 +906,39 @@ function packDispenser(params: Params): PackedMessage | null {
     Number(status),
   ];
 
-  // Optional trailing addresses, packed legacy-style as core does for this message.
-  for (const key of ['open_address', 'oracle_address']) {
-    const value = params[key];
-    if (typeof value === 'string' && value !== '') {
-      const packed = packAddressLegacy(value);
-      if (!packed) return null;
-      body.push(...packed);
-    }
+  // Trailing addresses, packed legacy-style as core does for this message — but only for the
+  // statuses that carry them. Core appends `open_address` when opening on an empty address, or
+  // when closing a dispenser held on a *different* address than the one signing; it appends
+  // `oracle_address` only while opening (`dispenser.py`). Appending whichever address the request
+  // happened to carry produced bytes core never composes, and byte equality is fail-closed, so it
+  // blocked the transaction outright — a close naming its own address was refused on those 21
+  // extra bytes.
+  const source = requireString(params, 'sourceAddress') ?? '';
+  const openAddress = requireString(params, 'open_address') ?? '';
+  const oracleAddress = requireString(params, 'oracle_address') ?? '';
+
+  const trailing: string[] = [];
+  if (openAddress !== ''
+    && (status === DISPENSER_STATUS.OPEN_EMPTY_ADDRESS
+      || (status === DISPENSER_STATUS.CLOSED && openAddress !== source))) {
+    trailing.push(openAddress);
+  }
+  if (oracleAddress !== ''
+    && (status === DISPENSER_STATUS.OPEN || status === DISPENSER_STATUS.OPEN_EMPTY_ADDRESS)) {
+    trailing.push(oracleAddress);
+  }
+
+  for (const address of trailing) {
+    const packed = packAddressLegacy(address);
+    if (!packed) return null;
+    body.push(...packed);
   }
 
   return withPrefix(MessageTypeId.DISPENSER, new Uint8Array(body));
 }
 
 /** pooldeposit: `">QQQQQQ"` — asset ids, quantities, min LP quantity, LP asset id. */
-function packPoolDeposit(params: Params): PackedMessage | null {
+function packPoolDeposit(params: Params, observed: Observed): PackedMessage | null {
   const assetA = requireString(params, 'asset_a');
   const assetB = requireString(params, 'asset_b');
   const qtyA = requireQuantity(params, 'quantity_a');
@@ -917,10 +946,41 @@ function packPoolDeposit(params: Params): PackedMessage | null {
   const minLp = requireQuantity(params, 'min_lp_quantity') ?? 0n;
   if (!assetA || !assetB || qtyA === null || qtyB === null) return null;
 
+  // The LP asset id core packs is not a function of the request alone.
+  //
+  //     if existing_pool is None and lp_asset is None:
+  //         lp_asset = assetnames.generate_random_asset(f"{sorted_a}:{sorted_b}")
+  //     ...
+  //     lp_asset_id = generate_asset_id(lp_asset) if existing_pool is None and lp_asset else 0
+  //
+  // So it is 0 for a deposit into an existing pool, the named asset's id when the request names
+  // one, and a *random* draw for the first deposit into a new pool that names none — which the
+  // wallet's own form allows, since the LP name is optional there. Packing 0 for that case made
+  // byte equality reject every first deposit; the LP field is only offered on a new pool, so
+  // leaving it blank was the ordinary path.
+  //
+  // Borrowing the id is safe for the same reason a new subasset's id is: core requires an LP asset
+  // to be numeric and unused (`pooldeposit.py` — "lp_asset ... is already in use", "must be a
+  // numeric asset"), so a substituted id is rejected by consensus and the deposit never executes.
+  // A named LP asset is the user's own choice and is packed from the request, where a substitution
+  // still fails equality.
   const lpAsset = requireString(params, 'lp_asset');
+  const drawn = observed?.lpAssetId;
+  // Absent from the request: 0 unless the composed message drew one, and only a draw from the
+  // numeric-asset range is one core could have generated. Anything else — an existing named
+  // asset's id, say — is declined rather than blessed by borrowing it.
+  const borrowedLpId = typeof drawn !== 'bigint' || drawn === 0n
+    ? 0n
+    : drawn > 26n ** 12n && drawn < 1n << 64n ? drawn : null;
+  if (lpAsset === null && borrowedLpId === null) return null;
+
   let ids: [bigint, bigint, bigint];
   try {
-    ids = [assetNameToId(assetA), assetNameToId(assetB), lpAsset ? assetNameToId(lpAsset) : 0n];
+    ids = [
+      assetNameToId(assetA),
+      assetNameToId(assetB),
+      lpAsset === null ? borrowedLpId! : assetNameToId(lpAsset),
+    ];
   } catch {
     return null;
   }
@@ -1002,7 +1062,7 @@ export function packComposeMessage(
     case 'dispenser':
       return packDispenser(params);
     case 'pooldeposit':
-      return packPoolDeposit(params);
+      return packPoolDeposit(params, observed);
     case 'poolwithdraw':
       return packPoolWithdraw(params);
     default:

--- a/src/core/counterparty/unpack/__tests__/composeFlowVerification.test.ts
+++ b/src/core/counterparty/unpack/__tests__/composeFlowVerification.test.ts
@@ -17,6 +17,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
+import { bytesToHex, packAddressLegacy } from '../index';
 import { COUNTERPARTY_PREFIX_HEX } from '../messageTypes';
 import { verifyTransaction } from '../verify';
 
@@ -35,20 +36,49 @@ interface Flow {
 
 const ASSET_ID_XCP = u64(1n);
 
+/**
+ * An address other than the one signing, and the 21 bytes a dispenser message carries it as.
+ *
+ * Legacy packing, not the modern tagged form: core imports `pack_legacy`/`unpack_legacy` for this
+ * message specifically (`dispenser.py`), so `00 || hash160` is what a close on another address
+ * actually contains. `unpackAddress` reads both, so the modern form would pass here too — and
+ * would be this file testing our own encoding rather than core's.
+ */
+const ADDRESS = '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa';
+const PACKED_ADDRESS = bytesToHex(packAddressLegacy(ADDRESS));
+
 const FLOWS: Flow[] = [
   {
     // Submits asset, give_remaining_normalized, status=10. The composer zeroes the three
     // quantities, which the request never named.
+    //
+    // Dispensers now pack, so production compares bytes (`packDispenser`) and reaches this path
+    // only if that ever returns null again. The rows stay as the fallback's coverage; the
+    // authority on what core composes for a dispenser is `pack/__tests__/dispenserGating.test.ts`.
     form: 'dispenser/close/form.tsx',
     type: 'dispenser',
     message: PREFIX + '0c' + ASSET_ID_XCP + u64(0n) + u64(0n) + u64(0n) + '0a',
     params: { asset: 'XCP', status: 10 },
   },
   {
+    // Closing a dispenser that sits on the signing address. The form used to submit
+    // open_address here regardless, and core packs no action address when it matches
+    // the source, so this row read `open_address: undefined` while the form sent a
+    // string — the assumption the header warns against, and it hid a real failure:
+    // every close by hash was blocked as an open-address mismatch.
     form: 'dispenser/close-by-hash/form.tsx',
     type: 'dispenser',
     message: PREFIX + '0c' + ASSET_ID_XCP + u64(0n) + u64(0n) + u64(0n) + '0a',
-    params: { asset: 'XCP', status: 10, open_address: undefined },
+    params: { asset: 'XCP', status: 10 },
+  },
+  {
+    // The same form closing a dispenser held on another address: open_address is
+    // submitted, and the composed close carries the packed action address.
+    form: 'dispenser/close-by-hash/form.tsx',
+    type: 'dispenser',
+    message:
+      PREFIX + '0c' + ASSET_ID_XCP + u64(0n) + u64(0n) + u64(0n) + '0a' + PACKED_ADDRESS,
+    params: { asset: 'XCP', status: 10, open_address: ADDRESS },
   },
   {
     // The open flow, for contrast: it does supply all three.

--- a/src/pages/compose/dispenser/close-by-hash/__tests__/form.test.tsx
+++ b/src/pages/compose/dispenser/close-by-hash/__tests__/form.test.tsx
@@ -1,0 +1,155 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { ComposerProvider } from '@/contexts/composer-context';
+import * as counterpartyApi from '@/core/counterparty/api';
+import { asBaseUnits, asDisplayUnits } from '@/core/numeric';
+import { DispenserCloseByHashForm } from '../form';
+
+vi.mock('@/core/counterparty/api');
+
+vi.mock('@/core/bitcoin/feeRate', () => ({
+  getFeeRates: vi.fn().mockResolvedValue({
+    fastestFee: 10,
+    halfHourFee: 5,
+    hourFee: 3,
+    economyFee: 1,
+    minimumFee: 1,
+  }),
+}));
+
+const ACTIVE_ADDRESS = '17TkmnxyBmtGBRgiQ4Y8Wa8HYYz6WWUtLj';
+const DISPENSER_HASH = '34f3f7565ce237346ad4b17e5acf43699dd317076d315ef3c3caf928e8a39dc5';
+
+vi.mock('@/contexts/wallet-context', () => ({
+  useWallet: () => ({
+    activeWallet: { id: 'test-wallet', name: 'Test Wallet' },
+    activeAddress: { address: '17TkmnxyBmtGBRgiQ4Y8Wa8HYYz6WWUtLj', walletId: 'test-wallet' },
+    authState: 'unlocked',
+    signTransaction: vi.fn(),
+    broadcastTransaction: vi.fn(),
+    unlockWallet: vi.fn(),
+    isKeychainLocked: vi.fn().mockResolvedValue(false),
+  }),
+}));
+
+vi.mock('@/contexts/settings-context', () => ({
+  useSettings: () => ({
+    settings: { showHelpText: false },
+    updateSettings: vi.fn(),
+    isLoading: false,
+  }),
+}));
+
+vi.mock('@/contexts/header-context', () => ({
+  useHeader: () => ({
+    setHeaderProps: vi.fn(),
+    setTitle: vi.fn(),
+    setAddressHeader: vi.fn(),
+    subheadings: { addresses: {} },
+  }),
+}));
+
+vi.mock('@/contexts/loading-context', () => ({
+  useLoading: () => ({
+    showLoading: vi.fn(() => 'loading-id'),
+    hideLoading: vi.fn(),
+    loading: false,
+    setLoading: vi.fn(),
+  }),
+}));
+
+function createMockDispenser(
+  overrides: Partial<counterpartyApi.DispenserDetails> = {}
+): counterpartyApi.DispenserDetails {
+  return {
+    asset: 'FAUXBATTLE',
+    source: ACTIVE_ADDRESS,
+    tx_hash: DISPENSER_HASH,
+    status: 0,
+    give_remaining: asBaseUnits(1000000),
+    give_remaining_normalized: asDisplayUnits('10'),
+    give_quantity: asBaseUnits(100000),
+    give_quantity_normalized: asDisplayUnits('1'),
+    satoshirate: asBaseUnits(5000),
+    satoshirate_normalized: asDisplayUnits('0.00005000'),
+    escrow_quantity: asBaseUnits(10000000),
+    escrow_quantity_normalized: asDisplayUnits('100'),
+    block_index: 800000,
+    block_time: 1700000000,
+    confirmed: true,
+    price: asBaseUnits(5000),
+    satoshi_price: 5000,
+    ...overrides,
+  };
+}
+
+describe('DispenserCloseByHashForm', () => {
+  const mockFormAction = vi.fn();
+  const mockFetchDispenserByHash = vi.mocked(counterpartyApi.fetchDispenserByHash);
+
+  const renderForm = (initialFormData: any = null) =>
+    render(
+      <MemoryRouter>
+        <ComposerProvider
+          composeApi={vi.fn().mockResolvedValue({ result: { tx_hash: 'test' } })}
+          initialTitle="Close"
+          composeType="dispenser"
+        >
+          <DispenserCloseByHashForm
+            formAction={mockFormAction}
+            initialFormData={initialFormData}
+          />
+        </ComposerProvider>
+      </MemoryRouter>
+    );
+
+  const submitAfterLookup = async () => {
+    await userEvent.type(screen.getByLabelText(/Transaction Hash/i), DISPENSER_HASH);
+    await waitFor(() => expect(mockFetchDispenserByHash).toHaveBeenCalled(), { timeout: 3000 });
+    await screen.findByText('FAUXBATTLE');
+    await userEvent.click(screen.getByRole('button', { name: 'Continue' }));
+    return mockFormAction.mock.calls[0]?.[0] as FormData | undefined;
+  };
+
+  beforeEach(() => vi.clearAllMocks());
+
+  // Regression: open_address was submitted as the dispenser's own host address even
+  // when that was the address doing the signing. Core packs an action address into a
+  // close only when it differs from the source, so the composed message carried none
+  // and verification refused to sign: "[DANGEROUS] Open address mismatch: expected
+  // 17Tkmn..., got undefined".
+  it('omits open_address when closing a dispenser on the active address', async () => {
+    mockFetchDispenserByHash.mockResolvedValue(createMockDispenser());
+
+    renderForm();
+
+    const formData = await submitAfterLookup();
+    expect(formData?.get('asset')).toBe('FAUXBATTLE');
+    expect(formData?.get('status')).toBe('10');
+    expect(formData?.get('open_address')).toBeNull();
+  });
+
+  it('sends open_address when the dispenser sits on another address', async () => {
+    mockFetchDispenserByHash.mockResolvedValue(
+      createMockDispenser({ source: '1CounterpartyXXXXXXXXXXXXXXXUWLpVr' })
+    );
+
+    renderForm();
+
+    const formData = await submitAfterLookup();
+    expect(formData?.get('open_address')).toBe('1CounterpartyXXXXXXXXXXXXXXXUWLpVr');
+  });
+
+  // Regression: returning to the form put initialFormData.open_address — an address —
+  // into the hash field, which then rejected it as "must be 64 hexadecimal characters"
+  // and fired a doomed lookup for a dispenser named after an address.
+  it('does not seed the hash field with an address after a failed compose', () => {
+    renderForm({ asset: 'FAUXBATTLE', status: '10', open_address: ACTIVE_ADDRESS });
+
+    expect(screen.getByLabelText(/Transaction Hash/i)).toHaveValue('');
+    expect(mockFetchDispenserByHash).not.toHaveBeenCalled();
+  });
+});

--- a/src/pages/compose/dispenser/close-by-hash/form.tsx
+++ b/src/pages/compose/dispenser/close-by-hash/form.tsx
@@ -21,9 +21,15 @@ export function DispenserCloseByHashForm({
 }: DispenserCloseByHashFormProps): ReactElement {
   const { activeAddress, activeWallet, showHelpText } = useComposer();
   const { pending } = useFormStatus();
-  const [txHash, setTxHash] = useState<string>(initialTxHash || initialFormData?.open_address || "");
+  // Not seeded from initialFormData: DispenserOptions carries no transaction hash,
+  // and open_address — the only address-shaped field on it — is the dispenser's
+  // host, which the hash input rejects as "must be 64 hexadecimal characters".
+  const [txHash, setTxHash] = useState<string>(initialTxHash || "");
   const [selectedDispenser, setSelectedDispenser] = useState<any | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);
+
+  const closingOnAnotherAddress =
+    !!selectedDispenser && selectedDispenser.source !== activeAddress?.address;
 
   // Fetch dispenser data when initialTxHash is provided or when txHash changes
   useEffect(() => {
@@ -108,8 +114,18 @@ export function DispenserCloseByHashForm({
           )}
           <input type="hidden" name="asset" value={selectedDispenser?.asset || ""} />
           <input type="hidden" name="status" value="10" />
-          {/* open_address is the dispenser's source address (for closing dispensers at different addresses) */}
-          <input type="hidden" name="open_address" value={selectedDispenser?.source || ""} />
+          {/* open_address names the address the dispenser sits on, and only belongs
+              in the request when that is not the address we are signing from. Core
+              packs an action address into a close only when it differs from the
+              source, so sending our own address here composes a message without one
+              and verification fails the close as an open-address mismatch. */}
+          {closingOnAnotherAddress && (
+            <input
+              type="hidden"
+              name="open_address"
+              value={selectedDispenser?.source ?? ""}
+            />
+          )}
         </>
       )}
     </ComposerForm>

--- a/src/pages/compose/dispenser/close/__tests__/form.test.tsx
+++ b/src/pages/compose/dispenser/close/__tests__/form.test.tsx
@@ -1,0 +1,183 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { ComposerProvider } from '@/contexts/composer-context';
+import * as counterpartyApi from '@/core/counterparty/api';
+import { asBaseUnits, asDisplayUnits } from '@/core/numeric';
+import { DispenserCloseForm } from '../form';
+
+vi.mock('@/core/counterparty/api');
+
+vi.mock('@/core/bitcoin/feeRate', () => ({
+  getFeeRates: vi.fn().mockResolvedValue({
+    fastestFee: 10,
+    halfHourFee: 5,
+    hourFee: 3,
+    economyFee: 1,
+    minimumFee: 1,
+  }),
+}));
+
+vi.mock('@/contexts/wallet-context', () => ({
+  useWallet: () => ({
+    activeWallet: { id: 'test-wallet', name: 'Test Wallet' },
+    activeAddress: { address: '17TkmnxyBmtGBRgiQ4Y8Wa8HYYz6WWUtLj', walletId: 'test-wallet' },
+    authState: 'unlocked',
+    signTransaction: vi.fn(),
+    broadcastTransaction: vi.fn(),
+    unlockWallet: vi.fn(),
+    isKeychainLocked: vi.fn().mockResolvedValue(false),
+  }),
+}));
+
+vi.mock('@/contexts/settings-context', () => ({
+  useSettings: () => ({
+    settings: { showHelpText: false },
+    updateSettings: vi.fn(),
+    isLoading: false,
+  }),
+}));
+
+vi.mock('@/contexts/header-context', () => ({
+  useHeader: () => ({
+    setHeaderProps: vi.fn(),
+    setTitle: vi.fn(),
+    setAddressHeader: vi.fn(),
+    subheadings: { addresses: {} },
+  }),
+}));
+
+vi.mock('@/contexts/loading-context', () => ({
+  useLoading: () => ({
+    showLoading: vi.fn(() => 'loading-id'),
+    hideLoading: vi.fn(),
+    loading: false,
+    setLoading: vi.fn(),
+  }),
+}));
+
+function createMockDispenser(
+  overrides: Partial<counterpartyApi.DispenserDetails> = {}
+): counterpartyApi.DispenserDetails {
+  return {
+    asset: 'PEPECASH',
+    source: '17TkmnxyBmtGBRgiQ4Y8Wa8HYYz6WWUtLj',
+    tx_hash: 'abc123',
+    status: 0,
+    give_remaining: asBaseUnits(1000000),
+    give_remaining_normalized: asDisplayUnits('10'),
+    give_quantity: asBaseUnits(100000),
+    give_quantity_normalized: asDisplayUnits('1'),
+    satoshirate: asBaseUnits(5000),
+    satoshirate_normalized: asDisplayUnits('0.00005000'),
+    escrow_quantity: asBaseUnits(10000000),
+    escrow_quantity_normalized: asDisplayUnits('100'),
+    block_index: 800000,
+    block_time: 1700000000,
+    confirmed: true,
+    price: asBaseUnits(5000),
+    satoshi_price: 5000,
+    ...overrides,
+  };
+}
+
+describe('DispenserCloseForm', () => {
+  const mockFormAction = vi.fn();
+  const mockFetchAddressDispensers = vi.mocked(counterpartyApi.fetchAddressDispensers);
+
+  const renderForm = (initialAsset?: string) =>
+    render(
+      <MemoryRouter>
+        <ComposerProvider
+          composeApi={vi.fn().mockResolvedValue({ result: { tx_hash: 'test' } })}
+          initialTitle="Close"
+          composeType="dispenser"
+        >
+          <DispenserCloseForm
+            formAction={mockFormAction}
+            initialFormData={null}
+            initialAsset={initialAsset}
+          />
+        </ComposerProvider>
+      </MemoryRouter>
+    );
+
+  beforeEach(() => vi.clearAllMocks());
+
+  const submit = async () => {
+    const button = screen.getByRole('button', { name: 'Continue' });
+    await userEvent.click(button);
+    return mockFormAction.mock.calls[0]?.[0] as FormData | undefined;
+  };
+
+  // Regression: the submitted asset was read from the :asset route param rather
+  // than from the dispenser the user picked. Reached from Actions -> Close there
+  // is no route param, so every close composed `asset=` and the node answered
+  // 400 "address doesn't have the asset".
+  it('submits the asset of the dispenser picked from the dropdown', async () => {
+    mockFetchAddressDispensers.mockResolvedValue({
+      result: [
+        createMockDispenser({ asset: 'PEPECASH', tx_hash: 'aaa' }),
+        createMockDispenser({ asset: 'RAREPEPE', tx_hash: 'bbb' }),
+      ],
+      result_count: 2,
+    });
+
+    renderForm(); // no route param, as when opened from the Actions page
+
+    await userEvent.click(await screen.findByRole('button', { name: /^Dispenser/ }));
+    await userEvent.click(await screen.findByRole('option', { name: /RAREPEPE/ }));
+
+    const formData = await submit();
+    expect(formData?.get('asset')).toBe('RAREPEPE');
+    expect(formData?.get('status')).toBe('10');
+  });
+
+  it('preselects the only dispenser when arriving with an asset', async () => {
+    mockFetchAddressDispensers.mockResolvedValue({
+      result: [
+        createMockDispenser({ asset: 'PEPECASH', tx_hash: 'aaa' }),
+        createMockDispenser({ asset: 'RAREPEPE', tx_hash: 'bbb' }),
+      ],
+      result_count: 2,
+    });
+
+    renderForm('RAREPEPE');
+
+    const formData = await waitFor(async () => {
+      const data = await submit();
+      expect(data?.get('asset')).toBe('RAREPEPE');
+      return data;
+    });
+    expect(formData?.get('give_remaining_normalized')).toBe('10');
+  });
+
+  it('cannot be submitted until a dispenser is chosen', async () => {
+    mockFetchAddressDispensers.mockResolvedValue({
+      result: [
+        createMockDispenser({ asset: 'PEPECASH', tx_hash: 'aaa' }),
+        createMockDispenser({ asset: 'RAREPEPE', tx_hash: 'bbb' }),
+      ],
+      result_count: 2,
+    });
+
+    renderForm();
+
+    await screen.findByRole('button', { name: /^Dispenser/ });
+    expect(screen.getByRole('button', { name: 'Continue' })).toBeDisabled();
+
+    await submit();
+    expect(mockFormAction).not.toHaveBeenCalled();
+  });
+
+  it('cannot be submitted when the address has no open dispensers', async () => {
+    mockFetchAddressDispensers.mockResolvedValue({ result: [], result_count: 0 });
+
+    renderForm();
+
+    await screen.findByText(/No open dispensers found/);
+    expect(screen.getByRole('button', { name: 'Continue' })).toBeDisabled();
+  });
+});

--- a/src/pages/compose/dispenser/close/form.tsx
+++ b/src/pages/compose/dispenser/close/form.tsx
@@ -8,12 +8,13 @@ import {
   ListboxOptions,
 } from "@headlessui/react";
 import type { ReactElement } from "react";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useFormStatus } from "react-dom";
 import { ComposerForm } from "@/components/composer/composer-form";
 import { AddressHeader } from "@/components/domain/address/address-header";
 import { FaCheck, FaCopy, FiChevronDown } from "@/components/icons";
 import { useComposer } from "@/contexts/composer-context-object";
+import type { DispenserDetails } from "@/core/counterparty/api";
 import { fetchAddressDispensers } from "@/core/counterparty/api";
 import type { DispenserOptions } from "@/core/counterparty/compose";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
@@ -44,14 +45,15 @@ export function DispenserCloseForm({
 
   // Form state
   const [selectedTxHash, setSelectedTxHash] = useState<string | null>(null);
-  const [dispensers, setDispensers] = useState<any[]>([]);
+  const [dispensers, setDispensers] = useState<DispenserDetails[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
   // Computed values
   const asset = initialAsset || initialFormData?.asset || "";
-  const relevantDispensers = asset
-    ? dispensers.filter((d) => d.asset === asset)
-    : dispensers;
+  const relevantDispensers = useMemo(
+    () => (asset ? dispensers.filter((d) => d.asset === asset) : dispensers),
+    [dispensers, asset],
+  );
   const selectedDispenser = relevantDispensers.find(
     (d) => d.tx_hash === selectedTxHash,
   );
@@ -86,6 +88,13 @@ export function DispenserCloseForm({
     loadDispensers();
   }, [activeAddress]);
 
+  // Arriving from a dispenser card narrows the list to one; select it so the
+  // asset is submitted without the user re-picking what they already picked.
+  useEffect(() => {
+    const only = relevantDispensers.length === 1 ? relevantDispensers[0] : null;
+    if (only) setSelectedTxHash(only.tx_hash);
+  }, [relevantDispensers]);
+
   // Handlers
   const AssetIcon = ({ asset }: { asset: string }): ReactElement => (
     <img
@@ -101,6 +110,7 @@ export function DispenserCloseForm({
   return (
     <ComposerForm
       formAction={formAction}
+      submitDisabled={!selectedDispenser}
       header={
         activeAddress && (
           <AddressHeader
@@ -196,7 +206,13 @@ export function DispenserCloseForm({
                   </ListboxOptions>
                 </div>
               </Listbox>
-              <input type="hidden" name="asset" value={asset} />
+              {/* The asset is what identifies the dispenser to close, so it has
+                  to come from the selection, not from the route. */}
+              <input
+                type="hidden"
+                name="asset"
+                value={selectedDispenser?.asset ?? ""}
+              />
               <input type="hidden" name="status" value="10" />
               {selectedDispenser && (
                 <div className="mt-3 text-sm p-3 bg-gray-50 rounded-md border border-gray-200 space-y-2">


### PR DESCRIPTION
Closing a dispenser was broken two different ways, reported by @mightbemike. Fixing them turned up two more of the same shape underneath.

## What users hit

**Close, from the Actions page.** The asset submitted by the form came from the `:asset` route param, never from the dispenser picked in the dropdown — selecting one only set its tx hash. From a dispenser card the route carries the asset and it worked; from Actions there is no param, so the compose went out with `asset=` and the node answered `["address doesn't have the asset "]`.

**Close by hash.** The form sent `open_address` as the dispenser's own host even when that host was the signing address. Core packs an action address into a close only when it differs from the source, so the message carried none and verification refused to sign — `[DANGEROUS] Open address mismatch: expected 17Tkmn..., got undefined`. The verifier was right and the request was wrong, which is the shape worth remembering: a check no honest response can satisfy is a bug in what we asked for. The same form also seeded its hash field from `initialFormData.open_address`, so returning from a failed compose put an address in a field that wants 64 hex characters.

`give_quantity=0` on a close is correct, incidentally — core leaves the quantities unconstrained there. The "Missing required parameter" seen in a terminal was bash splitting an unquoted `&`.

## What the sweep found

**No dispenser had ever been byte-verified.** `packDispenser` required `status` and all three quantities, but an open submits no status and a close submits no quantities — `composeDispenser` fills them in on the way to the API, *after* verification snapshots the request. So the packer returned null every time and every dispenser quietly took the weaker field-comparison path. A packer returning null is not a neutral skip: it silently downgrades the check. Its required params must mirror what compose sends, not what the form submits.

**A pool deposit's `lp_asset_id`.** Core packs 0 into an existing pool, the named asset's id when the request names one, and a *random draw* for the first deposit into a new pool naming none — which the form allows, since the LP name is optional and only offered on a new pool. Packing 0 could never match, so every first deposit into a new pool was refused. Three identical requests to a live node returned three different ids. The id is now borrowed from the composed message, bounded to the numeric range core draws from; core requires an LP asset to be numeric and unused, so a substituted id is consensus-rejected and the deposit never executes.

## Coverage

The two wrong packers were the two with no oracle case between them. The compose oracle gains dispensers, attach, dispense, detach, fairmint, pool withdraw and pool deposit in all three LP shapes; btcpay and detach join the on-chain round trip, since btcpay needs a pending order match and cannot be composed on request. Every compose type is now covered by one oracle or the other, `move` aside, which composes no message on either side.

Expectations in the two new offline test files are bytes counterparty-core actually returned, not our packer's own output.

## Also corrected

The compose flow table asserted `open_address: undefined` for the close-by-hash row while the form always sent a string — it is documented as holding what each form actually submits, "read off the form rather than assumed", and that assumption hid the failure. The e2e spec navigated to `/close/XCP` under a comment claiming the route required an asset, sidestepping the broken path.

## Verification

- 4387 unit tests pass; `tsc`, `biome`, `oxlint` clean
- 28/28 compose-oracle cases and 13/13 on-chain round trips pass **live against api.counterparty.io**
- Both new offline suites fail against the unfixed packer (4/8 and 2/5) and pass with it
- Stashing the packer fails exactly the five oracle cases these fixes address, and nothing else

https://claude.ai/code/session_01QJS9Bj6uAMoYPATvfr6GZ1
