### PR TITLE
Spike: read pending balance from the node instead of deriving it

### DIFF
--- a/src/core/balances/__tests__/pending.test.ts
+++ b/src/core/balances/__tests__/pending.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from 'vitest';
+import {
+  countUnreadable,
+  type MempoolLedgerEvent,
+  pendingByAsset,
+  summarize,
+} from '../pending';
+
+const MINE = '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa';
+const THEIRS = '1CounterpartyXXXXXXXXXXXXXXXUWLpVr';
+
+const debit = (
+  quantity: number | string,
+  overrides: Partial<MempoolLedgerEvent['params']> = {},
+  tx_hash = 'tx1'
+): MempoolLedgerEvent => ({
+  tx_hash,
+  event: 'DEBIT',
+  params: { address: MINE, asset: 'XCP', quantity, action: 'issuance fee', ...overrides },
+});
+
+const credit = (
+  quantity: number | string,
+  overrides: Partial<MempoolLedgerEvent['params']> = {},
+  tx_hash = 'tx1'
+): MempoolLedgerEvent => ({
+  tx_hash,
+  event: 'CREDIT',
+  params: { address: MINE, asset: 'XCP', quantity, calling_function: 'issuance', ...overrides },
+});
+
+describe('pendingByAsset', () => {
+  it('totals pending debits for an asset', () => {
+    const result = pendingByAsset([debit(100), debit(50, {}, 'tx2')], MINE);
+
+    expect(result.get('XCP')?.debited).toBe(150n);
+    expect(result.get('XCP')?.credited).toBe(0n);
+  });
+
+  it('keeps debits and credits apart rather than netting them', () => {
+    const result = pendingByAsset([debit(100), credit(30)], MINE);
+
+    expect(result.get('XCP')?.debited).toBe(100n);
+    expect(result.get('XCP')?.credited).toBe(30n);
+  });
+
+  // The endpoint matches addresses with SQL LIKE against a joined column, so its results are a
+  // superset. Without this filter a neighbour's debit would be subtracted from your balance.
+  it('ignores events belonging to another address', () => {
+    const result = pendingByAsset([debit(100), debit(999, { address: THEIRS })], MINE);
+
+    expect(result.get('XCP')?.debited).toBe(100n);
+  });
+
+  it('separates assets', () => {
+    const result = pendingByAsset([debit(100), debit(7, { asset: 'PEPECASH' })], MINE);
+
+    expect(result.get('XCP')?.debited).toBe(100n);
+    expect(result.get('PEPECASH')?.debited).toBe(7n);
+  });
+
+  // Counterparty quantities are unsigned 64-bit. Rounding one to a double is the exact failure this
+  // module exists to prevent, so a large value has to survive as an integer.
+  it('is exact for quantities beyond a double', () => {
+    const huge = '99526925811111111';
+    const result = pendingByAsset([debit(huge, { asset: 'PEPECASH' })], MINE);
+
+    expect(result.get('PEPECASH')?.debited).toBe(99526925811111111n);
+    expect(result.get('PEPECASH')?.debited.toString()).toBe(huge);
+  });
+
+  it('skips a quantity it cannot read exactly, rather than guessing', () => {
+    const result = pendingByAsset([debit(1.5), debit('not a number', {}, 'tx2')], MINE);
+    expect(result.size).toBe(0);
+  });
+
+  it('collects the reasons behind a figure', () => {
+    const result = pendingByAsset(
+      [debit(100, { action: 'issuance fee' }), debit(2, { action: 'fairmint payment' }, 'tx2')],
+      MINE
+    );
+
+    expect(result.get('XCP')?.reasons).toEqual(['issuance fee', 'fairmint payment']);
+  });
+
+  it('does not repeat a reason or a transaction', () => {
+    const result = pendingByAsset([debit(1), debit(2)], MINE);
+
+    expect(result.get('XCP')?.reasons).toEqual(['issuance fee']);
+    expect(result.get('XCP')?.txHashes).toEqual(['tx1']);
+  });
+
+  it('lists each contributing transaction for linking', () => {
+    const result = pendingByAsset([debit(1), debit(2, {}, 'tx2')], MINE);
+    expect(result.get('XCP')?.txHashes).toEqual(['tx1', 'tx2']);
+  });
+
+  it('ignores event types that are not ledger movements', () => {
+    const result = pendingByAsset(
+      [{ tx_hash: 'tx1', event: 'NEW_TRANSACTION', params: { address: MINE, asset: 'XCP', quantity: 5 } }],
+      MINE
+    );
+
+    expect(result.size).toBe(0);
+  });
+
+  it('returns nothing for an empty mempool', () => {
+    expect(pendingByAsset([], MINE).size).toBe(0);
+  });
+});
+
+describe('countUnreadable', () => {
+  // "Something is pending that I could not total" and "nothing is pending" are different claims,
+  // and only one of them is safe to render as a balance.
+  it('counts our own events that could not be folded in', () => {
+    expect(countUnreadable([debit(1.5), debit('x', {}, 'tx2'), debit(10, {}, 'tx3')], MINE)).toBe(2);
+  });
+
+  it('does not count unreadable events belonging to another address', () => {
+    expect(countUnreadable([debit(1.5, { address: THEIRS })], MINE)).toBe(0);
+  });
+
+  it('counts an event with no asset', () => {
+    expect(countUnreadable([debit(10, { asset: undefined })], MINE)).toBe(1);
+  });
+});
+
+describe('summarize', () => {
+  it('leaves the confirmed balance alone and reports spendable separately', () => {
+    const delta = pendingByAsset([debit(100)], MINE).get('XCP');
+    const summary = summarize(400n, delta);
+
+    expect(summary.confirmed).toBe(400n);
+    expect(summary.spendable).toBe(300n);
+    expect(summary.outgoing).toBe(100n);
+  });
+
+  it('reports nothing pending when the mempool is empty for that asset', () => {
+    const summary = summarize(400n, undefined);
+
+    expect(summary.confirmed).toBe(400n);
+    expect(summary.spendable).toBe(400n);
+    expect(summary.outgoing).toBe(0n);
+    expect(summary.inconsistent).toBe(false);
+  });
+
+  // Pending debits above the confirmed balance are impossible per the ledger, so seeing them means
+  // the two reads disagree — mid-reorg, or a stale balance. A negative "spendable" would be a
+  // confident lie; falling back to the confirmed figure and flagging it is not.
+  it('flags a disagreement instead of reporting a negative balance', () => {
+    const delta = pendingByAsset([debit(500)], MINE).get('XCP');
+    const summary = summarize(400n, delta);
+
+    expect(summary.inconsistent).toBe(true);
+    expect(summary.spendable).toBe(400n);
+  });
+
+  it('carries the reasons through for display', () => {
+    const delta = pendingByAsset([debit(100, { action: 'fairmint payment' })], MINE).get('XCP');
+    expect(summarize(400n, delta).reasons).toEqual(['fairmint payment']);
+  });
+
+  it('reports incoming separately, without adding it to spendable', () => {
+    const delta = pendingByAsset([credit(50)], MINE).get('XCP');
+    const summary = summarize(400n, delta);
+
+    expect(summary.incoming).toBe(50n);
+    // Unconfirmed money in is not money you can spend.
+    expect(summary.spendable).toBe(400n);
+  });
+});

