### PR TITLE
Sign site-driven inscriptions the wallet can prove, and only those

### DIFF
--- a/src/core/bitcoin/__tests__/psbt.test.ts
+++ b/src/core/bitcoin/__tests__/psbt.test.ts
@@ -4,7 +4,7 @@
 
 import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
 import { getPublicKey } from '@noble/secp256k1';
-import { p2pkh, p2wpkh, Transaction } from '@scure/btc-signer';
+import { Address, p2pkh, p2tr, p2wpkh, SigHash, TAPROOT_UNSPENDABLE_KEY, Transaction } from '@scure/btc-signer';
 import { describe, expect, it } from 'vitest';
 import { AddressFormat } from '../address';
 import {
@@ -357,6 +357,94 @@ describe('validateSignInputs', () => {
 
     const result = validateSignInputs(signInputs, walletAddresses);
     expect(result.valid).toBe(true);
+  });
+});
+
+
+/**
+ * The two taproot shapes an inscription flow hands this signer, built exactly as the launchpad
+ * builds them (`buildCommitFundingPsbt` / `buildRevealPsbt`): a key-path funding input with
+ * witnessUtxo but NO tapInternalKey (a site cannot know the internal key behind an address), and
+ * a script-path reveal whose leaf names the address's tweaked output key.
+ */
+describe('signPSBT taproot inscription shapes', () => {
+  const privKey = TEST_PRIVATE_KEY;
+  const internalKey = getPublicKey(hexToBytes(privKey), true).slice(1, 33);
+  const addrP2tr = p2tr(internalKey, undefined, undefined, true);
+  const outputKey = (Address().decode(addrP2tr.address!) as { type: 'tr'; pubkey: Uint8Array }).pubkey;
+
+  // A minimal ord-shaped leaf ending in <output key> OP_CHECKSIG, as the launchpad emits.
+  const leaf = new Uint8Array([
+    0x00, 0x63, 0x03, 0x6f, 0x72, 0x64, 0x68, 0x20, ...outputKey, 0xac,
+  ]);
+  const commitP2tr = p2tr(TAPROOT_UNSPENDABLE_KEY, { script: leaf, leafVersion: 0xc0 }, undefined, true);
+
+  it('signs a commit funding input that carries no tapInternalKey', () => {
+    const tx = new Transaction();
+    tx.addInput({
+      txid: hexToBytes('11'.repeat(32)),
+      index: 0,
+      witnessUtxo: { script: addrP2tr.script, amount: 100_000n },
+      sighashType: SigHash.ALL,
+    });
+    tx.addOutputAddress(commitP2tr.address!, 60_000n);
+    tx.addOutputAddress(addrP2tr.address!, 35_000n);
+
+    const signed = signPSBT(bytesToHex(tx.toPSBT()), privKey, [0], AddressFormat.P2TR);
+
+    const parsed = Transaction.fromPSBT(hexToBytes(signed));
+    expect(parsed.getInput(0).tapKeySig).toBeDefined();
+    // Finalizable straight to broadcastable bytes, as the site will do.
+    parsed.finalize();
+    expect(parsed.extract().length).toBeGreaterThan(0);
+  });
+
+  it('signs a reveal whose leaf names the tweaked output key', () => {
+    const tx = new Transaction({ allowUnknownOutputs: true });
+    tx.addInput({
+      txid: hexToBytes('22'.repeat(32)),
+      index: 0,
+      witnessUtxo: { script: commitP2tr.script, amount: 60_000n },
+      tapLeafScript: commitP2tr.tapLeafScript,
+      sighashType: SigHash.ALL,
+    });
+    tx.addOutput({ script: hexToBytes('6a08434e545250525459'), amount: 0n });
+    tx.addOutputAddress(addrP2tr.address!, 546n);
+
+    const signed = signPSBT(bytesToHex(tx.toPSBT()), privKey, [0], AddressFormat.P2TR);
+
+    // Finalized with the options the launchpad's finalizeSignedPsbt uses — allowUnknownInputs is
+    // what lets the finalizer assemble a witness for a leaf script it has no template for.
+    const parsed = Transaction.fromPSBT(hexToBytes(signed), {
+      allowUnknownInputs: true,
+      allowUnknownOutputs: true,
+      disableScriptCheck: true,
+    });
+    expect(parsed.getInput(0).tapScriptSig?.length).toBe(1);
+    parsed.finalize();
+    const raw = parsed.extract();
+    // The finalized witness is the 3-element shape core requires: signature, leaf, control block.
+    const reparsed = Transaction.fromRaw(raw, { allowUnknownOutputs: true, disableScriptCheck: true });
+    expect(reparsed.getInput(0).finalScriptWitness?.length).toBe(3);
+  });
+
+  it('does not sign a foreign taproot input in best-effort mode', () => {
+    const strangerScript = p2tr(
+      hexToBytes('c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5'),
+      undefined, undefined, true
+    );
+    const tx = new Transaction();
+    tx.addInput({
+      txid: hexToBytes('33'.repeat(32)),
+      index: 0,
+      witnessUtxo: { script: strangerScript.script, amount: 100_000n },
+      sighashType: SigHash.ALL,
+    });
+    tx.addOutputAddress(addrP2tr.address!, 90_000n);
+
+    expect(() => signPSBT(bytesToHex(tx.toPSBT()), privKey, [], AddressFormat.P2TR)).toThrow(
+      /No inputs could be signed/
+    );
   });
 });
 

--- a/src/core/bitcoin/__tests__/psbt.test.ts
+++ b/src/core/bitcoin/__tests__/psbt.test.ts
@@ -16,6 +16,7 @@ import {
   parsePSBT,
   resolvePsbtSighashType,
   signPSBT,
+  tapLeafOwnerAddress,
   validateSignInputs,
 } from '../psbt';
 
