### PR TITLE
Fix the recovery tool rejecting SegWit-funded dust, and two screen defects

### DIFF
--- a/src/core/bitcoin/__tests__/consolidateBatch.test.ts
+++ b/src/core/bitcoin/__tests__/consolidateBatch.test.ts
@@ -22,6 +22,7 @@ import {
   legacySighashAll,
   offCurveFakeKey,
   parseWireTx,
+  toSegwitSerialization,
   txidOf,
   type WireOutput,
 } from './helpers/bareMultisigFixtures';
@@ -155,6 +156,50 @@ describe('consolidateBareMultisigBatch', () => {
       await expect(
         consolidateBareMultisigBatch(TEST_PRIVATE_KEY, TEST_ADDRESS, batchData, 10)
       ).rejects.toThrow(/Script mismatch for UTXO/);
+    });
+
+    // Regression: the cross-check hashed prev_tx_hex directly, which for a SegWit funding
+    // transaction computes the wtxid rather than the txid — so every recovery whose dust was
+    // funded by a SegWit spend failed as "Previous transaction data does not match its txid".
+    // The fixture builder only ever produced legacy serializations, where the two hashes agree,
+    // which is how the confusion stayed green. Reported live: a 12-UTXO batch on a P2PKH address
+    // rejected on its first UTXO because the funding tx spent a P2WPKH input.
+    it('should accept a SegWit previous transaction whose stripped hash is the txid', async () => {
+      const legacyBytes = buildPrevTx([{ amount: 100_000n, script: historicalScript }], 77);
+      const utxo: ConsolidationUTXO = {
+        txid: txidOf(legacyBytes), // the real txid: sha256d over the stripped form
+        vout: 0,
+        amount: 100_000,
+        prev_tx_hex: bytesToHex(toSegwitSerialization(legacyBytes)),
+        script: bytesToHex(historicalScript),
+        position: 0,
+        script_type: 'bare_multisig',
+      };
+      const batchData = createBatchData({ utxos: [utxo] });
+
+      const result = await consolidateBareMultisigBatch(
+        TEST_PRIVATE_KEY, TEST_ADDRESS, batchData, 10
+      );
+      expect(result.totalInput).toBe(100_000);
+      expect(parseWireTx(hexToBytes(result.signedTxHex)).inputs).toHaveLength(1);
+    });
+
+    it('should still reject a SegWit previous transaction with the wrong txid', async () => {
+      const legacyBytes = buildPrevTx([{ amount: 100_000n, script: historicalScript }], 78);
+      const utxo: ConsolidationUTXO = {
+        txid: '11'.repeat(32),
+        vout: 0,
+        amount: 100_000,
+        prev_tx_hex: bytesToHex(toSegwitSerialization(legacyBytes)),
+        script: bytesToHex(historicalScript),
+        position: 0,
+        script_type: 'bare_multisig',
+      };
+      const batchData = createBatchData({ utxos: [utxo] });
+
+      await expect(
+        consolidateBareMultisigBatch(TEST_PRIVATE_KEY, TEST_ADDRESS, batchData, 10)
+      ).rejects.toThrow(/does not match its txid/);
     });
 
     it('should reject prev_tx_hex that does not hash to the txid', async () => {

--- a/src/core/bitcoin/__tests__/helpers/bareMultisigFixtures.ts
+++ b/src/core/bitcoin/__tests__/helpers/bareMultisigFixtures.ts
@@ -182,6 +182,29 @@ export function offCurveFakeKey(prefix: 0x02 | 0x03): Uint8Array {
 }
 
 /**
+ * Re-serialize a legacy (single-input) transaction in SegWit form: marker and
+ * flag after the version, a witness stack before the locktime. The txid is
+ * unchanged — it is defined over the stripped serialization — but sha256d of
+ * these bytes yields the wtxid instead, which is precisely the property the
+ * prev-tx cross-check regression needs a fixture for. Every funding
+ * transaction the legacy builder produces hashes the same either way, which
+ * is how a wtxid/txid confusion stayed green here.
+ */
+export function toSegwitSerialization(legacyTxBytes: Uint8Array): Uint8Array {
+  const version = legacyTxBytes.slice(0, 4);
+  const body = legacyTxBytes.slice(4, legacyTxBytes.length - 4);
+  const locktime = legacyTxBytes.slice(legacyTxBytes.length - 4);
+  // One input (buildPrevTx's shape): witness stack of two arbitrary items,
+  // like the real spend that surfaced the bug (a P2WPKH [signature, pubkey]).
+  const witness = concatBytes(
+    varint(2),
+    varint(3), Uint8Array.of(1, 2, 3),
+    varint(2), Uint8Array.of(4, 5),
+  );
+  return concatBytes(version, Uint8Array.of(0x00, 0x01), body, witness, locktime);
+}
+
+/**
  * Build a previous transaction paying the given outputs, with a fake outpoint
  * varied by `seed` so otherwise-identical fixtures get distinct txids.
  */

--- a/src/core/bitcoin/consolidateBatch.ts
+++ b/src/core/bitcoin/consolidateBatch.ts
@@ -3,7 +3,6 @@
  * Builds and signs recovery transactions from xcp.io recovery API batch data.
  */
 
-import { sha256 } from '@noble/hashes/sha2.js';
 import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
 import { getPublicKey } from '@noble/secp256k1';
 import { Transaction } from '@scure/btc-signer';
@@ -52,14 +51,23 @@ function verifyUtxoAgainstPrevTx(
 ): void {
   let prevTx = prevTxCache.get(utxo.txid);
   if (!prevTx) {
-    const prevTxBytes = hexToBytes(utxo.prev_tx_hex);
-    const computedTxid = bytesToHex(sha256(sha256(prevTxBytes)).reverse());
-    if (computedTxid !== utxo.txid.toLowerCase()) {
+    // Parse first and compare the parser's txid, rather than hashing the raw bytes. A txid is
+    // sha256d over the transaction WITHOUT witnesses; hashing the full serialization of a SegWit
+    // transaction computes the wtxid instead, so the old direct hash rejected every UTXO whose
+    // funding transaction spent a SegWit input — a false positive that blocked real recoveries
+    // ("Previous transaction data does not match its txid"). `Transaction.id` is
+    // sha256d(toBytes(true)): scriptSigs in, witnesses out, which is the definition.
+    //
+    // Equally binding: if the parser's re-serialization hashes to the claimed txid, collision
+    // resistance says the parser's view of the outputs IS that transaction's — which is the only
+    // thing the amount and script checks below rely on.
+    const parsed = Transaction.fromRaw(hexToBytes(utxo.prev_tx_hex), PREV_TX_PARSE_OPTS);
+    if (parsed.id !== utxo.txid.toLowerCase()) {
       throw new Error(
         `Previous transaction data does not match its txid for UTXO ${utxo.txid}:${utxo.vout}`
       );
     }
-    prevTx = Transaction.fromRaw(prevTxBytes, PREV_TX_PARSE_OPTS);
+    prevTx = parsed;
     prevTxCache.set(utxo.txid, prevTx);
   }
 

--- a/src/hooks/useMultiBatchConsolidation.ts
+++ b/src/hooks/useMultiBatchConsolidation.ts
@@ -156,8 +156,14 @@ export function useMultiBatchConsolidation() {
         analytics.track("consolidate", getBtcBucket(fromSatoshis(totalOutputSats, { asNumber: true })));
       }
 
-      // Report every batch, successful or not; the results screen breaks them down
+      // Report every batch, successful or not; the results screen breaks them down.
+      //
+      // Replace rather than push: the form this run was submitted from is consumed — its batch is
+      // spent (or failed) and "back" into it invites re-submitting the same UTXOs. Leaving it on
+      // the stack was also half of a navigation loop: results-back pushed a fresh recovery page,
+      // whose back popped to results, forever.
       navigate("/actions/consolidate/success", {
+        replace: true,
         state: {
           results: batchResults,
           totalBatches,

--- a/src/pages/actions/consolidate/success.tsx
+++ b/src/pages/actions/consolidate/success.tsx
@@ -22,7 +22,11 @@ function ConsolidateSuccessPage() {
   useEffect(() => {
     setHeaderProps({
       title: "Started Recovery",
-      onBack: () => navigate('/actions/consolidate'), // Back to recovery tool homepage
+      // Back to the recovery tool homepage, replacing this results screen. The other half of the
+      // navigation loop: pushing left the results underneath, so the recovery page's own back
+      // (navigate(-1)) returned here and the two pages ping-ponged. Replaced, the stack reads
+      // [..., actions, consolidate] and a second back leaves the tool, as back should.
+      onBack: () => navigate('/actions/consolidate', { replace: true }),
       rightButton: {
         icon: <FiX className="size-4" aria-hidden="true" />,
         onClick: () => navigate('/'),
@@ -179,14 +183,18 @@ function ConsolidateSuccessPage() {
         </div>
       </div>
       
-      {/* Info Message */}
-      <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
-        <p className="text-sm text-blue-900">
-          <strong>Note:</strong> Your transactions are now in the mempool and will be confirmed in the next blocks. 
-          The consolidated Bitcoin will be available once the transactions are confirmed.
-        </p>
-      </div>
-      
+      {/* Only when something was actually broadcast. This note used to render unconditionally,
+          so a run whose summary said "0 successful, nothing was sent" ended with a box saying
+          the transactions were in the mempool — two statements on one screen, one of them false. */}
+      {successfulBatches.length > 0 && (
+        <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
+          <p className="text-sm text-blue-900">
+            <strong>Note:</strong> Your transactions are now in the mempool and will be confirmed in the next blocks.
+            The consolidated Bitcoin will be available once the transactions are confirmed.
+          </p>
+        </div>
+      )}
+
       {/* Action Buttons */}
       <div className="flex space-x-3">
         <Button


### PR DESCRIPTION
A user's 12-UTXO recovery failed on its first UTXO with `Previous transaction data does not match its txid`. Three defects, one report.

## The false positive (our bug, not the indexer's)

The pre-broadcast cross-check is sound in intent: the legacy sighash doesn't commit to input values, so the tool demands each UTXO's funding transaction and proves the bytes hash to the txid — then reads the true amount and script from verified bytes. But it hashed the **full serialization**, and for a SegWit funding transaction that computes the **wtxid**. The served data was correct; we hashed the wrong thing.

Proven on the reported transaction (`28a72316…ee36`): SegWit marker present; `sha256d(full)` = `1520…0340` ≠ txid; witness-stripped hash = the txid exactly. Its vout 0 is the 1,000-sat bare-multisig dust the tool exists to recover.

**Fix:** parse first, compare `Transaction.fromRaw(bytes).id` — verified in the library source to be `sha256d(toBytes(true))`: scriptSigs in, witnesses out, the definition. Equally binding: if the parser's re-serialization hashes to the claimed txid, collision resistance says the parser's view of the outputs *is* that transaction.

**Why every test was green:** the fixtures only ever built legacy serializations, where txid == wtxid. A SegWit fixture now exists; its acceptance test fails on the old check (exactly that one, 21/22), and the tamper case — SegWit bytes under a wrong txid — still rejects, so nothing was loosened.

**Why some users succeeded:** the failure tracks whether the dust's *funding wallet* was SegWit. Legacy-era dust always passed. That cohort only grows, so this would have gotten steadily worse.

## Two more on the same screens

- A run with **0 broadcasts** ended under a note saying "your transactions are now in the mempool". It rendered unconditionally; now only when at least one batch broadcast.
- **Back looped**: results were pushed over the form, results-back pushed a fresh recovery page, whose back popped to results — ping-pong, growing the stack each round. Both edges now `replace`: finishing a run replaces the consumed form (whose batch is spent, and re-submitting it is the one thing back must not invite), and results-back replaces itself with the recovery home. Two backs now leave the tool.

## Verification

- 642 tests pass across `core/bitcoin`, `pages/actions`, and the consolidation hook; `tsc` clean
- New SegWit regression test fails on the unfixed code and passes on the fix
- The real failing transaction, run through the exact fixed call, returns the correct txid
- Not verified: the user's actual recovery re-run — that needs their wallet on this build

https://claude.ai/code/session_01QJS9Bj6uAMoYPATvfr6GZ1
