### PR TITLE
Show subasset order pairs by longname

### DIFF
--- a/src/components/ui/cards/manage-order-card.test.tsx
+++ b/src/components/ui/cards/manage-order-card.test.tsx
@@ -23,6 +23,33 @@ const openOrder: any = {
 describe('ManageOrderCard', () => {
   beforeEach(() => vi.clearAllMocks());
 
+  // Regression: the pair line read each side's canonical name, and a subasset's canonical name
+  // is numeric (A123...). The order Goat wanted to cancel showed a number nobody typed. Both
+  // sides must prefer the longname, and navigation must keep using the numeric name -- it is
+  // what the API routes by.
+  it('shows a subasset by its longname, on either side of the pair', () => {
+    const subassetOrder = {
+      ...openOrder,
+      give_asset: 'A95428956661682177',
+      give_asset_info: { asset_longname: 'PARENT.child' },
+      get_asset: 'XCP',
+    };
+    render(<ManageOrderCard order={subassetOrder} />);
+
+    expect(screen.getByText('PARENT.child/XCP')).toBeInTheDocument();
+    expect(screen.queryByText(/A95428956661682177/)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /PARENT\.child/ }));
+    expect(mockNavigate).toHaveBeenCalledWith('/market/orders/A95428956661682177/XCP');
+  });
+
+  it('falls back to the numeric name when no longname is carried', () => {
+    const bare = { ...openOrder, give_asset: 'A95428956661682177', get_asset: 'XCP' };
+    render(<ManageOrderCard order={bare} />);
+
+    expect(screen.getByText('A95428956661682177/XCP')).toBeInTheDocument();
+  });
+
   it('opens the order when the card body is clicked', () => {
     render(<ManageOrderCard order={openOrder} />);
 

--- a/src/components/ui/cards/manage-order-card.tsx
+++ b/src/components/ui/cards/manage-order-card.tsx
@@ -2,7 +2,7 @@ import type { ReactElement } from "react";
 import { useNavigate } from "react-router";
 import { AssetIcon } from "@/components/domain/asset/asset-icon";
 import type { Order } from "@/core/counterparty/api";
-import { formatAmount } from "@/core/format";
+import { formatAmount, formatAsset } from "@/core/format";
 import { getOrderBaseAmount, getTradingPair, isBuyOrder } from "@/core/tradingPair";
 
 interface ManageOrderCardProps {
@@ -24,7 +24,13 @@ export function ManageOrderCard({
   // Determine canonical trading pair and direction
   const [baseAsset, quoteAsset] = getTradingPair(order.give_asset, order.get_asset);
   const isBuy = isBuyOrder(order.give_asset, order.get_asset);
-  const baseDisplay = baseAsset;
+  // A subasset's canonical name is numeric; the longname is what the user recognizes. Each side's
+  // info is whichever of give/get that side came from — the sibling market card matched only the
+  // base side and this one matched neither, so a cancel list read A95428956661682177.
+  const infoFor = (asset: string) =>
+    asset === order.give_asset ? order.give_asset_info : order.get_asset_info;
+  const baseDisplay = formatAsset(baseAsset, { assetInfo: infoFor(baseAsset) });
+  const quoteDisplay = formatAsset(quoteAsset, { assetInfo: infoFor(quoteAsset) });
 
   // Get remaining amount in base asset terms
   const remainingAmount = getOrderBaseAmount(order, baseAsset);
@@ -53,7 +59,7 @@ export function ManageOrderCard({
           <AssetIcon asset={baseAsset} size="md" />
           <div className="flex-1 min-w-0">
             <div className="font-medium text-gray-900 text-sm truncate">
-              {baseDisplay}/{quoteAsset}
+              {baseDisplay}/{quoteDisplay}
             </div>
             <div className="text-xs text-gray-500">
               <span className={isBuy ? "text-green-600 font-medium" : "text-red-600 font-medium"}>

--- a/src/components/ui/cards/market-order-card.tsx
+++ b/src/components/ui/cards/market-order-card.tsx
@@ -1,7 +1,7 @@
 import type { KeyboardEvent, ReactElement } from "react";
 import { AssetIcon } from "@/components/domain/asset/asset-icon";
 import type { Order, OrderDetails } from "@/core/counterparty/api";
-import { formatAmount } from "@/core/format";
+import { formatAmount, formatAsset } from "@/core/format";
 import { getOrderBaseAmount, getOrderPricePerUnit, getTradingPair, isBuyOrder } from "@/core/tradingPair";
 
 interface MarketOrderCardProps {
@@ -25,7 +25,12 @@ export function MarketOrderCard({
 
   // Handle both Order and OrderDetails types - only OrderDetails has asset_info
   const orderDetails = order as OrderDetails;
-  const baseDisplay = (isBuy ? orderDetails.get_asset_info?.asset_longname : orderDetails.give_asset_info?.asset_longname) || baseAsset;
+  // Same rule as ManageOrderCard: prefer each side's longname. The old inline pick covered only
+  // the base side, so a subasset quote still rendered numeric.
+  const infoFor = (asset: string) =>
+    asset === orderDetails.give_asset ? orderDetails.give_asset_info : orderDetails.get_asset_info;
+  const baseDisplay = formatAsset(baseAsset, { assetInfo: infoFor(baseAsset) });
+  const quoteDisplay = formatAsset(quoteAsset, { assetInfo: infoFor(quoteAsset) });
 
   // Calculate price and remaining amount using trading pair utilities
   const price = getOrderPricePerUnit(order, baseAsset);
@@ -55,7 +60,7 @@ export function MarketOrderCard({
               <span className={isBuy ? "text-green-600 font-medium" : "text-red-600 font-medium"}>
                 {isBuy ? "Buy" : "Sell"}
               </span>
-              {" @ "}{formatAmount({ value: price, maximumFractionDigits: 8 })} {quoteAsset}
+              {" @ "}{formatAmount({ value: price, maximumFractionDigits: 8 })} {quoteDisplay}
             </span>
             <span>{formatAmount({ value: remainingAmount, maximumFractionDigits: 2 })} remaining</span>
           </div>

--- a/src/core/counterparty/api.ts
+++ b/src/core/counterparty/api.ts
@@ -201,6 +201,26 @@ export interface Order {
   block_time: number;
   give_asset: string;
   get_asset: string;
+  /**
+   * Present on verbose responses. A subasset's `give_asset`/`get_asset` is its numeric name
+   * (A123…); the PARENT.child the user knows lives in `asset_longname` here, and displays must
+   * prefer it — an order list showing A95428956661682177 names nothing anyone typed. The shapes
+   * are the ones OrderDetails always declared, hoisted so plain order lists get them too.
+   */
+  give_asset_info?: {
+    divisible: boolean;
+    asset_longname: string | null;
+    description: string;
+    locked: boolean;
+    issuer: string | null;
+  };
+  get_asset_info?: {
+    asset_longname: string | null;
+    description: string;
+    issuer: string;
+    divisible: boolean;
+    locked: boolean;
+  };
   give_quantity_normalized: DisplayUnits;
   get_quantity_normalized: DisplayUnits;
   give_remaining_normalized: DisplayUnits;
@@ -221,20 +241,6 @@ export interface OrderDetails extends Order {
   give_price: number;
   get_price: number;
   confirmed: boolean;
-  give_asset_info?: {
-    divisible: boolean;
-    asset_longname: string | null;
-    description: string;
-    locked: boolean;
-    issuer: string | null;
-  };
-  get_asset_info?: {
-    asset_longname: string | null;
-    description: string;
-    issuer: string;
-    divisible: boolean;
-    locked: boolean;
-  };
   give_price_normalized?: DisplayUnits;
   get_price_normalized?: DisplayUnits;
   fee_provided_normalized?: DisplayUnits;


### PR DESCRIPTION
The order Goat went to cancel read `A95428956661682177/XCP` instead of `PARENT.child/XCP`.

- **Manage card** (the Cancel list): displayed neither side's longname — dead `const baseDisplay = baseAsset`.
- **Market card**: matched only the base side inline; a subasset *quote* still rendered numeric.
- Both now route both sides through `formatAsset` with that side's own `asset_info` — the single existing definition of the longname preference. Navigation keeps numeric names (the API routes by them); a test pins that split.
- `Order` now declares `give/get_asset_info` (hoisted unchanged from `OrderDetails`) — verbose responses always carried them, the type just couldn't see them.

Regression test fails on the old card (`A95428956661682177` visible) and passes on the fix. 131 tests across cards/api/market green; tsc/biome clean; oxlint at baseline.

https://claude.ai/code/session_01QJS9Bj6uAMoYPATvfr6GZ1