### PR TITLE
Spike: notify when a dispenser sells or an order matches

### DIFF
--- a/src/core/__tests__/settings.test.ts
+++ b/src/core/__tests__/settings.test.ts
@@ -172,6 +172,7 @@ describe('DEFAULT_SETTINGS', () => {
       'hasVisitedRecoverBitcoin',
       'lastActiveAddress',
       'lastActiveWalletId',
+      'notificationsEnabled',
       'pinnedAssets',
       'priceUnit',
       'providerCapabilities',

--- a/src/core/counterparty/api.ts
+++ b/src/core/counterparty/api.ts
@@ -1123,6 +1123,34 @@ export async function fetchDispenserDispenses(
   });
 }
 
+/** One row of core's `address_events` feed. `params` varies by event type. */
+export interface AddressEventRecord {
+  event_index: number;
+  event: string;
+  params?: Record<string, unknown>;
+}
+
+/**
+ * Events touching any of several addresses, in one request.
+ *
+ * The plural route matters: core takes a comma-separated list and filters server-side by event
+ * name, so watching a wallet costs one call rather than one per address per event type. Results
+ * come back newest-first keyed on `event_index`, which is the cursor — but note it pages
+ * *backwards* (it means "start here and go older"), so it cannot express "everything since X".
+ * Callers watermark on `event_index` themselves.
+ */
+export async function fetchAddressEvents(
+  addresses: string[],
+  options: { eventNames?: readonly string[]; limit?: number; verbose?: boolean } = {}
+): Promise<PaginatedResponse<AddressEventRecord>> {
+  return cpApiGet<PaginatedResponse<AddressEventRecord>>('/v2/addresses/events', {
+    addresses: addresses.join(','),
+    ...(options.eventNames?.length ? { event_name: options.eventNames.join(',') } : {}),
+    verbose: options.verbose ?? true,
+    limit: options.limit ?? DEFAULT_LIMIT,
+  }, { skipCache: true });
+}
+
 export async function fetchMempoolDispenses(dispenserAddress: string): Promise<Dispense[]> {
   const data = await cpApiGet<PaginatedResponse<{ params: Dispense }>>('/v2/mempool/events/DISPENSE', {
     verbose: true,

--- a/src/core/notifications/__tests__/detect.test.ts
+++ b/src/core/notifications/__tests__/detect.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type AddressEvent,
+  detectFromEvents,
+  MAX_NOTIFICATIONS_PER_POLL,
+  type NotificationState,
+} from '../detect';
+
+const MINE = '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa';
+const THEIRS = '1CounterpartyXXXXXXXXXXXXXXXUWLpVr';
+const watched = new Set([MINE]);
+
+const dispense = (event_index: number, params: Record<string, unknown> = {}): AddressEvent => ({
+  event_index,
+  event: 'DISPENSE',
+  params: {
+    asset: 'RAREPEPE',
+    dispense_quantity_normalized: '1',
+    source: MINE,
+    destination: THEIRS,
+    tx_hash: `hash${event_index}`,
+    ...params,
+  },
+});
+
+const orderMatch = (event_index: number, params: Record<string, unknown> = {}): AddressEvent => ({
+  event_index,
+  event: 'ORDER_MATCH',
+  params: { forward_asset: 'XCP', backward_asset: 'BTC', tx_hash: `hash${event_index}`, ...params },
+});
+
+describe('detectFromEvents', () => {
+  // The rule deciding whether switching this on is pleasant or a wall of alerts about things that
+  // happened months ago.
+  it('says nothing on the first poll, but records the position', () => {
+    const result = detectFromEvents([dispense(10), dispense(9)], {}, watched);
+
+    expect(result.notifications).toEqual([]);
+    expect(result.state.lastEventIndex).toBe(10);
+  });
+
+  it('announces only what is above the watermark', () => {
+    const result = detectFromEvents(
+      [dispense(12), dispense(11), dispense(10)],
+      { lastEventIndex: 10 },
+      watched
+    );
+
+    expect(result.notifications.map((n) => n.id)).toEqual(['DISPENSE:12', 'DISPENSE:11']);
+    expect(result.state.lastEventIndex).toBe(12);
+  });
+
+  it('stays quiet when nothing has moved', () => {
+    const result = detectFromEvents([dispense(10)], { lastEventIndex: 10 }, watched);
+    expect(result.notifications).toEqual([]);
+  });
+
+  // Two polls racing, or a poll re-run after the worker restarts, must not report one sale twice.
+  it('does not repeat itself when the same page is read again', () => {
+    const first = detectFromEvents([dispense(11), dispense(10)], { lastEventIndex: 10 }, watched);
+    const second = detectFromEvents([dispense(11), dispense(10)], first.state, watched);
+
+    expect(first.notifications).toHaveLength(1);
+    expect(second.notifications).toEqual([]);
+  });
+
+  // A dispense names both sides. Getting the direction wrong would tell a buyer their dispenser
+  // sold something they in fact just bought.
+  it('reads a dispense from our own dispenser as a sale', () => {
+    const result = detectFromEvents([dispense(11)], { lastEventIndex: 10 }, watched);
+
+    expect(result.notifications[0]!.title).toBe('Dispenser sold');
+    expect(result.notifications[0]!.message).toBe('1 RAREPEPE dispensed');
+  });
+
+  it('reads a dispense paid to us as a purchase', () => {
+    const result = detectFromEvents(
+      [dispense(11, { source: THEIRS, destination: MINE })],
+      { lastEventIndex: 10 },
+      watched
+    );
+
+    expect(result.notifications[0]!.title).toBe('Dispense received');
+    expect(result.notifications[0]!.message).toBe('1 RAREPEPE received');
+  });
+
+  it('ignores a dispense between two strangers', () => {
+    const result = detectFromEvents(
+      [dispense(11, { source: THEIRS, destination: THEIRS })],
+      { lastEventIndex: 10 },
+      watched
+    );
+
+    expect(result.notifications).toEqual([]);
+    // Still consumed: it has been considered, and re-reading it would only re-skip it.
+    expect(result.state.lastEventIndex).toBe(11);
+  });
+
+  it('describes an order match by its pair', () => {
+    const result = detectFromEvents([orderMatch(11)], { lastEventIndex: 10 }, watched);
+
+    expect(result.notifications[0]!.title).toBe('Order matched');
+    expect(result.notifications[0]!.message).toBe('XCP for BTC');
+  });
+
+  // An amount we cannot read has no correct rendering, so the message drops it rather than
+  // inventing a number or printing "undefined".
+  it('omits the amount when the event does not carry one', () => {
+    const result = detectFromEvents(
+      [dispense(11, { dispense_quantity_normalized: undefined })],
+      { lastEventIndex: 10 },
+      watched
+    );
+
+    expect(result.notifications[0]!.message).toBe('RAREPEPE dispensed');
+  });
+
+  it('ignores event types it was not taught', () => {
+    const result = detectFromEvents(
+      [{ event_index: 11, event: 'SOMETHING_NEW', params: {} }],
+      { lastEventIndex: 10 },
+      watched
+    );
+
+    expect(result.notifications).toEqual([]);
+    expect(result.state.lastEventIndex).toBe(11);
+  });
+
+  // A wallet closed over a busy weekend should get a handful and a summary, not ninety alerts.
+  it('caps a burst and reports how many it held back', () => {
+    const events = Array.from({ length: 9 }, (_, i) => dispense(20 - i));
+    const result = detectFromEvents(events, { lastEventIndex: 10 }, watched);
+
+    expect(result.notifications).toHaveLength(MAX_NOTIFICATIONS_PER_POLL);
+    expect(result.suppressed).toBe(9 - MAX_NOTIFICATIONS_PER_POLL);
+    // The watermark still clears the whole page, so the held-back ones are not re-offered.
+    expect(result.state.lastEventIndex).toBe(20);
+  });
+
+  it('routes a notification at the transaction it came from', () => {
+    const result = detectFromEvents([dispense(11)], { lastEventIndex: 10 }, watched);
+    expect(result.notifications[0]!.route).toBe('/transactions/hash11');
+  });
+
+  it('leaves state untouched when there is nothing to read', () => {
+    const state: NotificationState = { lastEventIndex: 7 };
+    expect(detectFromEvents([], state, watched).state).toBe(state);
+  });
+});

--- a/src/core/notifications/detect.ts
+++ b/src/core/notifications/detect.ts
@@ -1,0 +1,147 @@
+/**
+ * Deciding what is worth a notification, kept away from the browser and the network.
+ *
+ * Everything here is a pure function over "what the node reports now" plus "what we already told
+ * the user about". That split is the point: the part that can double-notify, replay a year of
+ * history on first run, or announce a stranger's dispense is the part that has to be testable
+ * without a browser.
+ *
+ * The input is core's `address_events` feed, which already carries every event touching a watched
+ * address, typed and with a monotonic `event_index`. That index is the watermark, and the rule that
+ * makes this bearable is: on first sight, adopt the current position *silently*. Someone switching
+ * this on does not want to hear about last year.
+ */
+
+/** What the poller remembers between runs. One watermark covers every watched address. */
+export interface NotificationState {
+  /**
+   * Highest `event_index` already announced. Undefined means nothing has been polled yet — adopt
+   * the position and stay quiet.
+   */
+  lastEventIndex?: number;
+}
+
+/** A notification decided on but not yet handed to the browser. */
+export interface PendingNotification {
+  /**
+   * Stable per event, so re-running a poll over the same data replaces the notification rather
+   * than stacking a second copy — the notifications API treats a repeated id as an update.
+   */
+  id: string;
+  title: string;
+  message: string;
+  /** Where to send the user when they click it. */
+  route: string;
+}
+
+/** One row of core's address events feed. `params` varies by event type. */
+export interface AddressEvent {
+  event_index: number;
+  event: string;
+  params?: Record<string, unknown>;
+}
+
+/**
+ * Never raise more than this many at once. A wallet that was closed over a busy weekend should
+ * produce a handful of notifications and a summary, not ninety separate alerts.
+ */
+export const MAX_NOTIFICATIONS_PER_POLL = 5;
+
+/** The events asked for. Sent to the node as a server-side filter, so nothing else arrives. */
+export const WATCHED_EVENTS = ['DISPENSE', 'ORDER_MATCH'] as const;
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+/**
+ * A dispense touches two addresses and means opposite things to each. `source` is the dispenser —
+ * the seller — and `destination` is whoever paid. Reporting both as "sold" would tell a buyer their
+ * dispenser sold something they actually just bought.
+ */
+function describeDispense(
+  params: Record<string, unknown>,
+  watched: ReadonlySet<string>
+): { title: string; message: string } | null {
+  const asset = asString(params.asset) ?? 'an asset';
+  const amount = asString(params.dispense_quantity_normalized);
+  const quantity = amount ? `${amount} ${asset}` : asset;
+
+  const source = asString(params.source);
+  const destination = asString(params.destination);
+
+  if (source && watched.has(source)) {
+    return { title: 'Dispenser sold', message: `${quantity} dispensed` };
+  }
+  if (destination && watched.has(destination)) {
+    return { title: 'Dispense received', message: `${quantity} received` };
+  }
+  // Neither side is ours. The node filters by address, so this should not arrive — and if it does,
+  // announcing a stranger's trade is worse than staying quiet.
+  return null;
+}
+
+function describeOrderMatch(params: Record<string, unknown>): { title: string; message: string } {
+  const give = asString(params.forward_asset) ?? asString(params.give_asset);
+  const get = asString(params.backward_asset) ?? asString(params.get_asset);
+  return {
+    title: 'Order matched',
+    message: give && get ? `${give} for ${get}` : 'One of your orders matched',
+  };
+}
+
+/**
+ * Turn a page of address events into notifications.
+ *
+ * `events` is newest-first, as the node returns it. `watched` decides which side of a two-sided
+ * event we are on. Only entries strictly above the watermark are announced, so a poll racing
+ * another poll, or re-running after the worker restarts, cannot say the same thing twice.
+ */
+export function detectFromEvents(
+  events: AddressEvent[],
+  state: NotificationState,
+  watched: ReadonlySet<string>
+): { notifications: PendingNotification[]; state: NotificationState; suppressed: number } {
+  if (events.length === 0) return { notifications: [], state, suppressed: 0 };
+
+  const highest = events.reduce(
+    (max, event) => (event.event_index > max ? event.event_index : max),
+    events[0]!.event_index
+  );
+
+  // First sight: take the position, say nothing.
+  if (state.lastEventIndex === undefined) {
+    return { notifications: [], state: { lastEventIndex: highest }, suppressed: 0 };
+  }
+
+  const watermark = state.lastEventIndex;
+  const fresh = events.filter((event) => event.event_index > watermark);
+
+  const all: PendingNotification[] = [];
+  for (const event of fresh) {
+    const params = event.params ?? {};
+    const described =
+      event.event === 'DISPENSE'
+        ? describeDispense(params, watched)
+        : event.event === 'ORDER_MATCH'
+          ? describeOrderMatch(params)
+          : null;
+    if (!described) continue;
+
+    const txHash = asString(params.tx_hash);
+    all.push({
+      id: `${event.event}:${event.event_index}`,
+      title: described.title,
+      message: described.message,
+      route: txHash ? `/transactions/${txHash}` : '/index',
+    });
+  }
+
+  // The watermark advances past everything read, including events that produced no notification —
+  // they have been considered, and re-reading them next poll would only re-skip them.
+  return {
+    notifications: all.slice(0, MAX_NOTIFICATIONS_PER_POLL),
+    state: { lastEventIndex: highest },
+    suppressed: Math.max(0, all.length - MAX_NOTIFICATIONS_PER_POLL),
+  };
+}

--- a/src/core/settings.ts
+++ b/src/core/settings.ts
@@ -119,6 +119,15 @@ export interface AppSettings {
   /** Block signing if local verification fails */
   strictTransactionVerification: boolean;
 
+  /**
+   * Notify on dispenser sales and order status changes.
+   *
+   * The poller cannot read this — settings live in the keychain and read as defaults while locked,
+   * which is most of the time. `notificationService` mirrors it into extension-local storage
+   * instead; this field is what the settings screen renders, and the source of truth when unlocked.
+   */
+  notificationsEnabled?: boolean;
+
   /** User has visited recover bitcoin page */
   hasVisitedRecoverBitcoin?: boolean;
 
@@ -155,6 +164,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   connectedWebsites: [],
   providerCapabilities: {},
   pinnedAssets: ['XCP', 'PEPECASH', 'BITCRYSTALS', 'BITCORN', 'CROPS', 'MINTS'],
+  notificationsEnabled: false,
   hasVisitedRecoverBitcoin: false,
 };
 

--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -11,6 +11,7 @@ import { MessageBus, } from '@/services/core/MessageBus';
 import { ServiceRegistry } from '@/services/core/ServiceRegistry';
 import { getReadinessState, markServicesReady, whenServicesReady } from '@/services/core/serviceReadiness';
 import { eventEmitterService } from '@/services/eventEmitterService';
+import { handleNotificationClick, POLL_PERIOD_MINUTES, pollOnce } from '@/services/notificationService';
 import { getPopupMonitorService } from '@/services/popupMonitorService';
 import { getProviderService, registerProviderService } from '@/services/providerService';
 import { getUpdateService } from '@/services/updateService';
@@ -400,13 +401,20 @@ export default defineBackground(() => {
   // Set up Chrome alarms for session management and keep-alive
   const KEEP_ALIVE_ALARM_NAME = 'keep-alive';
   const SESSION_EXPIRY_ALARM_NAME = 'session-expiry';
-  
+  const NOTIFICATION_POLL_ALARM_NAME = 'notification-poll';
+
   // Create keep-alive alarm to prevent service worker termination
   // This replaces the memory-leaking setTimeout approach
   chrome.alarms.create(KEEP_ALIVE_ALARM_NAME, {
     periodInMinutes: 0.4 // 24 seconds (less than Chrome's 30s timeout)
   });
-  
+
+  // Notification polling. One request covers every watched address, and `pollOnce` makes none at
+  // all unless the feature is on and permitted — so an install that never enables it costs nothing.
+  chrome.alarms.create(NOTIFICATION_POLL_ALARM_NAME, {
+    periodInMinutes: POLL_PERIOD_MINUTES
+  });
+
   // Consolidated alarm handler to avoid multiple listeners
   if (chrome?.alarms?.onAlarm) {
     chrome.alarms.onAlarm.addListener(async (alarm) => {
@@ -422,7 +430,25 @@ export default defineBackground(() => {
           // Perform minimal activity to keep service worker alive
           await serviceKeepAlive('background');
           break;
+
+        case NOTIFICATION_POLL_ALARM_NAME:
+          // No-ops, without making a request, unless the user enabled notifications and Chrome
+          // granted the permission.
+          try {
+            await pollOnce();
+          } catch (error) {
+            console.error('[Background] Notification poll failed:', error);
+          }
+          break;
       }
+    });
+  }
+
+  // Registered unconditionally and at the top level of the worker: a notification can outlive the
+  // worker that raised it, and the click has to be able to wake a fresh one.
+  if (chrome?.notifications?.onClicked) {
+    chrome.notifications.onClicked.addListener((notificationId) => {
+      void handleNotificationClick(notificationId);
     });
   }
 

--- a/src/pages/settings/advanced.tsx
+++ b/src/pages/settings/advanced.tsx
@@ -1,5 +1,5 @@
 import { Description, Field, Label, RadioGroup } from "@headlessui/react";
-import type { ReactElement } from "react";
+import type { ReactElement, ReactNode } from "react";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router";
 import { FiHelpCircle } from "@/components/icons";
@@ -8,7 +8,9 @@ import { ApiUrlInput } from "@/components/ui/inputs/api-url-input";
 import { SettingSwitch } from "@/components/ui/inputs/setting-switch";
 import { useHeader } from "@/contexts/header-context";
 import { useSettings } from "@/contexts/settings-context";
+import { useWallet } from "@/contexts/wallet-context";
 import type { AutoLockTimer } from "@/core/settings";
+import { setNotificationWatch } from "@/services/notificationService";
 
 /**
  * Constants for navigation paths and auto-lock options.
@@ -40,7 +42,40 @@ export default function AdvancedSettingsPage(): ReactElement {
   const navigate = useNavigate();
   const { setHeaderProps } = useHeader();
   const { settings, updateSettings, isLoading } = useSettings();
+  const { wallets } = useWallet();
   const [isHelpTextOverride, setIsHelpTextOverride] = useState(false);
+  const [notificationError, setNotificationError] = useState<string | null>(null);
+
+  /**
+   * Turning notifications on has to ask Chrome first, and the request must come from this click —
+   * `chrome.permissions.request()` requires a user gesture, so it cannot be deferred to the poller.
+   * If the prompt is declined the setting stays off rather than reading as on and never firing.
+   */
+  const handleNotificationsChange = async (checked: boolean): Promise<void> => {
+    setNotificationError(null);
+
+    if (!checked) {
+      await updateSettings({ notificationsEnabled: false });
+      await setNotificationWatch(false, []);
+      return;
+    }
+
+    let granted = false;
+    try {
+      granted = await chrome.permissions.request({ permissions: ['notifications'] });
+    } catch (error) {
+      console.error('[Settings] Notification permission request failed:', error);
+    }
+
+    if (!granted) {
+      setNotificationError('Chrome denied the notification permission, so this stays off.');
+      return;
+    }
+
+    const addresses = wallets.flatMap((wallet) => wallet.addresses.map((a) => a.address));
+    await updateSettings({ notificationsEnabled: true });
+    await setNotificationWatch(true, addresses);
+  };
 
 
   // Configure header
@@ -130,6 +165,17 @@ export default function AdvancedSettingsPage(): ReactElement {
           onChange={(checked) => updateSettings({ enableAdvancedBroadcasts: checked })}
           showHelpText={shouldShowHelpText}
         />
+
+        <SettingSwitch
+          label="Notifications"
+          description="Get notified when a dispenser sells or an order fills. Checks your addresses in the background once per block, and stores them unencrypted so it can keep checking while the wallet is locked. Turning this off clears them."
+          checked={settings.notificationsEnabled === true}
+          onChange={handleNotificationsChange}
+          showHelpText={shouldShowHelpText}
+        />
+        {notificationError && (
+          <p className="text-sm text-red-600" role="status">{notificationError}</p>
+        )}
       </SettingsSection>
 
       <SettingsSection id="adv-connection" title="Connection">
@@ -197,7 +243,7 @@ function SettingsSection({
 }: {
   id: string;
   title: string;
-  children: ReactElement | ReactElement[];
+  children: ReactNode;
 }): ReactElement {
   return (
     <section aria-labelledby={id} className="space-y-4">

--- a/src/services/__tests__/notificationService.test.ts
+++ b/src/services/__tests__/notificationService.test.ts
@@ -1,0 +1,217 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as api from '@/core/counterparty/api';
+import {
+  hasNotificationPermission,
+  MAX_WATCHED_ADDRESSES,
+  pollOnce,
+  readWatch,
+  setNotificationWatch,
+} from '../notificationService';
+
+vi.mock('@/core/counterparty/api');
+
+const ADDRESS = '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa';
+const OTHER = '1CounterpartyXXXXXXXXXXXXXXXUWLpVr';
+
+/** A minimal in-memory stand-in for the three Chrome APIs this service touches. */
+function installChromeStub(options: { granted?: boolean } = {}) {
+  const store: Record<string, unknown> = {};
+  const created: Array<{ id: string; title: string }> = [];
+
+  (globalThis as any).chrome = {
+    storage: {
+      local: {
+        get: vi.fn(async (key: string) => (key in store ? { [key]: store[key] } : {})),
+        set: vi.fn(async (items: Record<string, unknown>) => Object.assign(store, items)),
+        remove: vi.fn(async (key: string) => { delete store[key]; }),
+      },
+    },
+    permissions: { contains: vi.fn(async () => options.granted ?? true) },
+    notifications: {
+      create: vi.fn(async (id: string, opts: { title: string }) => {
+        created.push({ id, title: opts.title });
+        return id;
+      }),
+      clear: vi.fn(async () => true),
+    },
+    runtime: { getURL: (path: string) => `chrome-extension://test/${path}` },
+  };
+
+  return { store, created };
+}
+
+const page = (records: unknown[]) =>
+  ({ result: records, result_count: records.length }) as any;
+
+const dispense = (event_index: number, source = ADDRESS) => ({
+  event_index,
+  event: 'DISPENSE',
+  params: {
+    asset: 'XCP',
+    dispense_quantity_normalized: '1',
+    source,
+    destination: OTHER,
+    tx_hash: `hash${event_index}`,
+  },
+});
+
+describe('notification watch state', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('reads as disabled when nothing has been stored', async () => {
+    installChromeStub();
+    expect(await readWatch()).toEqual({ enabled: false, addresses: [] });
+  });
+
+  it('stores the addresses to watch when enabled', async () => {
+    installChromeStub();
+    await setNotificationWatch(true, [ADDRESS]);
+
+    const watch = await readWatch();
+    expect(watch.enabled).toBe(true);
+    expect(watch.addresses).toEqual([ADDRESS]);
+  });
+
+  // The addresses are the part worth not leaving behind, so disabling removes the record rather
+  // than setting a flag beside it.
+  it('clears the stored addresses when disabled', async () => {
+    const { store } = installChromeStub();
+    await setNotificationWatch(true, [ADDRESS]);
+    expect(store.notificationWatch).toBeDefined();
+
+    await setNotificationWatch(false, []);
+    expect(store.notificationWatch).toBeUndefined();
+    expect((await readWatch()).enabled).toBe(false);
+  });
+
+  it('keeps the watermark when re-enabled over the same address set', async () => {
+    const { store } = installChromeStub();
+    store.notificationWatch = { enabled: true, addresses: [ADDRESS], state: { lastEventIndex: 99 } };
+
+    await setNotificationWatch(true, [ADDRESS]);
+    expect((await readWatch()).state?.lastEventIndex).toBe(99);
+  });
+
+  // A watermark taken against one set says nothing about an address newly added to it: older
+  // events for that address sit below the mark and would never be seen.
+  it('drops the watermark when the address set changes', async () => {
+    const { store } = installChromeStub();
+    store.notificationWatch = { enabled: true, addresses: [ADDRESS], state: { lastEventIndex: 99 } };
+
+    await setNotificationWatch(true, [ADDRESS, OTHER]);
+    expect((await readWatch()).state).toBeUndefined();
+  });
+
+  it('caps how many addresses travel in one request', async () => {
+    installChromeStub();
+    const many = Array.from({ length: MAX_WATCHED_ADDRESSES + 5 }, (_, i) => `addr${i}`);
+
+    await setNotificationWatch(true, many);
+    expect((await readWatch()).addresses).toHaveLength(MAX_WATCHED_ADDRESSES);
+  });
+});
+
+describe('pollOnce', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('makes no request while notifications are switched off', async () => {
+    installChromeStub();
+    expect(await pollOnce()).toBe(0);
+    expect(api.fetchAddressEvents).not.toHaveBeenCalled();
+  });
+
+  // The setting and the browser grant are separate facts; a revoked permission must stop the poll
+  // before it fetches, not after.
+  it('makes no request when the permission is not granted', async () => {
+    installChromeStub({ granted: false });
+    await setNotificationWatch(true, [ADDRESS]);
+
+    expect(await pollOnce()).toBe(0);
+    expect(api.fetchAddressEvents).not.toHaveBeenCalled();
+    expect(await hasNotificationPermission()).toBe(false);
+  });
+
+  // The whole efficiency argument in one assertion: every watched address in a single call.
+  it('asks for every watched address in one request', async () => {
+    installChromeStub();
+    vi.mocked(api.fetchAddressEvents).mockResolvedValue(page([]));
+
+    await setNotificationWatch(true, [ADDRESS, OTHER]);
+    await pollOnce();
+
+    expect(api.fetchAddressEvents).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(api.fetchAddressEvents).mock.calls[0]![0]).toEqual([ADDRESS, OTHER]);
+  });
+
+  it('raises a notification for an event above the watermark', async () => {
+    const { created } = installChromeStub();
+    vi.mocked(api.fetchAddressEvents).mockResolvedValue(page([dispense(10)]));
+
+    await setNotificationWatch(true, [ADDRESS]);
+    // First poll adopts the position silently.
+    expect(await pollOnce()).toBe(0);
+    expect(created).toHaveLength(0);
+
+    vi.mocked(api.fetchAddressEvents).mockResolvedValue(page([dispense(11), dispense(10)]));
+    expect(await pollOnce()).toBe(1);
+    expect(created.map((c) => c.id)).toEqual(['DISPENSE:11']);
+  });
+
+  // A node having a bad day must not be retried on every single tick.
+  it('backs off after a failure and skips the following ticks', async () => {
+    installChromeStub();
+    vi.mocked(api.fetchAddressEvents).mockRejectedValue(new Error('node down'));
+
+    await setNotificationWatch(true, [ADDRESS]);
+    await pollOnce();
+    expect((await readWatch()).failures).toBe(1);
+
+    // Inside the backoff window: no further request.
+    vi.mocked(api.fetchAddressEvents).mockClear();
+    await pollOnce();
+    expect(api.fetchAddressEvents).not.toHaveBeenCalled();
+  });
+
+  it('doubles the wait as failures repeat', async () => {
+    installChromeStub();
+    vi.mocked(api.fetchAddressEvents).mockRejectedValue(new Error('node down'));
+    await setNotificationWatch(true, [ADDRESS]);
+
+    await pollOnce();
+    expect((await readWatch()).backoffTicks).toBe(1);
+
+    await pollOnce(); // serves the backoff
+    await pollOnce(); // fails again
+    expect((await readWatch()).backoffTicks).toBe(2);
+  });
+
+  it('clears the backoff once the node answers again', async () => {
+    installChromeStub();
+    vi.mocked(api.fetchAddressEvents).mockRejectedValue(new Error('node down'));
+    await setNotificationWatch(true, [ADDRESS]);
+    await pollOnce();
+
+    vi.mocked(api.fetchAddressEvents).mockResolvedValue(page([]));
+    await pollOnce(); // serves out the one-tick backoff
+    await pollOnce(); // succeeds
+
+    const watch = await readWatch();
+    expect(watch.failures).toBe(0);
+    expect(watch.backoffTicks).toBe(0);
+  });
+
+  it('summarises a burst instead of firing all of it', async () => {
+    const { created } = installChromeStub();
+    vi.mocked(api.fetchAddressEvents).mockResolvedValue(page([dispense(1)]));
+    await setNotificationWatch(true, [ADDRESS]);
+    await pollOnce();
+
+    vi.mocked(api.fetchAddressEvents).mockResolvedValue(
+      page(Array.from({ length: 9 }, (_, i) => dispense(20 - i)))
+    );
+    await pollOnce();
+
+    expect(created.some((c) => c.title === 'More activity')).toBe(true);
+    expect(created.length).toBeLessThan(9);
+  });
+});

--- a/src/services/notificationService.ts
+++ b/src/services/notificationService.ts
@@ -1,0 +1,261 @@
+/**
+ * On-chain notifications: telling you about things you did not do.
+ *
+ * A dispenser selling, an order matching — events that arrive without you asking, which is exactly
+ * the set worth interrupting someone for. Anything you initiated yourself already has a screen.
+ *
+ * ## Why this keeps its own copy of the addresses
+ *
+ * Settings live inside the keychain, and `getActiveSettings()` reads as defaults while the wallet
+ * is locked. The wallet auto-locks after five minutes by default, so a poller that could only read
+ * settings would be asleep almost exactly when notifications are worth having. The enable flag and
+ * the address list are therefore mirrored into `chrome.storage.local`, which the service worker can
+ * read locked or not.
+ *
+ * That is a real trade, and the settings copy says so: addresses are public data, but this writes
+ * them somewhere unencrypted that they were not before. Switching the feature off deletes them.
+ *
+ * ## What keeps this off the node's back
+ *
+ * One request per poll, covering every watched address at once. Core's `/v2/addresses/events` takes
+ * a comma-separated list and filters by event name server-side, so cost is flat in the number of
+ * addresses rather than a call per address per event type. Beyond that:
+ *
+ * - the tick is slow (see `POLL_PERIOD_MINUTES`) and the page is small;
+ * - a failing node backs the poller off exponentially instead of retrying every tick;
+ * - nothing is requested at all when the feature is off, the permission is missing, or there are no
+ *   addresses to watch — for most installs the steady-state traffic is zero;
+ * - the address list is capped, so one enormous wallet cannot turn one request into a huge one.
+ */
+
+import { fetchAddressEvents } from '@/core/counterparty/api';
+import {
+  type AddressEvent,
+  detectFromEvents,
+  MAX_NOTIFICATIONS_PER_POLL,
+  type NotificationState,
+  type PendingNotification,
+  WATCHED_EVENTS,
+} from '@/core/notifications/detect';
+
+const STORAGE_KEY = 'notificationWatch';
+
+/**
+ * How often the alarm fires. Blocks arrive about every ten minutes, so a two-minute tick already
+ * costs several redundant polls per block; anything faster buys latency nobody asked for at a
+ * multiple of the traffic. Chrome's floor for periodic alarms is well below this.
+ */
+export const POLL_PERIOD_MINUTES = 2;
+
+/**
+ * Events read per poll. Enough that an ordinary gap is covered by one request, small enough that
+ * the response stays trivial. A wallet that missed more than this shows the cap's worth and
+ * summarises the rest, rather than paging back through history it would not display anyway.
+ */
+const PAGE_SIZE = 25;
+
+/**
+ * Addresses per request. The list travels in the query string, so an unbounded wallet would build
+ * an unbounded URL; watching the first slice is a better failure than a request the node rejects.
+ */
+const MAX_WATCHED_ADDRESSES = 20;
+
+/** Consecutive failures double the wait, up to this many ticks skipped. */
+const MAX_BACKOFF_TICKS = 15;
+
+/** The mirror the service worker reads. Deliberately not the keychain's settings. */
+export interface NotificationWatch {
+  enabled: boolean;
+  addresses: string[];
+  state?: NotificationState;
+  /** Ticks still to skip before the next attempt, after a failure. */
+  backoffTicks?: number;
+  /** Consecutive failures, which is what the backoff doubles on. */
+  failures?: number;
+}
+
+const EMPTY_WATCH: NotificationWatch = { enabled: false, addresses: [] };
+
+export async function readWatch(): Promise<NotificationWatch> {
+  if (!chrome?.storage?.local) return EMPTY_WATCH;
+  try {
+    const stored = await chrome.storage.local.get(STORAGE_KEY);
+    const value = stored[STORAGE_KEY];
+    if (!value || typeof value !== 'object') return EMPTY_WATCH;
+    const watch = value as Partial<NotificationWatch>;
+    return {
+      enabled: watch.enabled === true,
+      addresses: Array.isArray(watch.addresses)
+        ? watch.addresses.filter((a): a is string => typeof a === 'string')
+        : [],
+      state: watch.state && typeof watch.state === 'object' ? watch.state : undefined,
+      backoffTicks: typeof watch.backoffTicks === 'number' ? watch.backoffTicks : undefined,
+      failures: typeof watch.failures === 'number' ? watch.failures : undefined,
+    };
+  } catch {
+    return EMPTY_WATCH;
+  }
+}
+
+async function writeWatch(watch: NotificationWatch): Promise<void> {
+  if (!chrome?.storage?.local) return;
+  try {
+    await chrome.storage.local.set({ [STORAGE_KEY]: watch });
+  } catch (error) {
+    console.error('[Notifications] Could not persist watch state:', error);
+  }
+}
+
+/**
+ * Point the poller at a set of addresses, or switch it off.
+ *
+ * Disabling deletes the record rather than setting a flag beside it: the addresses are the part
+ * worth not leaving behind. The watermark goes with them, so re-enabling starts quiet instead of
+ * announcing everything that happened while it was off.
+ */
+export async function setNotificationWatch(enabled: boolean, addresses: string[]): Promise<void> {
+  if (!enabled) {
+    if (chrome?.storage?.local) {
+      try {
+        await chrome.storage.local.remove(STORAGE_KEY);
+      } catch (error) {
+        console.error('[Notifications] Could not clear watch state:', error);
+      }
+    }
+    return;
+  }
+
+  const existing = await readWatch();
+  const watched = addresses.slice(0, MAX_WATCHED_ADDRESSES);
+  // A watermark is only meaningful for the set it was taken against: widening the set leaves older
+  // events for the new addresses sitting below it, never to be seen. Dropping it re-adopts a
+  // position on the next poll, which is silent by design.
+  const sameSet =
+    existing.addresses.length === watched.length
+    && watched.every((address) => existing.addresses.includes(address));
+
+  await writeWatch({
+    enabled: true,
+    addresses: watched,
+    state: sameSet ? existing.state : undefined,
+  });
+}
+
+/** Whether the browser has actually granted the optional permission. */
+export async function hasNotificationPermission(): Promise<boolean> {
+  if (!chrome?.permissions?.contains) return false;
+  try {
+    return await chrome.permissions.contains({ permissions: ['notifications'] });
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Where a notification should take you when clicked.
+ *
+ * In memory only: the worker may be torn down between raising a notification and the click
+ * arriving, in which case the click opens the wallet without a deep link. Persisting these would
+ * mean keeping another record of on-chain activity for a fallback that is one tap from the right
+ * place anyway.
+ */
+const routes = new Map<string, string>();
+
+async function show(notification: PendingNotification): Promise<void> {
+  if (!chrome?.notifications?.create) return;
+  try {
+    await chrome.notifications.create(notification.id, {
+      // `basic` on purpose: the image and list templates degrade on macOS — images are dropped and
+      // only the first list item survives — so anything richer would render differently per
+      // platform for no gain here.
+      type: 'basic',
+      iconUrl: chrome.runtime.getURL('icon/96.png'),
+      title: notification.title,
+      message: notification.message,
+      // Priorities below zero are ChromeOS-only and error elsewhere; zero is the portable default.
+      priority: 0,
+    });
+    routes.set(notification.id, notification.route);
+  } catch (error) {
+    console.error('[Notifications] Could not show notification:', error);
+  }
+}
+
+/** Open the wallet at whatever the notification was about. */
+export async function handleNotificationClick(notificationId: string): Promise<void> {
+  const route = routes.get(notificationId);
+  routes.delete(notificationId);
+  try {
+    await chrome.notifications.clear(notificationId);
+    const url = chrome.runtime.getURL(`popup.html${route ? `#${route}` : ''}`);
+    await chrome.tabs.create({ url });
+  } catch (error) {
+    console.error('[Notifications] Could not handle click:', error);
+  }
+}
+
+/**
+ * One tick. Returns how many notifications were raised, which is what the tests assert on.
+ *
+ * Returns early — making no request at all — whenever there is nothing to do: feature off, no
+ * addresses, permission not granted, or still inside a backoff window. A failure doubles the
+ * backoff; a success clears it.
+ */
+export async function pollOnce(): Promise<number> {
+  const watch = await readWatch();
+  if (!watch.enabled || watch.addresses.length === 0) return 0;
+  if (!(await hasNotificationPermission())) return 0;
+
+  // Serving out a backoff after a failed poll. Counting ticks rather than timing keeps the whole
+  // thing on the alarm's clock, with no wall-time arithmetic to get wrong.
+  const remaining = watch.backoffTicks ?? 0;
+  if (remaining > 0) {
+    await writeWatch({ ...watch, backoffTicks: remaining - 1 });
+    return 0;
+  }
+
+  let events: AddressEvent[];
+  try {
+    const response = await fetchAddressEvents(watch.addresses, {
+      eventNames: WATCHED_EVENTS,
+      limit: PAGE_SIZE,
+    });
+    events = response.result ?? [];
+  } catch (error) {
+    const failures = (watch.failures ?? 0) + 1;
+    const backoff = Math.min(2 ** (failures - 1), MAX_BACKOFF_TICKS);
+    console.error(`[Notifications] Poll failed, skipping ${backoff} tick(s):`, error);
+    await writeWatch({ ...watch, failures, backoffTicks: backoff });
+    return 0;
+  }
+
+  const watched = new Set(watch.addresses);
+  const result = detectFromEvents(events, watch.state ?? {}, watched);
+
+  for (const notification of result.notifications) {
+    await show(notification);
+  }
+
+  // Anything past the cap is summarised rather than dropped in silence — the user should know the
+  // wallet saw more than it showed.
+  if (result.suppressed > 0) {
+    await show({
+      id: `summary:${result.state.lastEventIndex ?? 0}`,
+      title: 'More activity',
+      message: `${result.suppressed} more event${result.suppressed === 1 ? '' : 's'} not shown`,
+      route: '/index',
+    });
+  }
+
+  await writeWatch({
+    enabled: true,
+    addresses: watch.addresses,
+    state: result.state,
+    failures: 0,
+    backoffTicks: 0,
+  });
+
+  return result.notifications.length + (result.suppressed > 0 ? 1 : 0);
+}
+
+export { MAX_NOTIFICATIONS_PER_POLL, MAX_WATCHED_ADDRESSES };

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -26,6 +26,13 @@ export default defineConfig({
         'alarms',
         'scripting', // Required for Trezor Connect to inject content scripts
       ],
+      // Optional rather than required, deliberately. A new *required* permission disables the
+      // extension on update until every existing user re-consents — an unreasonable toll for a
+      // feature most of them will never switch on. Declared here, it costs nothing until someone
+      // turns notifications on, at which point `chrome.permissions.request()` asks once.
+      optional_permissions: [
+        'notifications',
+      ],
       host_permissions: [
         '*://connect.trezor.io/9/*', // Required for Trezor Connect popup communication
         'http://localhost:21325/*', // Trezor Bridge for emulator testing


### PR DESCRIPTION
A spike, not a proposal to ship. Off by default, behind an optional permission, so it can be lived with locally before anyone decides whether it belongs.

**To try it:** load the unpacked build, Settings → Advanced → Notifications. Chrome asks once. Turning it off deletes the stored addresses.

## Optional permission, deliberately

A new *required* permission disables the extension on update until every existing user re-consents — an unreasonable toll for a feature most of them will never switch on. Declared as `optional_permissions` it costs nothing until someone enables it, at which point `chrome.permissions.request()` asks once. That call needs a user gesture, so it happens on the toggle click rather than in the poller.

I could not test the Chrome Web Store's review treatment of this from here; that is worth confirming before it goes anywhere near a release.

## What keeps it off the node's back

This was the part worth getting right — a background poller is exactly the thing that quietly becomes a nuisance.

| | |
|---|---|
| One request per poll, all addresses | `/v2/addresses/events` takes a comma-separated list and filters by event name server-side. Cost is flat in address count, not a call per address per event type. |
| Zero traffic when off | No request at all if the feature is off, the permission is missing, or there are no addresses. Most installs never make one. |
| Exponential backoff | A failing node skips 1, 2, 4… ticks rather than being retried every time. |
| Capped address list | The list travels in the query string; an unbounded wallet would build an unbounded URL. |
| Capped bursts | Five notifications and a summary. A wallet closed over a busy weekend should not produce ninety alerts. |
| Slow tick | Two minutes. Blocks are ~10, so this is already several redundant polls per block; faster buys latency nobody asked for at a multiple of the traffic. |

The first draft did two calls per address per block and gated on block height. Finding the plural-address events route made it one call regardless of address count, and made the block-height check pointless — it was itself a request, so dropping it removed one.

## The rules that make it bearable rather than noisy

**Adopt silently on first sight.** Enabling this must not replay last year. Same when the address set changes: a watermark taken against one set says nothing about an address newly added to it, so it is dropped and re-adopted rather than skipping that address's history forever.

**Direction matters.** A dispense names both sides — `source` is the seller, `destination` the buyer. Reading it the wrong way round would tell a buyer their dispenser sold something they had just bought.

## The trade I want you to look at

Addresses are mirrored into extension-local storage, unencrypted. Settings live in the keychain and read as defaults while locked, and the wallet auto-locks after five minutes — a poller that could only read settings would be asleep almost exactly when notifications are worth having.

Addresses are public data, so this is not a key leak, but it does write them somewhere they were not before. The toggle's copy says so plainly. If you would rather not, the alternative is notifications that only work while unlocked, which is close to not having them.

## Structure

Deciding what is worth announcing is pure and tested without a browser (`core/notifications/detect.ts`, 14 tests). The service owns storage, backoff and the Chrome calls (`services/notificationService.ts`, 14 tests). The layering invariant caught two of my comments mentioning `chrome.` inside `core/` — reworded, since both modules are genuinely runtime-free.

## Verification

4414 unit tests pass; `tsc`, `biome`, `oxlint` clean. Build produces `"optional_permissions":["notifications"]` in the manifest. Not manually exercised in a browser — that is what this branch is for.

## Known gaps

- Only `DISPENSE` and `ORDER_MATCH`. The BTC-leg match with a payment deadline is the one with real money at stake and deserves its own treatment.
- Click routing is in-memory, so a click after the worker restarts opens the wallet without a deep link.
- Notifications appear as native macOS notifications there, which changes how priority and richer templates behave; `basic` is used throughout to avoid depending on any of it.

https://claude.ai/code/session_01QJS9Bj6uAMoYPATvfr6GZ1
