### PR TITLE
Send the multisig recovery pubkey on compose, and verify it comes back

### DIFF
--- a/src/contexts/composer-context.tsx
+++ b/src/contexts/composer-context.tsx
@@ -72,6 +72,7 @@ import {
   withPinnedDestinations,
 } from "@/core/counterparty/outputPolicy";
 import { packComposeMessage } from "@/core/counterparty/pack/messages";
+import { getSourcePubkey } from "@/core/counterparty/sourcePubkey";
 import { fetchInputValues } from "@/core/counterparty/transaction";
 import { unpackCounterpartyMessage } from "@/core/counterparty/unpack";
 import { packAddress } from "@/core/counterparty/unpack/address";
@@ -466,6 +467,11 @@ export function ComposerProvider<T>({
           rawTransaction: response.result.rawtransaction,
           ownAddresses: [activeAddress.address],
           intendedDestinations: accountedFor,
+          // The same key the compose request sent as multisig_pubkey (both read the provider), so
+          // any data output embedding a different recovery key is a substituted response, not a
+          // choice this wallet made. Null when the wallet had no key to send, which turns the
+          // check off rather than inventing an expectation.
+          expectedRecoveryPubkey: getSourcePubkey(activeAddress.address) ?? undefined,
           // An ownership transfer names its new owner nowhere in the message; the node reads it
           // from the output ahead of the data output.
           positionalDestination: composeType === 'issuance' && typeof dataForApi.transfer_destination === 'string'

--- a/src/contexts/wallet-context.tsx
+++ b/src/contexts/wallet-context.tsx
@@ -46,6 +46,7 @@ import {
 } from "react";
 import { onMessage } from 'webext-bridge/popup'; // Import for popup context
 import type { AddressFormat } from '@/core/bitcoin/address';
+import { setSourcePubkeyProvider } from '@/core/counterparty/sourcePubkey';
 import { withStateLock } from "@/core/wallet/stateLockManager";
 import { keychainExists as checkKeychainExists, watchKeychainRecord } from "@/platform/storage/walletStorage";
 import { getWalletService } from "@/services/walletService";
@@ -384,6 +385,24 @@ export function WalletProvider({ children }: { children: ReactNode }): ReactElem
       }
     });
   }, [walletService]); // Removed walletState - using ref instead to prevent stale closures