@@ -367,6 +368,41 @@ describe('validateSignInputs', () => {
  * witnessUtxo but NO tapInternalKey (a site cannot know the internal key behind an address), and
  * a script-path reveal whose leaf names the address's tweaked output key.
  */
+
+describe('tapLeafOwnerAddress', () => {
+  const privKey = TEST_PRIVATE_KEY;
+  const internalKey = getPublicKey(hexToBytes(privKey), true).slice(1, 33);
+  const addr = p2tr(internalKey, undefined, undefined, true);
+  const outputKey = (Address().decode(addr.address!) as { type: 'tr'; pubkey: Uint8Array }).pubkey;
+  const leaf = new Uint8Array([0x00, 0x63, 0x03, 0x6f, 0x72, 0x64, 0x68, 0x20, ...outputKey, 0xac]);
+
+  // The reveal case: the input pays the commit address (nobody's), the leaf names the signer.
+  it("resolves a reveal input to the leaf key's address, and validation accepts it", () => {
+    const input = {
+      index: 0, txid: '22'.repeat(32), vout: 0,
+      address: 'bc1p_commit_address_stand_in',
+      tapLeafScripts: [bytesToHex(leaf)],
+    };
+    expect(tapLeafOwnerAddress(input)).toBe(addr.address);
+
+    const validation = validateSignInputs(
+      { [addr.address!]: [0] },
+      [addr.address!],
+      1,
+      [tapLeafOwnerAddress(input) ?? input.address]
+    );
+    expect(validation.valid).toBe(true);
+  });
+
+  it('resolves nothing for multiple leaves, no leaves, or a malformed tail', () => {
+    const base = { index: 0, txid: '22'.repeat(32), vout: 0 };
+    expect(tapLeafOwnerAddress({ ...base, tapLeafScripts: [bytesToHex(leaf), bytesToHex(leaf)] })).toBeUndefined();
+    expect(tapLeafOwnerAddress(base)).toBeUndefined();
+    // Ends in OP_CHECKSIG but the push before it is not a 32-byte key.
+    expect(tapLeafOwnerAddress({ ...base, tapLeafScripts: ['00630368'.padEnd(70, '1') + 'ac'] })).toBeUndefined();
+  });
+});
+
 describe('signPSBT taproot inscription shapes', () => {
   const privKey = TEST_PRIVATE_KEY;
   const internalKey = getPublicKey(hexToBytes(privKey), true).slice(1, 33);

--- a/src/core/bitcoin/psbt.ts
+++ b/src/core/bitcoin/psbt.ts
@@ -7,7 +7,7 @@
 
 import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
 import { getPublicKey } from '@noble/secp256k1';
-import { p2wpkh, SigHash, Transaction } from '@scure/btc-signer';
+import { Address, p2wpkh, SigHash, Transaction } from '@scure/btc-signer';
 import { taprootTweakPrivKey } from '@scure/btc-signer/utils.js';
 import { AddressFormat, decodeAddressFromScript, encodeAddress, normalizeAddressForComparison } from '@/core/bitcoin/address';
 import { SigningError, ValidationError } from '@/core/errors';
@@ -427,6 +427,33 @@ export function extractPsbtDetails(psbtHex: string): PsbtDetails {
     unfunded,
     hasOpReturn,
   };
+}
+
+/**
+ * The address a tapleaf-bearing input is spendable by, when that can be read from the PSBT.
+ *
+ * An inscription reveal spends a P2TR commit whose *address* belongs to nobody — it is derived
+ * from the envelope — but whose single leaf ends in `<key> OP_CHECKSIG`. The address whose
+ * witness program is that key is the leaf's owner: the spending condition names it directly.
+ * Ownership validation uses this so a reveal counts as the signer's own input, without any
+ * blanket exemption — a declared leaf that is not really in the commit's tree yields a signature
+ * that finalizes into an unbroadcastable transaction, never someone else's coins.
+ *
+ * Only single-leaf inputs resolve: with several leaves the one that will be revealed is unknown,
+ * and no ownership claim can be made.
+ */
+export function tapLeafOwnerAddress(input: DecodedInput): string | undefined {
+  if (input.tapLeafScripts?.length !== 1) return undefined;
+  const script = input.tapLeafScripts[0]!;
+  // The leaf must end `20 <32-byte key> ac` — a push of the x-only key, then OP_CHECKSIG.
+  if (script.length < 68 || !script.endsWith('ac')) return undefined;
+  if (script.slice(-68, -66) !== '20') return undefined;
+  try {
+    const key = hexToBytes(script.slice(-66, -2));
+    return Address().encode({ type: 'tr', pubkey: key });
+  } catch {
+    return undefined;
+  }
 }
 
 /**

--- a/src/core/bitcoin/psbt.ts
+++ b/src/core/bitcoin/psbt.ts
@@ -8,6 +8,7 @@
 import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
 import { getPublicKey } from '@noble/secp256k1';
 import { p2wpkh, SigHash, Transaction } from '@scure/btc-signer';
+import { taprootTweakPrivKey } from '@scure/btc-signer/utils.js';
 import { AddressFormat, decodeAddressFromScript, encodeAddress, normalizeAddressForComparison } from '@/core/bitcoin/address';
 import { SigningError, ValidationError } from '@/core/errors';
 import { toSafeInteger } from '@/core/numeric';
@@ -178,6 +179,12 @@ export interface DecodedInput {
   address?: string;
   value?: number;          // in satoshis, if known from witnessUtxo
   sighashType?: number;    // sighash type from PSBT input (e.g. 0x83 for SINGLE|ANYONECANPAY)
+  /**
+   * Tapleaf scripts this input would reveal, hex, leaf-version byte stripped. An inscription
+   * reveal carries its ord envelope — and therefore its Counterparty message — here rather than
+   * in any output, so approval-side decoding needs the leaves the signature will commit to.
+   */
+  tapLeafScripts?: string[];
 }
 
 /**
@@ -349,6 +356,11 @@ export function extractPsbtDetails(psbtHex: string): PsbtDetails {
         totalInputValue += value;
       }
 
+      // The PSBT stores each leaf as script bytes with the leaf version appended.
+      const tapLeafScripts = input.tapLeafScript?.map(([, scriptWithVersion]) =>
+        bytesToHex(scriptWithVersion.subarray(0, -1))
+      );
+
       inputs.push({
         index: i,
         txid: txidHex,
@@ -356,6 +368,7 @@ export function extractPsbtDetails(psbtHex: string): PsbtDetails {
         address,
         value,
         sighashType: input.sighashType,
+        ...(tapLeafScripts && tapLeafScripts.length > 0 ? { tapLeafScripts } : {}),
       });
     }
   }
@@ -499,6 +512,27 @@ export function signPSBT(
         }
       }
 
+      // A key-path taproot input can only be matched to a key via tapInternalKey, and dApp PSBTs
+      // routinely omit it (a site cannot know the internal key behind an address). When the
+      // prevout provably pays this signer's own taproot address, supplying the key is completion,
+      // not trust: the signer re-derives tweak(internalKey) and refuses to sign unless it equals
+      // the prevout's witness program, so a wrong or foreign input stays unsigned.
+      if (addressFormat === AddressFormat.P2TR) {
+        const input = tx.getInput(inputIdx);
+        const prevout = (input.index !== undefined ? input.nonWitnessUtxo?.outputs[input.index] : undefined)
+          ?? input.witnessUtxo;
+        const prevoutAddress = prevout?.script
+          ? decodeAddressFromScript(bytesToHex(prevout.script))
+          : undefined;
+        const ownAddress = encodeAddress(pubkeyBytes, addressFormat);
+        if (
+          input && !input.tapInternalKey && prevoutAddress
+          && normalizeAddressForComparison(prevoutAddress) === normalizeAddressForComparison(ownAddress)
+        ) {
+          tx.updateInput(inputIdx, { tapInternalKey: pubkeyBytes.slice(1, 33) });
+        }
+      }
+
       // Determine sighash: use the explicit sighashTypes param if provided,
       // then fall back to the sighash embedded in the PSBT input, then default to ALL
       const input = tx.getInput(inputIdx);
@@ -523,7 +557,25 @@ export function signPSBT(
         tx.signIdx(privateKeyBytes, inputIdx, [sighashType]);
         signedCount++;
       } catch (inputErr) {
-        if (!bestEffort) throw inputErr;
+        // A tapscript spend of this signer's own taproot address — an inscription reveal — names
+        // the address's *output* key in the leaf, and that key is the tweak of the private key
+        // held here. The signer only matches raw keys against leaf scripts, so retry with the
+        // tweaked key. This can only produce a signature verifying against the signer's own
+        // tweaked key; a leaf naming anyone else's key still finds no match and stays unsigned.
+        const input = tx.getInput(inputIdx);
+        if (addressFormat === AddressFormat.P2TR && input?.tapLeafScript?.length) {
+          const tweakedKey = taprootTweakPrivKey(privateKeyBytes);
+          try {
+            tx.signIdx(tweakedKey, inputIdx, [sighashType]);
+            signedCount++;
+          } catch (leafErr) {
+            if (!bestEffort) throw leafErr;
+          } finally {
+            tweakedKey.fill(0);
+          }
+        } else if (!bestEffort) {
+          throw inputErr;
+        }
         // Best-effort mode: skip inputs we can't sign (e.g., other party's UTXO)
       }
     }

--- a/src/core/counterparty/__tests__/providerInscriptions.test.ts
+++ b/src/core/counterparty/__tests__/providerInscriptions.test.ts
@@ -16,6 +16,7 @@ import {
   resolveRevealMessage,
   verifyInscriptionCommit,
 } from '@/core/counterparty/providerInscriptions';
+import { analyzeTransactionSafety } from '@/core/counterparty/transactionSafety';
 
 // A fixed internal key for the "user": secp generator point x-coordinate is a valid x-only key.
 const USER_INTERNAL_KEY = hexToBytes(
@@ -238,5 +239,24 @@ describe('resolveRevealMessage', () => {
     ).toBeNull();
     expect(resolveRevealMessage(revealInputs(undefined), markerOutputs)).toBeNull();
     expect(resolveRevealMessage(revealInputs(['51']), markerOutputs)).toBeNull();
+  });
+});
+
+describe('reveal safety with the burn output', () => {
+  // The launchpad burns the inscription output on purpose: 546 sats to the Counterparty burn
+  // address. That sits exactly at the dust threshold the analyzer already treats as normal
+  // Counterparty behavior, so a recognized reveal raises no warnings for it.
+  it('raises nothing for marker plus burn dust once the message is recognized', () => {
+    const analysis = analyzeTransactionSafety(
+      'fairminter',
+      [
+        { value: 0, type: 'op_return', script: '6a08434e545250525459' },
+        { value: 546, type: 'p2pkh', address: '1CounterpartyXXXXXXXXXXXXXXXUWLpVr' },
+      ],
+      SIGNER_ADDRESS
+    );
+
+    expect(analysis.blocked).toBe(false);
+    expect(analysis.warnings.filter((w) => w.severity !== 'info')).toEqual([]);
   });
 });

--- a/src/core/counterparty/__tests__/providerInscriptions.test.ts
+++ b/src/core/counterparty/__tests__/providerInscriptions.test.ts
@@ -1,0 +1,242 @@
+/**
+ * The hostile-site suite for provider-path inscriptions.
+ *
+ * Every test models a site request: the honest launchpad shape, and then each way a hostile site
+ * could bend it — its own keys in the envelope, a drain output riding along, a commit address
+ * that doesn't match the declared envelope. The rule under test: a commit is signed only when the
+ * wallet can prove the committed coins stay under the signer's own key and the envelope decodes
+ * to a genuine Counterparty message.
+ */
+
+import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
+import { Address, p2tr, TAPROOT_UNSPENDABLE_KEY } from '@scure/btc-signer';
+import { describe, expect, it } from 'vitest';
+import { encodeCbor } from '@/core/counterparty/pack/cbor';
+import {
+  resolveRevealMessage,
+  verifyInscriptionCommit,
+} from '@/core/counterparty/providerInscriptions';
+
+// A fixed internal key for the "user": secp generator point x-coordinate is a valid x-only key.
+const USER_INTERNAL_KEY = hexToBytes(
+  '79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798'
+);
+const SIGNER_ADDRESS = p2tr(USER_INTERNAL_KEY, undefined, undefined, true).address!;
+// The key an envelope must name: the address's *output* key, not the internal key.
+const SIGNER_OUTPUT_KEY = Address().decode(SIGNER_ADDRESS) as { type: 'tr'; pubkey: Uint8Array };
+
+// A valid x-only point the signer does not control (2·G's x-coordinate).
+const ATTACKER_KEY = hexToBytes(
+  'c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5'
+);
+
+function push(ops: number[], data: Uint8Array): void {
+  if (data.length < 76) ops.push(data.length);
+  else if (data.length < 256) ops.push(0x4c, data.length);
+  else ops.push(0x4d, data.length & 0xff, (data.length >> 8) & 0xff);
+  ops.push(...data);
+}
+
+const FAIRMINTER_XCP_ARRAY = encodeCbor([
+  90n, 95428956661682177n, 0n, 100000000n, 1000000000n, 1000000000n, 0n, 100000000000n, 0n,
+  900000n, 0n, 10000000000n, 900420n, 0n, false, true, true, true, 5000000000n, 95428956661682178n,
+]);
+
+function buildEnvelope(pubkey: Uint8Array, metadataCbor: Uint8Array = FAIRMINTER_XCP_ARRAY): Uint8Array {
+  const encoder = new TextEncoder();
+  const ops: number[] = [0x00, 0x63];
+  push(ops, encoder.encode('ord'));
+  push(ops, new Uint8Array([0x07]));
+  push(ops, encoder.encode('xcp'));
+  push(ops, new Uint8Array([0x01]));
+  push(ops, encoder.encode('image/png'));
+  push(ops, new Uint8Array([0x05]));
+  push(ops, metadataCbor);
+  ops.push(0x00);
+  push(ops, new Uint8Array(64).fill(9));
+  ops.push(0x68);
+  push(ops, pubkey);
+  ops.push(0xac);
+  return new Uint8Array(ops);
+}
+
+const HONEST_LEAF = buildEnvelope(SIGNER_OUTPUT_KEY.pubkey);
+const HONEST_COMMIT_ADDRESS = p2tr(
+  TAPROOT_UNSPENDABLE_KEY,
+  { script: HONEST_LEAF, leafVersion: 0xc0 },
+  undefined,
+  true
+).address!;
+
+const honestContext = () => ({
+  revealScript: bytesToHex(HONEST_LEAF),
+  tapInternalKey: bytesToHex(TAPROOT_UNSPENDABLE_KEY),
+});
+
+const honestOutputs = () => [
+  { index: 0, value: 60908, address: HONEST_COMMIT_ADDRESS },
+  { index: 1, value: 50000, address: SIGNER_ADDRESS },
+];
+
+describe('verifyInscriptionCommit', () => {
+  it('accepts the honest launchpad shape and reports address and value', () => {
+    const result = verifyInscriptionCommit(honestContext(), honestOutputs(), SIGNER_ADDRESS);
+
+    expect(result.ok).toBe(true);
+    expect(result.commitAddress).toBe(HONEST_COMMIT_ADDRESS);
+    expect(result.commitValue).toBe(60908);
+    expect(result.envelope!.messageHex.startsWith('434e5452505254595a')).toBe(true);
+  });
+
+  // A real internal key — anyone's — allows a key-path sweep that never reveals anything.
+  it('refuses a commit whose internal key is not the unspendable point', () => {
+    const leaf = buildEnvelope(SIGNER_OUTPUT_KEY.pubkey);
+    const commitAddress = p2tr(ATTACKER_KEY, { script: leaf, leafVersion: 0xc0 }, undefined, true)
+      .address!;
+    const result = verifyInscriptionCommit(
+      { revealScript: bytesToHex(leaf), tapInternalKey: bytesToHex(ATTACKER_KEY) },
+      [{ index: 0, value: 60908, address: commitAddress }],
+      SIGNER_ADDRESS
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/unspendable internal key/);
+  });
+
+  // A genuine envelope over the site's key: the message is real, the coins are not the user's.
+  it("refuses an envelope whose checksig key is not the signer's", () => {
+    const leaf = buildEnvelope(ATTACKER_KEY);
+    const commitAddress = p2tr(
+      TAPROOT_UNSPENDABLE_KEY,
+      { script: leaf, leafVersion: 0xc0 },
+      undefined,
+      true
+    ).address!;
+    const result = verifyInscriptionCommit(
+      { revealScript: bytesToHex(leaf), tapInternalKey: bytesToHex(TAPROOT_UNSPENDABLE_KEY) },
+      [{ index: 0, value: 60908, address: commitAddress }],
+      SIGNER_ADDRESS
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/not spendable by your key/);
+  });
+
+  it('refuses a drain output riding alongside the commit', () => {
+    const outputs = [
+      ...honestOutputs(),
+      { index: 2, value: 200000, address: '1CounterpartyXXXXXXXXXXXXXXXUWLpVr' },
+    ];
+
+    const result = verifyInscriptionCommit(honestContext(), outputs, SIGNER_ADDRESS);
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/neither the inscription commit nor your change/);
+  });
+
+  it('refuses when no output pays the derived commit address', () => {
+    const result = verifyInscriptionCommit(
+      honestContext(),
+      [{ index: 0, value: 50000, address: SIGNER_ADDRESS }],
+      SIGNER_ADDRESS
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/does not pay the commit address/);
+  });
+
+  it('refuses a duplicated commit output', () => {
+    const outputs = [
+      { index: 0, value: 60908, address: HONEST_COMMIT_ADDRESS },
+      { index: 1, value: 60908, address: HONEST_COMMIT_ADDRESS },
+    ];
+
+    const result = verifyInscriptionCommit(honestContext(), outputs, SIGNER_ADDRESS);
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/more than once/);
+  });
+
+  it('refuses an unreadable envelope and an undecodable message', () => {
+    const garbage = verifyInscriptionCommit(
+      { revealScript: 'deadbeef', tapInternalKey: bytesToHex(TAPROOT_UNSPENDABLE_KEY) },
+      honestOutputs(),
+      SIGNER_ADDRESS
+    );
+    expect(garbage.ok).toBe(false);
+    expect(garbage.error).toMatch(/not a readable inscription envelope/);
+
+    // A structurally fine envelope whose message array names a real type but cannot unpack —
+    // a fairminter with one field where seventeen are the minimum.
+    const nonMessage = buildEnvelope(SIGNER_OUTPUT_KEY.pubkey, encodeCbor([90n, 1n]));
+    const result = verifyInscriptionCommit(
+      { revealScript: bytesToHex(nonMessage), tapInternalKey: bytesToHex(TAPROOT_UNSPENDABLE_KEY) },
+      honestOutputs(),
+      SIGNER_ADDRESS
+    );
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/does not decode to a Counterparty message/);
+  });
+
+  it('refuses a non-taproot signer', () => {
+    const result = verifyInscriptionCommit(
+      honestContext(),
+      honestOutputs(),
+      '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa'
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/taproot address/);
+  });
+});
+
+describe('resolveRevealMessage', () => {
+  const MARKER_SCRIPT = '6a08434e545250525459';
+  const revealInputs = (leaves: string[] | undefined, index = 0) => [
+    { index, ...(leaves ? { tapLeafScripts: leaves } : {}) },
+  ];
+  const markerOutputs = [
+    { type: 'op_return', script: MARKER_SCRIPT },
+    { type: 'p2pkh', script: '76a914000000000000000000000000000000000000000088ac' },
+  ];
+
+  it('reads the message from a marker-bearing reveal with one leaf on input 0', () => {
+    const envelope = resolveRevealMessage(
+      revealInputs([bytesToHex(HONEST_LEAF)]),
+      markerOutputs
+    );
+
+    expect(envelope).not.toBeNull();
+    expect(envelope!.mimeType).toBe('image/png');
+  });
+
+  // Core never looks at the witness without the marker output; neither may we.
+  it('returns null without the plaintext CNTRPRTY marker', () => {
+    const envelope = resolveRevealMessage(
+      revealInputs([bytesToHex(HONEST_LEAF)]),
+      [{ type: 'p2pkh', script: '76a914000000000000000000000000000000000000000088ac' }]
+    );
+
+    expect(envelope).toBeNull();
+  });
+
+  // Core reads input 0's witness alone; an envelope anywhere else never executes.
+  it('returns null when the envelope sits on a later input', () => {
+    const envelope = resolveRevealMessage(
+      revealInputs([bytesToHex(HONEST_LEAF)], 1),
+      markerOutputs
+    );
+
+    expect(envelope).toBeNull();
+  });
+
+  // Two leaves means the revealed script is unknowable before signing.
+  it('returns null for multiple leaves, no leaves, or a non-envelope leaf', () => {
+    expect(
+      resolveRevealMessage(
+        revealInputs([bytesToHex(HONEST_LEAF), bytesToHex(HONEST_LEAF)]),
+        markerOutputs
+      )
+    ).toBeNull();
+    expect(resolveRevealMessage(revealInputs(undefined), markerOutputs)).toBeNull();
+    expect(resolveRevealMessage(revealInputs(['51']), markerOutputs)).toBeNull();
+  });
+});

