### PR TITLE
Release 0.8.8 — precise fee rates, and protocol figures at XCP's precision

### DIFF
--- a/e2e/pages/market/btc-price.spec.ts
+++ b/e2e/pages/market/btc-price.spec.ts
@@ -41,7 +41,7 @@ async function stubBtcApis(page: Page, overrides: { statsStatus?: number; chartS
   await page.route('**/api/v3/coins/bitcoin/market_chart**', (route) =>
     route.fulfill(json(overrides.chartStatus ? { error: 'unavailable' } : CHART, overrides.chartStatus ?? 200)),
   );
-  await page.route('**/v1/fees/recommended', (route) => route.fulfill(json(FEES)));
+  await page.route('**/v1/fees/precise', (route) => route.fulfill(json(FEES)));
   await page.route('**/v2/price/ticker*', (route) => route.fulfill(json(XCP_TICKER)));
   // The stats fetcher falls back to other providers; fail them so a stubbed outage stays an outage.
   await page.route('**/api.coincap.io/**', (route) => route.fulfill(json({ error: 'unavailable' }, 503)));

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "xcp-wallet",
   "description": "Counterparty Web3 Wallet",
   "private": true,
-  "version": "0.8.7",
+  "version": "0.8.8",
   "license": "MIT",
   "type": "module",
   "engines": {

--- a/src/core/bitcoin/__tests__/feeRate.test.ts
+++ b/src/core/bitcoin/__tests__/feeRate.test.ts
@@ -40,9 +40,26 @@ describe('Fee Rate Utilities', () => {
       const feeRates = await fetchFromMempoolSpace();
       expect(feeRates).toEqual(mockFeeRates);
       expect(apiClient.get).toHaveBeenCalledWith(
-        'https://mempool.space/api/v1/fees/recommended',
+        'https://mempool.space/api/v1/fees/precise',
         { retries: 0 }
       );
+    });
+
+    it('should keep sub-sat/vB rates, quoted to two decimals', async () => {
+      vi.mocked(apiClient.get).mockResolvedValue(okResponse({
+        fastestFee: 1,
+        halfHourFee: 0.69,
+        hourFee: 0.408,
+        economyFee: 0.2,
+        minimumFee: 0.1
+      }));
+
+      const feeRates = await fetchFromMempoolSpace();
+      expect(feeRates).toEqual({
+        fastestFee: 1,
+        halfHourFee: 0.69,
+        hourFee: 0.41 // rounded up, never below the estimate it came from
+      });
     });
 
     it('should throw error when API response is not ok', async () => {
@@ -106,30 +123,26 @@ describe('Fee Rate Utilities', () => {
       await expect(fetchFromMempoolSpace()).rejects.toThrow('Network error');
     });
 
-    it('should handle zero fee rates', async () => {
-      const zeroFeeRates = {
+    it('should clamp zero fee rates to the minimum the fee input accepts', async () => {
+      vi.mocked(apiClient.get).mockResolvedValue(okResponse({
         fastestFee: 0,
         halfHourFee: 0,
         hourFee: 0
-      };
-
-      vi.mocked(apiClient.get).mockResolvedValue(okResponse(zeroFeeRates));
+      }));
 
       const feeRates = await fetchFromMempoolSpace();
-      expect(feeRates).toEqual(zeroFeeRates);
+      expect(feeRates).toEqual({ fastestFee: 0.1, halfHourFee: 0.1, hourFee: 0.1 });
     });
 
-    it('should handle negative fee rates', async () => {
-      const negativeFeeRates = {
+    it('should clamp negative fee rates to the minimum the fee input accepts', async () => {
+      vi.mocked(apiClient.get).mockResolvedValue(okResponse({
         fastestFee: -1,
         halfHourFee: -2,
         hourFee: -3
-      };
-
-      vi.mocked(apiClient.get).mockResolvedValue(okResponse(negativeFeeRates));
+      }));
 
       const feeRates = await fetchFromMempoolSpace();
-      expect(feeRates).toEqual(negativeFeeRates);
+      expect(feeRates).toEqual({ fastestFee: 0.1, halfHourFee: 0.1, hourFee: 0.1 });
     });
   });
 
@@ -245,6 +258,23 @@ describe('Fee Rate Utilities', () => {
       expect(feeRates).toEqual({
         fastestFee: 20.5,
         halfHourFee: 15.3,
+        hourFee: 10.1
+      });
+    });
+
+    it('should quote fractional fee rates to two decimals', async () => {
+      const blockstreamResponse = {
+        "2": 20.567,
+        "3": 15.301,
+        "6": 10.1
+      };
+
+      vi.mocked(apiClient.get).mockResolvedValue(okResponse(blockstreamResponse));
+
+      const feeRates = await fetchFromBlockstream();
+      expect(feeRates).toEqual({
+        fastestFee: 20.57,
+        halfHourFee: 15.31,
         hourFee: 10.1
       });
     });

--- a/src/core/bitcoin/feeRate.ts
+++ b/src/core/bitcoin/feeRate.ts
@@ -1,11 +1,30 @@
 import { CacheTTL, TTLCache } from '@/core/api/cache';
 import { apiClient } from '@/core/api/client';
 import { DataFetchError } from '@/core/errors';
+import { maximum, toBigNumber, toNumber } from '@/core/numeric';
 
 export interface FeeRates {
   fastestFee: number;
   halfHourFee: number;
   hourFee: number;
+}
+
+/** Presets are quoted to the two decimals the custom fee input accepts. */
+const QUOTED_DECIMALS = 2;
+/** And clamped to the same 0.1 sat/vB floor that input enforces. */
+const MIN_QUOTED_FEE_RATE = 0.1;
+
+/**
+ * Brings a source's rate to the precision the wallet quotes.
+ *
+ * Sources now report sub-sat/vB rates (mempool.space's precise endpoint answers 0.408 where the
+ * recommended one rounded to 1), which is the point of using them — but a preset still has to be a
+ * value the fee input itself would accept. Rounding is upward so a preset never sits below the
+ * estimate it came from.
+ */
+function quoteRate(rate: number): number {
+  const rounded = toBigNumber(rate).decimalPlaces(QUOTED_DECIMALS, 2); // ROUND_CEIL = 2
+  return toNumber(maximum(rounded, MIN_QUOTED_FEE_RATE));
 }
 
 /**
@@ -20,7 +39,10 @@ let inflightRequest: Promise<FeeRates> | null = null;
 /**
  * Fetch fee rates from mempool.space.
  *
- * Expected response shape:
+ * The precise endpoint rather than the recommended one: same fields, but unrounded, so a quiet
+ * mempool reads 0.41 sat/vB instead of the 1 sat/vB the rounded endpoint reports as its floor.
+ *
+ * Expected response shape (economyFee and minimumFee are also returned, and unused):
  * {
  *   fastestFee: number,
  *   halfHourFee: number,
@@ -28,7 +50,7 @@ let inflightRequest: Promise<FeeRates> | null = null;
  * }
  */
 export async function fetchFromMempoolSpace(): Promise<FeeRates> {
-  const response = await apiClient.get<Record<string, number>>('https://mempool.space/api/v1/fees/recommended', { retries: 0 });
+  const response = await apiClient.get<Record<string, number>>('https://mempool.space/api/v1/fees/precise', { retries: 0 });
   const data = response.data;
   if (
     typeof data.fastestFee !== 'number' || Number.isNaN(data.fastestFee) ||
@@ -36,13 +58,13 @@ export async function fetchFromMempoolSpace(): Promise<FeeRates> {
     typeof data.hourFee !== 'number' || Number.isNaN(data.hourFee)
   ) {
     throw new DataFetchError('Invalid response data format', 'mempool.space', {
-      endpoint: '/api/v1/fees/recommended',
+      endpoint: '/api/v1/fees/precise',
     });
   }
   return {
-    fastestFee: data.fastestFee,
-    halfHourFee: data.halfHourFee,
-    hourFee: data.hourFee,
+    fastestFee: quoteRate(data.fastestFee),
+    halfHourFee: quoteRate(data.halfHourFee),
+    hourFee: quoteRate(data.hourFee),
   };
 }
 
@@ -70,7 +92,11 @@ export async function fetchFromBlockstream(): Promise<FeeRates> {
       endpoint: '/api/fee-estimates',
     });
   }
-  return { fastestFee, halfHourFee, hourFee };
+  return {
+    fastestFee: quoteRate(fastestFee),
+    halfHourFee: quoteRate(halfHourFee),
+    hourFee: quoteRate(hourFee),
+  };
 }
 
 // Ordered list of fee rate fetchers.

--- a/src/core/counterparty/__tests__/protocolContext.test.ts
+++ b/src/core/counterparty/__tests__/protocolContext.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/core/counterparty/api', () => ({
+  fetchAssetDetails: vi.fn(),
+  fetchAssetFairminter: vi.fn(),
+  fetchAssetHolderCount: vi.fn(),
+  fetchOrder: vi.fn(),
+  fetchOrderMatch: vi.fn(),
+  fetchUtxoBalances: vi.fn(),
+}));
+vi.mock('@/core/counterparty/dispenseOutcome', () => ({
+  describePayout: vi.fn(),
+  resolveDispensersAt: vi.fn(),
+}));
+vi.mock('@/core/bitcoin/blockHeight', () => ({
+  getCurrentBlockHeight: vi.fn(async () => 0),
+}));
+
+import { fetchAssetDetails, fetchAssetFairminter, fetchAssetHolderCount } from '@/core/counterparty/api';
+import { resolveProtocolContext } from '../protocolContext';
+
+/** A fairmint of `asset`, the shape the approval screen resolves context from. */
+const fairmintOf = (asset: string) => ({ messageType: 'fairmint', data: { asset } });
+
+describe('resolveProtocolContext', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('XCP figures', () => {
+    it('trims a fairminter price to its significant digits', async () => {
+      // What core actually sends: the normalized figure at full working precision.
+      vi.mocked(fetchAssetFairminter).mockResolvedValue({
+        price_normalized: '0.00001000000000000',
+      } as any);
+
+      const { context } = await resolveProtocolContext(fairmintOf('MYASSET'));
+      expect(context.protocolFeeXcp).toBe('0.00001');
+    });
+
+    it('keeps every one of the eight places XCP is divisible to', async () => {
+      vi.mocked(fetchAssetFairminter).mockResolvedValue({
+        price_normalized: '1.23456789000000000',
+      } as any);
+
+      const { context } = await resolveProtocolContext(fairmintOf('MYASSET'));
+      expect(context.protocolFeeXcp).toBe('1.23456789');
+    });
+
+    it('states a price too small to show as a bound rather than as zero', async () => {
+      vi.mocked(fetchAssetFairminter).mockResolvedValue({
+        price_normalized: '0.000000001',
+      } as any);
+
+      const { context } = await resolveProtocolContext(fairmintOf('MYASSET'));
+      // "0 XCP" on a price row would read as a free mint.
+      expect(context.protocolFeeXcp).toBe('<0.00000001');
+    });
+
+    it('trims the protocol fee carried by the message itself', async () => {
+      const { context } = await resolveProtocolContext({
+        messageType: 'attach',
+        data: { asset: 'MYASSET' },
+        apiMessageData: { fee: 50000000 },
+      });
+
+      expect(context.protocolFeeXcp).toBe('0.5');
+    });
+
+    it('leaves a fairminter with no price unpriced', async () => {
+      vi.mocked(fetchAssetFairminter).mockResolvedValue({ price_normalized: null } as any);
+
+      const { context } = await resolveProtocolContext(fairmintOf('MYASSET'));
+      expect(context.protocolFeeXcp).toBeUndefined();
+    });
+  });
+
+  describe('dividend figures', () => {
+    it('trims the total payout and the XCP fee', async () => {
+      vi.mocked(fetchAssetDetails).mockResolvedValue({ supply_normalized: '1000' } as any);
+      vi.mocked(fetchAssetHolderCount).mockResolvedValue(3);
+
+      const { context } = await resolveProtocolContext({
+        messageType: 'dividend',
+        data: { asset: 'MYASSET', quantityPerUnit: 100000 }, // 0.001 per unit
+      });
+
+      expect(context.dividendTotal).toBe('1');
+      expect(context.dividendFeeXcp).toBe('0.0006');
+    });
+  });
+});

--- a/src/core/counterparty/protocolContext.ts
+++ b/src/core/counterparty/protocolContext.ts
@@ -32,12 +32,30 @@ import {
   oracleDispenseWarning,
 } from '@/core/counterparty/oraclePolicy';
 import type { SecurityWarning } from '@/core/counterparty/transactionSafety';
-import { fromSatoshis, isGreaterThan, toBigNumber } from '@/core/numeric';
+import { type BigNumber, formatDecimal, fromSatoshis, isGreaterThan, toBigNumber } from '@/core/numeric';
 
 export type { ProtocolContext };
 
 /** Core: `fee = int(0.0002 * UNIT * holder_count)` in `messages/dividend.py`. */
 const DIVIDEND_FEE_XCP_PER_HOLDER = '0.0002';
+
+/**
+ * A figure as a row on the approval screen should read it: at most eight decimals, no trailing
+ * zeros.
+ *
+ * Core's normalized values carry their full working precision, and they were reaching the screen
+ * verbatim — a fairminter priced at 0.00001 XCP arrived as `price_normalized`
+ * "0.00001000000000000" and was signed off from a row reading exactly that. Eight places is where
+ * the ledger itself stops, so everything past them is noise on the number being agreed to.
+ *
+ * A value too small to show at that precision is stated as a bound rather than rounded down to
+ * "0", which on a price row would read as free.
+ */
+function toDisplayAmount(value: string | number | BigNumber): string {
+  const amount = toBigNumber(value);
+  const shown = formatDecimal(amount);
+  return shown === '0' && amount.isGreaterThan(0) ? '<0.00000001' : shown;
+}
 
 export interface ProtocolContextInput {
   messageType: string | undefined;
@@ -75,7 +93,7 @@ export async function resolveProtocolContext(
   // `gas.get_transaction_fee`), always paid in XCP — a cost beyond the Bitcoin fee.
   const fee = apiMessageData?.fee;
   if (fee != null && isGreaterThan(String(fee), 0)) {
-    context.protocolFeeXcp = fromSatoshis(String(fee));
+    context.protocolFeeXcp = toDisplayAmount(fromSatoshis(String(fee)));
   }
 
   if (!messageType || data == null) return { context, warnings };
@@ -116,16 +134,15 @@ export async function resolveProtocolContext(
           const total = toBigNumber(details.supply_normalized).times(
             toBigNumber(fromSatoshis(String(perUnit)))
           );
-          context.dividendTotal = total.toFixed(8).replace(/\.?0+$/, '');
+          context.dividendTotal = toDisplayAmount(total);
         }
       }
       // The XCP half of the bill, which is charged per distinct holder rather than per unit.
       const holders = await fetchAssetHolderCount(fields.asset);
       if (holders != null && holders > 0) {
-        context.dividendFeeXcp = toBigNumber(DIVIDEND_FEE_XCP_PER_HOLDER)
-          .times(holders)
-          .toFixed(8)
-          .replace(/\.?0+$/, '');
+        context.dividendFeeXcp = toDisplayAmount(
+          toBigNumber(DIVIDEND_FEE_XCP_PER_HOLDER).times(holders)
+        );
       }
     }
 
@@ -133,7 +150,7 @@ export async function resolveProtocolContext(
       // A fairmint's cost is the fairminter's price, which is not in the message.
       const fairminter = await fetchAssetFairminter(fields.asset);
       if (fairminter?.price_normalized) {
-        context.protocolFeeXcp = String(fairminter.price_normalized);
+        context.protocolFeeXcp = toDisplayAmount(String(fairminter.price_normalized));
       }
     }
 


### PR DESCRIPTION
Two independent fixes and the version bump.

## Fee rates come from `/api/v1/fees/precise`

The recommended endpoint rounds to whole sat/vB, so its floor is 1. On a quiet mempool every preset collapsed to that figure and the wallet asked for several times the going rate. The precise endpoint answers the same three fields unrounded — 0.41 where the other says 1.

Rates from either source (mempool.space, and the blockstream.info fallback) are now brought to what the fee input itself accepts: two decimals, rounded up so a preset never sits below the estimate it came from, and clamped to the 0.1 sat/vB floor. Without that the dropdown would offer `0.408`, a value the same component reformats if it is typed into Custom, and a zero or negative figure from a source would reach the compose call unexamined.

The screen is unchanged — same Fastest / 30 Min / 1 Hour presets, same Custom field. Only the numbers improve. Being distinct again, the three presets also stop deduplicating into one row while the mempool is quiet.

## Protocol figures are trimmed to eight places

Reported from the wild: a fairmint approval showed its price as `0.00001000000000000 XCP`. Core's normalized values carry their full working precision and `protocolContext` was printing them verbatim.

Every figure that file hands the approval screen now goes through one helper — the fairminter price, the fee the message carries, and the two dividend figures, which were each hand-rolling `toFixed(8)` plus a regex that would eat a real trailing zero on any input without a decimal point. A value too small to show at eight places is stated as a bound (`<0.00000001`) rather than rounded to `0`, which on a price row would read as a free mint.

## Tests

- `feeRate.test.ts`: endpoint assertion, a precise-endpoint case (0.408 → 0.41), a blockstream 3-decimal case; the zero/negative cases now assert the clamp.
- `protocolContext.test.ts`: new file — the reported string, the 8-decimal case, the sub-satoshi bound, the dividend figures.
- `e2e/pages/market/btc-price.spec.ts`: fee route mock moved to `**/v1/fees/precise`, which would otherwise have stopped matching.

## Noted, not changed

`protocolContext` shows `price_normalized`, which core defines as XCP *per whole unit* (`price / quantity_by_price`). The compose review screen deliberately uses `getFairminterLotCost` instead, which prefers core's per-*lot* `price`. For any fairminter with a lot size above 1 the two screens quote prices differing by the lot size. Worth a follow-up; left alone here because it changes which number a signing screen states, not just how it is formatted.