+
+  // Give the compose layer a way to look up an address's public key. Compose needs it as the
+  // recovery key when a message overflows into bare-multisig encoding, and core cannot find one
+  // for a never-spent address (see core/counterparty/sourcePubkey.ts). Registered over the loaded
+  // wallets rather than just the active address: some flows compose from an address that is not
+  // the active one, and the lookup is a scan of state already in memory.
+  useEffect(() => {
+    setSourcePubkeyProvider((address: string) => {
+      for (const wallet of walletStateRef.current.wallets) {
+        for (const walletAddress of wallet.addresses) {
+          if (walletAddress.address === address) return walletAddress.pubKey || null;
+        }
+      }
+      return null;
+    });
+    return () => setSourcePubkeyProvider(null);
+    // walletStateRef is read at call time, so the provider needs registering once, not per change.
+  }, []);
 
   useEffect(() => {
     // Initial load with retry for cold-start race condition

--- a/src/core/counterparty/__tests__/compose.multisigPubkey.test.ts
+++ b/src/core/counterparty/__tests__/compose.multisigPubkey.test.ts
@@ -1,0 +1,113 @@
+/**
+ * The multisig_pubkey parameter on compose requests.
+ *
+ * Core encodes any message over 80 bytes as bare multisig and embeds the source's public key in
+ * each data output as its recovery key. It finds that key by scanning the address's spends, which
+ * fails for an address that has never spent — reproduced live: a long-data compose from a fresh
+ * address returns "Pubkey not found for …, please provide it with the `multisig_pubkey`
+ * parameter", and succeeds with it. The wallet holds the key, so it sends it on every compose;
+ * core reads it only on the multisig path, so for everything else the parameter is inert.
+ *
+ * `multisig_pubkey`, not `pubkeys`: core validates `pubkeys` entries by deriving a P2PKH address
+ * and comparing it to the source, so that route can never match a segwit or taproot source.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as apiClientUtils from '@/core/api/client';
+import { getActiveSettings } from '@/core/settings';
+import { composeBroadcast, composeSend } from '../compose';
+import { setSourcePubkeyProvider } from '../sourcePubkey';
+import {
+  createMockComposeResponse,
+  mockAddress,
+  mockDestAddress,
+  mockSatPerVbyte,
+  mockSettings,
+} from './helpers/composeTestHelpers';
+
+vi.mock('@/core/api/client');
+vi.mock('@/core/settings', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/core/settings')>();
+  return { ...actual, getActiveSettings: vi.fn().mockReturnValue(actual.DEFAULT_SETTINGS) };
+});
+vi.mock('@/core/counterparty/utxoSelection', () => ({
+  selectUtxosForTransaction: vi.fn().mockResolvedValue({
+    utxos: [{ txid: 'aa'.repeat(32), vout: 0, value: 100000, status: { confirmed: true } }],
+    inputsSet: `${'aa'.repeat(32)}:0`,
+    totalValue: 100000,
+    excludedWithAssets: 0,
+  }),
+}));
+
+const mockedApiClient = vi.mocked(apiClientUtils.apiClient, true);
+const mockedGetSettings = vi.mocked(getActiveSettings);
+
+const PUBKEY = '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798';
+
+const composedUrl = (): string => mockedApiClient.get.mock.calls[0]![0] as string;
+
+describe('multisig_pubkey on compose requests', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedGetSettings.mockReturnValue(mockSettings as any);
+    mockedApiClient.get.mockResolvedValue(createMockComposeResponse());
+  });
+
+  afterEach(() => setSourcePubkeyProvider(null));
+
+  it('sends the source pubkey when the wallet holds it', async () => {
+    setSourcePubkeyProvider((address) => (address === mockAddress ? PUBKEY : null));
+
+    await composeBroadcast({
+      sourceAddress: mockAddress,
+      text: 'hello',
+      sat_per_vbyte: mockSatPerVbyte,
+    });
+
+    expect(composedUrl()).toContain(`multisig_pubkey=${PUBKEY}`);
+  });
+
+  // The pre-existing behaviour, kept exactly: contexts that never register a provider — the
+  // background, tests, anything outside the popup — compose the same requests they always did,
+  // and core falls back to its own history scan.
+  it('omits the parameter when no provider is registered', async () => {
+    await composeBroadcast({
+      sourceAddress: mockAddress,
+      text: 'hello',
+      sat_per_vbyte: mockSatPerVbyte,
+    });
+
+    expect(composedUrl()).not.toContain('multisig_pubkey');
+  });
+
+  it('omits the parameter for an address the wallet does not hold', async () => {
+    setSourcePubkeyProvider(() => null);
+
+    await composeSend({
+      sourceAddress: mockAddress,
+      destination: mockDestAddress,
+      asset: 'XCP',
+      quantity: 100,
+      sat_per_vbyte: mockSatPerVbyte,
+    });
+
+    expect(composedUrl()).not.toContain('multisig_pubkey');
+  });
+
+  it('sends it on ordinary sends too, where core simply ignores it', async () => {
+    // Deliberate: whether a message overflows into multisig encoding depends on its size, which
+    // the wallet does not compute. Sending the key unconditionally means the boundary lives in
+    // exactly one place — core — instead of being re-derived here and drifting.
+    setSourcePubkeyProvider(() => PUBKEY);
+
+    await composeSend({
+      sourceAddress: mockAddress,
+      destination: mockDestAddress,
+      asset: 'XCP',
+      quantity: 100,
+      sat_per_vbyte: mockSatPerVbyte,
+    });
+
+    expect(composedUrl()).toContain(`multisig_pubkey=${PUBKEY}`);
+  });
+});

--- a/src/core/counterparty/__tests__/outputPolicy.test.ts
+++ b/src/core/counterparty/__tests__/outputPolicy.test.ts
@@ -168,6 +168,56 @@ describe('checkOutputPolicy', () => {
     expect(result.ok).toBe(true);
   });
 
+  describe('recovery key in data outputs', () => {
+    const dataPubkeyA = getPublicKey(hexToBytes('22'.repeat(32)), true);
+    const dataPubkeyB = getPublicKey(hexToBytes('44'.repeat(32)), true);
+    const strangerPubkey = getPublicKey(hexToBytes('55'.repeat(32)), true);
+
+    const dataScriptWithRecoveryKey = (recovery: Uint8Array) => new Uint8Array([
+      0x51, 0x21, ...dataPubkeyA, 0x21, ...dataPubkeyB, 0x21, ...recovery, 0x53, 0xae,
+    ]);
+
+    const policyInput = (recovery: Uint8Array, expected?: string) => ({
+      rawTransaction: rawTxWithScripts([
+        { scriptHex: bytesToHex(dataScriptWithRecoveryKey(recovery)), value: 546n },
+        { scriptHex: bytesToHex(p2wpkh(OWNER_PUBKEY).script), value: 190_000n },
+      ]),
+      ownAddresses: [OWNER],
+      intendedDestinations: [],
+      expectedRecoveryPubkey: expected,
+    });
+
+    it('accepts data outputs embedding the key the request sent', () => {
+      const result = checkOutputPolicy(policyInput(OWNER_PUBKEY, bytesToHex(OWNER_PUBKEY)));
+      expect(result.ok).toBe(true);
+    });
+
+    it('is not case-sensitive about the expected key', () => {
+      const result = checkOutputPolicy(
+        policyInput(OWNER_PUBKEY, bytesToHex(OWNER_PUBKEY).toUpperCase())
+      );
+      expect(result.ok).toBe(true);
+    });
+
+    // The compose request named the recovery key and core honors that parameter verbatim, so a
+    // different key in the response is a substitution: the dust would be spendable by whoever
+    // holds it. This is the check the request-side multisig_pubkey parameter exists to enable.
+    it('rejects data outputs embedding a key the request did not send', () => {
+      const result = checkOutputPolicy(policyInput(strangerPubkey, bytesToHex(OWNER_PUBKEY)));
+
+      expect(result.ok).toBe(false);
+      expect(result.error).toMatch(/recovery key/);
+    });
+
+    // No expectation, no check: an absent key means the wallet sent none, and core then chose one
+    // from the address's own history. Manufacturing a failure there would block every compose
+    // from a wallet that cannot supply keys (test-only wallets), which all worked before.
+    it('checks nothing when the request sent no key', () => {
+      const result = checkOutputPolicy(policyInput(strangerPubkey, undefined));
+      expect(result.ok).toBe(true);
+    });
+  });
+
   it('rejects an output whose script cannot be attributed to any address', () => {
     // An unattributable script might pay anyone, so it cannot be explained — unknown is not safe.
     const tx = new Transaction({ allowUnknownOutputs: true, allowLegacyWitnessUtxo: true });

--- a/src/core/counterparty/__tests__/sourcePubkey.test.ts
+++ b/src/core/counterparty/__tests__/sourcePubkey.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { getSourcePubkey, setSourcePubkeyProvider } from '../sourcePubkey';
+
+const ADDRESS = '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa';
+const PUBKEY = '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798';
+
+describe('sourcePubkey provider', () => {
+  afterEach(() => setSourcePubkeyProvider(null));
+
+  // The common case for every context that never registers: background, tests, anything outside
+  // the popup. Compose then omits the parameter, which is exactly the pre-existing behaviour.
+  it('answers null with no provider registered', () => {
+    expect(getSourcePubkey(ADDRESS)).toBeNull();
+  });
+
+  it('answers from the registered provider', () => {
+    setSourcePubkeyProvider((address) => (address === ADDRESS ? PUBKEY : null));
+
+    expect(getSourcePubkey(ADDRESS)).toBe(PUBKEY);
+    expect(getSourcePubkey('somewhere-else')).toBeNull();
+  });
+
+  // Test-only wallets store '' for the key. An empty multisig_pubkey parameter is one core would
+  // reject, so empty must read as "no key" rather than as a key.
+  it('treats an empty string from the provider as no key', () => {
+    setSourcePubkeyProvider(() => '');
+    expect(getSourcePubkey(ADDRESS)).toBeNull();
+  });
+
+  it('answers null for an empty address without consulting the provider', () => {
+    let consulted = false;
+    setSourcePubkeyProvider(() => {
+      consulted = true;
+      return PUBKEY;
+    });
+
+    expect(getSourcePubkey('')).toBeNull();
+    expect(consulted).toBe(false);
+  });
+
+  it('unregisters cleanly', () => {
+    setSourcePubkeyProvider(() => PUBKEY);
+    setSourcePubkeyProvider(null);
+    expect(getSourcePubkey(ADDRESS)).toBeNull();
+  });
+});

--- a/src/core/counterparty/compose.ts
+++ b/src/core/counterparty/compose.ts
@@ -1,6 +1,7 @@
 import { apiClient } from '@/core/api/client';
 import { requireCounterpartyFeature } from '@/core/counterparty/capabilities';
 import { checkInputPolicy } from '@/core/counterparty/inputPolicy';
+import { getSourcePubkey } from '@/core/counterparty/sourcePubkey';
 import { selectUtxosForTransaction } from '@/core/counterparty/utxoSelection';
 import { CounterpartyApiError } from '@/core/errors';
 import { getActiveSettings, LEGACY_MAX_ORDER_EXPIRATION, MAX_ORDER_EXPIRATION } from '@/core/settings';
@@ -476,6 +477,13 @@ export async function composeTransaction<T extends Record<string, unknown>>(
   const base = await getApiBase();
   const apiUrl = `${base}/v2/addresses/${sourceAddress}/compose/${endpoint}`;
   const settings = getActiveSettings();
+  // Sent on every compose, read by core only when the message overflows an OP_RETURN and falls
+  // back to bare multisig — where it becomes each data output's recovery key. Without it, core
+  // scans the address's spends for a key, and a never-spent address has revealed none: every
+  // long-data compose from a fresh wallet failed on "Pubkey not found". Harmless otherwise, and
+  // it also pins the recovery key to a value the wallet chose, which is what lets verification
+  // check it (`transactionSafety.ts`) instead of trusting whatever key the composer embedded.
+  const multisigPubkey = getSourcePubkey(sourceAddress);
 
   const makeRequest = async ({ inputsSet, allowUnconfirmed }: ComposeRequestOptions): Promise<ApiResponse> => {
     const params = new URLSearchParams(toStringParams({
@@ -487,6 +495,7 @@ export async function composeTransaction<T extends Record<string, unknown>>(
       verbose: 'true',
       ...(encoding && { encoding }),
       ...(inputsSet && { inputs_set: inputsSet }),
+      ...(multisigPubkey && { multisig_pubkey: multisigPubkey }),
     }));
 
     const response = await apiClient.get<ApiResponse | { error: string }>(
@@ -529,6 +538,9 @@ async function composeTransactionWithArrays<T extends Record<string, unknown>>(
   const base = await getApiBase();
   const apiUrl = `${base}/v2/addresses/${sourceAddress}/compose/${endpoint}`;
   const settings = getActiveSettings();
+  // Same as composeTransaction: the recovery key for multisig-encoded data, which MPMA — this
+  // path's caller — produces on almost every send.
+  const multisigPubkey = getSourcePubkey(sourceAddress);
 
   const makeRequest = async ({ inputsSet, allowUnconfirmed }: ComposeRequestOptions): Promise<ApiResponse> => {
     const params = new URLSearchParams(toStringParams({
@@ -540,6 +552,7 @@ async function composeTransactionWithArrays<T extends Record<string, unknown>>(
       verbose: 'true',
       ...(encoding && { encoding }),
       ...(inputsSet && { inputs_set: inputsSet }),
+      ...(multisigPubkey && { multisig_pubkey: multisigPubkey }),
     }));
 
     // Array params must be repeated plain keys: core's `query_params()` builds lists from

--- a/src/core/counterparty/outputPolicy.ts
+++ b/src/core/counterparty/outputPolicy.ts
@@ -55,7 +55,7 @@
 import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
 import { Transaction } from '@scure/btc-signer';
 import { decodeAddressFromScript, normalizeAddressForComparison } from '@/core/bitcoin/address';
-import { isBareMultisigDataOutput } from '@/core/counterparty/unpack/multisig';
+import { bareMultisigRecoveryPubkey, isBareMultisigDataOutput } from '@/core/counterparty/unpack/multisig';
 import { toSafeInteger } from '@/core/numeric';
 
 /** An output the user's request accounts for. */
@@ -77,6 +77,17 @@ export interface OutputPolicyInput {
    * `checkPositionalDestination`.
    */
   positionalDestination?: string;
+  /**
+   * The recovery key every bare-multisig data output must embed, when the request named one.
+   *
+   * The compose request sends `multisig_pubkey` — the signer's own key — and core honors it
+   * verbatim (`get_source_pubkey` returns the parameter before searching anything), so a data
+   * output carrying a different key is a tampered response: its dust would be spendable by
+   * whoever holds that key instead of the signer. Roughly 1,000 sats per data output, forever,
+   * to a stranger. Unset when the wallet had no key to send, which leaves the check off exactly
+   * when nothing pinned the value — an absent expectation must not manufacture a failure.
+   */
+  expectedRecoveryPubkey?: string;
 }
 
 /** An output that could not be explained, described for the error message. */
@@ -295,8 +306,23 @@ export function checkOutputPolicy(input: OutputPolicyInput): OutputPolicyResult 
 
     const scriptHex = bytesToHex(script);
 
-    // Data outputs carry the Counterparty message, not value.
-    if (isDataOutput(script, scriptHex)) continue;
+    // Data outputs carry the Counterparty message, not value — but their recovery slot is still
+    // checkable when the request pinned it (see `expectedRecoveryPubkey`).
+    if (isDataOutput(script, scriptHex)) {
+      if (input.expectedRecoveryPubkey) {
+        const embedded = bareMultisigRecoveryPubkey(scriptHex);
+        if (embedded !== null && embedded !== input.expectedRecoveryPubkey.toLowerCase()) {
+          return {
+            ok: false,
+            error:
+              'The composed transaction embeds a recovery key that is not yours in its data '
+              + 'outputs, so their dust would be spendable by someone else.',
+            unexplained: [],
+          };
+        }
+      }
+      continue;
+    }
 
     const address = decodeAddressFromScript(scriptHex);
     if (!address) {

--- a/src/core/counterparty/sourcePubkey.ts
+++ b/src/core/counterparty/sourcePubkey.ts
@@ -1,0 +1,46 @@
+/**
+ * The source address's public key, for compose calls that must name one.
+ *
+ * Any Counterparty message over 80 bytes is encoded as bare multisig, and each data output embeds
+ * the SOURCE's public key as its third slot so the dust is recoverable later (core's
+ * `prepare_multisig_output`). Core finds that key by scanning the address's spends — which works
+ * only once the address HAS spent, because that is the first time a pubkey appears on chain. A
+ * freshly funded wallet has never spent, so every long-data compose from one failed with "Pubkey
+ * not found for …, please provide it with the `multisig_pubkey` parameter" — reproduced verbatim
+ * against a live node from a never-spent address, and cured by the parameter.
+ *
+ * The wallet does not need to search: it derives the key alongside every address
+ * (`Address.pubKey`). This module is how the compose layer reaches it without importing wallet
+ * state — the same provider inversion `core/settings.ts` uses, and for the same layering reason:
+ * core must stay runtime-free, and which wallets exist is runtime state.
+ *
+ * `multisig_pubkey` is the right parameter, not `pubkeys`: core validates `pubkeys` entries by
+ * deriving a P2PKH address and comparing it to the source, so for a segwit or taproot source that
+ * route can never match. `multisig_pubkey` is taken as-is (validated only as a curve point).
+ * The stored key is the untweaked compressed key even for taproot addresses — which is exactly the
+ * key ECDSA CHECKMULTISIG recovery later needs, and the thing a signature-based extraction cannot
+ * recover from a taproot witness.
+ */
+
+type SourcePubkeyProvider = (address: string) => string | null;
+
+let provider: SourcePubkeyProvider | null = null;
+
+/** Registered by the wallet context; addresses and their keys are runtime state. */
+export function setSourcePubkeyProvider(nextProvider: SourcePubkeyProvider | null): void {
+  provider = nextProvider;
+}
+
+/**
+ * The compressed public key for an address this wallet holds, or null.
+ *
+ * Null degrades to today's behaviour — the parameter is omitted and core falls back to its own
+ * history scan, which still succeeds for any address that has spent. Test-only wallets store an
+ * empty string for the key; empty is not a key, so it is null here rather than an empty parameter
+ * core would reject.
+ */
+export function getSourcePubkey(address: string): string | null {
+  if (!provider || !address) return null;
+  const pubkey = provider(address);
+  return pubkey && pubkey.length > 0 ? pubkey : null;
+}

--- a/src/core/counterparty/transactionSafety.ts
+++ b/src/core/counterparty/transactionSafety.ts
@@ -7,6 +7,8 @@
  */
 
 import { normalizeAddressForComparison } from '@/core/bitcoin/address';
+import { getSourcePubkey } from '@/core/counterparty/sourcePubkey';
+import { bareMultisigRecoveryPubkey } from '@/core/counterparty/unpack/multisig';
 
 /** Severity of a security warning */
 export type WarningSeverity = 'block' | 'danger' | 'warning' | 'info';
@@ -45,10 +47,13 @@ const CP_MULTISIG_DATA_SCRIPT = /^51(21[0-9a-f]{66}){2,3}5[23]ae$/i;
 /**
  * True when the script matches the Counterparty multisig data-encoding shape.
  *
- * Edge case not yet checked: compose accepts a `multisig_pubkey` override, so
- * the embedded recovery key is *normally* the signer's but a hostile composer
- * could point it elsewhere. The info wording hedges accordingly; verifying the
- * third key against the signer's pubkey needs pubkey plumbing into this layer.
+ * The embedded recovery key is checked separately: compose accepts a
+ * `multisig_pubkey` override, so a hostile composer could point the recovery
+ * key — and every data output's dust with it — at a key that is not the
+ * signer's. `analyzeTransactionSafety` compares the third slot against the
+ * signer's own pubkey wherever the wallet holds that address, and the wallet's
+ * own compose path refuses the mismatch outright (`outputPolicy.ts`, which can
+ * be exact because that path also *sent* the key).
  */
 export function isCounterpartyDataScript(script: string | undefined): boolean {
   return !!script && CP_MULTISIG_DATA_SCRIPT.test(script);
@@ -210,6 +215,15 @@ export function analyzeTransactionSafety(
       .map(normalizeAddressForComparison)
   );
   const suspiciousOutputs: Array<{ address: string; value: number }> = [];
+  // The signers' own pubkeys, where this wallet holds them. A dApp transaction can name signer
+  // addresses the wallet does not hold (other participants of a PSBT); those contribute nothing,
+  // and with no keys known the recovery check below stays silent rather than guessing.
+  const signerPubkeys = new Set(
+    (Array.isArray(signerAddress) ? signerAddress : [signerAddress])
+      .map((address) => getSourcePubkey(address)?.toLowerCase())
+      .filter((pubkey): pubkey is string => !!pubkey)
+  );
+  let misdirectedRecoveryKeys = 0;
   /** Non-dust outputs whose script could not be resolved to any address. */
   const unattributableOutputs: Array<{ value: number }> = [];
   /** Recognized Counterparty multisig data outputs (payload, not payments). */
@@ -224,6 +238,10 @@ export function analyzeTransactionSafety(
     // pattern alone must not silence the warning for an unread payload.
     if (!output.address && messageType && isCounterpartyDataScript(output.script)) {
       dataOutputs.push({ value: output.value });
+      const recoveryKey = output.script ? bareMultisigRecoveryPubkey(output.script) : null;
+      if (recoveryKey && signerPubkeys.size > 0 && !signerPubkeys.has(recoveryKey)) {
+        misdirectedRecoveryKeys += 1;
+      }
       continue;
     }
 
@@ -241,6 +259,21 @@ export function analyzeTransactionSafety(
       // such an output raised nothing and showed only as "Unknown address" in the movement list.
       unattributableOutputs.push({ value: output.value });
     }
+  }
+
+  if (misdirectedRecoveryKeys > 0) {
+    // Each data output carries ~1,000 sats of dust, recoverable by whoever holds the embedded
+    // key. Normally that is the signer; a composer that points it elsewhere is quietly donating
+    // the signer's dust, forever. A warning rather than a block: the message itself may still be
+    // exactly what the user asked for, and the dust is bounded — but nobody chooses this
+    // knowingly, so it must not pass in silence.
+    warnings.push({
+      severity: 'warning',
+      title: 'Data Outputs Not Recoverable By You',
+      message:
+        `${misdirectedRecoveryKeys} data output${misdirectedRecoveryKeys > 1 ? 's embed' : ' embeds'} ` +
+        'a recovery key that is not yours, so their dust would be spendable by someone else.',
+    });
   }
 
   if (suspiciousOutputs.length > 0) {

--- a/src/core/counterparty/unpack/__tests__/multisig-encoding.test.ts
+++ b/src/core/counterparty/unpack/__tests__/multisig-encoding.test.ts
@@ -11,11 +11,11 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { setSourcePubkeyProvider } from '../../sourcePubkey';
 import { analyzeTransactionSafety } from '../../transactionSafety';
-import { bareMultisigRecoveryPubkey } from '../multisig';
 import { packAddress } from '../address';
 import { arc4, bytesToHex, hexToBytes } from '../binary';
 import { unpackCounterpartyMessage } from '../index';
 import { COUNTERPARTY_PREFIX_HEX } from '../messageTypes';
+import { bareMultisigRecoveryPubkey } from '../multisig';
 import { extractPayloadFromOutputs } from '../opReturn';
 import { verifyTransaction } from '../verify';
 

--- a/src/core/counterparty/unpack/__tests__/multisig-encoding.test.ts
+++ b/src/core/counterparty/unpack/__tests__/multisig-encoding.test.ts
@@ -8,8 +8,10 @@
  * and classified, so the block applies regardless of encoding.
  */
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
+import { setSourcePubkeyProvider } from '../../sourcePubkey';
 import { analyzeTransactionSafety } from '../../transactionSafety';
+import { bareMultisigRecoveryPubkey } from '../multisig';
 import { packAddress } from '../address';
 import { arc4, bytesToHex, hexToBytes } from '../binary';
 import { unpackCounterpartyMessage } from '../index';
@@ -323,5 +325,69 @@ describe('unclassified transactions fail toward unknown', () => {
 
     expect(safety.warnings).toEqual([]);
     expect(safety.blocked).toBe(false);
+  });
+});
+
+describe('the recovery key rides in the third slot', () => {
+  const signerPubkey = '02' + '11'.repeat(32);
+  const strangerPubkey = '03' + '22'.repeat(32);
+
+  /** A data script embedding `recovery` where core puts the source pubkey. */
+  const scriptWithRecoveryKey = (recovery: string): string =>
+    bytesToHex(new Uint8Array([
+      0x51,
+      0x21, ...new Uint8Array(33).fill(0x02),
+      0x21, ...new Uint8Array(33).fill(0x04),
+      0x21, ...hexToBytes(recovery),
+      0x53,
+      0xae,
+    ]));
+
+  afterEach(() => setSourcePubkeyProvider(null));
+
+  it('reads the third slot back out of a data script', () => {
+    expect(bareMultisigRecoveryPubkey(scriptWithRecoveryKey(signerPubkey))).toBe(signerPubkey);
+  });
+
+  it.each([
+    ['an OP_RETURN', '6a04deadbeef'],
+    ['a P2PKH script', '76a914' + '11'.repeat(20) + '88ac'],
+    ['a truncated multisig', ('51' + '21' + '02'.repeat(33) + '53ae')],
+  ])('claims nothing about %s', (_label, scriptHex) => {
+    expect(bareMultisigRecoveryPubkey(scriptHex)).toBeNull();
+  });
+
+  // The gap the old comment on isCounterpartyDataScript documented: compose accepts a
+  // multisig_pubkey override, so a hostile composer can point every data output's dust at a key
+  // that is not the signer's. Checkable exactly when the wallet holds the signer's key.
+  it('warns when a data output embeds a recovery key that is not the signers own', () => {
+    setSourcePubkeyProvider((address) => (address === 'bc1qsigner' ? signerPubkey : null));
+
+    const safety = analyzeTransactionSafety('send', [
+      { value: 546, type: 'multisig', script: scriptWithRecoveryKey(strangerPubkey) },
+    ], 'bc1qsigner');
+
+    expect(safety.warnings.some((w) => w.title === 'Data Outputs Not Recoverable By You')).toBe(true);
+  });
+
+  it('stays quiet when the recovery key is the signers own', () => {
+    setSourcePubkeyProvider(() => signerPubkey);
+
+    const safety = analyzeTransactionSafety('send', [
+      { value: 546, type: 'multisig', script: scriptWithRecoveryKey(signerPubkey) },
+    ], 'bc1qsigner');
+
+    expect(safety.warnings.some((w) => w.title === 'Data Outputs Not Recoverable By You')).toBe(false);
+  });
+
+  // With no key to compare against there is nothing to claim. Silence is the pre-existing
+  // behaviour, and a warning built on a guess would cry wolf on every PSBT whose signers this
+  // wallet does not hold.
+  it('stays quiet when the wallet holds no key for any signer', () => {
+    const safety = analyzeTransactionSafety('send', [
+      { value: 546, type: 'multisig', script: scriptWithRecoveryKey(strangerPubkey) },
+    ], 'bc1qsigner');
+
+    expect(safety.warnings.some((w) => w.title === 'Data Outputs Not Recoverable By You')).toBe(false);
   });
 });

--- a/src/core/counterparty/unpack/multisig.ts
+++ b/src/core/counterparty/unpack/multisig.ts
@@ -34,6 +34,22 @@ export function isBareMultisigDataOutput(scriptHex: string): boolean {
   return extractMultisigDataBytes(scriptHex) !== null;
 }
 
+/**
+ * The recovery key of a bare-multisig data output: the third slot, which core fills with the
+ * source's real public key (`prepare_multisig_output`) so the source can later spend the dust
+ * back. Unlike the two data slots it is not obfuscated — it must be a real key the network can
+ * check a signature against — so it reads straight out of the script.
+ *
+ * Null for anything that is not the 1-of-3 data shape. The historical 1-of-2 encoding also ends
+ * in the source's key, but nothing current composes it, and a shape this function does not
+ * recognize is one it must not claim to have read.
+ */
+export function bareMultisigRecoveryPubkey(scriptHex: string): string | null {
+  if (extractMultisigDataBytes(scriptHex) === null) return null;
+  // OP_1 (1) + [push33 + key] ×2 (68) + push33 (1) → third key at bytes 70..102.
+  return scriptHex.slice(70 * 2, 103 * 2).toLowerCase();
+}
+
 function extractMultisigDataBytes(scriptHex: string): Uint8Array | null {
   let bytes: Uint8Array;
   try {


### PR DESCRIPTION
Launching anything with a long message — a fairminter, a long-description issuance, a big broadcast — from a **fresh wallet** failed with `Pubkey not found for …, please provide it with the multisig_pubkey parameter`. A first-run failure that hits exactly the people least equipped to read it.

## Mechanism, verified at every link

Core encodes any message over 80 bytes as bare multisig, embedding the **source's pubkey** in each data output as its recovery key (`composer.py::prepare_multisig_output`). It finds that key by scanning the address's spends (`search_pubkey`) — which only works once the address *has spent*, the first moment a pubkey appears on chain. Reproduced live: a real never-spent address (funded 2, spent 0), long-data compose → the exact error; same compose with `multisig_pubkey` → a raw transaction.

The extension declared `multisig_pubkey` and `pubkeys` on its option types and **populated neither** — both dead fields since they were written.

## The fix, and why it's shaped this way

The wallet derives the pubkey alongside every address (`Address.pubKey` — mnemonic, private-key, and hardware wallets all fill it). A provider registered by the wallet context — the same inversion `core/settings.ts` uses, for the same layering reason — lets both compose paths send it on **every** request.

**Unconditional on purpose:** whether a message overflows into multisig depends on its size, which the wallet doesn't compute. Sending always keeps that boundary in exactly one place — core — instead of re-deriving it here and drifting. Where the encoding stays OP_RETURN, core ignores the parameter: **confirmed byte-identical against a live node**, with and without.

**`multisig_pubkey`, not `pubkeys`:** core validates `pubkeys` entries by deriving a *P2PKH address*, so that route can never match a segwit or taproot source. And the stored key is the *untweaked* compressed key even for taproot — exactly what ECDSA CHECKMULTISIG recovery needs, and what a signature-based extraction can't recover from a taproot witness (the gap the website-side fix has).

## Naming the key made it checkable — closing a documented gap

`transactionSafety.ts` had this comment: *"a hostile composer could point [the recovery key] elsewhere… verifying the third key against the signer's pubkey needs pubkey plumbing into this layer."* That plumbing now exists, so the gap closes in both paths:

- **Wallet composes** (`outputPolicy`): a data output embedding a key other than the one the request sent is **refused**. Exact and false-positive-free: core honors the parameter verbatim, so a mismatch is a substituted response — dust spendable by a stranger, forever.
- **dApp signing** (`analyzeTransactionSafety`): **warns** instead of blocking — the message may still be what the user asked, and the wallet may not hold every signer of a PSBT. Silent when it holds no signer key at all; a warning built on a guess would cry wolf on every foreign PSBT.

## Nothing pre-existing changes behaviour

- No provider registered (background, tests), unheld address, test-only wallet's empty key → parameter omitted, checks off, core scans history as before
- Short messages → byte-identical composes (proven live)
- Spent addresses → core's scan finds the *same* key the wallet sends
- Uncompressed recovery keys build a script the 105-byte extractor doesn't read → skip, never misjudge
- Check off when no expectation exists — an absent key must not manufacture a failure

## Class sweep (the consolidation bug's family)

Swept every `sha256d` site in `src` for txid/wtxid confusion: `bip322.ts` hashes locally-built legacy constructions (spec-verified separately); `messageVerifier` hashes a signed message, not a txid; `localTransactionParse.ts` already strips witnesses with a comment showing the author knew the rule. **One instance of the class existed — the consolidation check — and it's fixed in #303.**

## Verification

1116 tests across `core/counterparty` + `contexts` + `hooks`; 16 new tests across four layers (provider, compose param, extractor, policy + safety); oxlint at its 17-warning baseline; `tsc`/`biome` clean. Full-suite run finishing in the background — count to follow in a comment. Not verified: a real launch from a fresh funded wallet through the UI.

https://claude.ai/code/session_01QJS9Bj6uAMoYPATvfr6GZ1