--- a/src/core/counterparty/providerInscriptions.ts
+++ b/src/core/counterparty/providerInscriptions.ts
@@ -1,0 +1,222 @@
+/**
+ * The provider path's reading of inscription reveals and commits.
+ *
+ * A site-driven inscription reaches the wallet as two signPsbt requests. The *reveal* carries its
+ * Counterparty message in the tapleaf it will publish; the *commit* carries nothing readable at
+ * all — it pays BTC to a P2TR address derived from an envelope the transaction never shows. The
+ * provider gate rightly refuses BTC that moves for reasons the bytes cannot prove, so each half
+ * gets its own proof here.
+ *
+ * The reveal is recognized only under the conditions core's indexer applies
+ * (`bitcoin_client.rs`): the envelope is read from input 0's witness alone, and only when the
+ * transaction also carries the plaintext CNTRPRTY marker OP_RETURN. Recognizing more than core
+ * does would bless a "message" the chain will never execute.
+ *
+ * The commit is verifiable only when the site names the envelope it committed to. Everything is
+ * then recomputed, never trusted: the commit address is re-derived from the declared leaf and
+ * internal key, the message is decoded from the leaf, and — the load-bearing rule — the keys must
+ * be the signer's own. The internal key must be the BIP-341 unspendable point (no key-path spend
+ * for anyone) and the leaf's OP_CHECKSIG key must be the signer's taproot output key, so the
+ * committed coins remain spendable by this wallet alone. A site that controls either key could
+ * present a perfectly genuine envelope whose commit output it can sweep; the envelope proves what
+ * the BTC is *for*, the key rule proves who can *take* it.
+ */
+
+import { hexToBytes } from '@noble/hashes/utils.js';
+import { Address, p2tr, TAPROOT_UNSPENDABLE_KEY } from '@scure/btc-signer';
+import { unpackCounterpartyMessage } from '@/core/counterparty/unpack';
+import { COUNTERPARTY_PREFIX_HEX } from '@/core/counterparty/unpack/messageTypes';
+import { extractOpReturnPayload } from '@/core/counterparty/unpack/opReturn';
+import {
+  extractEnvelopeMessage,
+  type OrdEnvelopeMessage,
+} from '@/core/counterparty/unpack/ordEnvelope';
+
+/** The inscription context a site may pass alongside a commit signPsbt request. */
+export interface InscriptionCommitContext {
+  /** The reveal's tapleaf script, hex — the envelope the commit output commits to. */
+  revealScript: string;
+  /** The taproot internal key behind the commit address, hex, 32 bytes. */
+  tapInternalKey: string;
+}
+
+interface RevealInputLike {
+  index: number;
+  tapLeafScripts?: string[];
+}
+
+interface RevealOutputLike {
+  type: string;
+  script?: string;
+}
+
+/**
+ * Read the Counterparty message a reveal PSBT would publish, under core's own conditions.
+ *
+ * Null means "no message here", and the ordinary gate treats the transaction as it always has.
+ * The conditions are core's, not looser: envelope on input 0 (the only witness the indexer
+ * reads), exactly one leaf (a single-leaf commit is the only construction whose revealed script
+ * is knowable before signing), and the plaintext CNTRPRTY marker among the outputs (without it
+ * the indexer never looks at the witness at all).
+ */
+export function resolveRevealMessage(
+  inputs: RevealInputLike[],
+  outputs: RevealOutputLike[]
+): OrdEnvelopeMessage | null {
+  const firstInput = inputs.find((input) => input.index === 0);
+  const leaves = firstInput?.tapLeafScripts;
+  if (!leaves || leaves.length !== 1) return null;
+
+  const hasMarker = outputs.some(
+    (output) =>
+      output.type === 'op_return' &&
+      output.script !== undefined &&
+      extractOpReturnPayload(output.script) === COUNTERPARTY_PREFIX_HEX
+  );
+  if (!hasMarker) return null;
+
+  let leafBytes: Uint8Array;
+  try {
+    leafBytes = hexToBytes(leaves[0]!);
+  } catch {
+    return null;
+  }
+  const envelope = extractEnvelopeMessage(leafBytes);
+  if (!envelope) return null;
+
+  // Only a message the wallet can decode is worth passing to the gate — an undecodable one cannot
+  // be described to the user, and unverifiable means unsigned on this path.
+  const unpacked = unpackCounterpartyMessage(envelope.messageHex);
+  if (!unpacked.success) return null;
+
+  return envelope;
+}
+
+export interface CommitVerification {
+  ok: boolean;
+  /** Why the commit was refused; set exactly when ok is false. */
+  error?: string;
+  /** The decoded envelope, when the commit verified. */
+  envelope?: OrdEnvelopeMessage;
+  /** The commit address the declared envelope derives to. */
+  commitAddress?: string;
+  /** Satoshis the PSBT pays into the commit output. */
+  commitValue?: number;
+}
+
+interface CommitOutputLike {
+  index: number;
+  value: number;
+  address?: string;
+}
+
+/**
+ * Verify a commit PSBT against the envelope the site declared for it.
+ *
+ * Refusals name their reason — each one is rendered on the approval screen as the block message,
+ * and "the site passed a context that did not verify" is precisely the situation the user needs
+ * described. Nothing here trusts the context: it is treated as a claim, and every field of it is
+ * recomputed against the PSBT and the signer's own address.
+ */
+export function verifyInscriptionCommit(
+  context: InscriptionCommitContext,
+  outputs: CommitOutputLike[],
+  signerAddress: string
+): CommitVerification {
+  let signerKey: Uint8Array;
+  try {
+    const decoded = Address().decode(signerAddress);
+    if (decoded.type !== 'tr') {
+      return { ok: false, error: 'Inscription commits can only be signed from a taproot address.' };
+    }
+    signerKey = decoded.pubkey;
+  } catch {
+    return { ok: false, error: 'The signing address could not be read.' };
+  }
+
+  let leafBytes: Uint8Array;
+  let internalKey: Uint8Array;
+  try {
+    leafBytes = hexToBytes(context.revealScript);
+    internalKey = hexToBytes(context.tapInternalKey);
+  } catch {
+    return { ok: false, error: 'The inscription context could not be read as hex.' };
+  }
+
+  // No key-path spend for anyone: the internal key must be the BIP-341 unspendable point. A real
+  // key here — anyone's — would let its holder sweep the commit without revealing anything.
+  if (
+    internalKey.length !== 32 ||
+    !internalKey.every((byte, index) => byte === TAPROOT_UNSPENDABLE_KEY[index])
+  ) {
+    return {
+      ok: false,
+      error: 'The commit does not use the standard unspendable internal key, so someone could take its coins without revealing the inscription.',
+    };
+  }
+
+  const envelope = extractEnvelopeMessage(leafBytes);
+  if (!envelope) {
+    return { ok: false, error: 'The declared reveal script is not a readable inscription envelope.' };
+  }
+
+  const unpacked = unpackCounterpartyMessage(envelope.messageHex);
+  if (!unpacked.success) {
+    return { ok: false, error: 'The inscription does not decode to a Counterparty message.' };
+  }
+
+  // The load-bearing rule: the envelope's spending key must be this signer's own taproot output
+  // key. With the internal key unspendable, this makes the commit output spendable by this wallet
+  // alone — a lying site can at worst make the user inscribe something they control anyway.
+  if (
+    envelope.checksigPubkey.length !== signerKey.length ||
+    !envelope.checksigPubkey.every((byte, index) => byte === signerKey[index])
+  ) {
+    return {
+      ok: false,
+      error: 'The inscription is not spendable by your key, so its coins would belong to someone else.',
+    };
+  }
+
+  let commitAddress: string | undefined;
+  try {
+    commitAddress = p2tr(
+      internalKey,
+      { script: leafBytes, leafVersion: 0xc0 },
+      undefined,
+      true
+    ).address;
+  } catch {
+    commitAddress = undefined;
+  }
+  if (!commitAddress) {
+    return { ok: false, error: 'The commit address could not be derived from the declared envelope.' };
+  }
+
+  // Every output must be accounted for: the commit itself, or change back to the signer. An
+  // output to anywhere else is exactly the drain the provider gate exists to refuse.
+  let commitValue = 0;
+  let commitOutputs = 0;
+  for (const output of outputs) {
+    if (output.address === commitAddress) {
+      commitOutputs += 1;
+      commitValue += output.value;
+      continue;
+    }
+    if (output.address === signerAddress) continue;
+    return {
+      ok: false,
+      error: `The commit pays an output that is neither the inscription commit nor your change${output.address ? ` (${output.address})` : ''}.`,
+    };
+  }
+  if (commitOutputs !== 1) {
+    return {
+      ok: false,
+      error: commitOutputs === 0
+        ? 'The transaction does not pay the commit address the declared envelope derives to.'
+        : 'The transaction pays the commit address more than once.',
+    };
+  }
+
+  return { ok: true, envelope, commitAddress, commitValue };
+}

