### PR TITLE
Spike: refresh button, and what the mempool is doing to each row

### DIFF
--- a/src/components/domain/asset/asset-list.tsx
+++ b/src/components/domain/asset/asset-list.tsx
@@ -29,7 +29,18 @@ export const AssetList = ({ refreshNonce, onRefreshed }: AssetListProps = {}): R
   const [isFetchingMore, setIsFetchingMore] = useState(false);
   const [initialLoaded, setInitialLoaded] = useState(false);
 
-  useRefreshSignal(refreshNonce, () => setInitialLoaded(false));
+  // See BalanceList: the ref confines the completion callback to refreshes that were requested.
+  const refreshRequestedRef = useRef(false);
+  useRefreshSignal(refreshNonce, () => {
+    refreshRequestedRef.current = true;
+    setInitialLoaded(false);
+  });
+  const settleRefresh = () => {
+    if (refreshRequestedRef.current) {
+      refreshRequestedRef.current = false;
+      latestOnRefreshed.current?.();
+    }
+  };
 
   // Ref, not a dependency: callers pass an inline arrow that changes every parent render.
   const latestOnRefreshed = useRef(onRefreshed);
@@ -59,7 +70,12 @@ export const AssetList = ({ refreshNonce, onRefreshed }: AssetListProps = {}): R
 
   // Initial load
   useEffect(() => {
-    if (!activeAddress?.address || initialLoaded) return;
+    if (!activeAddress?.address || initialLoaded) {
+      // A refresh that raced the address going away is still over; without this the caller's
+      // spinner would wait on a load that is never going to start.
+      if (!activeAddress?.address) settleRefresh();
+      return;
+    }
 
     let isCancelled = false;
 
@@ -80,7 +96,7 @@ export const AssetList = ({ refreshNonce, onRefreshed }: AssetListProps = {}): R
         if (!isCancelled) setIsLoading(false);
         // Outside the cancelled guard: a cancelled load still ends the refresh the caller is
         // showing a spinner for.
-        latestOnRefreshed.current?.();
+        settleRefresh();
       }
     };
 

--- a/src/components/domain/asset/asset-list.tsx
+++ b/src/components/domain/asset/asset-list.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { AssetCard } from "@/components/domain/asset/asset-card";
 import { SearchResultCard } from "@/components/domain/asset/search-result-card";
 import { SearchInput } from "@/components/ui/inputs/search-input";
@@ -7,11 +7,19 @@ import { useHeader } from "@/contexts/header-context";
 import { useWallet } from "@/contexts/wallet-context";
 import { fetchOwnedAssets, type OwnedAsset } from "@/core/counterparty/api";
 import { useInView } from "@/hooks/useInView";
+import { useRefreshSignal } from "@/hooks/useRefreshSignal";
 import { useSearchQuery } from "@/hooks/useSearchQuery";
 
 const PAGE_SIZE = 20;
 