--- a/src/core/balances/pending.ts
+++ b/src/core/balances/pending.ts
@@ -1,0 +1,191 @@
+/**
+ * What the mempool is about to do to a balance.
+ *
+ * The problem this solves: `/addresses/{address}/balances` is the confirmed ledger. Counterparty
+ * debits at parse time, so an unconfirmed fairmint leaves the XCP it will spend sitting in your
+ * balance looking spendable — and nothing stops you composing a DEX order against the same coins.
+ * Whichever confirms second fails.
+ *
+ * The thing *not* to do is re-derive Counterparty's debit rules here. Which message types debit
+ * what, in which order, under which protocol activations, is consensus logic; a second
+ * implementation of it in a wallet would be wrong eventually and wrong silently. Core already
+ * parses mempool transactions and emits the same DEBIT and CREDIT events it emits for confirmed
+ * ones, with `action`/`calling_function` naming the reason. So the wallet asks rather than derives.
+ *
+ * Double counting is core's problem and core handles it: when a block is parsed, the mempool rows
+ * for the transactions it contained are deleted in the *same* database transaction that marks the
+ * block parsed (`parser/blocks.py`), specifically so an API reader cannot observe a transaction as
+ * both confirmed and pending. There is no window to defend against here.
+ *
+ * What this cannot see: a transaction the queried node has not accepted into its own mempool.
+ * Mempools differ, and a wallet pointed at a node that never saw the broadcast will show nothing
+ * pending. That is a floor on what any client-side answer can claim, which is why the UI wording
+ * this feeds should describe what is known rather than assert what is spendable.
+ */
+
+/** A DEBIT or CREDIT the node has parsed out of a mempool transaction. */
+export interface MempoolLedgerEvent {
+  tx_hash: string;
+  event: string;
+  params?: {
+    address?: string;
+    asset?: string;
+    /** Base units. Unsigned 64-bit, so it may arrive as a string. */
+    quantity?: number | string;
+    /** Why the debit happened, e.g. "issuance fee". DEBIT only. */
+    action?: string;
+    /** Why the credit happened, e.g. "issuance". CREDIT only. */
+    calling_function?: string;
+  };
+}
+
+/** The net effect of the mempool on one asset, in base units. */
+export interface PendingDelta {
+  asset: string;
+  /** Leaving the address if these confirm. */
+  debited: bigint;
+  /** Arriving if these confirm. */
+  credited: bigint;
+  /** Distinct reasons, in first-seen order, for explaining the figure. */
+  reasons: string[];
+  /** Distinct transactions contributing, so the UI can link to them. */
+  txHashes: string[];
+}
+
+/**
+ * Base units as an exact integer.
+ *
+ * Counterparty quantities are unsigned 64-bit and a JS double is exact only to 2^53-1, so anything
+ * large arrives as a string. `BigInt` is exact for both; `Number` would silently round, which for a
+ * balance is the whole bug this module exists to avoid. Anything not a whole number is rejected
+ * rather than truncated — a fractional base unit means the value is not what this thinks it is.
+ */
+function toBaseUnits(value: number | string | undefined): bigint | null {
+  if (value === undefined || value === null) return null;
+  if (typeof value === 'number') {
+    return Number.isSafeInteger(value) ? BigInt(value) : null;
+  }
+  const trimmed = value.trim();
+  return /^-?\d+$/.test(trimmed) ? BigInt(trimmed) : null;
+}
+
+function addReason(delta: PendingDelta, reason: string | undefined): void {
+  if (reason && !delta.reasons.includes(reason)) delta.reasons.push(reason);
+}
+
+/**
+ * Fold mempool ledger events into a per-asset view of what is pending for one address.
+ *
+ * `address` is matched exactly against each event's own `params.address`. The endpoint that
+ * supplies these matches addresses with a SQL `LIKE '%address%'` against a joined column, so its
+ * results are a superset by construction — filtering here is what makes the answer this address's
+ * rather than a neighbour's.
+ *
+ * Events missing an address, asset or a readable quantity are skipped: a partial figure presented
+ * as a balance is worse than admitting the mempool holds something unreadable, which
+ * {@link countUnreadable} reports separately.
+ */
+export function pendingByAsset(
+  events: MempoolLedgerEvent[],
+  address: string
+): Map<string, PendingDelta> {
+  const byAsset = new Map<string, PendingDelta>();
+
+  for (const event of events) {
+    const params = event.params;
+    if (!params || params.address !== address) continue;
+
+    const asset = params.asset;
+    if (!asset) continue;
+
+    const quantity = toBaseUnits(params.quantity);
+    if (quantity === null) continue;
+
+    let delta = byAsset.get(asset);
+    if (!delta) {
+      delta = { asset, debited: 0n, credited: 0n, reasons: [], txHashes: [] };
+      byAsset.set(asset, delta);
+    }
+
+    if (event.event === 'DEBIT') {
+      delta.debited += quantity;
+      addReason(delta, params.action);
+    } else if (event.event === 'CREDIT') {
+      delta.credited += quantity;
+      addReason(delta, params.calling_function);
+    } else {
+      continue;
+    }
+
+    if (!delta.txHashes.includes(event.tx_hash)) delta.txHashes.push(event.tx_hash);
+  }
+
+  // A zero net with no reasons carries no information; a zero net *with* reasons does (something is
+  // in flight that happens to balance out), so only the truly empty are dropped.
+  for (const [asset, delta] of byAsset) {
+    if (delta.debited === 0n && delta.credited === 0n && delta.reasons.length === 0) {
+      byAsset.delete(asset);
+    }
+  }
+
+  return byAsset;
+}
+
+/**
+ * Events for this address that could not be folded in — an unreadable quantity, a missing asset.
+ *
+ * Reported rather than ignored. "Something is pending that I could not total" is a different
+ * statement from "nothing is pending", and only one of them is safe to render as a balance.
+ */
+export function countUnreadable(events: MempoolLedgerEvent[], address: string): number {
+  let unreadable = 0;
+  for (const event of events) {
+    if (event.event !== 'DEBIT' && event.event !== 'CREDIT') continue;
+    const params = event.params;
+    if (!params || params.address !== address) continue;
+    if (!params.asset || toBaseUnits(params.quantity) === null) unreadable += 1;
+  }
+  return unreadable;
+}
+
+/** What a balance row should say about one asset. */
+export interface PendingSummary {
+  /** Confirmed, straight from the ledger. Never adjusted. */
+  confirmed: bigint;
+  /** Confirmed minus pending debits: what a new transaction can actually draw on. */
+  spendable: bigint;
+  /** Pending debits, as a positive number. */
+  outgoing: bigint;
+  /** Pending credits, as a positive number. */
+  incoming: bigint;
+  reasons: string[];
+  /**
+   * True when pending debits exceed the confirmed balance, which the ledger says cannot happen.
+   * Signals a disagreement — a node mid-reorg, a stale balance read — rather than a spendable
+   * figure, so callers show the confirmed number and say nothing about spendable.
+   */
+  inconsistent: boolean;
+}
+
+/**
+ * Combine a confirmed balance with the pending view.
+ *
+ * `spendable` is deliberately a separate figure rather than a replacement for `confirmed`. A
+ * headline number that quietly changes meaning is its own defect: someone who reads "4 XCP" and
+ * later reads "0 XCP" with no explanation has been told two different things by the same label.
+ * Show the confirmed balance, and say what is in flight beside it.
+ */
+export function summarize(confirmed: bigint, delta: PendingDelta | undefined): PendingSummary {
+  const outgoing = delta?.debited ?? 0n;
+  const incoming = delta?.credited ?? 0n;
+  const inconsistent = outgoing > confirmed;
+
+  return {
+    confirmed,
+    spendable: inconsistent ? confirmed : confirmed - outgoing,
+    outgoing,
+    incoming,
+    reasons: delta?.reasons ?? [],
+    inconsistent,
+  };
+}

