### PR TITLE
Market search finds subassets; search result cards fill the row

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xcp-wallet",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xcp-wallet",
-      "version": "0.8.6",
+      "version": "0.8.7",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "xcp-wallet",
   "description": "Counterparty Web3 Wallet",
   "private": true,
-  "version": "0.8.6",
+  "version": "0.8.7",
   "license": "MIT",
   "type": "module",
   "engines": {

--- a/src/components/domain/asset/search-result-card.tsx
+++ b/src/components/domain/asset/search-result-card.tsx
@@ -69,7 +69,7 @@ export function SearchResultCard({
   
   return (
     <button type="button"
-      className={`text-left relative flex items-center p-3 bg-white rounded-lg shadow-sm cursor-pointer hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${className}`}
+      className={`w-full text-left relative flex items-center p-3 bg-white rounded-lg shadow-sm cursor-pointer hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${className}`}
       onClick={handleClick}
       aria-label={`View ${symbol}`}
     >

--- a/src/components/domain/balance/balance-card.tsx
+++ b/src/components/domain/balance/balance-card.tsx
@@ -96,8 +96,8 @@ export function BalanceCard({
                 useGrouping: true,
               })}
             </span>
-            {/* Reserve room for the menu button, which floats over the card's top right. */}
-            {pendingStatus && <PendingStatus label={pendingStatus} className="ml-2 mr-6" />}
+            {/* The floating menu button sits a row above this line, so no room is reserved. */}
+            {pendingStatus && <PendingStatus label={pendingStatus} className="ml-2" />}
           </div>
         </div>
       </button>

--- a/src/components/domain/balance/pending-status.tsx
+++ b/src/components/domain/balance/pending-status.tsx
@@ -19,7 +19,10 @@ interface PendingStatusProps {
  */
 export function PendingStatus({ label, className = "" }: PendingStatusProps): ReactElement {
   return (
-    <span className={`text-xs italic text-gray-400 ${className}`}>
+    // text-right: the flex row places this at the right edge, but the span's own box can be
+    // wider than its text (the menu-clearance margin, or a wrapped two-word label), and then the
+    // text sat left inside a right-positioned box.
+    <span className={`text-xs italic text-gray-400 text-right ${className}`}>
       {label}
     </span>
   );

--- a/src/core/__tests__/format.test.ts
+++ b/src/core/__tests__/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { formatAddress, formatAmount, formatAsset, formatDate } from '@/core/format';
+import { formatAddress, formatAmount, formatAsset, formatDate, normalizeAssetQuery } from '@/core/format';
 
 describe('format utilities', () => {
   describe('formatAmount', () => {
@@ -377,5 +377,23 @@ describe('formatAmount, given the string a quantity arrived as', () => {
     expect(formatAmount({ value: 'not a number' })).toBe('N/A');
     expect(formatAmount({ value: '' })).toBe('N/A');
     expect(formatAmount({ value: null })).toBe('N/A');
+  });
+});
+
+describe('normalizeAssetQuery', () => {
+  it('uppercases a named-asset query, the charset convention', () => {
+    expect(normalizeAssetQuery('pepecash')).toBe('PEPECASH');
+    expect(normalizeAssetQuery('  xcp ')).toBe('XCP');
+  });
+
+  // A subasset longname is case-sensitive; uppercasing PARENT.child names a different asset,
+  // which is why a fully and correctly typed longname found nothing in the market search.
+  it('leaves a subasset query exactly as typed', () => {
+    expect(normalizeAssetQuery('PARENT.child')).toBe('PARENT.child');
+    expect(normalizeAssetQuery(' A95428956661682177.sub ')).toBe('A95428956661682177.sub');
+  });
+
+  it('the dot decides, even for a lowercase parent', () => {
+    expect(normalizeAssetQuery('parent.Child')).toBe('parent.Child');
   });
 });

--- a/src/core/format.ts
+++ b/src/core/format.ts
@@ -105,6 +105,21 @@ export function formatAddress(address: string | null | undefined, shorten: boole
  * formatAsset("XCP") // "XCP"
  * formatAsset("MYLONGASSETNAME", { shorten: true }) // "MYLONGASSET..."
  */
+/**
+ * An asset query as the API wants it: named assets uppercased, subassets left alone.
+ *
+ * Named assets are uppercase by charset, so uppercasing a partial or sloppy query is a
+ * convenience. A subasset longname is case-sensitive — its child part draws on a 68-character
+ * set with both cases — so the same convenience destroys it: PARENT.child uppercased names a
+ * different (usually nonexistent) asset, and the market search failed even on a fully typed,
+ * fully correct longname. The dot decides which rule applies; it is not a legal character in a
+ * named asset.
+ */
+export function normalizeAssetQuery(query: string): string {
+  const trimmed = query.trim();
+  return trimmed.includes(".") ? trimmed : trimmed.toUpperCase();
+}
+
 export function formatAsset(
   assetName: string,
   options?: {

--- a/src/hooks/useMarketData.ts
+++ b/src/hooks/useMarketData.ts
@@ -10,6 +10,7 @@ import {
   type Order,
   type OrderDetails,
 } from "@/core/counterparty/api";
+import { normalizeAssetQuery } from "@/core/format";
 import { usePaginatedFetch } from "@/hooks/usePaginatedFetch";
 
 // Key extractors for deduplication
@@ -141,9 +142,13 @@ export function useMarketData({
   const filteredUserOrders = useMemo(() => {
     if (!searchQuery.trim()) return userOrders.data;
     const query = searchQuery.toLowerCase();
+    // Longnames too, like the dispenser filter five lines up: a subasset's give/get_asset is its
+    // numeric name, so matching only those made every longname fragment come back empty.
     return userOrders.data.filter((o) =>
       o.give_asset.toLowerCase().includes(query) ||
-      o.get_asset.toLowerCase().includes(query)
+      o.get_asset.toLowerCase().includes(query) ||
+      (o.give_asset_info?.asset_longname?.toLowerCase() || "").includes(query) ||
+      (o.get_asset_info?.asset_longname?.toLowerCase() || "").includes(query)
     );
   }, [userOrders.data, searchQuery]);
 
@@ -158,7 +163,7 @@ export function useMarketData({
     setDispenserSearchLoading(true);
     setDispenserSearchError(null);
     try {
-      const res = await fetchAssetDispensers(query.toUpperCase(), { status: "open", limit: PAGE_SIZE });
+      const res = await fetchAssetDispensers(normalizeAssetQuery(query), { status: "open", limit: PAGE_SIZE });
       setDispenserResults(res.result);
     } catch (err) {
       console.error("Failed to search dispensers:", err);
@@ -179,7 +184,9 @@ export function useMarketData({
     setOrderSearchLoading(true);
     setOrderSearchError(null);
     try {
-      const res = await fetchAssetOrders(query.toUpperCase(), { status: "open", limit: PAGE_SIZE });
+      // normalizeAssetQuery, not toUpperCase: uppercasing a subasset longname names a different
+      // asset, so even an exactly typed PARENT.child found nothing here.
+      const res = await fetchAssetOrders(normalizeAssetQuery(query), { status: "open", limit: PAGE_SIZE });
       setOrderResults(res.result);
     } catch (err) {
       console.error("Failed to search orders:", err);

--- a/src/pages/market/index.tsx
+++ b/src/pages/market/index.tsx
@@ -24,7 +24,7 @@ import {
   type PoolPosition,
 } from "@/core/counterparty/api";
 import { normalizePoolPosition } from "@/core/counterparty/pool";
-import { formatAddress } from "@/core/format";
+import { formatAddress, normalizeAssetQuery } from "@/core/format";
 import { toNumber } from "@/core/numeric";
 import { formatPrice } from "@/core/priceFormat";
 import { getTradingPair } from "@/core/tradingPair";
@@ -408,7 +408,7 @@ export default function MarketPage(): ReactElement {
                   {isSearching ? (
                     <div>
                       <p className="text-sm text-gray-500 mb-2">
-                        Results for "{searchQuery.toUpperCase()}"
+                        Results for "{normalizeAssetQuery(searchQuery)}"
                       </p>
                       {dispenserSearchLoading ? (
                         <Spinner message="Searching..." />
@@ -426,15 +426,15 @@ export default function MarketPage(): ReactElement {
                           ))}
                           {dispenserResults.length >= PAGE_SIZE && (
                             <button type="button"
-                              onClick={() => navigate(`/market/dispensers/${searchQuery.toUpperCase()}`)}
+                              onClick={() => navigate(`/market/dispensers/${normalizeAssetQuery(searchQuery)}`)}
                               className="w-full py-2 text-sm text-blue-600 hover:text-blue-800 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
                             >
-                              View all dispensers for {searchQuery.toUpperCase()} →
+                              View all dispensers for {normalizeAssetQuery(searchQuery)} →
                             </button>
                           )}
                         </div>
                       ) : (
-                        <EmptyState message={`No open dispensers for ${searchQuery.toUpperCase()}`} />
+                        <EmptyState message={`No open dispensers for ${normalizeAssetQuery(searchQuery)}`} />
                       )}
                     </div>
                   ) : dispensers.isLoading ? (
@@ -524,7 +524,7 @@ export default function MarketPage(): ReactElement {
                   {isSearching ? (
                     <div>
                       <p className="text-sm text-gray-500 mb-2">
-                        Results for "{searchQuery.toUpperCase()}"
+                        Results for "{normalizeAssetQuery(searchQuery)}"
                       </p>
                       {orderSearchLoading ? (
                         <Spinner message="Searching..." />


### PR DESCRIPTION
Two fixes from release-candidate testing.

**Search (orders tab, and browse mode on all tabs):**
- Manage-mode order filter matched only the numeric `give_asset`/`get_asset` — the dispenser filter five lines up already matched longnames. Diverged duplicates, reunited. (#305's type fix is what made this possible.)
- Browse-mode search **uppercased the query** before the exact-asset lookup — and subasset longnames are case-sensitive, so even a fully typed `PARENT.child` found nothing. `normalizeAssetQuery` uppercases only dotless queries (a dot is not legal in a named asset); result labels and navigation use the same rule so links go where labels say.
- Pools still match numeric-only: `Pool` rows carry no longname data to match.

**Width:** `SearchResultCard`'s root is a *button* — shrink-to-fit — while every neighbouring card is a block div. `w-full` makes it a row.

546 tests green across the touched areas; tsc/biome clean; oxlint at baseline.

https://claude.ai/code/session_01QJS9Bj6uAMoYPATvfr6GZ1