-export const AssetList = (): React.ReactElement => {
+interface AssetListProps {
+  /** Changes to ask for a fresh load; see `useRefreshSignal`. */
+  refreshNonce?: number;
+  /** Called when a requested refresh finishes, successfully or not. */
+  onRefreshed?: () => void;
+}
+
+export const AssetList = ({ refreshNonce, onRefreshed }: AssetListProps = {}): React.ReactElement => {
   const { activeAddress } = useWallet();
   const { cacheOwnedAssets } = useHeader();
   const [ownedAssets, setOwnedAssets] = useState<OwnedAsset[]>([]);
@@ -20,6 +28,12 @@ export const AssetList = (): React.ReactElement => {
   const [isLoading, setIsLoading] = useState(false);
   const [isFetchingMore, setIsFetchingMore] = useState(false);
   const [initialLoaded, setInitialLoaded] = useState(false);
+
+  useRefreshSignal(refreshNonce, () => setInitialLoaded(false));
+
+  // Ref, not a dependency: callers pass an inline arrow that changes every parent render.
+  const latestOnRefreshed = useRef(onRefreshed);
+  latestOnRefreshed.current = onRefreshed;
   const { searchQuery, setSearchQuery, searchResults, isSearching } = useSearchQuery();
 
   const { ref: loadMoreRef, inView } = useInView({ rootMargin: "300px", threshold: 0 });
@@ -64,6 +78,9 @@ export const AssetList = (): React.ReactElement => {
         console.error("Error fetching owned assets:", error);
       } finally {
         if (!isCancelled) setIsLoading(false);
+        // Outside the cancelled guard: a cancelled load still ends the refresh the caller is
+        // showing a spinner for.
+        latestOnRefreshed.current?.();
       }
     };
 

--- a/src/components/domain/balance/balance-card.tsx
+++ b/src/components/domain/balance/balance-card.tsx
@@ -2,6 +2,7 @@ import type { ReactElement } from "react";
 import { useNavigate } from "react-router";
 import { AssetIcon } from "@/components/domain/asset/asset-icon";
 import { BalanceMenu } from "@/components/domain/balance/balance-menu";
+import { PendingStatus } from "@/components/domain/balance/pending-status";
 import type { TokenBalance } from "@/core/counterparty/api";
 import { formatAmount, formatAsset } from "@/core/format";
 
@@ -17,6 +18,11 @@ interface BalanceCardProps {
   showMenu?: boolean;
   /** Optional custom CSS classes */
   className?: string;
+  /**
+   * What the mempool is doing to this asset, e.g. "Sending". Shown bottom-right in italics beside
+   * the amount. The amount itself is the confirmed balance and is never adjusted to match.
+   */
+  pendingStatus?: string;
 }
 
 /**
@@ -44,7 +50,8 @@ export function BalanceCard({
   token,
   onClick,
   showMenu = true,
-  className = ""
+  className = "",
+  pendingStatus,
 }: BalanceCardProps): ReactElement {
   const navigate = useNavigate();
 
@@ -79,14 +86,18 @@ export function BalanceCard({
             {formatAsset(token.asset, { assetInfo: token.asset_info, shorten: true })}
           </div>
 
-          {/* Balance Amount */}
-          <div className="text-sm text-gray-500">
-            {formatAmount({
-              value: token.quantity_normalized,
-              minimumFractionDigits: isDivisible ? 8 : 0,
-              maximumFractionDigits: isDivisible ? 8 : 0,
-              useGrouping: true,
-            })}
+          {/* Balance amount, with whatever the mempool is doing to it on the right. */}
+          <div className="flex justify-between items-baseline">
+            <span className="text-sm text-gray-500">
+              {formatAmount({
+                value: token.quantity_normalized,
+                minimumFractionDigits: isDivisible ? 8 : 0,
+                maximumFractionDigits: isDivisible ? 8 : 0,
+                useGrouping: true,
+              })}
+            </span>
+            {/* Reserve room for the menu button, which floats over the card's top right. */}
+            {pendingStatus && <PendingStatus label={pendingStatus} className="ml-2 mr-6" />}
           </div>
         </div>
       </button>

--- a/src/components/domain/balance/balance-header.test.tsx
+++ b/src/components/domain/balance/balance-header.test.tsx
@@ -49,6 +49,58 @@ describe('BalanceHeader', () => {
     vi.clearAllMocks();
   });
 
+  describe('pending line', () => {
+    // What lets the balance itself be the spendable figure: the in-flight remainder is stated
+    // beside it rather than silently missing from it.
+    it('shows what is pending when a total is known', () => {
+      render(<BalanceHeader balance={mockBalance} pendingOutgoing="1.5" />);
+
+      expect(screen.getByText(/−1\.5 pending/)).toBeInTheDocument();
+    });
+
+    it('shows nothing when nothing is pending', () => {
+      render(<BalanceHeader balance={mockBalance} pendingOutgoing="0" />);
+
+      expect(screen.queryByText(/pending/)).not.toBeInTheDocument();
+    });
+
+    it('shows nothing when the props are not supplied', () => {
+      render(<BalanceHeader balance={mockBalance} />);
+
+      expect(screen.queryByText(/pending/)).not.toBeInTheDocument();
+    });
+
+    // A pending debit exists but could not be totalled, so nothing was subtracted from the
+    // balance. Saying so beats showing a number nobody has.
+    it('says the amount is unknown rather than inventing one', () => {
+      render(<BalanceHeader balance={mockBalance} unknownPending />);
+
+      expect(screen.getByText(/pending amount unknown/)).toBeInTheDocument();
+    });
+
+    it('shows incoming with an explicit plus, separate from the balance', () => {
+      render(<BalanceHeader balance={mockBalance} pendingIncoming="5" />);
+
+      expect(screen.getByText(/\+5 incoming/)).toBeInTheDocument();
+    });
+
+    it('can say both directions at once', () => {
+      render(<BalanceHeader balance={mockBalance} pendingOutgoing="1" pendingIncoming="5" />);
+
+      expect(screen.getByText(/−1 pending/)).toBeInTheDocument();
+      expect(screen.getByText(/\+5 incoming/)).toBeInTheDocument();
+    });
+
+    // A known total wins over the unknown flag: the flag says "a term was missing", and when a
+    // figure is present anyway the figure is the more useful of the two statements.
+    it('prefers a known figure over the unknown message', () => {
+      render(<BalanceHeader balance={mockBalance} pendingOutgoing="2" unknownPending />);
+
+      expect(screen.getByText(/−2 pending/)).toBeInTheDocument();
+      expect(screen.queryByText(/pending amount unknown/)).not.toBeInTheDocument();
+    });
+  });
+
   it('should render balance information', () => {
     render(<BalanceHeader balance={mockBalance} />);
     

--- a/src/components/domain/balance/balance-header.tsx
+++ b/src/components/domain/balance/balance-header.tsx
@@ -2,6 +2,7 @@ import type { ReactElement } from 'react';
 import { AssetIcon } from '@/components/domain/asset/asset-icon';
 import type { TokenBalance } from '@/core/counterparty/api';
 import { formatAmount } from '@/core/format';
+import { toBigNumber } from '@/core/numeric';
 
 /**
  * Props for the BalanceHeader component.
@@ -11,6 +12,24 @@ interface BalanceHeaderProps {
   balance: TokenBalance;
   /** Optional CSS classes */
   className?: string;
+  /**
+   * Display units already committed by unconfirmed transactions. When present and non-zero, a
+   * "pending" line renders under the balance — which is what lets the balance itself be the
+   * spendable figure without silently disagreeing with an explorer: the two lines together are
+   * the whole story (what you can spend now, and what is in flight).
+   */
+  pendingOutgoing?: string;
+  /**
+   * Display units arriving from unconfirmed transactions. Never part of the balance figure —
+   * unconfirmed money in is not money you can spend — so it renders with an explicit plus.
+   */
+  pendingIncoming?: string;
+  /**
+   * Something is pending whose total could not be read. The balance then shows the confirmed
+   * figure (nothing was subtracted — a partial subtraction would understate what is committed),
+   * and the note says so instead of showing a number nobody has.
+   */
+  unknownPending?: boolean;
 }
 
 /**
@@ -38,7 +57,20 @@ interface BalanceHeaderProps {
  * (since #291) depends on it, so the two overwrote each other and the dispenser form's balance
  * alternated between 0 and the real amount at render speed.
  */
-export const BalanceHeader = ({ balance, className = '' }: BalanceHeaderProps): ReactElement => {
+export const BalanceHeader = ({
+  balance,
+  className = '',
+  pendingOutgoing,
+  pendingIncoming,
+  unknownPending,
+}: BalanceHeaderProps): ReactElement => {
+  const hasPending = !!pendingOutgoing && toBigNumber(pendingOutgoing).isGreaterThan(0);
+  const hasIncoming = !!pendingIncoming && toBigNumber(pendingIncoming).isGreaterThan(0);
+  const pendingDigits = {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: balance.asset_info?.divisible ? 8 : 0,
+    useGrouping: true,
+  };
   // Format the balance based on divisibility
   const formattedBalance = balance.quantity_normalized
     ? formatAmount({
@@ -58,7 +90,25 @@ export const BalanceHeader = ({ balance, className = '' }: BalanceHeaderProps): 
       <AssetIcon asset={balance.asset} size="lg" className="mr-4" />
       <div>
         <h2 className={`${textSizeClass} font-bold break-all`}>{displayName}</h2>
-        <p className="text-sm text-gray-600">Balance: {formattedBalance}</p>
+        <p className="text-sm text-gray-600">
+          Balance: {formattedBalance}
+          {/* Signed, because unsigned was genuinely ambiguous: "9 (1 pending)" reads as
+              about-to-be-10 as easily as about-to-be-8. Minus means leaving and already excluded
+              from the figure; plus means arriving and not yet included. */}
+          {hasPending && (
+            <span className="text-xs italic text-gray-400">
+              {' '}(−{formatAmount({ value: pendingOutgoing!, ...pendingDigits })} pending)
+            </span>
+          )}
+          {hasIncoming && (
+            <span className="text-xs italic text-gray-400">
+              {' '}(+{formatAmount({ value: pendingIncoming!, ...pendingDigits })} incoming)
+            </span>
+          )}
+          {!hasPending && unknownPending && (
+            <span className="text-xs italic text-gray-400"> (pending amount unknown)</span>
+          )}
+        </p>
       </div>
     </div>
   );

--- a/src/components/domain/balance/balance-list.tsx
+++ b/src/components/domain/balance/balance-list.tsx
@@ -1,4 +1,4 @@
-import { type ReactElement, useCallback, useEffect, useRef, useState } from "react";
+import { type ReactElement, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { SearchResultCard } from "@/components/domain/asset/search-result-card";
 import { BalanceCard } from "@/components/domain/balance/balance-card";
 import { SearchInput } from "@/components/ui/inputs/search-input";
@@ -6,12 +6,14 @@ import { Spinner } from "@/components/ui/spinner";
 import { useHeader } from "@/contexts/header-context";
 import { useSettings } from "@/contexts/settings-context";
 import { useWallet } from "@/contexts/wallet-context";
+import { pendingLabel } from "@/core/balances/pendingLabel";
+import { spendableBalance, tracksPendingLedgerDebits } from "@/core/balances/spendable";
 import { fetchBTCBalance } from "@/core/bitcoin/balance";
 import type { TokenBalance } from "@/core/counterparty/api";
 import { fetchTokenBalance, fetchTokenBalances } from "@/core/counterparty/api";
 import { asDisplayUnits, fromSatoshis, isGreaterThan } from '@/core/numeric';
 import { useInView } from "@/hooks/useInView";
-import { usePendingStatus } from "@/hooks/usePendingStatus";
+import { usePendingDeltas } from "@/hooks/usePendingStatus";
 import { useRefreshSignal } from "@/hooks/useRefreshSignal";
 import { useSearchQuery } from "@/hooks/useSearchQuery";
 
@@ -53,12 +55,38 @@ export const BalanceList = ({ refreshNonce, onRefreshed }: BalanceListProps = {}
 
   // Read alongside the balances and on the same refresh, so the amount and what is happening to it
   // never come from two different moments.
-  const { byAsset: pendingByAssetLabel } = usePendingStatus(activeAddress?.address, refreshNonce);
+  const { byAsset: pendingDeltas } = usePendingDeltas(activeAddress?.address, refreshNonce);
+
+  /**
+   * The figure on the card is what is spendable, not what the ledger has confirmed.
+   *
+   * The alternative was showing the confirmed balance here and the spendable one in the forms, but
+   * two screens disagreeing about the same asset is worse than one number that differs from an
+   * explorer — and the italic status beside it is what explains the difference. Everywhere in this
+   * wallet, the number means the same thing: what you can spend right now.
+   */
+  const displayBalance = useCallback((balance: TokenBalance): TokenBalance => {
+    const pending = pendingDeltas.get(balance.asset);
+    if (!pending || !tracksPendingLedgerDebits(balance.asset)) return balance;
+
+    const { spendable } = spendableBalance(balance.quantity_normalized, pending.debitedNormalized);
+    if (spendable === balance.quantity_normalized) return balance;
+    return { ...balance, quantity_normalized: asDisplayUnits(spendable) };
+  }, [pendingDeltas]);
 
   // Held in a ref for the same reason as in useRefreshSignal: callers pass an inline arrow, and
   // depending on it would restart the load on every render of the parent.
   const latestOnRefreshed = useRef(onRefreshed);
   latestOnRefreshed.current = onRefreshed;
+
+  const pendingByAssetLabel = useMemo(() => {
+    const labels = new Map<string, string>();
+    for (const [asset, delta] of pendingDeltas) {
+      const label = pendingLabel(delta.reasons);
+      if (label) labels.set(asset, label);
+    }
+    return labels;
+  }, [pendingDeltas]);
 
   const upsertBalance = useCallback((balance: TokenBalance) => {
     if (!balance?.asset || balance?.quantity_normalized === undefined) {
@@ -244,10 +272,10 @@ export const BalanceList = ({ refreshNonce, onRefreshed }: BalanceListProps = {}
       ) : (
         <>
           {pinnedBalances.map((balance) => (
-            <BalanceCard token={balance} key={balance.asset} pendingStatus={pendingByAssetLabel.get(balance.asset)} />
+            <BalanceCard token={displayBalance(balance)} key={balance.asset} pendingStatus={pendingByAssetLabel.get(balance.asset)} />
           ))}
           {otherBalances.map((balance) => (
-            <BalanceCard token={balance} key={balance.asset} pendingStatus={pendingByAssetLabel.get(balance.asset)} />
+            <BalanceCard token={displayBalance(balance)} key={balance.asset} pendingStatus={pendingByAssetLabel.get(balance.asset)} />
           ))}
           <div ref={loadMoreRef} className="flex flex-col justify-center items-center py-1">
             {hasMore ? (

--- a/src/components/domain/balance/balance-list.tsx
+++ b/src/components/domain/balance/balance-list.tsx
@@ -6,14 +6,14 @@ import { Spinner } from "@/components/ui/spinner";
 import { useHeader } from "@/contexts/header-context";
 import { useSettings } from "@/contexts/settings-context";
 import { useWallet } from "@/contexts/wallet-context";
-import { pendingLabel } from "@/core/balances/pendingLabel";
+
 import { spendableBalance, tracksPendingLedgerDebits } from "@/core/balances/spendable";
 import { fetchBTCBalance } from "@/core/bitcoin/balance";
 import type { TokenBalance } from "@/core/counterparty/api";
 import { fetchTokenBalance, fetchTokenBalances } from "@/core/counterparty/api";
 import { asDisplayUnits, fromSatoshis, isGreaterThan } from '@/core/numeric';
 import { useInView } from "@/hooks/useInView";
-import { usePendingDeltas } from "@/hooks/usePendingStatus";
+import { labelsFromDeltas, usePendingDeltas } from "@/hooks/usePendingStatus";
 import { useRefreshSignal } from "@/hooks/useRefreshSignal";
 import { useSearchQuery } from "@/hooks/useSearchQuery";
 
@@ -50,8 +50,21 @@ export const BalanceList = ({ refreshNonce, onRefreshed }: BalanceListProps = {}
   }, [settings?.pinnedAssets]);
 
   // A refresh reuses the same lever the pinned-asset list already pulls, rather than adding a
-  // second path through the loading code.
-  useRefreshSignal(refreshNonce, () => setInitialLoaded(false));
+  // second path through the loading code. The ref records that a refresh was asked for, so the
+  // completion callback fires for refreshes alone — the load path also runs on mount, on address
+  // changes and on pinned-asset changes, and announcing those as "your refresh finished" made the
+  // callback's contract a lie the current caller merely happened to tolerate.
+  const refreshRequestedRef = useRef(false);
+  useRefreshSignal(refreshNonce, () => {
+    refreshRequestedRef.current = true;
+    setInitialLoaded(false);
+  });
+  const settleRefresh = () => {
+    if (refreshRequestedRef.current) {
+      refreshRequestedRef.current = false;
+      latestOnRefreshed.current?.();
+    }
+  };
 
   // Read alongside the balances and on the same refresh, so the amount and what is happening to it
   // never come from two different moments.
@@ -79,14 +92,7 @@ export const BalanceList = ({ refreshNonce, onRefreshed }: BalanceListProps = {}
   const latestOnRefreshed = useRef(onRefreshed);
   latestOnRefreshed.current = onRefreshed;
 
-  const pendingByAssetLabel = useMemo(() => {
-    const labels = new Map<string, string>();
-    for (const [asset, delta] of pendingDeltas) {
-      const label = pendingLabel(delta.reasons);
-      if (label) labels.set(asset, label);
-    }
-    return labels;
-  }, [pendingDeltas]);
+  const pendingByAssetLabel = useMemo(() => labelsFromDeltas(pendingDeltas), [pendingDeltas]);
 
   const upsertBalance = useCallback((balance: TokenBalance) => {
     if (!balance?.asset || balance?.quantity_normalized === undefined) {
@@ -113,6 +119,9 @@ export const BalanceList = ({ refreshNonce, onRefreshed }: BalanceListProps = {}
         setAllBalances([]);
         setOffset(0);
         setHasMore(true);
+        // A refresh that raced the address going away is still over; leaving the spinner running
+        // because there was nothing to load would strand it.
+        settleRefresh();
       }
       return;
     }
@@ -168,7 +177,7 @@ export const BalanceList = ({ refreshNonce, onRefreshed }: BalanceListProps = {}
         // Outside the isCancelled guard on purpose. A cancelled load still ends the refresh the
         // caller is showing a spinner for; leaving it spinning because the address changed
         // mid-flight would strand it there.
-        latestOnRefreshed.current?.();
+        settleRefresh();
       }
     };
 

--- a/src/components/domain/balance/balance-list.tsx
+++ b/src/components/domain/balance/balance-list.tsx
@@ -1,4 +1,4 @@
-import { type ReactElement, useCallback, useEffect, useState } from "react";
+import { type ReactElement, useCallback, useEffect, useRef, useState } from "react";
 import { SearchResultCard } from "@/components/domain/asset/search-result-card";
 import { BalanceCard } from "@/components/domain/balance/balance-card";
 import { SearchInput } from "@/components/ui/inputs/search-input";
@@ -11,11 +11,25 @@ import type { TokenBalance } from "@/core/counterparty/api";
 import { fetchTokenBalance, fetchTokenBalances } from "@/core/counterparty/api";
 import { asDisplayUnits, fromSatoshis, isGreaterThan } from '@/core/numeric';
 import { useInView } from "@/hooks/useInView";
+import { usePendingStatus } from "@/hooks/usePendingStatus";
+import { useRefreshSignal } from "@/hooks/useRefreshSignal";
 import { useSearchQuery } from "@/hooks/useSearchQuery";
 
 
 
-export const BalanceList = (): ReactElement => {
+interface BalanceListProps {
+  /**
+   * Changes to ask for a fresh load. A counter rather than a boolean so two presses are two
+   * refreshes; the caller clears the relevant caches first, or this reads them straight back.
+   */
+  refreshNonce?: number;
+  /** Called when a requested refresh has finished, successfully or not, so the caller can stop
+   * showing it as in flight. Fires on completion rather than on success: a refresh that failed is
+   * still over, and a spinner that never stops is a worse lie than a stale number. */
+  onRefreshed?: () => void;
+}
+
+export const BalanceList = ({ refreshNonce, onRefreshed }: BalanceListProps = {}): ReactElement => {
   const { activeWallet, activeAddress } = useWallet();
   const { settings } = useSettings();
   const { cacheBalances } = useHeader();
@@ -32,6 +46,19 @@ export const BalanceList = (): ReactElement => {
   useEffect(() => {
     setInitialLoaded(false);
   }, [settings?.pinnedAssets]);
+
+  // A refresh reuses the same lever the pinned-asset list already pulls, rather than adding a
+  // second path through the loading code.
+  useRefreshSignal(refreshNonce, () => setInitialLoaded(false));
+
+  // Read alongside the balances and on the same refresh, so the amount and what is happening to it
+  // never come from two different moments.
+  const { byAsset: pendingByAssetLabel } = usePendingStatus(activeAddress?.address, refreshNonce);
+
+  // Held in a ref for the same reason as in useRefreshSignal: callers pass an inline arrow, and
+  // depending on it would restart the load on every render of the parent.
+  const latestOnRefreshed = useRef(onRefreshed);
+  latestOnRefreshed.current = onRefreshed;
 
   const upsertBalance = useCallback((balance: TokenBalance) => {
     if (!balance?.asset || balance?.quantity_normalized === undefined) {
@@ -110,6 +137,10 @@ export const BalanceList = (): ReactElement => {
           setOffset(0);
           setHasMore(true);
         }
+        // Outside the isCancelled guard on purpose. A cancelled load still ends the refresh the
+        // caller is showing a spinner for; leaving it spinning because the address changed
+        // mid-flight would strand it there.
+        latestOnRefreshed.current?.();
       }
     };
 
@@ -213,10 +244,10 @@ export const BalanceList = (): ReactElement => {
       ) : (
         <>
           {pinnedBalances.map((balance) => (
-            <BalanceCard token={balance} key={balance.asset} />
+            <BalanceCard token={balance} key={balance.asset} pendingStatus={pendingByAssetLabel.get(balance.asset)} />
           ))}
           {otherBalances.map((balance) => (
-            <BalanceCard token={balance} key={balance.asset} />
+            <BalanceCard token={balance} key={balance.asset} pendingStatus={pendingByAssetLabel.get(balance.asset)} />
           ))}
           <div ref={loadMoreRef} className="flex flex-col justify-center items-center py-1">
             {hasMore ? (

--- a/src/components/domain/balance/pending-status.tsx
+++ b/src/components/domain/balance/pending-status.tsx
@@ -10,17 +10,16 @@ interface PendingStatusProps {
  * "Sending", "Attaching", "Minting" — what the mempool is doing to this row.
  *
  * Italic and quiet on purpose. It is a note about the row, not a second figure competing with the
- * balance; a status that reads as loudly as the amount makes every card look like a warning. It is
- * announced politely rather than assertively for the same reason — a row changing to "Sending" is
- * worth hearing about after whatever you were reading, not over the top of it.
+ * balance; a status that reads as loudly as the amount makes every card look like a warning.
+ *
+ * Deliberately not a live region. Every row can carry one of these, and a single refresh updates
+ * them all at once — a list of role="status" elements announces each change over the last, which
+ * is noise, not information. The text is in the accessibility tree and reads with the row; a
+ * screen-reader user encounters it exactly where a sighted user does.
  */
 export function PendingStatus({ label, className = "" }: PendingStatusProps): ReactElement {
   return (
-    <span
-      className={`text-xs italic text-gray-400 ${className}`}
-      role="status"
-      aria-live="polite"
-    >
+    <span className={`text-xs italic text-gray-400 ${className}`}>
       {label}
     </span>
   );

--- a/src/components/domain/balance/pending-status.tsx
+++ b/src/components/domain/balance/pending-status.tsx
@@ -1,0 +1,27 @@
+import type { ReactElement } from "react";
+
+interface PendingStatusProps {
+  /** A word from `core/balances/pendingLabel`, e.g. "Sending". */
+  label: string;
+  className?: string;
+}
+
+/**
+ * "Sending", "Attaching", "Minting" — what the mempool is doing to this row.
+ *
+ * Italic and quiet on purpose. It is a note about the row, not a second figure competing with the
+ * balance; a status that reads as loudly as the amount makes every card look like a warning. It is
+ * announced politely rather than assertively for the same reason — a row changing to "Sending" is
+ * worth hearing about after whatever you were reading, not over the top of it.
+ */
+export function PendingStatus({ label, className = "" }: PendingStatusProps): ReactElement {
+  return (
+    <span
+      className={`text-xs italic text-gray-400 ${className}`}
+      role="status"
+      aria-live="polite"
+    >
+      {label}
+    </span>
+  );
+}

--- a/src/components/domain/utxo/utxo-card.tsx
+++ b/src/components/domain/utxo/utxo-card.tsx
@@ -1,15 +1,22 @@
 import type { ReactElement } from "react";
 import { useNavigate } from "react-router";
 import { AssetIcon } from "@/components/domain/asset/asset-icon";
+import { PendingStatus } from "@/components/domain/balance/pending-status";
 import { UtxoMenu } from "@/components/domain/utxo/utxo-menu";
 import type { UtxoBalance } from "@/core/counterparty/api";
 import { formatAmount, formatAsset, formatTxid } from "@/core/format";
 
 interface UtxoCardProps {
   token: UtxoBalance;
+  /**
+   * What the mempool is doing to this UTXO, e.g. "Detaching". Takes the place of the transaction
+   * id rather than crowding in beside it: while a UTXO is being moved or detached, what is
+   * happening to it is the more useful of the two, and the id is one tap away on the card itself.
+   */
+  pendingStatus?: string;
 }
 
-export function UtxoCard({ token }: UtxoCardProps): ReactElement {
+export function UtxoCard({ token, pendingStatus }: UtxoCardProps): ReactElement {
   const navigate = useNavigate();
 
   const handleClick = () => {
@@ -42,9 +49,13 @@ export function UtxoCard({ token }: UtxoCardProps): ReactElement {
                 useGrouping: true,
               })}
             </span>
-            <span className="text-xs text-gray-400 font-mono ml-2">
-              {formatTxid(token.utxo)}
-            </span>
+            {pendingStatus ? (
+              <PendingStatus label={pendingStatus} className="ml-2" />
+            ) : (
+              <span className="text-xs text-gray-400 font-mono ml-2">
+                {formatTxid(token.utxo)}
+              </span>
+            )}
           </div>
         </div>
       </button>

--- a/src/components/domain/utxo/utxo-list.tsx
+++ b/src/components/domain/utxo/utxo-list.tsx
@@ -32,7 +32,18 @@ export const UtxoList = ({ refreshNonce, onRefreshed }: UtxoListProps = {}): Rea
   // No `initialLoaded` flag here: this list reloads when the address changes, so a refresh is
   // expressed as another reason to re-run that same effect.
   const [reloadCount, setReloadCount] = useState(0);
-  useRefreshSignal(refreshNonce, () => setReloadCount((previous) => previous + 1));
+  // See BalanceList: the ref confines the completion callback to refreshes that were requested.
+  const refreshRequestedRef = useRef(false);
+  useRefreshSignal(refreshNonce, () => {
+    refreshRequestedRef.current = true;
+    setReloadCount((previous) => previous + 1);
+  });
+  const settleRefresh = () => {
+    if (refreshRequestedRef.current) {
+      refreshRequestedRef.current = false;
+      latestOnRefreshed.current?.();
+    }
+  };
 
   // Keyed on the UTXO, not the asset: moving one attached output should mark one row.
   const { byUtxo: pendingByUtxoLabel } = usePendingStatus(activeAddress?.address, refreshNonce);
@@ -46,6 +57,8 @@ export const UtxoList = ({ refreshNonce, onRefreshed }: UtxoListProps = {}): Rea
     if (!activeAddress || !activeWallet) {
       setBalances([]);
       setIsInitialLoading(false);
+      // A refresh that raced the address going away is still over.
+      settleRefresh();
       return;
     }
 
@@ -84,7 +97,7 @@ export const UtxoList = ({ refreshNonce, onRefreshed }: UtxoListProps = {}): Rea
         if (!isCancelled) setIsInitialLoading(false);
         // Outside the cancelled guard: a cancelled load still ends the refresh the caller is
         // showing a spinner for.
-        latestOnRefreshed.current?.();
+        settleRefresh();
       }
     };
 

--- a/src/components/domain/utxo/utxo-list.tsx
+++ b/src/components/domain/utxo/utxo-list.tsx
@@ -1,4 +1,4 @@
-import { type ReactElement, useEffect, useMemo, useState } from "react";
+import { type ReactElement, useEffect, useMemo, useRef, useState } from "react";
 import { UtxoCard } from "@/components/domain/utxo/utxo-card";
 import { SearchInput } from "@/components/ui/inputs/search-input";
 import { Spinner } from "@/components/ui/spinner";
@@ -6,10 +6,19 @@ import { useWallet } from "@/contexts/wallet-context";
 import type { UtxoBalance } from "@/core/counterparty/api";
 import { fetchTokenBalances } from "@/core/counterparty/api";
 import { useInView } from "@/hooks/useInView";
+import { usePendingStatus } from "@/hooks/usePendingStatus";
+import { useRefreshSignal } from "@/hooks/useRefreshSignal";
 
 const PAGE_SIZE = 20;
 
-export const UtxoList = (): ReactElement => {
+interface UtxoListProps {
+  /** Changes to ask for a fresh load; see `useRefreshSignal`. */
+  refreshNonce?: number;
+  /** Called when a requested refresh finishes, successfully or not. */
+  onRefreshed?: () => void;
+}
+
+export const UtxoList = ({ refreshNonce, onRefreshed }: UtxoListProps = {}): ReactElement => {
   const { activeWallet, activeAddress } = useWallet();
   const [balances, setBalances] = useState<UtxoBalance[]>([]);
   const [offset, setOffset] = useState(0);
@@ -19,6 +28,18 @@ export const UtxoList = (): ReactElement => {
   const [searchQuery, setSearchQuery] = useState("");
 
   const { ref: loadMoreRef, inView } = useInView({ rootMargin: "300px", threshold: 0 });
+
+  // No `initialLoaded` flag here: this list reloads when the address changes, so a refresh is
+  // expressed as another reason to re-run that same effect.
+  const [reloadCount, setReloadCount] = useState(0);
+  useRefreshSignal(refreshNonce, () => setReloadCount((previous) => previous + 1));
+
+  // Keyed on the UTXO, not the asset: moving one attached output should mark one row.
+  const { byUtxo: pendingByUtxoLabel } = usePendingStatus(activeAddress?.address, refreshNonce);
+
+  // Ref, not a dependency: callers pass an inline arrow that changes every parent render.
+  const latestOnRefreshed = useRef(onRefreshed);
+  latestOnRefreshed.current = onRefreshed;
 
   // Initial load (and reset) when address changes
   useEffect(() => {
@@ -61,13 +82,16 @@ export const UtxoList = (): ReactElement => {
         if (!isCancelled) setHasMore(false);
       } finally {
         if (!isCancelled) setIsInitialLoading(false);
+        // Outside the cancelled guard: a cancelled load still ends the refresh the caller is
+        // showing a spinner for.
+        latestOnRefreshed.current?.();
       }
     };
 
     loadInitial();
 
     return () => { isCancelled = true; };
-  }, [activeAddress, activeWallet]);
+  }, [activeAddress, activeWallet, reloadCount]);
 
   // Load more on scroll
   useEffect(() => {
@@ -142,7 +166,7 @@ export const UtxoList = (): ReactElement => {
         <div className="text-center py-4 text-gray-500">No matching UTXOs</div>
       ) : (
         filteredBalances.map((token) => (
-          <UtxoCard token={token} key={token.utxo} />
+          <UtxoCard token={token} key={token.utxo} pendingStatus={pendingByUtxoLabel.get(token.utxo)} />
         ))
       )}
       {!searchQuery && (

--- a/src/core/balances/__tests__/invalidate.test.ts
+++ b/src/core/balances/__tests__/invalidate.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as btc from '@/core/bitcoin/balance';
+import * as api from '@/core/counterparty/api';
+import { invalidateAddressBalances } from '../invalidate';
+
+vi.mock('@/core/bitcoin/balance');
+vi.mock('@/core/counterparty/api');
+
+const ADDRESS = '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa';
+
+describe('invalidateAddressBalances', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  // The whole point. Clearing one cache and not the other produces a refresh that redraws and
+  // shows the same stale number, which is worse than no refresh button.
+  it('clears both the Counterparty and the BTC cache', () => {
+    invalidateAddressBalances(ADDRESS);
+
+    expect(api.clearApiCacheMatching).toHaveBeenCalledWith(ADDRESS);
+    expect(btc.clearBalanceCache).toHaveBeenCalledWith(ADDRESS);
+  });
+
+  it('scopes both to the address rather than wiping everything', () => {
+    invalidateAddressBalances(ADDRESS);
+
+    expect(api.clearApiCacheMatching).toHaveBeenCalledTimes(1);
+    expect(btc.clearBalanceCache).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(btc.clearBalanceCache).mock.calls[0]![0]).toBe(ADDRESS);
+  });
+
+  it('does nothing without an address, rather than clearing every address', () => {
+    invalidateAddressBalances('');
+
+    expect(api.clearApiCacheMatching).not.toHaveBeenCalled();
+    // clearBalanceCache() with no argument wipes the cache for every address.
+    expect(btc.clearBalanceCache).not.toHaveBeenCalled();
+  });
+});

--- a/src/core/balances/__tests__/pending.test.ts
+++ b/src/core/balances/__tests__/pending.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from 'vitest';
+import {
+  countUnreadable,
+  type MempoolLedgerEvent,
+  pendingByAsset,
+  summarize,
+} from '../pending';
+
+const MINE = '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa';
+const THEIRS = '1CounterpartyXXXXXXXXXXXXXXXUWLpVr';
+
+const debit = (
+  quantity: number | string,
+  overrides: Partial<MempoolLedgerEvent['params']> = {},
+  tx_hash = 'tx1'
+): MempoolLedgerEvent => ({
+  tx_hash,
+  event: 'DEBIT',
+  params: { address: MINE, asset: 'XCP', quantity, action: 'issuance fee', ...overrides },
+});
+
+const credit = (
+  quantity: number | string,
+  overrides: Partial<MempoolLedgerEvent['params']> = {},
+  tx_hash = 'tx1'
+): MempoolLedgerEvent => ({
+  tx_hash,
+  event: 'CREDIT',
+  params: { address: MINE, asset: 'XCP', quantity, calling_function: 'issuance', ...overrides },
+});
+
+describe('pendingByAsset', () => {
+  it('totals pending debits for an asset', () => {
+    const result = pendingByAsset([debit(100), debit(50, {}, 'tx2')], MINE);
+
+    expect(result.get('XCP')?.debited).toBe(150n);
+    expect(result.get('XCP')?.credited).toBe(0n);
+  });
+
+  it('keeps debits and credits apart rather than netting them', () => {
+    const result = pendingByAsset([debit(100), credit(30)], MINE);
+
+    expect(result.get('XCP')?.debited).toBe(100n);
+    expect(result.get('XCP')?.credited).toBe(30n);
+  });
+
+  // The endpoint matches addresses with SQL LIKE against a joined column, so its results are a
+  // superset. Without this filter a neighbour's debit would be subtracted from your balance.
+  it('ignores events belonging to another address', () => {
+    const result = pendingByAsset([debit(100), debit(999, { address: THEIRS })], MINE);
+
+    expect(result.get('XCP')?.debited).toBe(100n);
+  });
+
+  it('separates assets', () => {
+    const result = pendingByAsset([debit(100), debit(7, { asset: 'PEPECASH' })], MINE);
+
+    expect(result.get('XCP')?.debited).toBe(100n);
+    expect(result.get('PEPECASH')?.debited).toBe(7n);
+  });
+
+  // Counterparty quantities are unsigned 64-bit. Rounding one to a double is the exact failure this
+  // module exists to prevent, so a large value has to survive as an integer.
+  it('is exact for quantities beyond a double', () => {
+    const huge = '99526925811111111';
+    const result = pendingByAsset([debit(huge, { asset: 'PEPECASH' })], MINE);
+
+    expect(result.get('PEPECASH')?.debited).toBe(99526925811111111n);
+    expect(result.get('PEPECASH')?.debited.toString()).toBe(huge);
+  });
+
+  it('skips a quantity it cannot read exactly, rather than guessing', () => {
+    const result = pendingByAsset([debit(1.5), debit('not a number', {}, 'tx2')], MINE);
+    expect(result.size).toBe(0);
+  });
+
+  it('collects the reasons behind a figure', () => {
+    const result = pendingByAsset(
+      [debit(100, { action: 'issuance fee' }), debit(2, { action: 'fairmint payment' }, 'tx2')],
+      MINE
+    );
+
+    expect(result.get('XCP')?.reasons).toEqual(['issuance fee', 'fairmint payment']);
+  });
+
+  it('does not repeat a reason or a transaction', () => {
+    const result = pendingByAsset([debit(1), debit(2)], MINE);
+
+    expect(result.get('XCP')?.reasons).toEqual(['issuance fee']);
+    expect(result.get('XCP')?.txHashes).toEqual(['tx1']);
+  });
+
+  it('lists each contributing transaction for linking', () => {
+    const result = pendingByAsset([debit(1), debit(2, {}, 'tx2')], MINE);
+    expect(result.get('XCP')?.txHashes).toEqual(['tx1', 'tx2']);
+  });
+
+  it('ignores event types that are not ledger movements', () => {
+    const result = pendingByAsset(
+      [{ tx_hash: 'tx1', event: 'NEW_TRANSACTION', params: { address: MINE, asset: 'XCP', quantity: 5 } }],
+      MINE
+    );
+
+    expect(result.size).toBe(0);
+  });
+
+  it('returns nothing for an empty mempool', () => {
+    expect(pendingByAsset([], MINE).size).toBe(0);
+  });
+});
+
+describe('countUnreadable', () => {
+  // "Something is pending that I could not total" and "nothing is pending" are different claims,
+  // and only one of them is safe to render as a balance.
+  it('counts our own events that could not be folded in', () => {
+    expect(countUnreadable([debit(1.5), debit('x', {}, 'tx2'), debit(10, {}, 'tx3')], MINE)).toBe(2);
+  });
+
+  it('does not count unreadable events belonging to another address', () => {
+    expect(countUnreadable([debit(1.5, { address: THEIRS })], MINE)).toBe(0);
+  });
+
+  it('counts an event with no asset', () => {
+    expect(countUnreadable([debit(10, { asset: undefined })], MINE)).toBe(1);
+  });
+});
+
+describe('summarize', () => {
+  it('leaves the confirmed balance alone and reports spendable separately', () => {
+    const delta = pendingByAsset([debit(100)], MINE).get('XCP');
+    const summary = summarize(400n, delta);
+
+    expect(summary.confirmed).toBe(400n);
+    expect(summary.spendable).toBe(300n);
+    expect(summary.outgoing).toBe(100n);
+  });
+
+  it('reports nothing pending when the mempool is empty for that asset', () => {
+    const summary = summarize(400n, undefined);
+
+    expect(summary.confirmed).toBe(400n);
+    expect(summary.spendable).toBe(400n);
+    expect(summary.outgoing).toBe(0n);
+    expect(summary.inconsistent).toBe(false);
+  });
+
+  // Pending debits above the confirmed balance are impossible per the ledger, so seeing them means
+  // the two reads disagree — mid-reorg, or a stale balance. A negative "spendable" would be a
+  // confident lie; falling back to the confirmed figure and flagging it is not.
+  it('flags a disagreement instead of reporting a negative balance', () => {
+    const delta = pendingByAsset([debit(500)], MINE).get('XCP');
+    const summary = summarize(400n, delta);
+
+    expect(summary.inconsistent).toBe(true);
+    expect(summary.spendable).toBe(400n);
+  });
+
+  it('carries the reasons through for display', () => {
+    const delta = pendingByAsset([debit(100, { action: 'fairmint payment' })], MINE).get('XCP');
+    expect(summarize(400n, delta).reasons).toEqual(['fairmint payment']);
+  });
+
+  it('reports incoming separately, without adding it to spendable', () => {
+    const delta = pendingByAsset([credit(50)], MINE).get('XCP');
+    const summary = summarize(400n, delta);
+
+    expect(summary.incoming).toBe(50n);
+    // Unconfirmed money in is not money you can spend.
+    expect(summary.spendable).toBe(400n);
+  });
+});

--- a/src/core/balances/__tests__/pending.test.ts
+++ b/src/core/balances/__tests__/pending.test.ts
@@ -3,6 +3,7 @@ import {
   countUnreadable,
   type MempoolLedgerEvent,
   pendingByAsset,
+  pendingByUtxo,
   summarize,
 } from '../pending';
 
@@ -106,6 +107,43 @@ describe('pendingByAsset', () => {
 
   it('returns nothing for an empty mempool', () => {
     expect(pendingByAsset([], MINE).size).toBe(0);
+  });
+});
+
+describe('pendingByUtxo ownership', () => {
+  const utxoEvent = (overrides: Record<string, unknown>): MempoolLedgerEvent => ({
+    tx_hash: 'tx1',
+    event: 'DEBIT',
+    params: {
+      asset: 'XCP',
+      quantity: 5,
+      action: 'detach from utxo',
+      utxo: 'aabb:0',
+      ...overrides,
+    } as MempoolLedgerEvent['params'],
+  });
+
+  it('counts a movement on a UTXO this address owns', () => {
+    const result = pendingByUtxo([utxoEvent({ utxo_address: MINE })], MINE);
+    expect(result.get('aabb:0')?.debited).toBe(5n);
+  });
+
+  // The endpoint matches addresses with SQL LIKE, so strangers arrive in the result set.
+  it('ignores a movement on a stranger UTXO', () => {
+    const result = pendingByUtxo([utxoEvent({ utxo_address: THEIRS })], MINE);
+    expect(result.size).toBe(0);
+  });
+
+  // The regression: an event naming us in neither field used to pass the old exclude-on-mismatch
+  // guard whenever utxo_address was simply absent.
+  it('ignores an event that names this address in no field at all', () => {
+    const result = pendingByUtxo([utxoEvent({ address: THEIRS })], MINE);
+    expect(result.size).toBe(0);
+  });
+
+  it('accepts ownership via the address field when utxo_address is unset', () => {
+    const result = pendingByUtxo([utxoEvent({ address: MINE })], MINE);
+    expect(result.get('aabb:0')?.debited).toBe(5n);
   });
 });
 

--- a/src/core/balances/__tests__/pending.test.ts
+++ b/src/core/balances/__tests__/pending.test.ts
@@ -110,6 +110,25 @@ describe('pendingByAsset', () => {
   });
 });
 
+describe('creditedNormalized', () => {
+  it('totals incoming display units', () => {
+    const events = [
+      credit(100, { quantity_normalized: '1' } as never),
+      credit(50, { quantity_normalized: '0.5' } as never, 'tx2'),
+    ];
+    expect(pendingByAsset(events, MINE).get('XCP')?.creditedNormalized).toBe('1.5');
+  });
+
+  // Same null-poisoning as the outgoing side: a total missing a term is unknown, not smaller.
+  it('goes unknown when any credit lacks a readable figure', () => {
+    const events = [
+      credit(100, { quantity_normalized: '1' } as never),
+      credit(50, {} as never, 'tx2'),
+    ];
+    expect(pendingByAsset(events, MINE).get('XCP')?.creditedNormalized).toBeNull();
+  });
+});
+
 describe('pendingByUtxo ownership', () => {
   const utxoEvent = (overrides: Record<string, unknown>): MempoolLedgerEvent => ({
     tx_hash: 'tx1',

--- a/src/core/balances/__tests__/pendingLabel.test.ts
+++ b/src/core/balances/__tests__/pendingLabel.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { GENERIC_PENDING_LABEL, pendingLabel } from '../pendingLabel';
+
+describe('pendingLabel', () => {
+  it('says nothing when nothing is pending', () => {
+    expect(pendingLabel([])).toBeNull();
+  });
+
+  it.each([
+    ['send', 'Sending'],
+    ['sweep', 'Sweeping'],
+    ['open order', 'Ordering'],
+    ['issuance', 'Issuing'],
+    ['dispense', 'Dispensing'],
+    ['attach to utxo', 'Attaching'],
+    ['detach from utxo', 'Detaching'],
+    ['utxo move', 'Moving'],
+    ['pool deposit', 'Depositing'],
+    ['unescrowed fairmint payment', 'Minting'],
+  ])('reads %s as %s', (action, expected) => {
+    expect(pendingLabel([action])).toBe(expected);
+  });
+
+  // A single operation debits both the asset and its fee, producing two events. The label should
+  // say the operation once rather than collapsing to a generic because two reasons differ.
+  it('treats an operation and its fee as one thing', () => {
+    expect(pendingLabel(['issuance', 'issuance fee'])).toBe('Issuing');
+    expect(pendingLabel(['attach to utxo', 'attach to utxo fee'])).toBe('Attaching');
+    expect(pendingLabel(['pool deposit', 'pool deposit fee'])).toBe('Depositing');
+  });
+
+  // Picking one would describe the wrong transaction.
+  it('falls back to a generic when two different things are in flight', () => {
+    expect(pendingLabel(['send', 'dividend'])).toBe(GENERIC_PENDING_LABEL);
+  });
+
+  // A protocol addition should appear as "Pending", not vanish from the screen.
+  it('falls back to a generic for an action it does not know', () => {
+    expect(pendingLabel(['some future action'])).toBe(GENERIC_PENDING_LABEL);
+  });
+
+  it('does not invent a word when an unknown action joins a known one', () => {
+    expect(pendingLabel(['send', 'some future action'])).toBe(GENERIC_PENDING_LABEL);
+  });
+
+  // Deliberately absent: core reports a lock as plain `issuance`, so "Locking" would be us
+  // guessing at intent the ledger never stated.
+  it('does not claim to know a lock is happening', () => {
+    expect(pendingLabel(['issuance'])).toBe('Issuing');
+  });
+});

--- a/src/core/balances/__tests__/spendable.test.ts
+++ b/src/core/balances/__tests__/spendable.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { spendableBalance, tracksPendingLedgerDebits } from '../spendable';
+
+describe('spendableBalance', () => {
+  // The case that started this: hold 10, one committed in the mempool, Max should offer 9.
+  it('subtracts what the mempool has committed', () => {
+    const result = spendableBalance('10', '1');
+
+    expect(result.spendable).toBe('9');
+    expect(result.pendingOutgoing).toBe('1');
+    expect(result.unknownPending).toBe(false);
+  });
+
+  it('offers the whole balance when nothing is pending', () => {
+    expect(spendableBalance('10', '0').spendable).toBe('10');
+    expect(spendableBalance('10', undefined).spendable).toBe('10');
+  });
+
+  it('is exact with fractional amounts', () => {
+    expect(spendableBalance('1.5', '0.25').spendable).toBe('1.25');
+  });
+
+  // Eight decimal places is the divisible-asset floor; binary floating point would lose it.
+  it('does not lose the eighth decimal place', () => {
+    expect(spendableBalance('0.00000003', '0.00000001').spendable).toBe('0.00000002');
+  });
+
+  it('handles a balance far above the safe integer range', () => {
+    expect(spendableBalance('99526925811111111', '11111111').spendable).toBe('99526925800000000');
+  });
+
+  // The whole point of the null: a total missing one of its terms is unknown, not smaller.
+  // Subtracting a partial figure would understate what is committed and let the overspend through
+  // while looking as though it had been handled.
+  it('subtracts nothing when the pending total cannot be stated', () => {
+    const result = spendableBalance('10', null);
+
+    expect(result.spendable).toBe('10');
+    expect(result.unknownPending).toBe(true);
+  });
+
+  it('distinguishes an unknown total from an absent one', () => {
+    expect(spendableBalance('10', null).unknownPending).toBe(true);
+    expect(spendableBalance('10', undefined).unknownPending).toBe(false);
+  });
+
+  // Impossible per the ledger, so it means the two reads disagree. Zero cannot cause an overspend;
+  // a negative Max would be nonsense.
+  it('offers zero rather than a negative when pending exceeds the balance', () => {
+    expect(spendableBalance('1', '5').spendable).toBe('0');
+  });
+
+  it('treats a missing balance as nothing spendable', () => {
+    expect(spendableBalance(null, '1').spendable).toBe('0');
+    expect(spendableBalance(undefined, undefined).spendable).toBe('0');
+  });
+});
+
+describe('tracksPendingLedgerDebits', () => {
+  // BTC's balance comes from the UTXO set, and a pending BTC send produces no Counterparty DEBIT.
+  // Subtracting one from the other would be arithmetic across two unrelated systems.
+  it('excludes BTC', () => {
+    expect(tracksPendingLedgerDebits('BTC')).toBe(false);
+    expect(tracksPendingLedgerDebits('btc')).toBe(false);
+  });
+
+  // Callers reach here before an asset has been chosen.
+  it('answers false for an absent asset rather than throwing', () => {
+    expect(tracksPendingLedgerDebits(null)).toBe(false);
+    expect(tracksPendingLedgerDebits(undefined)).toBe(false);
+    expect(tracksPendingLedgerDebits('')).toBe(false);
+  });
+
+  it('includes Counterparty assets', () => {
+    expect(tracksPendingLedgerDebits('XCP')).toBe(true);
+    expect(tracksPendingLedgerDebits('PEPECASH')).toBe(true);
+    expect(tracksPendingLedgerDebits('A95428956661682177')).toBe(true);
+  });
+});

--- a/src/core/balances/invalidate.ts
+++ b/src/core/balances/invalidate.ts
@@ -1,0 +1,32 @@
+/**
+ * Forgetting everything cached about one address's balances.
+ *
+ * The balances on the home screen come from two independent caches, and a refresh that clears one
+ * of them is worse than no refresh at all — it redraws, looks like it worked, and shows the same
+ * stale number. The BTC row is the one that matters most here: it is what someone waiting on a
+ * deposit is staring at, and it is the one served by the *other* cache.
+ *
+ * - Counterparty balances go through the API client's response cache, keyed by URL, 60s TTL.
+ * - BTC comes from `core/bitcoin/balance`, which keeps its own keyed TTL cache per address.
+ *
+ * Anything added later that feeds a balance row belongs here too. That is the whole reason this is
+ * one named operation rather than two calls at the call site: the next person adding a cache should
+ * find one obvious place that already means "forget this address".
+ */
+
+import { clearBalanceCache } from '@/core/bitcoin/balance';
+import { clearApiCacheMatching } from '@/core/counterparty/api';
+
+/**
+ * Drop every cached balance for an address, so the next read goes to the network.
+ *
+ * Matching is by substring on the API cache keys, which are URLs containing the address. That is
+ * broader than balances alone — orders, dispensers and anything else keyed on this address go too.
+ * Deliberate: a manual refresh means "I do not trust what is on screen", and a partially refreshed
+ * screen is the confusing outcome.
+ */
+export function invalidateAddressBalances(address: string): void {
+  if (!address) return;
+  clearApiCacheMatching(address);
+  clearBalanceCache(address);
+}

--- a/src/core/balances/pending.ts
+++ b/src/core/balances/pending.ts
@@ -70,6 +70,12 @@ export interface PendingDelta {
    * committed, and quietly let through the overspend this exists to prevent.
    */
   debitedNormalized: string | null;
+  /**
+   * Total arriving, in display units, under the same null-poisoning rule. Informational — nothing
+   * gates on it, since unconfirmed money in is not money out at risk — but a partial figure shown
+   * as a total would still be a wrong statement, so unknown stays unknown here too.
+   */
+  creditedNormalized: string | null;
 }
 
 /**
@@ -135,7 +141,7 @@ export function pendingByAsset(
 
     let delta = byAsset.get(asset);
     if (!delta) {
-      delta = { asset, debited: 0n, credited: 0n, reasons: [], txHashes: [], debitedNormalized: '0' };
+      delta = { asset, debited: 0n, credited: 0n, reasons: [], txHashes: [], debitedNormalized: '0', creditedNormalized: '0' };
       byAsset.set(asset, delta);
     }
 
@@ -145,6 +151,7 @@ export function pendingByAsset(
       addReason(delta, params.action);
     } else if (event.event === 'CREDIT') {
       delta.credited += quantity;
+      delta.creditedNormalized = addNormalized(delta.creditedNormalized, params.quantity_normalized);
       addReason(delta, params.calling_function);
     } else {
       continue;
@@ -202,7 +209,7 @@ export function pendingByUtxo(
 
     let delta = byUtxo.get(utxo);
     if (!delta) {
-      delta = { asset, debited: 0n, credited: 0n, reasons: [], txHashes: [], debitedNormalized: '0' };
+      delta = { asset, debited: 0n, credited: 0n, reasons: [], txHashes: [], debitedNormalized: '0', creditedNormalized: '0' };
       byUtxo.set(utxo, delta);
     }
 
@@ -212,6 +219,7 @@ export function pendingByUtxo(
       addReason(delta, params.action);
     } else {
       delta.credited += quantity;
+      delta.creditedNormalized = addNormalized(delta.creditedNormalized, params.quantity_normalized);
       addReason(delta, params.calling_function);
     }
 

--- a/src/core/balances/pending.ts
+++ b/src/core/balances/pending.ts
@@ -189,8 +189,12 @@ export function pendingByUtxo(
 
     const utxo = params.utxo;
     if (typeof utxo !== 'string' || utxo.length === 0) continue;
-    // A UTXO-held balance names its owner in `utxo_address`; `address` is unset for these.
-    if (params.utxo_address !== undefined && params.utxo_address !== address) continue;
+    // Ownership must be positive, not merely unexcluded. The endpoint matches addresses with a
+    // SQL LIKE, so its results are a superset, and a UTXO-held balance names its owner in
+    // `utxo_address` (with `address` unset) while an address-level movement does the reverse. An
+    // event naming us in neither field is someone else's, whatever fields it happens to omit —
+    // the earlier exclude-on-mismatch guard let an event with both fields absent through.
+    if (params.utxo_address !== address && params.address !== address) continue;
 
     const asset = params.asset;
     const quantity = toBaseUnits(params.quantity);

--- a/src/core/balances/pending.ts
+++ b/src/core/balances/pending.ts
@@ -1,0 +1,191 @@
+/**
+ * What the mempool is about to do to a balance.
+ *
+ * The problem this solves: `/addresses/{address}/balances` is the confirmed ledger. Counterparty
+ * debits at parse time, so an unconfirmed fairmint leaves the XCP it will spend sitting in your
+ * balance looking spendable — and nothing stops you composing a DEX order against the same coins.
+ * Whichever confirms second fails.
+ *
+ * The thing *not* to do is re-derive Counterparty's debit rules here. Which message types debit
+ * what, in which order, under which protocol activations, is consensus logic; a second
+ * implementation of it in a wallet would be wrong eventually and wrong silently. Core already
+ * parses mempool transactions and emits the same DEBIT and CREDIT events it emits for confirmed
+ * ones, with `action`/`calling_function` naming the reason. So the wallet asks rather than derives.
+ *
+ * Double counting is core's problem and core handles it: when a block is parsed, the mempool rows
+ * for the transactions it contained are deleted in the *same* database transaction that marks the
+ * block parsed (`parser/blocks.py`), specifically so an API reader cannot observe a transaction as
+ * both confirmed and pending. There is no window to defend against here.
+ *
+ * What this cannot see: a transaction the queried node has not accepted into its own mempool.
+ * Mempools differ, and a wallet pointed at a node that never saw the broadcast will show nothing
+ * pending. That is a floor on what any client-side answer can claim, which is why the UI wording
+ * this feeds should describe what is known rather than assert what is spendable.
+ */
+
+/** A DEBIT or CREDIT the node has parsed out of a mempool transaction. */
+export interface MempoolLedgerEvent {
+  tx_hash: string;
+  event: string;
+  params?: {
+    address?: string;
+    asset?: string;
+    /** Base units. Unsigned 64-bit, so it may arrive as a string. */
+    quantity?: number | string;
+    /** Why the debit happened, e.g. "issuance fee". DEBIT only. */
+    action?: string;
+    /** Why the credit happened, e.g. "issuance". CREDIT only. */
+    calling_function?: string;
+  };
+}
+
+/** The net effect of the mempool on one asset, in base units. */
+export interface PendingDelta {
+  asset: string;
+  /** Leaving the address if these confirm. */
+  debited: bigint;
+  /** Arriving if these confirm. */
+  credited: bigint;
+  /** Distinct reasons, in first-seen order, for explaining the figure. */
+  reasons: string[];
+  /** Distinct transactions contributing, so the UI can link to them. */
+  txHashes: string[];
+}
+
+/**
+ * Base units as an exact integer.
+ *
+ * Counterparty quantities are unsigned 64-bit and a JS double is exact only to 2^53-1, so anything
+ * large arrives as a string. `BigInt` is exact for both; `Number` would silently round, which for a
+ * balance is the whole bug this module exists to avoid. Anything not a whole number is rejected
+ * rather than truncated — a fractional base unit means the value is not what this thinks it is.
+ */
+function toBaseUnits(value: number | string | undefined): bigint | null {
+  if (value === undefined || value === null) return null;
+  if (typeof value === 'number') {
+    return Number.isSafeInteger(value) ? BigInt(value) : null;
+  }
+  const trimmed = value.trim();
+  return /^-?\d+$/.test(trimmed) ? BigInt(trimmed) : null;
+}
+
+function addReason(delta: PendingDelta, reason: string | undefined): void {
+  if (reason && !delta.reasons.includes(reason)) delta.reasons.push(reason);
+}
+
+/**
+ * Fold mempool ledger events into a per-asset view of what is pending for one address.
+ *
+ * `address` is matched exactly against each event's own `params.address`. The endpoint that
+ * supplies these matches addresses with a SQL `LIKE '%address%'` against a joined column, so its
+ * results are a superset by construction — filtering here is what makes the answer this address's
+ * rather than a neighbour's.
+ *
+ * Events missing an address, asset or a readable quantity are skipped: a partial figure presented
+ * as a balance is worse than admitting the mempool holds something unreadable, which
+ * {@link countUnreadable} reports separately.
+ */
+export function pendingByAsset(
+  events: MempoolLedgerEvent[],
+  address: string
+): Map<string, PendingDelta> {
+  const byAsset = new Map<string, PendingDelta>();
+
+  for (const event of events) {
+    const params = event.params;
+    if (!params || params.address !== address) continue;
+
+    const asset = params.asset;
+    if (!asset) continue;
+
+    const quantity = toBaseUnits(params.quantity);
+    if (quantity === null) continue;
+
+    let delta = byAsset.get(asset);
+    if (!delta) {
+      delta = { asset, debited: 0n, credited: 0n, reasons: [], txHashes: [] };
+      byAsset.set(asset, delta);
+    }
+
+    if (event.event === 'DEBIT') {
+      delta.debited += quantity;
+      addReason(delta, params.action);
+    } else if (event.event === 'CREDIT') {
+      delta.credited += quantity;
+      addReason(delta, params.calling_function);
+    } else {
+      continue;
+    }
+
+    if (!delta.txHashes.includes(event.tx_hash)) delta.txHashes.push(event.tx_hash);
+  }
+
+  // A zero net with no reasons carries no information; a zero net *with* reasons does (something is
+  // in flight that happens to balance out), so only the truly empty are dropped.
+  for (const [asset, delta] of byAsset) {
+    if (delta.debited === 0n && delta.credited === 0n && delta.reasons.length === 0) {
+      byAsset.delete(asset);
+    }
+  }
+
+  return byAsset;
+}
+
+/**
+ * Events for this address that could not be folded in — an unreadable quantity, a missing asset.
+ *
+ * Reported rather than ignored. "Something is pending that I could not total" is a different
+ * statement from "nothing is pending", and only one of them is safe to render as a balance.
+ */
+export function countUnreadable(events: MempoolLedgerEvent[], address: string): number {
+  let unreadable = 0;
+  for (const event of events) {
+    if (event.event !== 'DEBIT' && event.event !== 'CREDIT') continue;
+    const params = event.params;
+    if (!params || params.address !== address) continue;
+    if (!params.asset || toBaseUnits(params.quantity) === null) unreadable += 1;
+  }
+  return unreadable;
+}
+
+/** What a balance row should say about one asset. */
+export interface PendingSummary {
+  /** Confirmed, straight from the ledger. Never adjusted. */
+  confirmed: bigint;
+  /** Confirmed minus pending debits: what a new transaction can actually draw on. */
+  spendable: bigint;
+  /** Pending debits, as a positive number. */
+  outgoing: bigint;
+  /** Pending credits, as a positive number. */
+  incoming: bigint;
+  reasons: string[];
+  /**
+   * True when pending debits exceed the confirmed balance, which the ledger says cannot happen.
+   * Signals a disagreement — a node mid-reorg, a stale balance read — rather than a spendable
+   * figure, so callers show the confirmed number and say nothing about spendable.
+   */
+  inconsistent: boolean;
+}
+
+/**
+ * Combine a confirmed balance with the pending view.
+ *
+ * `spendable` is deliberately a separate figure rather than a replacement for `confirmed`. A
+ * headline number that quietly changes meaning is its own defect: someone who reads "4 XCP" and
+ * later reads "0 XCP" with no explanation has been told two different things by the same label.
+ * Show the confirmed balance, and say what is in flight beside it.
+ */
+export function summarize(confirmed: bigint, delta: PendingDelta | undefined): PendingSummary {
+  const outgoing = delta?.debited ?? 0n;
+  const incoming = delta?.credited ?? 0n;
+  const inconsistent = outgoing > confirmed;
+
+  return {
+    confirmed,
+    spendable: inconsistent ? confirmed : confirmed - outgoing,
+    outgoing,
+    incoming,
+    reasons: delta?.reasons ?? [],
+    inconsistent,
+  };
+}

--- a/src/core/balances/pending.ts
+++ b/src/core/balances/pending.ts
@@ -132,6 +132,58 @@ export function pendingByAsset(
 }
 
 /**
+ * The same fold, keyed on the UTXO a movement touches rather than the asset.
+ *
+ * A UTXO row asks a different question from a balance row. "Is this particular output being
+ * detached" is not answered by "something is happening to XCP", and an address moving one of five
+ * attached outputs should mark one row rather than all of them. Ledger events name the UTXO they
+ * concern, so this groups on that; events without one are address-level and belong to
+ * {@link pendingByAsset}.
+ */
+export function pendingByUtxo(
+  events: MempoolLedgerEvent[],
+  address: string
+): Map<string, PendingDelta> {
+  const byUtxo = new Map<string, PendingDelta>();
+
+  for (const event of events) {
+    if (event.event !== 'DEBIT' && event.event !== 'CREDIT') continue;
+
+    const params = event.params as
+      | (NonNullable<MempoolLedgerEvent['params']> & { utxo?: string; utxo_address?: string })
+      | undefined;
+    if (!params) continue;
+
+    const utxo = params.utxo;
+    if (typeof utxo !== 'string' || utxo.length === 0) continue;
+    // A UTXO-held balance names its owner in `utxo_address`; `address` is unset for these.
+    if (params.utxo_address !== undefined && params.utxo_address !== address) continue;
+
+    const asset = params.asset;
+    const quantity = toBaseUnits(params.quantity);
+    if (!asset || quantity === null) continue;
+
+    let delta = byUtxo.get(utxo);
+    if (!delta) {
+      delta = { asset, debited: 0n, credited: 0n, reasons: [], txHashes: [] };
+      byUtxo.set(utxo, delta);
+    }
+
+    if (event.event === 'DEBIT') {
+      delta.debited += quantity;
+      addReason(delta, params.action);
+    } else {
+      delta.credited += quantity;
+      addReason(delta, params.calling_function);
+    }
+
+    if (!delta.txHashes.includes(event.tx_hash)) delta.txHashes.push(event.tx_hash);
+  }
+
+  return byUtxo;
+}
+
+/**
  * Events for this address that could not be folded in — an unreadable quantity, a missing asset.
  *
  * Reported rather than ignored. "Something is pending that I could not total" is a different

--- a/src/core/balances/pending.ts
+++ b/src/core/balances/pending.ts
@@ -23,6 +23,8 @@
  * this feeds should describe what is known rather than assert what is spendable.
  */
 
+import { toBigNumber } from '@/core/numeric';
+
 /** A DEBIT or CREDIT the node has parsed out of a mempool transaction. */
 export interface MempoolLedgerEvent {
   tx_hash: string;
@@ -36,6 +38,15 @@ export interface MempoolLedgerEvent {
     action?: string;
     /** Why the credit happened, e.g. "issuance". CREDIT only. */
     calling_function?: string;
+    /**
+     * The same quantity in display units, as core computed it.
+     *
+     * Preferred over converting `quantity` here, because converting needs the asset's divisibility
+     * and this codebase's balance hook defaults that to `true` when it does not know — a wrong
+     * `true` is a factor-of-1e8 error in a figure that gates spending. Core knows, so core's number
+     * is used and no divisibility is assumed anywhere in this module.
+     */
+    quantity_normalized?: string;
   };
 }
 
@@ -50,6 +61,15 @@ export interface PendingDelta {
   reasons: string[];
   /** Distinct transactions contributing, so the UI can link to them. */
   txHashes: string[];
+  /**
+   * Total leaving, in display units, or null when it cannot be stated exactly.
+   *
+   * Null when any contributing debit arrived without a normalized figure. It means "there is
+   * something outgoing but I cannot total it", which callers must treat as unknown rather than
+   * zero: reducing a spendable balance by a number that is missing a term would understate what is
+   * committed, and quietly let through the overspend this exists to prevent.
+   */
+  debitedNormalized: string | null;
 }
 
 /**
@@ -67,6 +87,18 @@ function toBaseUnits(value: number | string | undefined): bigint | null {
   }
   const trimmed = value.trim();
   return /^-?\d+$/.test(trimmed) ? BigInt(trimmed) : null;
+}
+
+/**
+ * Running total of display-unit debits, where a single missing figure poisons the total.
+ *
+ * Once null it stays null: a sum missing one of its terms is not a smaller sum, it is an unknown
+ * one, and the difference matters when the result decides how much someone may spend.
+ */
+function addNormalized(running: string | null, next: string | undefined): string | null {
+  if (running === null) return null;
+  if (next === undefined || !/^-?\d*\.?\d+$/.test(next.trim())) return null;
+  return toBigNumber(running).plus(toBigNumber(next.trim())).toString();
 }
 
 function addReason(delta: PendingDelta, reason: string | undefined): void {
@@ -103,12 +135,13 @@ export function pendingByAsset(
 
     let delta = byAsset.get(asset);
     if (!delta) {
-      delta = { asset, debited: 0n, credited: 0n, reasons: [], txHashes: [] };
+      delta = { asset, debited: 0n, credited: 0n, reasons: [], txHashes: [], debitedNormalized: '0' };
       byAsset.set(asset, delta);
     }
 
     if (event.event === 'DEBIT') {
       delta.debited += quantity;
+      delta.debitedNormalized = addNormalized(delta.debitedNormalized, params.quantity_normalized);
       addReason(delta, params.action);
     } else if (event.event === 'CREDIT') {
       delta.credited += quantity;
@@ -165,12 +198,13 @@ export function pendingByUtxo(
 
     let delta = byUtxo.get(utxo);
     if (!delta) {
-      delta = { asset, debited: 0n, credited: 0n, reasons: [], txHashes: [] };
+      delta = { asset, debited: 0n, credited: 0n, reasons: [], txHashes: [], debitedNormalized: '0' };
       byUtxo.set(utxo, delta);
     }
 
     if (event.event === 'DEBIT') {
       delta.debited += quantity;
+      delta.debitedNormalized = addNormalized(delta.debitedNormalized, params.quantity_normalized);
       addReason(delta, params.action);
     } else {
       delta.credited += quantity;

--- a/src/core/balances/pendingLabel.ts
+++ b/src/core/balances/pendingLabel.ts
@@ -1,0 +1,91 @@
+/**
+ * Turning core's ledger action into a word to show beside a balance.
+ *
+ * Every string on the left of this table is one core actually writes into a DEBIT or CREDIT
+ * (`action=` / `calling_function=` in `counterpartycore/lib`). Nothing here is inferred from
+ * context, and that restraint is the point: "locking" reads well next to an asset, but core reports
+ * a lock as plain `issuance`, so showing it would mean guessing at intent the ledger never stated.
+ * A word we cannot source from the event does not go on the screen.
+ *
+ * Fees are mapped to the same word as the operation they belong to. A send that debits both the
+ * asset and a fee produces two events, and the label should say "Sending" once rather than
+ * dissolving into a generic because two reasons disagreed.
+ */
+
+/** Present participles, because the thing is happening now. */
+const LABELS: Record<string, string> = {
+  // Sends and sweeps
+  send: 'Sending',
+  'mpma send': 'Sending',
+  sweep: 'Sweeping',
+  'sweep fee': 'Sweeping',
+
+  // DEX
+  'open order': 'Ordering',
+  'cancel order': 'Cancelling',
+  'order match': 'Matching',
+  filled: 'Matching',
+  btcpay: 'Paying',
+
+  // Issuance
+  issuance: 'Issuing',
+  'issuance fee': 'Issuing',
+  'reset issuance': 'Resetting',
+
+  // Dispensers
+  dispense: 'Dispensing',
+  'open dispenser': 'Opening',
+  'open dispenser empty addr': 'Opening',
+  'refill dispenser': 'Refilling',
+  'close dispenser': 'Closing',
+
+  // UTXO attachment
+  'attach to utxo': 'Attaching',
+  'attach to utxo fee': 'Attaching',
+  'detach from utxo': 'Detaching',
+  'utxo move': 'Moving',
+
+  // Pools
+  'pool deposit': 'Depositing',
+  'pool deposit fee': 'Depositing',
+  'pool withdraw': 'Withdrawing',
+  'pool withdraw fee': 'Withdrawing',
+  'escrowed pool liquidity': 'Depositing',
+
+  // Fairminters
+  'fairminter fee': 'Minting',
+  'fairminter pool fee': 'Minting',
+  'fairminter pool deposit': 'Minting',
+  'unescrowed fairmint payment': 'Minting',
+  'unescrowed fairmint': 'Minting',
+  'fairmint commission': 'Minting',
+  premint: 'Minting',
+  'escrowed premint': 'Minting',
+  'unescrowed premint': 'Minting',
+
+  // Other
+  dividend: 'Paying dividend',
+  'dividend fee': 'Paying dividend',
+  burn: 'Burning',
+};
+
+/** Shown when something is in flight that this table has no word for. */
+export const GENERIC_PENDING_LABEL = 'Pending';
+
+/**
+ * One word for everything currently in flight against an asset.
+ *
+ * Returns null when nothing is pending. When the reasons disagree — a send and a dividend in the
+ * same block's mempool — it falls back to {@link GENERIC_PENDING_LABEL} rather than picking one and
+ * describing the wrong transaction. An unrecognised action does the same, so a protocol addition
+ * shows up as "Pending" instead of vanishing from the screen.
+ */
+export function pendingLabel(reasons: readonly string[]): string | null {
+  if (reasons.length === 0) return null;
+
+  const labels = new Set(reasons.map((reason) => LABELS[reason] ?? GENERIC_PENDING_LABEL));
+  if (labels.size === 1) {
+    return labels.values().next().value ?? GENERIC_PENDING_LABEL;
+  }
+  return GENERIC_PENDING_LABEL;
+}

--- a/src/core/balances/spendable.ts
+++ b/src/core/balances/spendable.ts
@@ -1,0 +1,100 @@
+/**
+ * How much of a balance a new transaction may actually draw on.
+ *
+ * Counterparty debits at parse time, so coins committed by an unconfirmed transaction still sit in
+ * the confirmed balance. The node will not stop you spending them twice: `get_balance` reads the
+ * confirmed ledger, and a send's compose-time validation does not check sufficiency at all — that
+ * happens at consensus, by which point the second transaction is already broadcast and its fee
+ * already spent. The wallet is the only place this can be caught.
+ *
+ * So Max offers what is spendable while the balance keeps showing what is held. Both are true, and
+ * conflating them is what makes a number people rely on start changing meaning: someone who reads
+ * "10" on the card and "9" in the form is being told two different facts, which is fine as long as
+ * the form says why. Someone whose card silently reads "9" has been told one wrong one.
+ *
+ * ## The direction this errs in
+ *
+ * If a pending transaction never confirms — dropped, replaced, never relayed — Max offered 9 when
+ * 10 was really available. The user sends again later and nothing is lost. The opposite mistake
+ * broadcasts a transaction that fails at consensus and spends a fee for nothing. Under-offering is
+ * recoverable, over-offering is not, so every unknown here resolves towards offering less.
+ *
+ * Except one: when the pending total cannot be *stated*, nothing is subtracted at all. That is not
+ * an exception to the rule but the same rule applied — a partial subtraction understates what is
+ * committed and lets the overspend through anyway, while looking as though it was handled.
+ */
+
+import { toBigNumber } from '@/core/numeric';
+
+/**
+ * Plain decimal, never exponential.
+ *
+ * BigNumber's `toString` switches to exponent form for small magnitudes, so a spendable balance of
+ * two satoshis renders as "2e-8" — which then goes straight into an amount field as literal text.
+ * `toFixed` keeps the notation these figures are read and typed in.
+ */
+function decimal(value: ReturnType<typeof toBigNumber>): string {
+  return value.toFixed();
+}
+
+/** What a form needs to offer a Max and explain it. */
+export interface SpendableBalance {
+  /** Display units. What Max should offer. */
+  spendable: string;
+  /** Display units, positive. What the mempool has committed; zero when nothing is pending. */
+  pendingOutgoing: string;
+  /** True when a pending debit exists but could not be totalled, so nothing was subtracted. */
+  unknownPending: boolean;
+}
+
+/**
+ * Reduce a confirmed balance by what the mempool has already committed.
+ *
+ * @param confirmed - Display units, as the balance hooks report it.
+ * @param pendingOutgoing - Display units from core's own `quantity_normalized`, or null when a
+ *   contributing debit had no readable figure. Null subtracts nothing and says so.
+ */
+export function spendableBalance(
+  confirmed: string | null | undefined,
+  pendingOutgoing: string | null | undefined
+): SpendableBalance {
+  const confirmedAmount = toBigNumber(confirmed ?? '0');
+
+  if (pendingOutgoing === null || pendingOutgoing === undefined) {
+    return {
+      spendable: decimal(confirmedAmount),
+      pendingOutgoing: '0',
+      unknownPending: pendingOutgoing === null,
+    };
+  }
+
+  const pending = toBigNumber(pendingOutgoing);
+  if (pending.isLessThanOrEqualTo(0)) {
+    return { spendable: decimal(confirmedAmount), pendingOutgoing: '0', unknownPending: false };
+  }
+
+  // Pending above the confirmed balance is impossible per the ledger, so it means the two reads
+  // disagree — a node mid-reorg, a balance fetched a moment earlier. Offering zero is the
+  // conservative reading and cannot produce an overspend; a negative Max would be nonsense.
+  const spendable = confirmedAmount.minus(pending);
+  return {
+    spendable: spendable.isLessThan(0) ? '0' : decimal(spendable),
+    pendingOutgoing: decimal(pending),
+    unknownPending: false,
+  };
+}
+
+/**
+ * Whether a Counterparty pending figure applies to this asset at all.
+ *
+ * BTC does not go through the Counterparty ledger — its balance comes from the UTXO set, and a
+ * pending BTC send produces no DEBIT event here. Subtracting a Counterparty figure from a BTC
+ * balance would be arithmetic between two unrelated systems, and BTC's own unconfirmed handling
+ * lives with UTXO selection instead.
+ *
+ * An absent asset answers false as well: callers pass one before a selection has been made, and
+ * there is nothing to track pending movement against.
+ */
+export function tracksPendingLedgerDebits(asset: string | null | undefined): boolean {
+  return !!asset && asset.toUpperCase() !== 'BTC';
+}

--- a/src/core/counterparty/api.ts
+++ b/src/core/counterparty/api.ts
@@ -1123,6 +1123,30 @@ export async function fetchDispenserDispenses(
   });
 }
 
+/**
+ * Ledger movements the node has parsed out of its own mempool for these addresses.
+ *
+ * The events are the same DEBIT/CREDIT core emits for confirmed transactions, so a caller can total
+ * what is in flight without re-deriving which message types debit what — see
+ * `core/balances/pending.ts`.
+ *
+ * Two things about this endpoint shape the caller. It matches addresses with a SQL `LIKE` against a
+ * joined column, so results are a superset and must be filtered on each event's own
+ * `params.address`. And it is never cached: a pending balance read from a minute-old response is
+ * the staleness this is meant to cure.
+ */
+export async function fetchMempoolLedgerEvents(
+  addresses: string[],
+  options: { limit?: number; verbose?: boolean } = {}
+): Promise<PaginatedResponse<{ tx_hash: string; event: string; params?: Record<string, unknown> }>> {
+  return cpApiGet('/v2/addresses/mempool', {
+    addresses: addresses.join(','),
+    event_name: 'DEBIT,CREDIT',
+    verbose: options.verbose ?? true,
+    limit: options.limit ?? 100,
+  }, { skipCache: true });
+}
+
 export async function fetchMempoolDispenses(dispenserAddress: string): Promise<Dispense[]> {
   const data = await cpApiGet<PaginatedResponse<{ params: Dispense }>>('/v2/mempool/events/DISPENSE', {
     verbose: true,

--- a/src/core/counterparty/api.ts
+++ b/src/core/counterparty/api.ts
@@ -1132,8 +1132,10 @@ export async function fetchDispenserDispenses(
  *
  * Two things about this endpoint shape the caller. It matches addresses with a SQL `LIKE` against a
  * joined column, so results are a superset and must be filtered on each event's own
- * `params.address`. And it is never cached: a pending balance read from a minute-old response is
- * the staleness this is meant to cure.
+ * `params.address`. And it goes through the ordinary short-lived cache: several parts of a screen
+ * ask this at once — a pool form reads two assets, a list reads many — and collapsing those into
+ * one call matters more than a few seconds of freshness. The refresh button clears the cache for
+ * the address before reloading, so the moment freshness is promised is the moment it is delivered.
  */
 export async function fetchMempoolLedgerEvents(
   addresses: string[],
@@ -1144,7 +1146,7 @@ export async function fetchMempoolLedgerEvents(
     event_name: 'DEBIT,CREDIT',
     verbose: options.verbose ?? true,
     limit: options.limit ?? 100,
-  }, { skipCache: true });
+  });
 }
 
 export async function fetchMempoolDispenses(dispenserAddress: string): Promise<Dispense[]> {

--- a/src/hooks/__tests__/useRefreshSignal.test.ts
+++ b/src/hooks/__tests__/useRefreshSignal.test.ts
@@ -1,0 +1,76 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useRefreshSignal } from '../useRefreshSignal';
+
+describe('useRefreshSignal', () => {
+  // The lists already load when they mount. Treating the counter's initial value as a request
+  // would load everything twice on every visit to the home screen.
+  it('does not fire on the first render', () => {
+    const onRefresh = vi.fn();
+    renderHook(() => useRefreshSignal(0, onRefresh));
+
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+
+  it('fires when the nonce changes', () => {
+    const onRefresh = vi.fn();
+    const { rerender } = renderHook(({ nonce }) => useRefreshSignal(nonce, onRefresh), {
+      initialProps: { nonce: 0 },
+    });
+
+    rerender({ nonce: 1 });
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  // Pressing refresh twice must be two refreshes; this is the reason the signal is a counter
+  // rather than a boolean.
+  it('fires again for each further change', () => {
+    const onRefresh = vi.fn();
+    const { rerender } = renderHook(({ nonce }) => useRefreshSignal(nonce, onRefresh), {
+      initialProps: { nonce: 0 },
+    });
+
+    rerender({ nonce: 1 });
+    rerender({ nonce: 2 });
+    expect(onRefresh).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not fire when the parent re-renders without a new nonce', () => {
+    const onRefresh = vi.fn();
+    const { rerender } = renderHook(({ nonce }) => useRefreshSignal(nonce, onRefresh), {
+      initialProps: { nonce: 3 },
+    });
+
+    rerender({ nonce: 3 });
+    rerender({ nonce: 3 });
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+
+  // Callers pass an inline arrow, so the callback is a different function every render. Depending
+  // on it would re-run the effect constantly — for a callback that reloads a list, endlessly.
+  it('uses the latest callback without re-firing when only the callback changes', () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const { rerender } = renderHook(
+      ({ nonce, cb }) => useRefreshSignal(nonce, cb),
+      { initialProps: { nonce: 0, cb: first } }
+    );
+
+    rerender({ nonce: 0, cb: second });
+    expect(first).not.toHaveBeenCalled();
+    expect(second).not.toHaveBeenCalled();
+
+    rerender({ nonce: 1, cb: second });
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  // A list the caller never refreshes passes undefined; it must simply never fire.
+  it('never fires when no nonce is supplied', () => {
+    const onRefresh = vi.fn();
+    const { rerender } = renderHook(() => useRefreshSignal(undefined, onRefresh));
+
+    rerender();
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useAssetDetails.ts
+++ b/src/hooks/useAssetDetails.ts
@@ -3,7 +3,7 @@ import { useWallet } from "@/contexts/wallet-context";
 import { spendableBalance, tracksPendingLedgerDebits } from "@/core/balances/spendable";
 import type { AssetInfo } from "@/core/counterparty/api";
 import type { DisplayUnits } from '@/core/numeric';
-import { asDisplayUnits } from '@/core/numeric';
+import { asDisplayUnits, toBigNumber } from '@/core/numeric';
 import { useAssetBalance } from "@/hooks/useAssetBalance";
 import { useAssetInfo } from "@/hooks/useAssetInfo";
 import { useAssetUtxos } from "@/hooks/useAssetUtxos";
@@ -29,6 +29,12 @@ export interface AssetDetails {
   spendableBalance: DisplayUnits;
   /** Display units, positive. What the mempool has committed; "0" when nothing is pending. */
   pendingOutgoing: DisplayUnits;
+  /**
+   * Display units, positive. What the mempool is bringing in — informational, never added to the
+   * spendable figure (unconfirmed money in is not money you can spend). "0" when nothing is
+   * arriving or the total could not be read; good news does not need an unknown-state warning.
+   */
+  pendingIncoming: DisplayUnits;
   /**
    * Something is outgoing but could not be totalled, so nothing was subtracted. Forms that explain
    * a reduced Max should say this rather than claim a figure they do not have.
@@ -105,6 +111,7 @@ export function useAssetDetails(asset: string, options?: UseAssetDetailsOptions)
     // and a wrong `true` is a factor-of-1e8 error in a number that gates spending.
     const pending = pendingDeltas.get(asset);
     const spendable = spendableBalance(balance.balance, pending?.debitedNormalized);
+    const incoming = pending?.creditedNormalized;
 
     return {
       isDivisible: balance.isDivisible,
@@ -112,6 +119,7 @@ export function useAssetDetails(asset: string, options?: UseAssetDetailsOptions)
       availableBalance: asDisplayUnits(balance.balance),
       spendableBalance: asDisplayUnits(spendable.spendable),
       pendingOutgoing: asDisplayUnits(spendable.pendingOutgoing),
+      pendingIncoming: asDisplayUnits(incoming && toBigNumber(incoming).isGreaterThan(0) ? incoming : '0'),
       unknownPending: spendable.unknownPending,
       utxoBalances: utxos.utxos || undefined,
     };

--- a/src/hooks/useAssetDetails.ts
+++ b/src/hooks/useAssetDetails.ts
@@ -1,10 +1,13 @@
 import { useEffect, useMemo, useRef } from "react";
+import { useWallet } from "@/contexts/wallet-context";
+import { spendableBalance, tracksPendingLedgerDebits } from "@/core/balances/spendable";
 import type { AssetInfo } from "@/core/counterparty/api";
 import type { DisplayUnits } from '@/core/numeric';
 import { asDisplayUnits } from '@/core/numeric';
 import { useAssetBalance } from "@/hooks/useAssetBalance";
 import { useAssetInfo } from "@/hooks/useAssetInfo";
 import { useAssetUtxos } from "@/hooks/useAssetUtxos";
+import { usePendingDeltas } from "@/hooks/usePendingStatus";
 
 /**
  * Represents the details of an asset, including balance and UTXO information.
@@ -14,6 +17,23 @@ export interface AssetDetails {
   assetInfo: AssetInfo | null;
   /** Display units — already divided by divisibility, as the balance hook returns it. */
   availableBalance: DisplayUnits;
+  /**
+   * Display units. What a new transaction may actually draw on: the confirmed balance less
+   * anything the mempool has already committed.
+   *
+   * Kept separate from `availableBalance` rather than replacing it, because they answer different
+   * questions. A balance shown to the user is what they hold; a Max offered to a form is what they
+   * can spend. Silently showing the second where the first belongs makes a number people rely on
+   * change meaning without saying so, and disagree with every explorer.
+   */
+  spendableBalance: DisplayUnits;
+  /** Display units, positive. What the mempool has committed; "0" when nothing is pending. */
+  pendingOutgoing: DisplayUnits;
+  /**
+   * Something is outgoing but could not be totalled, so nothing was subtracted. Forms that explain
+   * a reduced Max should say this rather than claim a figure they do not have.
+   */
+  unknownPending: boolean;
   utxoBalances?: Array<{
     txid: string;
     amount: string;
@@ -41,6 +61,12 @@ export function useAssetDetails(asset: string, options?: UseAssetDetailsOptions)
   const assetInfo = useAssetInfo(asset);
   const balance = useAssetBalance(asset);
   const utxos = useAssetUtxos(asset);
+  const { activeAddress } = useWallet();
+  // BTC is excluded: its balance comes from the UTXO set, not the Counterparty ledger, so no DEBIT
+  // event here describes a pending BTC send and subtracting one would mix two unrelated systems.
+  const { byAsset: pendingDeltas } = usePendingDeltas(
+    tracksPendingLedgerDebits(asset) ? activeAddress?.address : undefined
+  );
 
   // Cache loading state calculation
   const isLoading = useMemo(() => 
@@ -74,13 +100,22 @@ export function useAssetDetails(asset: string, options?: UseAssetDetailsOptions)
       return null;
     }
 
+    // Core supplies the pending figure already normalized, so no divisibility is assumed here —
+    // which matters, because `useAssetBalance` defaults divisibility to true when it does not know
+    // and a wrong `true` is a factor-of-1e8 error in a number that gates spending.
+    const pending = pendingDeltas.get(asset);
+    const spendable = spendableBalance(balance.balance, pending?.debitedNormalized);
+
     return {
       isDivisible: balance.isDivisible,
       assetInfo: assetInfo.data,
       availableBalance: asDisplayUnits(balance.balance),
+      spendableBalance: asDisplayUnits(spendable.spendable),
+      pendingOutgoing: asDisplayUnits(spendable.pendingOutgoing),
+      unknownPending: spendable.unknownPending,
       utxoBalances: utxos.utxos || undefined,
     };
-  }, [assetInfo.data, balance.balance, balance.isDivisible, utxos.utxos]);
+  }, [assetInfo.data, balance.balance, balance.isDivisible, utxos.utxos, pendingDeltas, asset]);
 
   return {
     isLoading,

--- a/src/hooks/usePendingStatus.ts
+++ b/src/hooks/usePendingStatus.ts
@@ -1,0 +1,67 @@
+import { useEffect, useState } from 'react';
+import { pendingByAsset, pendingByUtxo } from '@/core/balances/pending';
+import { pendingLabel } from '@/core/balances/pendingLabel';
+import { fetchMempoolLedgerEvents } from '@/core/counterparty/api';
+import { useRefreshSignal } from '@/hooks/useRefreshSignal';
+
+/**
+ * What the mempool is currently doing to an address's rows, as a word per asset and per UTXO.
+ *
+ * Read when the screen loads and again when the user refreshes — no polling, no background work.
+ * A status label only has to be right while someone is looking at it, and by then they are.
+ *
+ * Failure is silent and empty. Not every node keeps a mempool this can read, and a home screen that
+ * shows an error banner because an optional annotation could not be fetched has made the wallet
+ * look broken to tell you nothing.
+ */
+export function usePendingStatus(
+  address: string | undefined,
+  refreshNonce?: number
+): { byAsset: Map<string, string>; byUtxo: Map<string, string> } {
+  const [byAsset, setByAsset] = useState<Map<string, string>>(new Map());
+  const [byUtxo, setByUtxo] = useState<Map<string, string>>(new Map());
+  const [reloadCount, setReloadCount] = useState(0);
+
+  useRefreshSignal(refreshNonce, () => setReloadCount((previous) => previous + 1));
+
+  useEffect(() => {
+    if (!address) {
+      setByAsset(new Map());
+      setByUtxo(new Map());
+      return;
+    }
+
+    let isCancelled = false;
+
+    const read = async () => {
+      try {
+        const response = await fetchMempoolLedgerEvents([address]);
+        if (isCancelled) return;
+
+        const events = response.result ?? [];
+        const toLabels = (deltas: Map<string, { reasons: string[] }>) => {
+          const labels = new Map<string, string>();
+          for (const [key, delta] of deltas) {
+            const label = pendingLabel(delta.reasons);
+            if (label) labels.set(key, label);
+          }
+          return labels;
+        };
+
+        setByAsset(toLabels(pendingByAsset(events, address)));
+        setByUtxo(toLabels(pendingByUtxo(events, address)));
+      } catch {
+        // Deliberately quiet — see the note above.
+        if (!isCancelled) {
+          setByAsset(new Map());
+          setByUtxo(new Map());
+        }
+      }
+    };
+
+    read();
+    return () => { isCancelled = true; };
+  }, [address, reloadCount]);
+
+  return { byAsset, byUtxo };
+}

--- a/src/hooks/usePendingStatus.ts
+++ b/src/hooks/usePendingStatus.ts
@@ -1,33 +1,42 @@
-import { useEffect, useState } from 'react';
-import { pendingByAsset, pendingByUtxo } from '@/core/balances/pending';
+import { useEffect, useMemo, useState } from 'react';
+import { type PendingDelta, pendingByAsset, pendingByUtxo } from '@/core/balances/pending';
 import { pendingLabel } from '@/core/balances/pendingLabel';
 import { fetchMempoolLedgerEvents } from '@/core/counterparty/api';
 import { useRefreshSignal } from '@/hooks/useRefreshSignal';
 
+const EMPTY = new Map<string, PendingDelta>();
+
 /**
- * What the mempool is currently doing to an address's rows, as a word per asset and per UTXO.
+ * What the mempool is currently doing to an address's rows.
  *
- * Read when the screen loads and again when the user refreshes — no polling, no background work.
- * A status label only has to be right while someone is looking at it, and by then they are.
+ * Read when a screen loads and again when the user refreshes — no polling, no background work. A
+ * status label or a Max figure only has to be right while someone is looking at it, and by then
+ * they are.
  *
- * Failure is silent and empty. Not every node keeps a mempool this can read, and a home screen that
- * shows an error banner because an optional annotation could not be fetched has made the wallet
- * look broken to tell you nothing.
+ * The request is not cache-busted, deliberately. Several callers can ask at once — a pool deposit
+ * form reads two assets, the home screen reads a list — and the API client's short response cache
+ * collapses those into one call. Pressing refresh clears that cache for the address first, so the
+ * one place freshness is promised is the one place it is guaranteed.
+ *
+ * Failure is silent and empty. Not every node keeps a mempool this can read, and a screen that
+ * shows an error because an optional annotation could not be fetched has made the wallet look
+ * broken in order to tell you nothing. Everything downstream treats "no data" as "subtract
+ * nothing", which is what the wallet did before this existed.
  */
-export function usePendingStatus(
+export function usePendingDeltas(
   address: string | undefined,
   refreshNonce?: number
-): { byAsset: Map<string, string>; byUtxo: Map<string, string> } {
-  const [byAsset, setByAsset] = useState<Map<string, string>>(new Map());
-  const [byUtxo, setByUtxo] = useState<Map<string, string>>(new Map());
+): { byAsset: Map<string, PendingDelta>; byUtxo: Map<string, PendingDelta> } {
+  const [byAsset, setByAsset] = useState<Map<string, PendingDelta>>(EMPTY);
+  const [byUtxo, setByUtxo] = useState<Map<string, PendingDelta>>(EMPTY);
   const [reloadCount, setReloadCount] = useState(0);
 
   useRefreshSignal(refreshNonce, () => setReloadCount((previous) => previous + 1));
 
   useEffect(() => {
     if (!address) {
-      setByAsset(new Map());
-      setByUtxo(new Map());
+      setByAsset(EMPTY);
+      setByUtxo(EMPTY);
       return;
     }
 
@@ -37,24 +46,13 @@ export function usePendingStatus(
       try {
         const response = await fetchMempoolLedgerEvents([address]);
         if (isCancelled) return;
-
         const events = response.result ?? [];
-        const toLabels = (deltas: Map<string, { reasons: string[] }>) => {
-          const labels = new Map<string, string>();
-          for (const [key, delta] of deltas) {
-            const label = pendingLabel(delta.reasons);
-            if (label) labels.set(key, label);
-          }
-          return labels;
-        };
-
-        setByAsset(toLabels(pendingByAsset(events, address)));
-        setByUtxo(toLabels(pendingByUtxo(events, address)));
+        setByAsset(pendingByAsset(events, address));
+        setByUtxo(pendingByUtxo(events, address));
       } catch {
-        // Deliberately quiet — see the note above.
         if (!isCancelled) {
-          setByAsset(new Map());
-          setByUtxo(new Map());
+          setByAsset(EMPTY);
+          setByUtxo(EMPTY);
         }
       }
     };
@@ -64,4 +62,26 @@ export function usePendingStatus(
   }, [address, reloadCount]);
 
   return { byAsset, byUtxo };
+}
+
+/**
+ * The same reading, reduced to one word per row for the balance and UTXO lists.
+ */
+export function usePendingStatus(
+  address: string | undefined,
+  refreshNonce?: number
+): { byAsset: Map<string, string>; byUtxo: Map<string, string> } {
+  const { byAsset, byUtxo } = usePendingDeltas(address, refreshNonce);
+
+  return useMemo(() => {
+    const toLabels = (deltas: Map<string, PendingDelta>) => {
+      const labels = new Map<string, string>();
+      for (const [key, delta] of deltas) {
+        const label = pendingLabel(delta.reasons);
+        if (label) labels.set(key, label);
+      }
+      return labels;
+    };
+    return { byAsset: toLabels(byAsset), byUtxo: toLabels(byUtxo) };
+  }, [byAsset, byUtxo]);
 }

--- a/src/hooks/usePendingStatus.ts
+++ b/src/hooks/usePendingStatus.ts
@@ -64,6 +64,16 @@ export function usePendingDeltas(
   return { byAsset, byUtxo };
 }
 
+/** Each delta reduced to one display word, dropping the ones with nothing to say. */
+export function labelsFromDeltas(deltas: Map<string, PendingDelta>): Map<string, string> {
+  const labels = new Map<string, string>();
+  for (const [key, delta] of deltas) {
+    const label = pendingLabel(delta.reasons);
+    if (label) labels.set(key, label);
+  }
+  return labels;
+}
+
 /**
  * The same reading, reduced to one word per row for the balance and UTXO lists.
  */
@@ -73,15 +83,8 @@ export function usePendingStatus(
 ): { byAsset: Map<string, string>; byUtxo: Map<string, string> } {
   const { byAsset, byUtxo } = usePendingDeltas(address, refreshNonce);
 
-  return useMemo(() => {
-    const toLabels = (deltas: Map<string, PendingDelta>) => {
-      const labels = new Map<string, string>();
-      for (const [key, delta] of deltas) {
-        const label = pendingLabel(delta.reasons);
-        if (label) labels.set(key, label);
-      }
-      return labels;
-    };
-    return { byAsset: toLabels(byAsset), byUtxo: toLabels(byUtxo) };
-  }, [byAsset, byUtxo]);
+  return useMemo(
+    () => ({ byAsset: labelsFromDeltas(byAsset), byUtxo: labelsFromDeltas(byUtxo) }),
+    [byAsset, byUtxo]
+  );
 }

--- a/src/hooks/useRefreshSignal.ts
+++ b/src/hooks/useRefreshSignal.ts
@@ -1,0 +1,30 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Run something when a refresh is asked for, but not on the first render.
+ *
+ * The lists on the home screen already load when they mount. Reacting to the initial value of a
+ * refresh counter as though it were a request would load everything twice on every visit to the
+ * screen, so the first render is deliberately ignored and only later changes count.
+ *
+ * The callback is held in a ref rather than listed as a dependency. Callers pass an inline arrow,
+ * which is a new function on every render of the parent; depending on it would re-run this effect
+ * constantly, and for a callback that reloads a list that is an endless loop rather than a
+ * performance note.
+ *
+ * @param nonce - Changes to request a refresh. Undefined means the caller never refreshes this one.
+ * @param onRefresh - What to do about it, usually resetting whatever guards the initial load.
+ */
+export function useRefreshSignal(nonce: number | undefined, onRefresh: () => void): void {
+  const isFirstRender = useRef(true);
+  const latestOnRefresh = useRef(onRefresh);
+  latestOnRefresh.current = onRefresh;
+
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    latestOnRefresh.current();
+  }, [nonce]);
+}

--- a/src/pages/assets/[asset]/balance.tsx
+++ b/src/pages/assets/[asset]/balance.tsx
@@ -153,7 +153,9 @@ export default function AssetBalancePage(): ReactElement {
           locked: info?.locked ?? false,
           supply: info?.supply,
         },
-        quantity_normalized: asDisplayUnits(assetDetails.availableBalance || "0"),
+        // Spendable, not confirmed: the number a balance page answers for is "what can I do with
+        // this right now", and the pending line beside it carries the in-flight remainder.
+        quantity_normalized: asDisplayUnits(assetDetails.spendableBalance ?? assetDetails.availableBalance ?? "0"),
       };
     }
     // Fall back to cached data for instant display
@@ -200,7 +202,7 @@ export default function AssetBalancePage(): ReactElement {
 
   return (
     <section className="p-4 space-y-6" aria-labelledby="balance-title">
-      <BalanceHeader balance={balanceData} className="mt-1 mb-5" />
+      <BalanceHeader balance={balanceData} className="mt-1 mb-5" pendingOutgoing={assetDetails?.pendingOutgoing} pendingIncoming={assetDetails?.pendingIncoming} unknownPending={assetDetails?.unknownPending} />
       {poolDetails && (
         <div className="bg-white rounded-lg p-4 shadow-sm">
           <h2 className="text-sm font-medium text-gray-900">Pool Position</h2>

--- a/src/pages/assets/[asset]/index.tsx
+++ b/src/pages/assets/[asset]/index.tsx
@@ -294,7 +294,7 @@ export default function AssetPage(): ReactElement {
           <div className="flex justify-between">
             <span className="text-sm text-gray-500">Your Balance</span>
             <span className="text-sm text-gray-900">
-              {assetDetails?.availableBalance || (isLoading ? "Loading…" : "0")}
+              {assetDetails?.spendableBalance ?? assetDetails?.availableBalance ?? (isLoading ? "Loading…" : "0")}
             </span>
           </div>
         </div>

--- a/src/pages/compose/dispenser/form.tsx
+++ b/src/pages/compose/dispenser/form.tsx
@@ -100,12 +100,14 @@ export const DispenserForm = memo(function DispenserForm({
     }
   }, [asset]);
 
-  // Update available balance when asset details load
+  // The escrow comes out of the same balance, so what can be escrowed is what is spendable. Falls
+  // back to the confirmed figure, which is what this offered before pending was tracked.
   useEffect(() => {
-    if (assetDetails?.availableBalance) {
-      setAvailableBalance(assetDetails.availableBalance);
+    const offerable = assetDetails?.spendableBalance ?? assetDetails?.availableBalance;
+    if (offerable) {
+      setAvailableBalance(offerable);
     }
-  }, [assetDetails?.availableBalance]);
+  }, [assetDetails?.spendableBalance, assetDetails?.availableBalance]);
 
 
   // Reset form fields when initialFormData changes to null
@@ -183,7 +185,7 @@ export const DispenserForm = memo(function DispenserForm({
           <BalanceHeader
             balance={{
               asset: selectedAsset,
-              quantity_normalized: asDisplayUnits(availableBalance),
+              quantity_normalized: asDisplayUnits(assetDetails?.availableBalance ?? availableBalance),
               asset_info: assetDetails.assetInfo ? {
                 asset_longname: assetDetails.assetInfo.asset_longname,
                 description: assetDetails.assetInfo.description || '',

--- a/src/pages/compose/dispenser/form.tsx
+++ b/src/pages/compose/dispenser/form.tsx
@@ -185,7 +185,7 @@ export const DispenserForm = memo(function DispenserForm({
           <BalanceHeader
             balance={{
               asset: selectedAsset,
-              quantity_normalized: asDisplayUnits(assetDetails?.availableBalance ?? availableBalance),
+              quantity_normalized: asDisplayUnits(assetDetails?.spendableBalance ?? availableBalance),
               asset_info: assetDetails.assetInfo ? {
                 asset_longname: assetDetails.assetInfo.asset_longname,
                 description: assetDetails.assetInfo.description || '',
@@ -203,6 +203,9 @@ export const DispenserForm = memo(function DispenserForm({
               },
             }}
             className="mt-1 mb-5"
+            pendingOutgoing={assetDetails.pendingOutgoing}
+            pendingIncoming={assetDetails.pendingIncoming}
+            unknownPending={assetDetails.unknownPending}
           />
         ) : activeAddress ? (
           <AddressHeader

--- a/src/pages/compose/dividend/form.tsx
+++ b/src/pages/compose/dividend/form.tsx
@@ -36,6 +36,12 @@ export function DividendForm({
   );
   const { data: dividendAssetInfo } = useAssetDetails(selectedDividendAsset);
   const [dividendAssetBalance, setDividendAssetBalance] = useState<string>("0");
+  /**
+   * A dividend is paid out of this balance, so what can be paid is what is spendable. The directly
+   * fetched figure stands in until the hook resolves; it is the confirmed balance, which is the
+   * behaviour this had before pending was tracked at all — no reduction rather than a wrong one.
+   */
+  const spendableDividendBalance = dividendAssetInfo?.spendableBalance ?? dividendAssetBalance;
   const [quantityPerUnit, setQuantityPerUnit] = useState<string>(
     initialFormData?.quantity_per_unit != null ? String(initialFormData.quantity_per_unit) : ""
   );
@@ -81,12 +87,12 @@ export function DividendForm({
 
   // Handlers
   const calculateMaxAmountPerUnit = () => {
-    if (!assetInfo?.assetInfo?.supply || !dividendAssetBalance) {
+    if (!assetInfo?.assetInfo?.supply || !spendableDividendBalance) {
       return "0";
     }
 
     const maxPerUnitBN = calculateMaxDividendPerUnit(
-      dividendAssetBalance,
+      spendableDividendBalance,
       assetInfo.assetInfo.supply,
       assetInfo.assetInfo.divisible ?? false
     );
@@ -155,7 +161,7 @@ export function DividendForm({
 
           <AmountWithMaxInput
             asset={selectedDividendAsset}
-            availableBalance={dividendAssetBalance}
+            availableBalance={spendableDividendBalance}
             value={quantityPerUnit}
             onChange={setQuantityPerUnit}
             setError={setError}

--- a/src/pages/compose/fairminter/fairmint/form.tsx
+++ b/src/pages/compose/fairminter/fairmint/form.tsx
@@ -111,7 +111,9 @@ export function FairmintForm({
   // Update currency balance when details are loaded
   useEffect(() => {
     if (currencyDetails) {
-      setCurrencyBalance(currencyDetails.availableBalance || "0");
+      // Spendable: max lots are derived from this figure, so XCP already committed in the
+      // mempool must not buy lots twice.
+      setCurrencyBalance(currencyDetails.spendableBalance ?? currencyDetails.availableBalance ?? "0");
     }
   }, [currencyDetails]);
   
@@ -271,7 +273,7 @@ export function FairmintForm({
             <BalanceHeader 
               balance={{
                 asset: currencyType,
-                quantity_normalized: asDisplayUnits(currencyDetails.availableBalance || "0"),
+                quantity_normalized: asDisplayUnits(currencyDetails.spendableBalance ?? currencyDetails.availableBalance ?? "0"),
                 asset_info: currencyDetails.assetInfo ? {
                   asset_longname: currencyDetails.assetInfo.asset_longname,
                   description: currencyDetails.assetInfo.description || '',
@@ -281,7 +283,10 @@ export function FairmintForm({
                   supply: currencyDetails.assetInfo.supply,
                 } : undefined,
               }}
-              className="mt-1 mb-5" 
+              className="mt-1 mb-5"
+              pendingOutgoing={currencyDetails.pendingOutgoing}
+            pendingIncoming={currencyDetails.pendingIncoming}
+              unknownPending={currencyDetails.unknownPending}
             />
           ) : null}
           

--- a/src/pages/compose/issuance/destroy-supply/form.tsx
+++ b/src/pages/compose/issuance/destroy-supply/form.tsx
@@ -141,13 +141,13 @@ export function DestroySupplyForm({
 
           <AmountWithMaxInput
             asset={asset}
-            availableBalance={assetDetails?.availableBalance || "0"}
+            availableBalance={assetDetails?.spendableBalance ?? assetDetails?.availableBalance ?? "0"}
             value={amount}
             onChange={handleAmountChange}
             feeRate={feeRate}
             setError={(message) => {}}
             sourceAddress={activeAddress}
-            maxAmount={assetDetails?.availableBalance || "0"}
+            maxAmount={assetDetails?.spendableBalance ?? assetDetails?.availableBalance ?? "0"}
             showHelpText={showHelpText}
             label="Amount to Destroy"
             name="quantity"

--- a/src/pages/compose/issuance/destroy-supply/form.tsx
+++ b/src/pages/compose/issuance/destroy-supply/form.tsx
@@ -113,9 +113,12 @@ export function DestroySupplyForm({
                 locked: assetDetails.assetInfo?.locked ?? false,
                 supply: assetDetails.assetInfo?.supply
               },
-              quantity_normalized: asDisplayUnits(assetDetails.availableBalance)
+              quantity_normalized: asDisplayUnits(assetDetails.spendableBalance ?? assetDetails.availableBalance)
             }}
             className="mt-1 mb-5"
+            pendingOutgoing={assetDetails.pendingOutgoing}
+            pendingIncoming={assetDetails.pendingIncoming}
+            unknownPending={assetDetails.unknownPending}
           />
         ) : null
       }

--- a/src/pages/compose/order/form.tsx
+++ b/src/pages/compose/order/form.tsx
@@ -204,7 +204,7 @@ export function OrderForm({
         <BalanceHeader
           balance={{
             asset: baseAsset,
-            quantity_normalized: asDisplayUnits(giveAssetDetails.availableBalance),
+            quantity_normalized: asDisplayUnits(giveAssetDetails.spendableBalance ?? giveAssetDetails.availableBalance),
             asset_info: giveAssetDetails.assetInfo ? {
               asset_longname: giveAssetDetails.assetInfo.asset_longname,
               description: giveAssetDetails.assetInfo.description || '',
@@ -215,6 +215,9 @@ export function OrderForm({
             } : undefined,
           }}
           className="mt-1 mb-5"
+          pendingOutgoing={giveAssetDetails.pendingOutgoing}
+            pendingIncoming={giveAssetDetails.pendingIncoming}
+          unknownPending={giveAssetDetails.unknownPending}
         />
       ) : activeAddress ? (
         <AddressHeader

--- a/src/pages/compose/order/form.tsx
+++ b/src/pages/compose/order/form.tsx
@@ -137,8 +137,8 @@ export function OrderForm({
   const isGiveAssetDivisible = giveAssetDetails?.isDivisible ?? true;
   const isGetAssetDivisible = getAssetDetails?.isDivisible ?? true;
   const isQuoteAssetDivisible = quoteAssetDetails?.isDivisible ?? true;
-  const availableBalance = giveAssetDetails?.availableBalance ?? "0";
-  const quoteAssetBalance = quoteAssetDetails?.availableBalance ?? "0";
+  const availableBalance = giveAssetDetails?.spendableBalance ?? giveAssetDetails?.availableBalance ?? "0";
+  const quoteAssetBalance = quoteAssetDetails?.spendableBalance ?? quoteAssetDetails?.availableBalance ?? "0";
 
   // Trading pair data - for orders, swap direction depends on buy/sell
   const tradingPairGive = isBuy ? quoteAsset : baseAsset;

--- a/src/pages/compose/pool/deposit/form.tsx
+++ b/src/pages/compose/pool/deposit/form.tsx
@@ -113,7 +113,7 @@ export function PoolDepositForm({
   const assetABalanceHeader: TokenBalance | null = assetADetailsReady && assetADetails
     ? {
         asset: assetA,
-        quantity_normalized: assetADetails.availableBalance,
+        quantity_normalized: assetADetails.spendableBalance ?? assetADetails.availableBalance,
         asset_info: assetADetails.assetInfo ? {
           asset_longname: assetADetails.assetInfo.asset_longname,
           description: assetADetails.assetInfo.description || "",
@@ -160,7 +160,7 @@ export function PoolDepositForm({
       {pool ? (
         <PoolHeader pool={pool} className="mt-1 mb-5" />
       ) : assetABalanceHeader ? (
-        <BalanceHeader balance={assetABalanceHeader} className="mt-1 mb-5" />
+        <BalanceHeader balance={assetABalanceHeader} className="mt-1 mb-5" pendingOutgoing={assetADetails?.pendingOutgoing} pendingIncoming={assetADetails?.pendingIncoming} unknownPending={assetADetails?.unknownPending} />
       ) : null}
       {/* Deposit/Withdraw tabs with the settings cog, mirroring the DEX order form */}
       <div className="flex justify-between items-center mb-2">

--- a/src/pages/compose/pool/deposit/form.tsx
+++ b/src/pages/compose/pool/deposit/form.tsx
@@ -219,14 +219,14 @@ export function PoolDepositForm({
 
           <AmountWithMaxInput
             asset={assetA}
-            availableBalance={assetADetails?.availableBalance || "0"}
+            availableBalance={assetADetails?.spendableBalance ?? assetADetails?.availableBalance ?? "0"}
             value={quantityA}
             onChange={setQuantityA}
             feeRate={feeRate}
             setError={setLocalError}
             showHelpText={showHelpText}
             sourceAddress={activeAddress}
-            maxAmount={assetADetails?.availableBalance || "0"}
+            maxAmount={assetADetails?.spendableBalance ?? assetADetails?.availableBalance ?? "0"}
             label="Amount"
             name="quantity_a_display"
             disabled={pending || !assetA}
@@ -243,14 +243,14 @@ export function PoolDepositForm({
 
           <AmountWithMaxInput
             asset={assetB}
-            availableBalance={assetBDetails?.availableBalance || "0"}
+            availableBalance={assetBDetails?.spendableBalance ?? assetBDetails?.availableBalance ?? "0"}
             value={quantityB}
             onChange={setQuantityB}
             feeRate={feeRate}
             setError={setLocalError}
             showHelpText={showHelpText}
             sourceAddress={activeAddress}
-            maxAmount={assetBDetails?.availableBalance || "0"}
+            maxAmount={assetBDetails?.spendableBalance ?? assetBDetails?.availableBalance ?? "0"}
             label="Amount"
             name="quantity_b_display"
             disabled={pending || !assetB}

--- a/src/pages/compose/send/form.tsx
+++ b/src/pages/compose/send/form.tsx
@@ -204,13 +204,13 @@ export function SendForm({
 
           <AmountWithMaxInput
             asset={initialAsset || initialFormData?.asset || "BTC"}
-            availableBalance={assetDetails?.availableBalance || "0"}
+            availableBalance={assetDetails?.spendableBalance ?? assetDetails?.availableBalance ?? "0"}
             value={amount}
             onChange={handleAmountChange}
             feeRate={feeRate}
             setError={setValidationError}
             sourceAddress={activeAddress}
-            maxAmount={assetDetails?.availableBalance || "0"}
+            maxAmount={assetDetails?.spendableBalance ?? assetDetails?.availableBalance ?? "0"}
             showHelpText={showHelpText}
             label="Amount"
             name="quantity"

--- a/src/pages/compose/send/form.tsx
+++ b/src/pages/compose/send/form.tsx
@@ -166,7 +166,7 @@ export function SendForm({
           <BalanceHeader
             balance={{
               asset: initialAsset || initialFormData?.asset || "BTC",
-              quantity_normalized: asDisplayUnits(assetDetails.availableBalance),
+              quantity_normalized: asDisplayUnits(assetDetails.spendableBalance ?? assetDetails.availableBalance),
               asset_info: assetDetails.assetInfo ? {
                 asset_longname: assetDetails.assetInfo.asset_longname,
                 description: assetDetails.assetInfo.description || '',
@@ -177,6 +177,9 @@ export function SendForm({
               } : undefined,
             }}
             className="mt-1 mb-5"
+            pendingOutgoing={assetDetails.pendingOutgoing}
+            pendingIncoming={assetDetails.pendingIncoming}
+            unknownPending={assetDetails.unknownPending}
           />
         ) : null
       }

--- a/src/pages/compose/swap/form.tsx
+++ b/src/pages/compose/swap/form.tsx
@@ -133,7 +133,7 @@ export function SwapForm({
   const giveDetailsReady = giveDetails?.assetInfo?.asset === giveAsset;
   const isGiveDivisible = giveDetailsReady && giveDetails ? giveDetails.isDivisible : true;
   const isGetDivisible = getDetails?.assetInfo?.asset === getAsset ? getDetails.isDivisible : true;
-  const availableBalance = giveDetailsReady && giveDetails ? giveDetails.availableBalance : "";
+  const availableBalance = giveDetailsReady && giveDetails ? (giveDetails.spendableBalance ?? giveDetails.availableBalance) : "";
 
   const hasBtc = giveAsset === "BTC" || getAsset === "BTC";
   const pairSelected = Boolean(giveAsset && getAsset && giveAsset !== getAsset);

--- a/src/pages/compose/utxo/attach/form.tsx
+++ b/src/pages/compose/utxo/attach/form.tsx
@@ -74,9 +74,12 @@ export function UtxoAttachForm({
                 locked: assetDetails.assetInfo?.locked ?? false,
                 supply: assetDetails.assetInfo?.supply
               },
-              quantity_normalized: asDisplayUnits(assetDetails.availableBalance)
+              quantity_normalized: asDisplayUnits(assetDetails.spendableBalance ?? assetDetails.availableBalance)
             }}
             className="mt-1 mb-5"
+            pendingOutgoing={assetDetails.pendingOutgoing}
+            pendingIncoming={assetDetails.pendingIncoming}
+            unknownPending={assetDetails.unknownPending}
           />
         )
       }

--- a/src/pages/compose/utxo/attach/form.tsx
+++ b/src/pages/compose/utxo/attach/form.tsx
@@ -98,13 +98,13 @@ export function UtxoAttachForm({
           />
           <AmountWithMaxInput
             asset={initialAsset || initialFormData?.asset || "XCP"}
-            availableBalance={assetDetails?.availableBalance || "0"}
+            availableBalance={assetDetails?.spendableBalance ?? assetDetails?.availableBalance ?? "0"}
             value={quantity}
             onChange={setQuantity}
             feeRate={feeRate}
             setError={() => {}} // No-op since Composer handles errors
             sourceAddress={activeAddress}
-            maxAmount={assetDetails?.availableBalance || "0"}
+            maxAmount={assetDetails?.spendableBalance ?? assetDetails?.availableBalance ?? "0"}
             showHelpText={showHelpText}
             label="Amount"
             name="quantity"

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from "react";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useLocation, useNavigate, useSearchParams } from "react-router";
 import { AssetList } from "@/components/domain/asset/asset-list";
 import { BalanceList } from "@/components/domain/balance/balance-list";
@@ -12,11 +12,12 @@ import {
   FaLock,
   FaPaperPlane,
   FaQrcode,
-  TbPinned
+  FiRefreshCw
 } from "@/components/icons";
 import { Button } from "@/components/ui/button";
 import { useHeader } from "@/contexts/header-context";
 import { useWallet } from "@/contexts/wallet-context";
+import { invalidateAddressBalances } from "@/core/balances/invalidate";
 import { fetchTokenBalances } from "@/core/counterparty/api";
 import { formatAddress } from "@/core/format";
 
@@ -28,7 +29,6 @@ const PATHS = {
   SEND_BTC: "/compose/send/BTC",
   ADDRESS_HISTORY: "/addresses/history",
   SELECT_ADDRESS: "/addresses",
-  PINNED_ASSETS: "/settings/pinned-assets",
   BUY_XCP: "/market/dispensers/XCP",
 } as const;
 
@@ -42,6 +42,34 @@ export default function HomePage(): ReactElement {
   const [copiedToClipboard, setCopiedToClipboard] = useState(false);
   const [hasUtxos, setHasUtxos] = useState(false);
   const [utxoCheckDone, setUtxoCheckDone] = useState(false);
+  /**
+   * A counter per tab, because all three lists stay mounted behind `display: none` and the refresh
+   * button sits in a header shared by all of them. One shared counter would reload whichever list
+   * you were *not* looking at as well, tripling the work; a single counter handed only to the
+   * active list would look like a change to the others every time you switched tabs.
+   *
+   * A counter rather than a boolean so pressing twice is two refreshes — a flag would swallow the
+   * second press while the first is in flight, which is exactly when people press again.
+   */
+  const [refreshNonces, setRefreshNonces] = useState({ Balances: 0, Assets: 0, UTXOs: 0 });
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  /**
+   * Forget what is cached for this address, then ask the visible list for it again.
+   *
+   * Clearing is the whole job: two independent caches serve this screen, and a reload without
+   * dropping them repaints the same stale numbers within their TTL. See
+   * `core/balances/invalidate.ts`. The clear is address-wide rather than per-tab, so switching tabs
+   * after a refresh also shows fresh data — only the reload is scoped to what you can see.
+   */
+  const handleRefresh = (): void => {
+    if (!activeAddress?.address || isRefreshing) return;
+    invalidateAddressBalances(activeAddress.address);
+    setIsRefreshing(true);
+    setRefreshNonces((previous) => ({ ...previous, [activeTab]: previous[activeTab] + 1 }));
+  };
+
+  const stopRefreshing = useCallback(() => setIsRefreshing(false), []);
 
   useEffect(() => {
     setHeaderProps({
@@ -210,12 +238,19 @@ export default function HomePage(): ReactElement {
           >
             Get XCP
           </button>
+          {/* Refresh rather than the pinned-assets shortcut, which moved to Settings. The thing
+              people do at this screen while waiting on a transaction is look again, and there was
+              nothing here to press. */}
           <button type="button"
-            onClick={() => navigate(PATHS.PINNED_ASSETS)}
-            className="p-1 hover:bg-gray-100 rounded-full transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
-            aria-label="Manage Pinned Assets"
+            onClick={handleRefresh}
+            disabled={isRefreshing}
+            className="p-1 hover:bg-gray-100 rounded-full transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-default"
+            aria-label="Refresh balances"
           >
-            <TbPinned className="size-5 text-gray-600" aria-hidden="true" />
+            <FiRefreshCw
+              className={`size-5 text-gray-600 ${isRefreshing ? "animate-spin" : ""}`}
+              aria-hidden="true"
+            />
           </button>
         </div>
       </div>
@@ -242,14 +277,14 @@ export default function HomePage(): ReactElement {
           {content}
         </div>
         <div className="flex-grow overflow-y-auto no-scrollbar px-4 pb-4" style={{ display: activeTab === "Balances" ? "block" : "none" }}>
-          <BalanceList />
+          <BalanceList refreshNonce={refreshNonces.Balances} onRefreshed={stopRefreshing} />
         </div>
         <div className="flex-grow overflow-y-auto no-scrollbar px-4 pb-4" style={{ display: activeTab === "Assets" ? "block" : "none" }}>
-          <AssetList />
+          <AssetList refreshNonce={refreshNonces.Assets} onRefreshed={stopRefreshing} />
         </div>
         {hasUtxos && (
           <div className="flex-grow overflow-y-auto no-scrollbar px-4 pb-4" style={{ display: activeTab === "UTXOs" ? "block" : "none" }}>
-            <UtxoList />
+            <UtxoList refreshNonce={refreshNonces.UTXOs} onRefreshed={stopRefreshing} />
           </div>
         )}
       </div>


### PR DESCRIPTION
Started as a refresh button; grew — with explicit decisions along the way — into the wallet's answer to "what does the number next to an asset mean". **The rule this PR lands: everywhere, that number is what you can spend right now.**

## What's in it, in commit order

1. **Refresh button** replaces the pinned-assets shortcut on the home header (pinning stays at Settings → Pinned Assets). Clears **both** balance caches (Counterparty response cache + the separate BTC cache — clearing one repaints the same stale number) then reloads the tab you're looking at. Per-tab counters, so it doesn't reload the two lists you aren't viewing; a counter not a flag, so pressing twice is two refreshes.
2. **Pending status verbs** on balance/UTXO cards — *Sending, Attaching, Detaching, Moving, Minting* — bottom-right, italic. On UTXO cards the verb replaces the txid while active. Words come only from core's own ledger `action`s; an operation and its fee collapse to one word; unknown actions show "Pending" rather than vanishing. "Locking" deliberately absent — core reports a lock as plain `issuance`, and we don't guess intent.
3. **Max offers spendable** (confirmed − mempool-committed) in every form: send, attach, destroy, pool deposit both sides, dispenser escrow, swap, order both sides, dividend per-unit, **and fairmint max-lots** (a second missed Max found in the final sweep — XCP already committed could buy lots twice). Wired once in `useAssetDetails`. The node does not protect against this: `get_balance` reads confirmed ledger and compose-time validation doesn't check sufficiency, so the wallet is the only place the double-spend-a-pending-balance mistake can be caught.
4. **Displays follow**: the balance list, balance detail page, asset overview, and all eight `BalanceHeader` sites show spendable.
5. **A signed inline note explains the difference**:
   ```
   Balance: 9.00000000 (−1 pending)      ← leaving; already excluded from the figure
   Balance: 9.00000000 (+5 incoming)     ← arriving; never included until confirmed
   Balance: 10.00000000 (pending amount unknown)
   ```
   Signed because unsigned was ambiguous ("9 (1 pending)" reads as about-to-be-10 as easily as 8). The **plus** note is the answer to the original "tx incoming?" complaint, at the spot people stare while waiting.

## The safety spine underneath

- Pending figures come from core's own mempool `DEBIT`/`CREDIT` events (`/v2/addresses/mempool`) — **no re-derivation of consensus debit rules**. Core deletes mempool rows atomically with block-parse, so confirmed+pending double-counting cannot be observed.
- Amounts use core's `quantity_normalized` — **no divisibility assumed anywhere** (a wrong `true` is a 1e8 error in a figure that gates spending).
- **A total missing a term is unknown, not smaller**: one unreadable debit nulls the whole figure and nothing is subtracted (a partial subtraction would let the overspend through while looking handled). Unknown outgoing keeps its note; unknown incoming shows nothing (good news needs no disclaimer).
- Every unknown errs toward offering **less**; pending > confirmed (impossible per ledger ⇒ reads disagree) offers zero, never negative; missing spendable degrades to confirmed — the pre-feature behaviour — never to a Max of 0.
- Ownership filtering is **positive** (the mempool endpoint LIKE-matches, returning a superset); BTC is excluded by name (`tracksPendingLedgerDebits`) since its balance already nets the mempool via `funded − spent + memFunded − memSpent`.

## Review guide — what to click

- Home: press refresh on each tab; watch the spinner stop; switch tabs after refreshing.
- With something in the mempool: card verb, header note, Max on the send form, fairmint lots.
- The judgment calls to veto: the **−/+ wording and size**, the verb-replaces-txid choice on UTXO cards, and whether "(pending amount unknown)" earns its place.

## Known gaps, deliberate

- Compose forms read pending through the ordinary 60s cache; only home-refresh clears it early.
- `countUnreadable` is exported+tested but unused — kept for a future "N unreadable events" detail line; delete if you'd rather not carry it.
- Everything here is test-verified but this branch has **never been browser-exercised** — that's this review.

Full suite, tsc, biome clean; oxlint at its 17-warning baseline. Branch is merged current with main (includes #303/#304).

https://claude.ai/code/session_01QJS9Bj6uAMoYPATvfr6GZ1