--- a/src/core/counterparty/api.ts
+++ b/src/core/counterparty/api.ts
@@ -1123,6 +1123,30 @@ export async function fetchDispenserDispenses(
   });
 }
 
+/**
+ * Ledger movements the node has parsed out of its own mempool for these addresses.
+ *
+ * The events are the same DEBIT/CREDIT core emits for confirmed transactions, so a caller can total
+ * what is in flight without re-deriving which message types debit what — see
+ * `core/balances/pending.ts`.
+ *
+ * Two things about this endpoint shape the caller. It matches addresses with a SQL `LIKE` against a
+ * joined column, so results are a superset and must be filtered on each event's own
+ * `params.address`. And it is never cached: a pending balance read from a minute-old response is
+ * the staleness this is meant to cure.
+ */
+export async function fetchMempoolLedgerEvents(
+  addresses: string[],
+  options: { limit?: number; verbose?: boolean } = {}
+): Promise<PaginatedResponse<{ tx_hash: string; event: string; params?: Record<string, unknown> }>> {
+  return cpApiGet('/v2/addresses/mempool', {
+    addresses: addresses.join(','),
+    event_name: 'DEBIT,CREDIT',
+    verbose: options.verbose ?? true,
+    limit: options.limit ?? 100,
+  }, { skipCache: true });
+}
+
 export async function fetchMempoolDispenses(dispenserAddress: string): Promise<Dispense[]> {
   const data = await cpApiGet<PaginatedResponse<{ params: Dispense }>>('/v2/mempool/events/DISPENSE', {
     verbose: true,


### PR DESCRIPTION
Research spike into @davesta's STARMONEY report. No UI yet — the finding is the deliverable, and the display decisions are the part worth arguing with before anything gets drawn.

## The good news: we don't have to derive this

My worry was that computing "what's committed but not yet debited" means re-implementing Counterparty's debit rules in the wallet — which message types debit what, in what order, under which activations. That's consensus logic, and a second copy of it would be wrong eventually and wrong silently.

It isn't necessary. **Core parses mempool transactions and emits the same `DEBIT`/`CREDIT` events it emits for confirmed ones**, with `action`/`calling_function` naming the reason. The wallet asks instead of deriving.

Verified live — a pending issuance returns its `CREDIT` of the new asset and its `DEBIT` of the XCP fee, both labelled. And a fairmint debits XCP with an action string (`fairmint.py:287`), so davesta's exact case arrives pre-explained.

## Three things I checked because they'd have sunk it

**Double counting.** I expected a race between "confirmed in a block" and "still in mempool". Core closes it: mempool rows for a block's transactions are deleted **in the same database transaction** that marks the block parsed, with a comment saying that's exactly so an API reader can't observe both. Nothing to defend against.

**Address matching.** `/v2/addresses/mempool` matches with SQL `LIKE '%address%'` against a joined column, so results are a *superset*. Every event is filtered on its own `params.address` here — without that, a neighbour's debit could be subtracted from your balance.

**64-bit exactness.** Quantities stay `bigint` end to end. Rounding one through a double is the precise failure this exists to prevent.

## What it can't do

It only sees what **the queried node** has in its mempool. Point the wallet at a node that never saw your broadcast and it shows nothing pending. That's a floor on any client-side answer, and it's why the UI wording should describe what's known rather than assert what's spendable.

## Two display decisions baked in

**The confirmed balance is never adjusted.** `spendable` is a separate figure. A headline number that quietly changes meaning is its own defect — read "4 XCP", then later "0 XCP", same label, two different claims.

**Pending debits exceeding the confirmed balance is reported as a disagreement, not rendered.** The ledger says it can't happen, so seeing it means the two reads disagree (mid-reorg, stale balance). A confident negative would be a lie.

## One correction to the original feedback

davesta asked for escrow display on DEX orders too. That's **already correct behaviour** — an order debits `give_quantity` at parse time with action `"open order"` (`order.py:439`), so a confirmed open order's funds are already out of your balance. The gap there isn't accounting, it's that nothing tells you *why* your XCP dropped or that cancelling returns it. Different feature.

## Verification

19 tests on the pure module; 4406 unit tests pass overall; `tsc` and `biome` clean. Live-checked against api.counterparty.io.

https://claude.ai/code/session_01QJS9Bj6uAMoYPATvfr6GZ1