--- a/src/core/counterparty/signRequestAnalysis.ts
+++ b/src/core/counterparty/signRequestAnalysis.ts
@@ -21,6 +21,10 @@ import type { InputAttachedAssets } from '@/core/counterparty/inputAssets';
 import { checkMessageStructure, type StructureFinding } from '@/core/counterparty/messageStructure';
 import { type ProtocolContext, resolveProtocolContext } from '@/core/counterparty/protocolContext';
 import {
+  type InscriptionCommitContext,
+  verifyInscriptionCommit,
+} from '@/core/counterparty/providerInscriptions';
+import {
   type CounterpartyMessage,
   decodeCounterpartyMessage,
   describeMpmaSend,
@@ -72,9 +76,18 @@ export interface SignRequestAnalysisInput {
    * overlap. Passed as a promise rather than a value to keep that overlap.
    */
   attachedAssets: Promise<InputAttachedAssets[]>;
+  /**
+   * The site's claim that this PSBT funds an inscription commit. Verified here, never trusted:
+   * on proof, the envelope's message becomes the transaction's Counterparty payload and the
+   * commit output is reported instead of flagged; on any failure, the request is hard-blocked
+   * with the specific reason.
+   */
+  inscriptionContext?: InscriptionCommitContext;
 }
 
 export interface SignRequestAnalysis {
+  /** The verified inscription commit, when the request carried a context that proved out. */
+  verifiedCommit?: { address: string; value: number };
   /** The API's rendering of the message, when it could supply one. Never used to decide safety. */
   counterpartyMessage: CounterpartyMessage | undefined;
   verification: ProviderVerificationResult;
@@ -96,13 +109,34 @@ export async function analyzeSignRequest(
   input: SignRequestAnalysisInput
 ): Promise<SignRequestAnalysis> {
   const {
-    counterpartyDataHex,
     inputs,
     outputs,
     signerAddresses,
     signedInputIndices,
     transactionId,
   } = input;
+  let counterpartyDataHex = input.counterpartyDataHex;
+
+  // A commit context is a claim to be proven, and proof changes what the transaction *is*: the
+  // envelope's message becomes its Counterparty payload, exactly as though an OP_RETURN carried
+  // it. Failure is a hard block with the reason — a site that names an envelope it cannot back
+  // has described a different transaction than the one it asked to sign.
+  let verifiedCommit: { address: string; value: number } | undefined;
+  let commitRefusal: string | undefined;
+  if (!counterpartyDataHex && input.inscriptionContext) {
+    const signer = signerAddresses[0];
+    if (signer) {
+      const check = verifyInscriptionCommit(input.inscriptionContext, outputs, signer);
+      if (check.ok && check.envelope && check.commitAddress) {
+        counterpartyDataHex = check.envelope.messageHex;
+        verifiedCommit = { address: check.commitAddress, value: check.commitValue ?? 0 };
+      } else {
+        commitRefusal = check.error ?? 'The inscription context did not verify.';
+      }
+    } else {
+      commitRefusal = 'The inscription context names no signing address to verify against.';
+    }
+  }
 
   // The API's rendering is for display only — richer than the local unpack, and not trusted by
   // anything below that decides whether signing is safe.
@@ -120,7 +154,21 @@ export async function analyzeSignRequest(
   const verification = verifyProviderTransaction(counterpartyDataHex, counterpartyMessage);
 
   const messageType = counterpartyMessage?.messageType ?? verification.localUnpack?.messageType;
-  const safety = analyzeTransactionSafety(messageType, outputs, signerAddresses);
+  const safety = analyzeTransactionSafety(messageType, outputs, signerAddresses, { verifiedCommit });
+
+  if (commitRefusal) {
+    safety.warnings = [
+      {
+        severity: 'block',
+        title: 'Blocked: Inscription Did Not Verify',
+        message:
+          `${commitRefusal} The site's description of this inscription could not be proven ` +
+          'against the transaction, so it will not be signed.',
+      },
+      ...safety.warnings,
+    ];
+    safety.blocked = true;
+  }
 
   // mpma_send is described from the bytes, not from the API's rendering of them — see
   // resolveMpmaRecipients for why the API cannot be used for this type. Without it the screen says
@@ -194,6 +242,7 @@ export async function analyzeSignRequest(
   );
 
   return {
+    verifiedCommit,
     counterpartyMessage,
     verification,
     safety,

--- a/src/core/counterparty/transactionSafety.ts
+++ b/src/core/counterparty/transactionSafety.ts
@@ -156,7 +156,16 @@ const DATA_CARRYING_OUTPUT_TYPES = new Set([
 export function analyzeTransactionSafety(
   messageType: string | undefined,
   outputs: AnalyzableOutput[],
-  signerAddress: string | string[]
+  signerAddress: string | string[],
+  options: {
+    /**
+     * An inscription commit output the caller has already verified — address re-derived from the
+     * declared envelope, keys proven to be the signer's (`providerInscriptions.ts`). Reported as
+     * information rather than flagged: the coins stay under the signer's key, which is the fact
+     * the external-address warning exists to check.
+     */
+    verifiedCommit?: { address: string; value: number };
+  } = {}
 ): SafetyAnalysis {
   const warnings: SecurityWarning[] = [];
   let blocked = false;
@@ -248,6 +257,9 @@ export function analyzeTransactionSafety(
     // Skip outputs back to the signer (change)
     if (output.address && normalizedSigners.has(normalizeAddressForComparison(output.address))) continue;
 
+    // Skip the verified inscription commit — described by its own info entry below.
+    if (options.verifiedCommit && output.address === options.verifiedCommit.address) continue;
+
     // Skip dust outputs — normal for Counterparty (multisig encoding, dispenser triggers)
     if (output.value <= DUST_THRESHOLD) continue;
 
@@ -259,6 +271,18 @@ export function analyzeTransactionSafety(
       // such an output raised nothing and showed only as "Unknown address" in the movement list.
       unattributableOutputs.push({ value: output.value });
     }
+  }
+
+  if (options.verifiedCommit) {
+    const btcAmount = (options.verifiedCommit.value / 100_000_000).toFixed(8);
+    warnings.push({
+      severity: 'info',
+      title: 'Inscription Commit',
+      message:
+        `This funds an inscription: ${btcAmount} BTC goes to ${options.verifiedCommit.address.slice(0, 12)}…, ` +
+        'an address derived from the inscription itself and spendable only by your key. ' +
+        'The follow-up reveal transaction publishes the content and returns the remainder.',
+    });
   }
 
   if (misdirectedRecoveryKeys > 0) {

--- a/src/core/counterparty/unpack/__tests__/ordEnvelope.test.ts
+++ b/src/core/counterparty/unpack/__tests__/ordEnvelope.test.ts
@@ -1,0 +1,216 @@
+/**
+ * The envelope reader against both constructions that exist in the wild: core's own composes
+ * (metadata = bare CBOR array) and the launchpad's ord-style inscriptions (metadata = CBOR map
+ * with the message under "xcp"). Fixtures are built with the same push/tag logic as the
+ * launchpad's `buildInscriptionScript`, so what is tested is the construction sites actually
+ * emit — and the round-trip test proves the reassembled message flows through the wallet's
+ * ordinary unpack exactly as an OP_RETURN payload would.
+ */
+
+import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
+import { describe, expect, it } from 'vitest';
+import { encodeCbor } from '@/core/counterparty/pack/cbor';
+import { decodeCbor } from '@/core/counterparty/unpack/cbor';
+import { unpackCounterpartyMessage } from '@/core/counterparty/unpack/index';
+import { extractEnvelopeMessage } from '@/core/counterparty/unpack/ordEnvelope';
+
+const USER_KEY = new Uint8Array(32).fill(7);
+
+function push(ops: number[], data: Uint8Array): void {
+  if (data.length < 76) ops.push(data.length);
+  else if (data.length < 256) ops.push(0x4c, data.length);
+  else ops.push(0x4d, data.length & 0xff, (data.length >> 8) & 0xff);
+  ops.push(...data);
+}
+
+function pushTaggedChunked(ops: number[], tag: number, data: Uint8Array): void {
+  for (let i = 0; i < data.length; i += 520) {
+    push(ops, new Uint8Array([tag]));
+    push(ops, data.slice(i, i + 520));
+  }
+}
+
+/** Mirror of the launchpad's buildInscriptionScript, parameterized on the metadata bytes. */
+function buildEnvelope(options: {
+  metadataCbor: Uint8Array;
+  body: Uint8Array;
+  mimeType?: string;
+  metaprotocol?: string;
+  pubkey?: Uint8Array;
+}): Uint8Array {
+  const encoder = new TextEncoder();
+  const ops: number[] = [0x00, 0x63];
+  push(ops, encoder.encode('ord'));
+  if (options.metaprotocol !== undefined) {
+    push(ops, new Uint8Array([0x07]));
+    push(ops, encoder.encode(options.metaprotocol));
+  }
+  push(ops, new Uint8Array([0x01]));
+  push(ops, encoder.encode(options.mimeType ?? 'image/png'));
+  pushTaggedChunked(ops, 0x05, options.metadataCbor);
+  ops.push(0x00);
+  for (let i = 0; i < options.body.length; i += 520) {
+    push(ops, options.body.slice(i, i + 520));
+  }
+  ops.push(0x68); // OP_ENDIF
+  push(ops, options.pubkey ?? USER_KEY);
+  ops.push(0xac); // OP_CHECKSIG
+  return new Uint8Array(ops);
+}
+
+/** CBOR map with text keys — the ord metadata shape; the wallet only decodes maps, so encode here. */
+function encodeCborMap(entries: [string, Uint8Array][]): Uint8Array {
+  const bytes: number[] = [0xa0 + entries.length];
+  const encoder = new TextEncoder();
+  for (const [key, valueBytes] of entries) {
+    const keyBytes = encoder.encode(key);
+    bytes.push(0x60 + keyBytes.length, ...keyBytes, ...valueBytes);
+  }
+  return new Uint8Array(bytes);
+}
+
+// The launchpad's XCP-69 fairminter array: [90, asset_id, parent, price, qty_by_price, max_tx,
+// max_addr, hard_cap, premint, start, end, soft_cap, deadline, commission, burn, lock_desc,
+// lock_qty, divisible, pool_qty, lp_asset_id]
+const FAIRMINTER_XCP_ARRAY = encodeCbor([
+  90n, 95428956661682177n, 0n, 100000000n, 1000000000n, 1000000000n, 0n, 100000000000n, 0n,
+  900000n, 0n, 10000000000n, 900420n, 0n, false, true, true, true, 5000000000n, 95428956661682178n,
+]);
+
+const BODY = new Uint8Array(1200).map((_, i) => i % 251);
+
+describe('extractEnvelopeMessage', () => {
+  it('reads a core-style envelope whose metadata is the bare message array', () => {
+    const script = buildEnvelope({
+      metadataCbor: FAIRMINTER_XCP_ARRAY,
+      body: BODY,
+      metaprotocol: 'xcp',
+    });
+
+    const message = extractEnvelopeMessage(script);
+    expect(message).not.toBeNull();
+    expect(message!.mimeType).toBe('image/png');
+    expect(message!.contentLength).toBe(BODY.length);
+    expect(bytesToHex(message!.checksigPubkey)).toBe(bytesToHex(USER_KEY));
+    // CNTRPRTY prefix, then the type id byte core would emit (90 = 0x5a).
+    expect(message!.messageHex.startsWith('434e5452505254595a')).toBe(true);
+  });
+
+  it('reads the launchpad shape: metadata map with the message under "xcp"', () => {
+    const metadata = encodeCborMap([['xcp', FAIRMINTER_XCP_ARRAY]]);
+    const script = buildEnvelope({ metadataCbor: metadata, body: BODY, metaprotocol: 'xcp' });
+
+    const mapMessage = extractEnvelopeMessage(script);
+    const arrayMessage = extractEnvelopeMessage(
+      buildEnvelope({ metadataCbor: FAIRMINTER_XCP_ARRAY, body: BODY, metaprotocol: 'xcp' })
+    );
+    // Core re-encodes both shapes to byte-identical messages; so must this.
+    expect(mapMessage!.messageHex).toBe(arrayMessage!.messageHex);
+  });
+
+  it('round-trips into the ordinary unpack as a fairminter with the image as description', () => {
+    const metadata = encodeCborMap([['xcp', FAIRMINTER_XCP_ARRAY]]);
+    const script = buildEnvelope({ metadataCbor: metadata, body: BODY, metaprotocol: 'xcp' });
+    const message = extractEnvelopeMessage(script)!;
+
+    const unpacked = unpackCounterpartyMessage(message.messageHex);
+    expect(unpacked.success).toBe(true);
+    expect(unpacked.messageType).toBe('fairminter');
+    const data = unpacked.data as { asset: string; mimeType: string; description: string };
+    expect(data.asset).toBe('A95428956661682177');
+    expect(data.mimeType).toBe('image/png');
+    // Binary content reads as hex, core's bytes_to_content rule for a non-textual MIME type.
+    expect(data.description).toBe(bytesToHex(BODY));
+  });
+
+  it('keeps ordinals provenance keys out of the message', () => {
+    const metadata = encodeCborMap([
+      ['asset', encodeCbor(['DECOY'])],
+      ['xcp', FAIRMINTER_XCP_ARRAY],
+    ]);
+    const script = buildEnvelope({ metadataCbor: metadata, body: BODY, metaprotocol: 'xcp' });
+    const bare = extractEnvelopeMessage(
+      buildEnvelope({ metadataCbor: FAIRMINTER_XCP_ARRAY, body: BODY, metaprotocol: 'xcp' })
+    );
+
+    expect(extractEnvelopeMessage(script)!.messageHex).toBe(bare!.messageHex);
+  });
+
+  it('appends no content field when the envelope has no body', () => {
+    const script = buildEnvelope({
+      metadataCbor: FAIRMINTER_XCP_ARRAY,
+      body: new Uint8Array(0),
+      metaprotocol: 'xcp',
+      mimeType: 'text/plain',
+    });
+
+    const message = extractEnvelopeMessage(script)!;
+    const cborPart = hexToBytes(message.messageHex.slice(18)); // past prefix + type id
+    const fields = decodeCbor(cborPart);
+    expect(Array.isArray(fields)).toBe(true);
+    // 19 message fields + mime type, no content element.
+    expect((fields as unknown[]).length).toBe(20);
+  });
+
+  it.each([
+    ['not an envelope: no leading OP_FALSE', new Uint8Array([0x51, 0x63, 0x68, 0xac])],
+    ['not an envelope: OP_RETURN script', new Uint8Array([0x6a, 0x04, 1, 2, 3, 4])],
+    ['truncated push', new Uint8Array([0x00, 0x63, 0x4c, 0xff, 0x01])],
+  ])('returns null for %s', (_name, script) => {
+    expect(extractEnvelopeMessage(script)).toBeNull();
+  });
+
+  it('returns null for an envelope that is not an ord inscription', () => {
+    // "foo" instead of "ord" at instruction 2.
+    const script = buildEnvelope({ metadataCbor: FAIRMINTER_XCP_ARRAY, body: BODY, metaprotocol: 'xcp' });
+    const mutated = script.slice();
+    mutated.set(new TextEncoder().encode('foo'), 3);
+    expect(extractEnvelopeMessage(mutated)).toBeNull();
+  });
+
+  it('returns null when the map carries no xcp key, or an empty one', () => {
+    const noKey = buildEnvelope({
+      metadataCbor: encodeCborMap([['name', encodeCbor(['x'])]]),
+      body: BODY,
+      metaprotocol: 'xcp',
+    });
+    const emptyArray = buildEnvelope({
+      metadataCbor: encodeCborMap([['xcp', encodeCbor([])]]),
+      body: BODY,
+      metaprotocol: 'xcp',
+    });
+
+    expect(extractEnvelopeMessage(noKey)).toBeNull();
+    expect(extractEnvelopeMessage(emptyArray)).toBeNull();
+  });
+
+  it('returns null when metadata is missing entirely', () => {
+    const encoder = new TextEncoder();
+    const ops: number[] = [0x00, 0x63];
+    push(ops, encoder.encode('ord'));
+    push(ops, new Uint8Array([0x07]));
+    push(ops, encoder.encode('xcp'));
+    push(ops, new Uint8Array([0x01]));
+    push(ops, encoder.encode('image/png'));
+    ops.push(0x00);
+    push(ops, BODY.slice(0, 100));
+    ops.push(0x68);
+    push(ops, USER_KEY);
+    ops.push(0xac);
+
+    expect(extractEnvelopeMessage(new Uint8Array(ops))).toBeNull();
+  });
+
+  it('reports the checksig key even for chunked metadata and body', () => {
+    const bigBody = new Uint8Array(2000).fill(0xab);
+    const script = buildEnvelope({
+      metadataCbor: FAIRMINTER_XCP_ARRAY,
+      body: bigBody,
+      metaprotocol: 'xcp',
+    });
+
+    const message = extractEnvelopeMessage(script)!;
+    expect(message.contentLength).toBe(2000);
+    expect(bytesToHex(message.checksigPubkey)).toBe(bytesToHex(USER_KEY));
+  });
+});

--- a/src/core/counterparty/unpack/cbor.ts
+++ b/src/core/counterparty/unpack/cbor.ts
@@ -1,4 +1,12 @@
-export type CborValue = bigint | number | boolean | string | Uint8Array | CborValue[] | null;
+export type CborValue =
+  | bigint
+  | number
+  | boolean
+  | string
+  | Uint8Array
+  | CborValue[]
+  | Map<CborValue, CborValue>
+  | null;
 
 interface DecodedValue {
   value: CborValue;
@@ -70,6 +78,24 @@ function decodeValue(data: Uint8Array, offset: number, depth = 0): DecodedValue 
       itemOffset = decoded.offset;
     }
     return { value: values, offset: itemOffset };
+  }
+
+  // Maps never occur in Counterparty messages themselves (those are flat arrays), but ord
+  // inscription metadata may be a map carrying the message array under an "xcp" key — core's
+  // parser accepts that shape (`extract_data_from_witness`, gated by `ordinals_metadata_support`).
+  // Duplicate keys resolve last-write-wins, matching serde_cbor's BTreeMap for the primitive keys
+  // that can actually collide here.
+  if (majorType === 5) {
+    const entries = new Map<CborValue, CborValue>();
+    const itemCount = toSafeLength(length);
+    let itemOffset = valueOffset;
+    for (let index = 0; index < itemCount; index += 1) {
+      const key = decodeValue(data, itemOffset, depth + 1);
+      const value = decodeValue(data, key.offset, depth + 1);
+      entries.set(key.value, value.value);
+      itemOffset = value.offset;
+    }
+    return { value: entries, offset: itemOffset };
   }
 
   if (majorType === 7 && additionalInfo === 20) return { value: false, offset: offset + 1 };

--- a/src/core/counterparty/unpack/messages/fairminter.ts
+++ b/src/core/counterparty/unpack/messages/fairminter.ts
@@ -1,3 +1,5 @@
+import { bytesToHex } from '@noble/hashes/utils.js';
+import { isTextualMimeType } from '@/core/counterparty/inscriptionEnvelope';
 import { assetIdToName } from '@/core/counterparty/unpack/assetId';
 import { type CborValue, decodeCbor } from '@/core/counterparty/unpack/cbor';
 
@@ -39,6 +41,23 @@ function flag(value: CborValue, field: string): boolean {
 function text(value: CborValue, field: string): string {
   if (typeof value === 'string') return value;
   if (value instanceof Uint8Array) return new TextDecoder('utf-8', { fatal: true }).decode(value);
+  throw new Error(`Invalid fairminter ${field}`);
+}
+
+/**
+ * A description that arrived as bytes, read the way core reads it (`helpers.bytes_to_content`):
+ * textual MIME types decode as UTF-8, everything else hexlifies. An image-carrying fairminter —
+ * an inscription — has PNG bytes here, and decoding those as strict UTF-8 threw, which failed the
+ * whole unpack for a message core parses fine.
+ */
+function content(value: CborValue, mimeType: string, field: string): string {
+  if (typeof value === 'string') return value;
+  if (value instanceof Uint8Array) {
+    if (isTextualMimeType(mimeType || 'text/plain')) {
+      return new TextDecoder('utf-8', { fatal: true }).decode(value);
+    }
+    return bytesToHex(value);
+  }
   throw new Error(`Invalid fairminter ${field}`);
 }
 
@@ -89,6 +108,10 @@ export function unpackFairminter(payload: Uint8Array): FairminterData {
     // none, and any comparison against the request would then reject honest transactions. Callers
     // that need a default for display should apply it themselves.
     mimeType: text(fields[mimeTypeIndex]!, 'MIME type'),
-    description: text(fields[descriptionIndex]!, 'description'),
+    description: content(
+      fields[descriptionIndex]!,
+      text(fields[mimeTypeIndex]!, 'MIME type'),
+      'description'
+    ),
   };
 }

--- a/src/core/counterparty/unpack/ordEnvelope.ts
+++ b/src/core/counterparty/unpack/ordEnvelope.ts
@@ -1,0 +1,233 @@
+/**
+ * Reading a Counterparty message out of an ord inscription envelope.
+ *
+ * A taproot-encoded Counterparty transaction carries its message in the reveal's tapleaf script,
+ * not in an OP_RETURN — the OP_RETURN holds only the bare CNTRPRTY marker. When a site asks this
+ * wallet to sign an inscription reveal (or names the envelope alongside a commit), the only honest
+ * way to know what the transaction says is to read the envelope the way the chain will.
+ *
+ * This mirrors core's `extract_data_from_witness` (counterparty-rs `bitcoin_client.rs`), which is
+ * the consensus reader for these bytes:
+ *
+ *   OP_FALSE OP_IF "ord" 0x07 <metaprotocol> 0x01 <mime type>
+ *     (0x05 <metadata chunk>)*   — CBOR: either [message_type_id, ...fields] directly, or a map
+ *                                  whose "xcp" key holds that array (ordinals_metadata_support)
+ *     OP_0 (<content chunk>)*    — the inscription body
+ *   OP_ENDIF <32-byte x-only pubkey> OP_CHECKSIG
+ *
+ * and reassembles the message exactly as core does: `[type_id] ++ CBOR([...fields, mime_type,
+ * content?])`, with the content appended only when body chunks exist. Divergences are deliberate
+ * and strictly *narrower* than core — anything this refuses that core would accept fails toward
+ * not signing, never the reverse. Where core is lax (it never checks the metaprotocol says "xcp",
+ * reads whatever sits at the mime position, and truncates the type id to a byte), this is lax in
+ * exactly the same way, because the point is to report what the chain will execute.
+ */
+
+import { bytesToHex } from '@noble/hashes/utils.js';
+import { type CborEncodable, encodeCbor } from '@/core/counterparty/pack/cbor';
+import { type CborValue, decodeCbor } from '@/core/counterparty/unpack/cbor';
+import { COUNTERPARTY_PREFIX_HEX } from '@/core/counterparty/unpack/messageTypes';
+
+/** One parsed script instruction: an opcode byte, or the bytes a push pushed. */
+type Instruction = { op: number } | { push: Uint8Array };
+
+/**
+ * Parse a script into instructions. Only push encodings and bare opcodes — the envelope grammar
+ * needs nothing more. Returns null on a malformed push (truncated data), as bitcoin's own
+ * instruction iterator yields an error there.
+ */
+function parseInstructions(script: Uint8Array): Instruction[] | null {
+  const instructions: Instruction[] = [];
+  let i = 0;
+  while (i < script.length) {
+    const byte = script[i]!;
+    if (byte === 0x00) {
+      // OP_0 pushes empty bytes; core's iterator reports it as an empty push.
+      instructions.push({ push: new Uint8Array(0) });
+      i += 1;
+    } else if (byte >= 0x01 && byte <= 0x4b) {
+      if (i + 1 + byte > script.length) return null;
+      instructions.push({ push: script.slice(i + 1, i + 1 + byte) });
+      i += 1 + byte;
+    } else if (byte === 0x4c) {
+      if (i + 2 > script.length) return null;
+      const length = script[i + 1]!;
+      if (i + 2 + length > script.length) return null;
+      instructions.push({ push: script.slice(i + 2, i + 2 + length) });
+      i += 2 + length;
+    } else if (byte === 0x4d) {
+      if (i + 3 > script.length) return null;
+      const length = script[i + 1]! | (script[i + 2]! << 8);
+      if (i + 3 + length > script.length) return null;
+      instructions.push({ push: script.slice(i + 3, i + 3 + length) });
+      i += 3 + length;
+    } else if (byte === 0x4e) {
+      if (i + 5 > script.length) return null;
+      const length =
+        script[i + 1]! | (script[i + 2]! << 8) | (script[i + 3]! << 16) | (script[i + 4]! << 24);
+      if (length < 0 || i + 5 + length > script.length) return null;
+      instructions.push({ push: script.slice(i + 5, i + 5 + length) });
+      i += 5 + length;
+    } else {
+      instructions.push({ op: byte });
+      i += 1;
+    }
+  }
+  return instructions;
+}
+
+const OP_IF = 0x63;
+const OP_CHECKSIG = 0xac;
+
+function isPush(instruction: Instruction | undefined): instruction is { push: Uint8Array } {
+  return instruction !== undefined && 'push' in instruction;
+}
+
+function isOp(instruction: Instruction | undefined, opcode: number): boolean {
+  return instruction !== undefined && 'op' in instruction && instruction.op === opcode;
+}
+
+function pushEquals(instruction: Instruction | undefined, bytes: number[]): boolean {
+  if (!isPush(instruction)) return false;
+  if (instruction.push.length !== bytes.length) return false;
+  return bytes.every((byte, index) => instruction.push[index] === byte);
+}
+
+export interface OrdEnvelopeMessage {
+  /**
+   * The full Counterparty payload, CNTRPRTY prefix included — the same shape
+   * `extractCounterpartyPayload` returns for OP_RETURN carriers, so everything downstream
+   * (unpack, verification, the provider gate) treats both carriers identically.
+   */
+  messageHex: string;
+  /** The envelope's stated MIME type, empty when unreadable — core defaults the same way. */
+  mimeType: string;
+  /** Length of the inscription body in bytes. */
+  contentLength: number;
+  /** The x-only key the envelope's trailing OP_CHECKSIG binds spending to. */
+  checksigPubkey: Uint8Array;
+}
+
+/**
+ * Read a Counterparty message from a tapleaf script, or null when the script is not an ord
+ * envelope carrying one.
+ *
+ * Null is the common case — a taproot script-path spend can be anything — and callers treat it as
+ * "no Counterparty data here", exactly as a payload-less OP_RETURN reads. A script that *is* an
+ * envelope but whose metadata does not yield a message also returns null: core raises there, the
+ * transaction carries no executable message, and there is nothing to report.
+ */
+export function extractEnvelopeMessage(script: Uint8Array): OrdEnvelopeMessage | null {
+  const instructions = parseInstructions(script);
+  if (!instructions || instructions.length < 7) return null;
+
+  // Envelope shape: empty push (or OP_FALSE, which parses as one), OP_IF, …, OP_CHECKSIG.
+  const first = instructions[0];
+  if (!isPush(first) || first.push.length !== 0) return null;
+  if (!isOp(instructions[1], OP_IF)) return null;
+  if (!isOp(instructions[instructions.length - 1], OP_CHECKSIG)) return null;
+
+  // ord marker and the metaprotocol tag. Core checks exactly this much: "ord" at [2] and the
+  // 0x07 tag at [3]. The metaprotocol *value* at [4] and the 0x01 tag at [5] go unchecked, and
+  // the mime type is read positionally from [6].
+  if (!pushEquals(instructions[2], [0x6f, 0x72, 0x64])) return null;
+  if (!pushEquals(instructions[3], [0x07])) return null;
+
+  let mimeType = '';
+  const mimeInstruction = instructions[6];
+  if (isPush(mimeInstruction)) {
+    try {
+      mimeType = new TextDecoder('utf-8', { fatal: true }).decode(mimeInstruction.push);
+    } catch {
+      mimeType = '';
+    }
+  }
+
+  // Collect metadata and body chunks. Tag pushes flip the current section; every other push in a
+  // section is a chunk of it. The loop stops three instructions short: OP_ENDIF, the pubkey, and
+  // OP_CHECKSIG — mirroring core, which never re-checks what those three are beyond the last.
+  const metadataChunks: Uint8Array[] = [];
+  const bodyChunks: Uint8Array[] = [];
+  let section: 'none' | 'metadata' | 'body' = 'none';
+  for (let i = 7; i < instructions.length - 3; i += 1) {
+    const instruction = instructions[i]!;
+    if (pushEquals(instruction, [0x05])) {
+      section = 'metadata';
+      continue;
+    }
+    if (isPush(instruction) && instruction.push.length === 0) {
+      section = 'body';
+      continue;
+    }
+    if (section === 'none' || !isPush(instruction)) continue;
+    (section === 'metadata' ? metadataChunks : bodyChunks).push(instruction.push);
+  }
+
+  if (metadataChunks.length === 0) return null;
+
+  const metadataLength = metadataChunks.reduce((total, chunk) => total + chunk.length, 0);
+  const metadata = new Uint8Array(metadataLength);
+  let offset = 0;
+  for (const chunk of metadataChunks) {
+    metadata.set(chunk, offset);
+    offset += chunk.length;
+  }
+
+  const bodyLength = bodyChunks.reduce((total, chunk) => total + chunk.length, 0);
+  const body = new Uint8Array(bodyLength);
+  offset = 0;
+  for (const chunk of bodyChunks) {
+    body.set(chunk, offset);
+    offset += chunk.length;
+  }
+
+  // The metadata is CBOR: the message array directly, or a map carrying it under "xcp" while the
+  // other keys hold ordinals provenance the consensus parser ignores.
+  let decoded: CborValue;
+  try {
+    decoded = decodeCbor(metadata);
+  } catch {
+    return null;
+  }
+
+  let messageArray: CborValue[];
+  if (Array.isArray(decoded)) {
+    if (decoded.length === 0) return null;
+    messageArray = decoded;
+  } else if (decoded instanceof Map) {
+    const xcp = decoded.get('xcp');
+    if (!Array.isArray(xcp) || xcp.length === 0) return null;
+    messageArray = xcp;
+  } else {
+    return null;
+  }
+
+  const [typeIdValue, ...fields] = messageArray;
+  if (typeof typeIdValue !== 'bigint') return null;
+  // Core casts the id to u8, truncating; a wrong-width id yields the same (likely undecodable)
+  // message there and here.
+  const typeId = Number(typeIdValue & 0xffn);
+
+  // Reassemble exactly as core does: fields, then the mime type, then the content — the content
+  // only when body chunks existed at all.
+  const repacked: CborEncodable[] = [...(fields as CborEncodable[]), mimeType];
+  if (bodyChunks.length > 0) repacked.push(body);
+
+  let cborBytes: Uint8Array;
+  try {
+    cborBytes = encodeCbor(repacked);
+  } catch {
+    return null;
+  }
+
+  const pubkeyInstruction = instructions[instructions.length - 2];
+  if (!isPush(pubkeyInstruction) || pubkeyInstruction.push.length !== 32) return null;
+
+  return {
+    messageHex:
+      COUNTERPARTY_PREFIX_HEX + typeId.toString(16).padStart(2, '0') + bytesToHex(cborBytes),
+    mimeType,
+    contentLength: bodyLength,
+    checksigPubkey: pubkeyInstruction.push,
+  };
+}

--- a/src/hooks/useSignPsbtRequest.ts
+++ b/src/hooks/useSignPsbtRequest.ts
@@ -15,6 +15,10 @@ import { useSearchParams } from 'react-router';
 import { extractPsbtDetails, type PsbtDetails } from '@/core/bitcoin/psbt';
 import { fetchInputsAttachedAssets } from '@/core/counterparty/inputAssets';
 import {
+  type InscriptionCommitContext,
+  resolveRevealMessage,
+} from '@/core/counterparty/providerInscriptions';
+import {
   analyzeSignRequest,
   type SignRequestAnalysis,
 } from '@/core/counterparty/signRequestAnalysis';
@@ -46,7 +50,8 @@ export function useSignPsbtRequest(signerAddress?: string) {
   const decodePsbt = useCallback(async (
     psbtHex: string,
     signerAddresses?: string[],
-    signedInputIndices?: number[]
+    signedInputIndices?: number[],
+    inscriptionContext?: InscriptionCommitContext
   ): Promise<DecodedPsbtInfo> => {
     // First, extract pure Bitcoin details (no API calls)
     const psbtDetails = extractPsbtDetails(psbtHex);
@@ -67,6 +72,16 @@ export function useSignPsbtRequest(signerAddress?: string) {
         psbtDetails.outputs.map((output) => output.script ?? ''),
         firstInputTxid
       ) ?? undefined;
+    }
+
+    // An inscription reveal carries its message in input 0's tapleaf instead of any output — the
+    // outputs hold only the bare CNTRPRTY marker. Recognized under core's own conditions
+    // (`providerInscriptions.ts`), the envelope's message takes the payload's place and the
+    // ordinary gate and display apply to it. Raw-transaction requests have no equivalent: an
+    // unsigned raw transaction cannot carry the leaf it will reveal, so that path stays blocked.
+    if (!counterpartyDataHex) {
+      const reveal = resolveRevealMessage(psbtDetails.inputs, psbtDetails.outputs);
+      if (reveal) counterpartyDataHex = reveal.messageHex;
     }
 
     // Enrich the outputs before analysing them, so the safety checks see every address that could
@@ -101,6 +116,7 @@ export function useSignPsbtRequest(signerAddress?: string) {
       signedInputIndices: signedInputIndices ?? [],
       transactionId: txid,
       attachedAssets: attachedAssetsPromise,
+      inscriptionContext,
     });
 
     return {
@@ -137,7 +153,8 @@ export function useSignPsbtRequest(signerAddress?: string) {
         const decoded = await decodePsbt(
           req.psbtHex,
           requestedSigners.length > 0 ? requestedSigners : signerAddress ? [signerAddress] : [],
-          Object.values(req.signInputs ?? {}).flat()
+          Object.values(req.signInputs ?? {}).flat(),
+          req.inscription
         );
         setDecodedInfo(decoded);
       } catch (err) {
@@ -164,7 +181,8 @@ export function useSignPsbtRequest(signerAddress?: string) {
             const decoded = await decodePsbt(
               req.psbtHex,
               requestedSigners.length > 0 ? requestedSigners : signerAddress ? [signerAddress] : [],
-              Object.values(req.signInputs ?? {}).flat()
+              Object.values(req.signInputs ?? {}).flat(),
+              req.inscription
             );
             setDecodedInfo(decoded);
           }

--- a/src/platform/provider/signFlow.ts
+++ b/src/platform/provider/signFlow.ts
@@ -38,6 +38,13 @@ export type SignPsbtRequest = SignFlowEntry<{
   psbtHex: string;
   signInputs?: Record<string, number[]>;
   sighashTypes?: number[];
+  /**
+   * A site's claim about the inscription commit this PSBT funds: the reveal's tapleaf script and
+   * the taproot internal key, both hex. Never trusted — the approval screen recomputes the commit
+   * address and message from it and hard-refuses on any mismatch
+   * (`core/counterparty/providerInscriptions.ts`).
+   */
+  inscription?: { revealScript: string; tapInternalKey: string };
 }>;
 
 /**

--- a/src/services/providerService.ts
+++ b/src/services/providerService.ts
@@ -10,7 +10,7 @@
 import { normalizeAddressForComparison } from '@/core/bitcoin/address';
 import { fetchBTCBalance } from '@/core/bitcoin/balance';
 import { signMessage as signMessageDirect } from '@/core/bitcoin/messageSigner';
-import { extractPsbtDetails, validateSignInputs } from '@/core/bitcoin/psbt';
+import { extractPsbtDetails, tapLeafOwnerAddress, validateSignInputs } from '@/core/bitcoin/psbt';
 import { fetchTokenBalances } from '@/core/counterparty/api';
 import { generateRequestId } from '@/core/id';
 import { checkReplayAttempt, markTransactionBroadcasted, recordTransaction } from '@/core/replayPrevention';
@@ -739,11 +739,14 @@ export function createProviderService(): ProviderService {
               activeAddress.address,
               ...(paired ? [paired.legacy.address, paired.segwit.address] : []),
             ];
+            // Ownership per input: normally the prevout's own address, but an inscription
+            // reveal spends a commit output whose address belongs to nobody — there the input is
+            // owned by whoever the declared leaf's checksig key encodes to (tapLeafOwnerAddress).
             const validation = validateSignInputs(
               signInputs,
               allowedAddresses,
               psbtDetails.inputs.length,
-              psbtDetails.inputs.map(input => input.address)
+              psbtDetails.inputs.map(input => tapLeafOwnerAddress(input) ?? input.address)
             );
             if (!validation.valid) throw new Error(validation.error);
 

--- a/src/services/providerService.ts
+++ b/src/services/providerService.ts
@@ -669,13 +669,29 @@ export function createProviderService(): ProviderService {
             throw new Error('PSBT parameters must be an object with hex property');
           }
 
-          const { hex: psbtHex, signInputs, sighashTypes } = psbtParams as { hex?: string; signInputs?: Record<string, number[]>; sighashTypes?: number[] };
+          const { hex: psbtHex, signInputs, sighashTypes, inscription } = psbtParams as {
+            hex?: string;
+            signInputs?: Record<string, number[]>;
+            sighashTypes?: number[];
+            inscription?: { revealScript?: string; tapInternalKey?: string };
+          };
 
           if (!psbtHex) {
             throw new Error('PSBT hex is required');
           }
           if (typeof psbtHex !== 'string') {
             throw new Error('PSBT hex must be a string');
+          }
+          // Shape-checked here, verified on the approval screen: the context is a claim the site
+          // makes about what the commit funds, and every field of it gets recomputed there.
+          if (inscription !== undefined && (
+            inscription === null || typeof inscription !== 'object'
+            || typeof inscription.revealScript !== 'string'
+            || typeof inscription.tapInternalKey !== 'string'
+            || !/^[0-9a-fA-F]+$/.test(inscription.revealScript)
+            || !/^[0-9a-fA-F]{64}$/.test(inscription.tapInternalKey)
+          )) {
+            throw new Error('inscription must carry revealScript and tapInternalKey as hex strings');
           }
           if (signInputs !== undefined && (
             signInputs === null || typeof signInputs !== 'object' || Array.isArray(signInputs)
@@ -786,6 +802,12 @@ export function createProviderService(): ProviderService {
                 psbtHex,
                 signInputs,
                 sighashTypes,
+                ...(inscription ? {
+                  inscription: {
+                    revealScript: inscription.revealScript!,
+                    tapInternalKey: inscription.tapInternalKey!,
+                  },
+                } : {}),
                 address: activeAddress.address,
                 walletId: activeWallet.id,
                 timestamp: Date.now(),


### PR DESCRIPTION
## What this is

Xcer's "Blocked: Not a Counterparty Transaction" on a launchpad inscription, fixed properly: the provider path can now sign inscription commits and reveals **it can prove**, and nothing else. The gate stays fully closed to unprovable BTC movement — it gains the ability to verify the one legitimate case.

## Why it was blocked

Taproot encoding hides the Counterparty message in the reveal's tapleaf. To output-only inspection the commit is a plain BTC payment to a stranger's address — indistinguishable from a drain, which is exactly what the gate refuses. Both halves of every site-driven inscription were categorically blocked.

## The rules (each mirrored from core or proven locally)

**Reveal** — recognized under core's indexer conditions (`bitcoin_client.rs::extract_data_from_witness`), no looser: envelope read from input 0 only, exactly one leaf, plaintext `CNTRPRTY` marker among the outputs. The message is reassembled byte-for-byte as core does (both metadata shapes: bare array, and ord map with the `xcp` key) and takes the payload's place — gate, verification and display treat it like any OP_RETURN carrier.

**Commit** — the site passes `inscription: { revealScript, tapInternalKey }` with `signPsbt`. All of it is treated as a claim: the wallet re-derives the commit address, requires it paid exactly once with all other outputs returning to the signer, decodes the envelope to a message that unpacks, and enforces the **key-ownership rule**: internal key = BIP-341 unspendable point, leaf checksig key = the signer's own taproot output key. A genuine envelope over a site's keys is how a drain would dress up — the envelope proves what the BTC is *for*; the key rule proves who can *take* it. Any failure hard-blocks with its specific reason.

## Gaps this exposed and fixed

- **Signer**: dApp key-path taproot inputs carry no `tapInternalKey` (a site can't know it) — injected only when the prevout provably pays the signer's own address, and @scure re-verifies before signing. Reveal leaves name the *tweaked* output key — retried with the tweaked private key exactly when a leaf is present; a foreign leaf still finds no match.
- **CBOR decoder**: no map support; ord metadata carries the message array under an `"xcp"` text key (core: `ordinals_metadata_support`, active since 952800).
- **Fairminter unpack**: binary descriptions were read as strict UTF-8 and threw; core hexlifies via `helpers.bytes_to_content`. An image-carrying fairminter — every launchpad launch — failed to unpack at all.

## Hostile-site tests

Wrong internal key (sweepable commit), envelope over the attacker's key, drain output riding along, missing/duplicated commit output, undecodable envelope/message, non-taproot signer, envelope on the wrong input, missing marker, multiple leaves, foreign taproot input in best-effort signing. 27 new tests across three suites; the reveal fixture round-trips through `unpackCounterpartyMessage` into a fairminter whose description is the image, hex-encoded, as core reads it.

## What it deliberately does not do

- Raw-transaction requests stay blocked for inscriptions: an unsigned raw tx cannot carry the leaf it will reveal, so there is nothing to prove.
- No override buttons anywhere; every refusal is hard and named.
- The launchpad needs a two-line change to pass the context on the commit (separate change, same session). Reveals need nothing from the site.

https://claude.ai/code/session_01QJS9Bj6uAMoYPATvfr6GZ1
