### PR TITLE
Asset actions offer only what the node will accept

### DIFF
--- a/src/core/counterparty/__tests__/normalize.reset.test.ts
+++ b/src/core/counterparty/__tests__/normalize.reset.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { asDisplayUnits } from '@/core/numeric';
+import type { AssetInfo } from '../api';
+import * as api from '../api';
+import { normalizeFormData } from '../normalize';
+
+vi.mock('../api', () => ({
+  fetchAssetDetails: vi.fn(),
+}));
+
+const mockFetchAssetDetails = vi.mocked(api.fetchAssetDetails);
+
+/** An existing, currently indivisible asset. */
+function indivisibleAsset(): AssetInfo {
+  return {
+    asset: 'MYASSET',
+    asset_longname: null,
+    description: '',
+    issuer: 'bc1qowner',
+    divisible: false,
+    locked: false,
+    supply: '1000',
+    supply_normalized: asDisplayUnits('1000'),
+  };
+}
+
+function resetForm(fields: Record<string, string>): FormData {
+  const formData = new FormData();
+  formData.set('asset', 'MYASSET');
+  formData.set('reset', 'true');
+  for (const [k, v] of Object.entries(fields)) formData.set(k, v);
+  return formData;
+}
+
+describe('normalizeFormData — reset issuance divisibility', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetchAssetDetails.mockResolvedValue(indivisibleAsset());
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('scales a reset quantity by the divisibility the form asks for, not the ledger\'s', async () => {
+    // The asset is indivisible today. A reset is the only issuance core lets change that, and it
+    // records the message's own `divisible`, so a supply of 5 divisible units must go out as
+    // 500000000 base units. Scaling by the ledger's current `false` would send 5 — a supply 1e8
+    // smaller than the one the user typed.
+    const result = await normalizeFormData(resetForm({ quantity: '5', divisible: 'true' }), 'issuance');
+
+    expect(result.normalizedData.quantity).toBe('500000000');
+    expect(result.normalizedData.divisible).toBe(true);
+    expect(result.normalizedData.reset).toBe(true);
+  });
+
+  it('keeps a reset quantity whole when the form asks for an indivisible asset', async () => {
+    const result = await normalizeFormData(
+      resetForm({ quantity: '2026', divisible: 'false' }),
+      'issuance'
+    );
+
+    expect(result.normalizedData.quantity).toBe('2026');
+    expect(result.normalizedData.divisible).toBe(false);
+  });
+
+  it('truncates a fractional quantity when the reset makes the asset indivisible', async () => {
+    mockFetchAssetDetails.mockResolvedValue({ ...indivisibleAsset(), divisible: true });
+
+    const result = await normalizeFormData(
+      resetForm({ quantity: '7.9', divisible: 'false' }),
+      'issuance'
+    );
+
+    expect(result.normalizedData.quantity).toBe('7');
+  });
+
+  it('still reads divisibility from the ledger for a non-reset reissuance', async () => {
+    // Without `reset`, core rejects any change of divisibility, so the ledger is authoritative and
+    // a form value must not be able to rescale the quantity.
+    mockFetchAssetDetails.mockResolvedValue({ ...indivisibleAsset(), divisible: true });
+
+    const formData = new FormData();
+    formData.set('asset', 'MYASSET');
+    formData.set('quantity', '3');
+    formData.set('divisible', 'false');
+
+    const result = await normalizeFormData(formData, 'issuance');
+
+    expect(result.normalizedData.quantity).toBe('300000000');
+  });
+});

--- a/src/core/counterparty/api.ts
+++ b/src/core/counterparty/api.ts
@@ -192,6 +192,41 @@ export interface OwnedAsset {
   locked: boolean;
 }
 
+/**
+ * One row of an asset's issuance history.
+ *
+ * The most recent valid row is the asset's live state as counterparty-core sees it:
+ * `issuance.validate` reads `fair_minting`, `description_locked`, `locked` and `issuer` off
+ * exactly this record (`last_issuance`), and core keeps it current by *appending* rows rather
+ * than mutating the asset — closing a fairminter, for instance, writes a fresh issuance with
+ * `fair_minting: false` and any `lock_quantity`/`lock_description` the sale asked for
+ * (`messages/fairminter.py`, `close_fairminter`).
+ */
+export interface AssetIssuance {
+  tx_hash: string;
+  block_index: number;
+  asset: string;
+  asset_longname: string | null;
+  quantity: ApiQuantity;
+  quantity_normalized: DisplayUnits;
+  divisible: boolean;
+  source: string;
+  /** The owner as of this issuance — a transfer records the destination here. */
+  issuer: string;
+  transfer: boolean;
+  description: string;
+  /** Supply frozen. Sticky: once any issuance sets it, the asset stays locked. */
+  locked: boolean;
+  /** Description frozen — core refuses any later issuance that carries a description. */
+  description_locked?: boolean;
+  /** A fairminter is open or pending on this asset; every reissuance is refused while set. */
+  fair_minting?: boolean;
+  reset: boolean;
+  status?: string;
+  asset_events?: string;
+  block_time?: number;
+}
+
 // =============================================================================
 // TYPES - Orders & Trading
 // =============================================================================
@@ -641,6 +676,25 @@ export async function fetchTokenUtxos(
     { verbose: options.verbose ?? true }
   );
   return (data.result ?? []).filter((b) => b.utxo !== null);
+}
+
+/**
+ * The asset's most recent valid issuance — the record core validates against.
+ *
+ * `/v2/assets/{asset}` cannot answer this: its `assets_info` projection carries no `fair_minting`
+ * column at all, so that flag reads `undefined` for every asset including ones actively minting.
+ * The issuances endpoint already filters to `status: "valid"` and returns newest first, so one row
+ * is the whole answer.
+ *
+ * Returns null when the asset has no issuance history or the lookup fails — an unknown state, not
+ * a negative one.
+ */
+export async function fetchAssetLatestIssuance(asset: string): Promise<AssetIssuance | null> {
+  const data = await cpApiGet<PaginatedResponse<AssetIssuance>>(
+    `/v2/assets/${encodePath(asset)}/issuances`,
+    { verbose: true, limit: 1, offset: 0 }
+  );
+  return data.result?.[0] ?? null;
 }
 
 /**

--- a/src/core/counterparty/normalize.ts
+++ b/src/core/counterparty/normalize.ts
@@ -266,6 +266,20 @@ export async function normalizeFormData(
       continue;
     }
 
+    // A reset issuance is the one path that may change divisibility: core gates "cannot change
+    // divisibility" on `not reset` (`messages/issuance.py`), and the reset branch of `parse`
+    // records the message's own `divisible` on the new issuance. So the quantity here is scaled by
+    // the divisibility the user is choosing, not the one the asset has today — reading the ledger
+    // would scale a new divisible supply by the old indivisible rule and land 1e8 off. Same reason
+    // the fairminter branch below trusts the form.
+    if (composeType === 'issuance' && toBoolean(rawData['reset'])) {
+      const isDivisible = toBoolean(rawData['divisible']);
+      normalizedData[quantityField] = isDivisible
+        ? toSatoshis(value.toString())
+        : toBigNumber(value.toString()).integerValue().toString();
+      continue;
+    }
+
     // For issuance of NEW assets, use the divisible field from the form
     if (composeType === 'issuance' && !assetInfoCache.has(assetName)) {
       try {

--- a/src/core/validation/__tests__/amount.test.ts
+++ b/src/core/validation/__tests__/amount.test.ts
@@ -8,6 +8,8 @@ import {
   isDustAmount,
   isValidNumber,
   MAX_SATOSHIS,
+  MAX_SUPPLY,
+  maxSupplyForDivisibility,
   SATOSHIS_PER_BTC, 
   validateAmount,
   validateBalance,
@@ -351,5 +353,25 @@ describe('isDustAmount', () => {
     expect(isDustAmount(DUST_LIMIT)).toBe(false);
     expect(isDustAmount(1000)).toBe(false);
     expect(isDustAmount(-100)).toBe(false);
+  });
+});
+
+describe('maxSupplyForDivisibility', () => {
+  it('offers the raw ceiling for an indivisible asset', () => {
+    // Base units and display units are the same thing when there are no fractions.
+    expect(maxSupplyForDivisibility(false)).toBe(MAX_SUPPLY);
+  });
+
+  it('shifts the ceiling eight places for a divisible asset', () => {
+    // MAX_SUPPLY is a base-unit limit. Offering it undivided as a divisible maximum would offer
+    // 1e8 times what core accepts, and every amount input built on it would validate against a
+    // number no issuance can reach.
+    expect(maxSupplyForDivisibility(true)).toBe('92233720368.54775807');
+  });
+
+  it('stays exact at the ceiling, where a double cannot', () => {
+    // 19 significant digits; a double carries 15. The helper must never round-trip through one.
+    expect(maxSupplyForDivisibility(false)).toBe('9223372036854775807');
+    expect(Number(maxSupplyForDivisibility(false)).toString()).not.toBe(MAX_SUPPLY);
   });
 });

--- a/src/core/validation/__tests__/assetOwner.test.ts
+++ b/src/core/validation/__tests__/assetOwner.test.ts
@@ -114,6 +114,44 @@ describe('Asset Owner Validation', () => {
       expect(mockFetchAssetDetails).toHaveBeenCalledWith('DROPLISTER.xcp');
     });
 
+    it('should prefer the current owner over the original issuer', async () => {
+      // Core sets `issuer` once, at first issuance, and moves `owner` alone on every
+      // ASSET_TRANSFER. Resolving a typed asset name to `issuer` would address the send to
+      // whoever gave the asset away.
+      mockFetchAssetDetails.mockResolvedValue({
+        asset: 'DROPLISTER.xcp',
+        asset_longname: null,
+        issuer: '19QWXpMXeLkoEKEJv2xo9rn8wkPCyxACSX',
+        owner: 'bc1q6yy9jshvvyzxdqy8j4wv74jgjhzrmppj7u9ful',
+        divisible: true,
+        locked: false,
+        supply_normalized: asDisplayUnits('1000000000')
+      });
+
+      const result = await lookupAssetOwner('DROPLISTER.xcp');
+
+      expect(result.isValid).toBe(true);
+      expect(result.ownerAddress).toBe('bc1q6yy9jshvvyzxdqy8j4wv74jgjhzrmppj7u9ful');
+    });
+
+    it('should fall back to the issuer when the asset has never been transferred', async () => {
+      // Assets that never changed hands report the two fields identically, and older responses
+      // may omit `owner` entirely; neither case should stop a lookup from resolving.
+      mockFetchAssetDetails.mockResolvedValue({
+        asset: 'DROPLISTER.xcp',
+        asset_longname: null,
+        issuer: '19QWXpMXeLkoEKEJv2xo9rn8wkPCyxACSX',
+        divisible: true,
+        locked: false,
+        supply_normalized: asDisplayUnits('1000000000')
+      });
+
+      const result = await lookupAssetOwner('DROPLISTER.xcp');
+
+      expect(result.isValid).toBe(true);
+      expect(result.ownerAddress).toBe('19QWXpMXeLkoEKEJv2xo9rn8wkPCyxACSX');
+    });
+
     it('should handle case insensitive input', async () => {
       const mockAssetInfo = {
         asset: 'DROPLISTER.xcp',
@@ -139,7 +177,7 @@ describe('Asset Owner Validation', () => {
       const result = await lookupAssetOwner('NONEXISTENT.xcp');
 
       expect(result.isValid).toBe(false);
-      expect(result.error).toBe('Asset not found or has no issuer');
+      expect(result.error).toBe('Asset not found or has no owner');
     });
 
     it('should return error for asset without issuer', async () => {
@@ -157,7 +195,7 @@ describe('Asset Owner Validation', () => {
       const result = await lookupAssetOwner('NOISSUER.xcp');
 
       expect(result.isValid).toBe(false);
-      expect(result.error).toBe('Asset not found or has no issuer');
+      expect(result.error).toBe('Asset not found or has no owner');
     });
 
     it('should return error for invalid asset format', async () => {

--- a/src/core/validation/amount.ts
+++ b/src/core/validation/amount.ts
@@ -3,12 +3,17 @@
  * Handles validation for Bitcoin amounts, token quantities, and numeric inputs
  */
 
-import { BigNumber, toBigNumber } from '@/core/numeric';
+import { BigNumber, fromSatoshis, toBigNumber } from '@/core/numeric';
 
 // Constants
 export const DUST_LIMIT = 546; // satoshis
 export const MAX_SATOSHIS = 2100000000000000; // 21 million BTC in satoshis
 export const SATOSHIS_PER_BTC = 100000000;
+/**
+ * The largest supply an asset can hold, in base units: SQLite3's signed 64-bit ceiling, which
+ * `issuance.validate` checks every quantity against ("total quantity overflow").
+ */
+export const MAX_SUPPLY = '9223372036854775807';
 
 export interface AmountValidationResult {
   isValid: boolean;
@@ -127,7 +132,7 @@ export function validateQuantity(
   const {
     divisible = true,
     allowZero = false,
-    maxSupply = '9223372036854775807', // Max int64
+    maxSupply = MAX_SUPPLY,
     minQuantity = '0'
   } = options;
 
@@ -259,6 +264,20 @@ export function validateBalance(
   return { isValid: true };
 }
 
+
+/**
+ * The largest issuable supply, in the display units an amount input works in.
+ *
+ * `MAX_SUPPLY` is a base-unit ceiling, so a divisible asset can only reach it with eight decimal
+ * places of headroom — offering the raw figure as a divisible maximum would offer 1e8 times what
+ * core accepts.
+ *
+ * @param divisible - Whether the asset being issued is divisible
+ * @returns The maximum, in display units
+ */
+export function maxSupplyForDivisibility(divisible: boolean): string {
+  return divisible ? fromSatoshis(MAX_SUPPLY) : MAX_SUPPLY;
+}
 
 /**
  * Converts BTC to satoshis

--- a/src/core/validation/assetOwner.ts
+++ b/src/core/validation/assetOwner.ts
@@ -79,17 +79,24 @@ export async function lookupAssetOwner(assetName: string): Promise<AssetOwnerLoo
 
     // Fetch asset details from Counterparty API
     const assetInfo = await fetchAssetDetails(queryName);
-    
-    if (!assetInfo || !assetInfo.issuer) {
+
+    // `owner` is the address that currently controls the asset; `issuer` is whoever created it and
+    // is never rewritten (core sets it on first issuance only, and moves `owner` alone on every
+    // ASSET_TRANSFER). Resolving a typed asset name to `issuer` therefore addressed a send to the
+    // previous owner of any asset that had ever changed hands. Falling back to `issuer` keeps
+    // never-transferred assets — where the two agree — working if `owner` is absent.
+    const ownerAddress = assetInfo?.owner || assetInfo?.issuer;
+
+    if (!ownerAddress) {
       return {
         isValid: false,
-        error: 'Asset not found or has no issuer'
+        error: 'Asset not found or has no owner'
       };
     }
 
     return {
       isValid: true,
-      ownerAddress: assetInfo.issuer,
+      ownerAddress,
       assetName: queryName
     };
 

--- a/src/hooks/useAssetLatestIssuance.ts
+++ b/src/hooks/useAssetLatestIssuance.ts
@@ -1,0 +1,75 @@
+import { useEffect, useState } from "react";
+import { type AssetIssuance, fetchAssetLatestIssuance } from "@/core/counterparty/api";
+
+interface LatestIssuanceState {
+  isLoading: boolean;
+  error: Error | null;
+  /**
+   * The asset's most recent valid issuance, or null when it is not established — still loading,
+   * the lookup failed, or the asset has no issuance history. Callers must treat null as unknown
+   * rather than as a set of false flags.
+   */
+  data: AssetIssuance | null;
+}
+
+/**
+ * The asset's live protocol state, read where counterparty-core reads it.
+ *
+ * Core's `issuance.validate` decides what an owner may do from the *last issuance row*
+ * (`last_issuance`), not from any asset summary, and it keeps that row current by appending new
+ * ones: closing a fairminter appends an issuance with `fair_minting: false`, a transfer appends
+ * one whose `issuer` is the new owner. The `/v2/assets/{asset}` projection drops `fair_minting`
+ * entirely, so this is the only place the flag is visible.
+ *
+ * @param asset - The asset name, or an empty string to stay idle
+ * @returns Loading state and the latest issuance
+ *
+ * @example
+ * const { data: latestIssuance } = useAssetLatestIssuance('MYASSET');
+ * const isFairMinting = latestIssuance?.fair_minting === true;
+ */
+export function useAssetLatestIssuance(asset: string): LatestIssuanceState {
+  const [state, setState] = useState<LatestIssuanceState>({
+    isLoading: false,
+    error: null,
+    data: null,
+  });
+
+  useEffect(() => {
+    // Neither protocol asset has an issuance row — BTC is not a Counterparty asset at all, and
+    // XCP's supply came from burns, so `/v2/assets/XCP/issuances` answers with an empty list.
+    // Skipping the round trip beats making one to learn nothing.
+    if (!asset || asset.trim() === "" || asset === "BTC" || asset === "XCP") {
+      setState({ isLoading: false, error: null, data: null });
+      return;
+    }
+
+    // A flag rather than the AbortController the sibling useAsset* hooks use: `cpApiGet` takes no
+    // signal, so there is no request to abort — only a stale response to ignore.
+    let cancelled = false;
+    setState({ isLoading: true, error: null, data: null });
+
+    fetchAssetLatestIssuance(asset)
+      .then((issuance) => {
+        if (!cancelled) setState({ isLoading: false, error: null, data: issuance });
+      })
+      .catch((err) => {
+        // A failed lookup leaves the state unknown. Callers decide what to do with that; the asset
+        // page lets an unknown `fair_minting` through rather than hiding every action because a
+        // node hiccuped, since core will still refuse the transaction if one is in fact open.
+        if (!cancelled) {
+          setState({
+            isLoading: false,
+            error: err instanceof Error ? err : new Error(String(err)),
+            data: null,
+          });
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [asset]);
+
+  return state;
+}

--- a/src/pages/assets/[asset]/__tests__/index.test.tsx
+++ b/src/pages/assets/[asset]/__tests__/index.test.tsx
@@ -1,0 +1,339 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AssetInfo } from '@/core/counterparty/api';
+import { asDisplayUnits } from '@/core/numeric';
+import type { AssetDetails } from '@/hooks/useAssetDetails';
+
+const OWNER = 'bc1qownerownerownerownerownerownerownerow';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router', () => ({
+  useNavigate: () => mockNavigate,
+  useParams: () => ({ asset: 'MYASSET' }),
+}));
+
+vi.mock('@/components/domain/asset/asset-header', () => ({
+  AssetHeader: (): ReactElement => <div data-testid="asset-header" />,
+}));
+
+vi.mock('@/contexts/header-context', () => ({
+  useHeader: () => ({ setHeaderProps: vi.fn(), getCachedOwnedAsset: () => undefined }),
+}));
+
+vi.mock('@/contexts/wallet-context', () => ({
+  useWallet: () => ({ activeAddress: { address: OWNER } }),
+}));
+
+vi.mock('@/core/counterparty/api', () => ({
+  fetchDividendsByAsset: vi.fn().mockResolvedValue({ result: [] }),
+}));
+
+const mockUseAssetDetails = vi.fn();
+vi.mock('@/hooks/useAssetDetails', () => ({
+  useAssetDetails: () => mockUseAssetDetails(),
+}));
+
+const mockUseLatestIssuance = vi.fn();
+vi.mock('@/hooks/useAssetLatestIssuance', () => ({
+  useAssetLatestIssuance: () => mockUseLatestIssuance(),
+}));
+
+/** The shape of the latest-issuance row, which is where core reads `fair_minting`. */
+function issuanceRow(fairMinting: boolean) {
+  return { isLoading: false, error: null, data: { fair_minting: fairMinting } };
+}
+
+import AssetPage from '../index';
+
+/**
+ * A divisible asset with a supply of 1,000 whole units. `supply` is base units and
+ * `supply_normalized` is display units — the 1e8 gap between them is the point of these tests.
+ */
+function assetInfo(overrides: Partial<AssetInfo> = {}): AssetInfo {
+  return {
+    asset: 'MYASSET',
+    asset_longname: null,
+    description: 'test asset',
+    issuer: OWNER,
+    divisible: true,
+    locked: false,
+    owner: OWNER,
+    supply: '100000000000',
+    supply_normalized: asDisplayUnits('1000'),
+    ...overrides,
+  } as AssetInfo;
+}
+
+function details(info: AssetInfo, availableBalance: string): { isLoading: false; error: null; data: AssetDetails } {
+  return {
+    isLoading: false,
+    error: null,
+    data: {
+      isDivisible: info.divisible,
+      assetInfo: info,
+      availableBalance: asDisplayUnits(availableBalance),
+      spendableBalance: asDisplayUnits(availableBalance),
+      pendingOutgoing: asDisplayUnits('0'),
+      pendingIncoming: asDisplayUnits('0'),
+      unknownPending: false,
+      utxoBalances: undefined,
+    },
+  };
+}
+
+const resetAction = () => screen.queryByText('Reset Supply');
+
+describe('AssetPage — Reset Supply gating', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseLatestIssuance.mockReturnValue(issuanceRow(false));
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('offers Reset Supply when the issuer holds the whole supply of a divisible asset', () => {
+    // The regression this pins: the gate used to compare `availableBalance` ("1000", display
+    // units) against `supply` ("100000000000", base units). Those are the same supply, so the
+    // action must appear — the old strict-equality check hid it from every divisible asset.
+    mockUseAssetDetails.mockReturnValue(details(assetInfo(), '1000'));
+
+    render(<AssetPage />);
+
+    expect(resetAction()).toBeInTheDocument();
+  });
+
+  it('offers Reset Supply when the balance carries trailing zeros the supply does not', () => {
+    mockUseAssetDetails.mockReturnValue(details(assetInfo(), '1000.00000000'));
+
+    render(<AssetPage />);
+
+    expect(resetAction()).toBeInTheDocument();
+  });
+
+  it('offers Reset Supply for an asset with no supply at all', () => {
+    mockUseAssetDetails.mockReturnValue(
+      details(assetInfo({ supply: '0', supply_normalized: asDisplayUnits('0') }), '0')
+    );
+
+    render(<AssetPage />);
+
+    expect(resetAction()).toBeInTheDocument();
+  });
+
+  it('withholds Reset Supply when someone other than the issuer holds part of the supply', () => {
+    // core: "Cannot reset an asset with many holders".
+    mockUseAssetDetails.mockReturnValue(details(assetInfo(), '999'));
+
+    render(<AssetPage />);
+
+    expect(resetAction()).not.toBeInTheDocument();
+  });
+
+  it('withholds Reset Supply from a non-issuer holding the whole supply', () => {
+    mockUseAssetDetails.mockReturnValue(
+      details(assetInfo({ issuer: 'bc1qsomeoneelse', owner: 'bc1qsomeoneelse' }), '1000')
+    );
+
+    render(<AssetPage />);
+
+    expect(resetAction()).not.toBeInTheDocument();
+  });
+
+  it('withholds Reset Supply from a locked asset', () => {
+    // core: "cannot reset a locked asset".
+    mockUseAssetDetails.mockReturnValue(details(assetInfo({ locked: true }), '1000'));
+
+    render(<AssetPage />);
+
+    expect(resetAction()).not.toBeInTheDocument();
+  });
+
+  it('withholds Reset Supply when the description is locked', () => {
+    // core: "Cannot reset issuance with locked description".
+    mockUseAssetDetails.mockReturnValue(details(assetInfo({ description_locked: true }), '1000'));
+
+    render(<AssetPage />);
+
+    expect(resetAction()).not.toBeInTheDocument();
+  });
+
+  it('withholds Reset Supply while a fairminter is running', () => {
+    // core: "cannot issue during fair minting".
+    mockUseAssetDetails.mockReturnValue(details(assetInfo(), '1000'));
+    mockUseLatestIssuance.mockReturnValue(issuanceRow(true));
+
+    render(<AssetPage />);
+
+    expect(resetAction()).not.toBeInTheDocument();
+  });
+
+  it('navigates to the reset-supply composer when the action is taken', () => {
+    mockUseAssetDetails.mockReturnValue(details(assetInfo(), '1000'));
+
+    render(<AssetPage />);
+    screen.getByText('Reset Supply').click();
+
+    expect(mockNavigate).toHaveBeenCalledWith('/compose/issuance/reset-supply/MYASSET');
+  });
+});
+
+const ALL_ACTIONS = [
+  'Start Mint',
+  'Issue Supply',
+  'Lock Supply',
+  'Issue Subasset',
+  'Pay Dividend',
+  'Reset Supply',
+  'Lock Description',
+  'Update Description',
+  'Transfer Ownership',
+];
+
+/** The action titles currently on screen. */
+function visibleActions(): string[] {
+  return ALL_ACTIONS.filter((title) => screen.queryByText(title) !== null);
+}
+
+describe('AssetPage - ownership follows owner, not issuer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseLatestIssuance.mockReturnValue(issuanceRow(false));
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('offers owner actions to the current owner of a transferred asset', () => {
+    // core rewrites owner on ASSET_TRANSFER and leaves issuer at the original creator, so an asset
+    // received by transfer reads issuer=<someone else>, owner=<us>. Gating on issuer left the new
+    // owner with nothing to do.
+    mockUseAssetDetails.mockReturnValue(
+      details(assetInfo({ issuer: 'bc1qoriginalcreator', owner: OWNER }), '1000')
+    );
+
+    render(<AssetPage />);
+
+    expect(visibleActions()).toEqual(ALL_ACTIONS);
+  });
+
+  it('offers nothing to the original issuer once the asset has been transferred away', () => {
+    mockUseAssetDetails.mockReturnValue(
+      details(assetInfo({ issuer: OWNER, owner: 'bc1qnewowner' }), '1000')
+    );
+
+    render(<AssetPage />);
+
+    expect(visibleActions()).toEqual([]);
+  });
+
+  it('offers nothing on an asset with neither issuer nor owner, as XCP reads', () => {
+    mockUseAssetDetails.mockReturnValue(
+      details(assetInfo({ issuer: undefined, owner: undefined, locked: true }), '1000')
+    );
+
+    render(<AssetPage />);
+
+    expect(visibleActions()).toEqual([]);
+  });
+});
+
+describe('AssetPage - actions hidden by asset state', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseLatestIssuance.mockReturnValue(issuanceRow(false));
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('lists every action for an unlocked, unminted asset the owner fully holds', () => {
+    mockUseAssetDetails.mockReturnValue(details(assetInfo(), '1000'));
+
+    render(<AssetPage />);
+
+    expect(visibleActions()).toEqual(ALL_ACTIONS);
+  });
+
+  it('drops supply-changing actions once the supply is locked', () => {
+    // core: "locked asset and non-zero quantity" / "cannot reset a locked asset", and
+    // fairminter.validate refuses a mint on a locked asset.
+    mockUseAssetDetails.mockReturnValue(details(assetInfo({ locked: true }), '1000'));
+
+    render(<AssetPage />);
+
+    expect(visibleActions()).toEqual([
+      'Issue Subasset',
+      'Pay Dividend',
+      'Lock Description',
+      'Update Description',
+      'Transfer Ownership',
+    ]);
+  });
+
+  it('drops both description actions once the description is locked', () => {
+    // core: "Cannot update a locked description".
+    mockUseAssetDetails.mockReturnValue(details(assetInfo({ description_locked: true }), '1000'));
+
+    render(<AssetPage />);
+
+    expect(visibleActions()).toEqual([
+      'Start Mint',
+      'Issue Supply',
+      'Lock Supply',
+      'Issue Subasset',
+      'Pay Dividend',
+      'Transfer Ownership',
+    ]);
+  });
+
+  it('drops every issuance action while a fairminter is live', () => {
+    // Each of those is a reissuance of this asset, which core refuses outright: "cannot issue
+    // during fair minting". Two survive. Issue Subasset creates a *new* asset with its own empty
+    // issuance history, so the parent's fairminter never enters the check; Pay Dividend is not an
+    // issuance at all and dividend.validate says nothing about fair minting. Start Mint goes
+    // because one is already open ("Fair minter already opened").
+    mockUseAssetDetails.mockReturnValue(details(assetInfo(), '1000'));
+    mockUseLatestIssuance.mockReturnValue(issuanceRow(true));
+
+    render(<AssetPage />);
+
+    expect(visibleActions()).toEqual(['Issue Subasset', 'Pay Dividend']);
+  });
+
+  it('keeps every action when the issuance lookup fails and the state is unknown', () => {
+    // An unreachable node must not silently strip the page of everything the owner can do.
+    mockUseAssetDetails.mockReturnValue(details(assetInfo(), '1000'));
+    mockUseLatestIssuance.mockReturnValue({ isLoading: false, error: null, data: null });
+
+    render(<AssetPage />);
+
+    expect(visibleActions()).toEqual(ALL_ACTIONS);
+  });
+
+  it('drops Issue Subasset on a subasset, which cannot nest', () => {
+    mockUseAssetDetails.mockReturnValue(
+      details(assetInfo({ asset_longname: 'PARENT.child' }), '1000')
+    );
+
+    render(<AssetPage />);
+
+    expect(screen.queryByText('Issue Subasset')).not.toBeInTheDocument();
+  });
+
+  it('drops Pay Dividend when there is no supply to pay out on', () => {
+    mockUseAssetDetails.mockReturnValue(
+      details(assetInfo({ supply: '0', supply_normalized: asDisplayUnits('0') }), '0')
+    );
+
+    render(<AssetPage />);
+
+    expect(screen.queryByText('Pay Dividend')).not.toBeInTheDocument();
+    // Reset is still on offer: no supply means no holders to strand.
+    expect(screen.getByText('Reset Supply')).toBeInTheDocument();
+  });
+});

--- a/src/pages/assets/[asset]/index.tsx
+++ b/src/pages/assets/[asset]/index.tsx
@@ -10,8 +10,9 @@ import { useHeader } from "@/contexts/header-context";
 import { useWallet } from "@/contexts/wallet-context";
 import { type Dividend, fetchDividendsByAsset, type PaginatedResponse } from "@/core/counterparty/api";
 import { formatAddress, formatAmount, formatTimeAgo } from "@/core/format";
-import { asDisplayUnits, isGreaterThan } from "@/core/numeric";
+import { asDisplayUnits, isEqualTo, isGreaterThan } from "@/core/numeric";
 import { useAssetDetails } from "@/hooks/useAssetDetails";
+import { useAssetLatestIssuance } from "@/hooks/useAssetLatestIssuance";
 
 
 /**
@@ -41,6 +42,9 @@ export default function AssetPage(): ReactElement {
   const { setHeaderProps, getCachedOwnedAsset } = useHeader();
   const { activeAddress } = useWallet();
   const { data: assetDetails, isLoading, error } = useAssetDetails(asset || "");
+  // The asset summary carries no `fair_minting`; core reads it off the latest issuance, so we do
+  // too. The same row is what core's `issuance.validate` calls `last_issuance`.
+  const { data: latestIssuance } = useAssetLatestIssuance(asset || "");
 
   // Get cached data for instant display
   const cachedAsset = useMemo(() => getCachedOwnedAsset(asset || ""), [getCachedOwnedAsset, asset]);
@@ -102,34 +106,53 @@ export default function AssetPage(): ReactElement {
   }, [setHeaderProps, navigate]);
 
   /**
-   * Generates a list of available actions based on asset details and ownership.
-   * @returns {Action[]} The list of actionable options for the asset.
+   * The actions this address can actually take on this asset.
+   *
+   * Each entry is gated on the same conditions counterparty-core validates, so the list only
+   * offers transactions the node would accept: an action core would reject is not shown at all
+   * rather than shown and refused at compose time. Every gate below cites the rule it mirrors.
+   *
+   * @returns {ActionSection[]} The list of actionable options for the asset.
    */
   const getActionSections = (): ActionSection[] => {
     if (!assetDetails?.assetInfo || !asset) return [];
 
+    const info = assetDetails.assetInfo;
     const actions = [];
-    const isOwner = assetDetails.assetInfo.issuer === activeAddress?.address;
-    const isLocked = assetDetails.assetInfo.locked;
-    const totalSupply = assetDetails.assetInfo.supply || "0";
-    const hasSupply = isGreaterThan(totalSupply ?? 0, 0);
-    const issuerBalance = assetDetails.availableBalance || "0";
-    const canResetSupply = !isLocked && isOwner && (!hasSupply || issuerBalance === totalSupply);
-    const hasFairMinting = assetDetails.assetInfo.fair_minting;
 
-    // Add Start Mint (fairminter) option based on counterparty-core rules:
-    // 1. Asset cannot be BTC or XCP
-    // 2. Must be the owner (issuer) of the asset
-    // 3. Asset must not be locked
-    // 4. No fairminter already exists (fair_minting must be false)
-    const canStartFairminter = 
-      asset !== "BTC" && 
-      asset !== "XCP" && 
-      isOwner && 
-      !isLocked && 
-      !hasFairMinting;
+    // Ownership follows `owner`, not `issuer`. Core writes `assets_info.issuer` once, at first
+    // issuance, and never again; every ASSET_TRANSFER moves `owner` alone (`api/apiwatcher.py`).
+    // Core's own `issuance.validate` compares the source against the *latest* issuance's issuer,
+    // which a transfer rewrites to the destination — that is `owner`. Keying off `issuer` gave
+    // every action to the address that gave the asset away and none to the one now holding it.
+    const controller = info.owner ?? info.issuer;
+    const isOwner = Boolean(controller) && controller === activeAddress?.address;
 
-    if (canStartFairminter) {
+    // BTC has no issuance at all and XCP's supply came from burns; neither carries an owner, so
+    // `isOwner` is already false for both. Naming the case anyway keeps the dividend and
+    // fairminter bans below readable rather than incidental.
+    const isProtocolAsset = asset === "BTC" || asset === "XCP";
+    /** The precondition every action shares: you control it, and it is not a protocol asset. */
+    const canAct = isOwner && !isProtocolAsset;
+    const isLocked = info.locked;
+    const isDescriptionLocked = info.description_locked ?? false;
+    const isSubasset = Boolean(info.asset_longname);
+
+    const totalSupply = info.supply_normalized || "0";
+    const hasSupply = isGreaterThan(totalSupply, 0);
+    const ownerBalance = assetDetails.availableBalance || "0";
+
+    // Shared precondition for every action that reissues *this* asset. Core rejects all of them
+    // while a fairminter is live: `issuance.validate` → "cannot issue during fair minting". Two
+    // actions below are deliberately not covered by it — Issue Subasset creates a new asset with
+    // its own empty issuance history, and Pay Dividend is not an issuance at all. An unestablished
+    // state reads as "not minting" and blocks nothing; see `useAssetLatestIssuance`.
+    const isFairMinting = latestIssuance?.fair_minting === true;
+    const canReissue = canAct && !isFairMinting;
+
+    // Start Mint — `fairminter.validate`: the asset must exist, be unlocked, be issued by the
+    // source, and have no fairminter already open.
+    if (canAct && !isLocked && !isFairMinting) {
       actions.push({
         id: "start-mint",
         title: "Start Mint",
@@ -138,7 +161,9 @@ export default function AssetPage(): ReactElement {
       });
     }
 
-    if (!isLocked) {
+    // A locked supply is exactly what these two change, so both go once `locked` is set —
+    // core: "locked asset and non‐zero quantity" for the first, and a second lock is a no-op.
+    if (canReissue && !isLocked) {
       actions.push(
         {
           id: "issue-supply",
@@ -155,7 +180,9 @@ export default function AssetPage(): ReactElement {
       );
     }
 
-    if (!assetDetails.assetInfo.asset_longname) {
+    // Subassets cannot nest, and core checks only that the parent is owned by the source — a
+    // locked or fair-minting parent still accepts new children.
+    if (canAct && !isSubasset) {
       actions.push({
         id: "issue-subasset",
         title: "Issue Subasset",
@@ -164,7 +191,11 @@ export default function AssetPage(): ReactElement {
       });
     }
 
-    if (isOwner && hasSupply) {
+    // `dividend.validate`: "only issuer can pay dividends" — where core's "issuer" is the latest
+    // issuance's, i.e. the current owner (`ledger.issuances.get_asset_issuer`). Dividends on BTC
+    // or XCP are banned outright, and with no supply there are no holders, which core rejects as
+    // "zero dividend".
+    if (canAct && hasSupply) {
       actions.push({
         id: "pay-dividend",
         title: "Pay Dividend",
@@ -173,35 +204,54 @@ export default function AssetPage(): ReactElement {
       });
     }
 
-    if (isOwner && canResetSupply) {
+    // Reset rewrites supply and description together, so core blocks it on either lock
+    // ("cannot reset a locked asset" / "Cannot reset issuance with locked description") and
+    // requires the owner to be the sole holder of the whole supply. Display units on both sides:
+    // `info.supply` is base units, `availableBalance` is already divided by divisibility.
+    const canResetSupply =
+      canReissue &&
+      !isLocked &&
+      !isDescriptionLocked &&
+      (!hasSupply || isEqualTo(ownerBalance, totalSupply));
+
+    if (canResetSupply) {
       actions.push({
         id: "reset-supply",
         title: "Reset Supply",
-        description: "Reset asset description and other properties",
+        description: "Destroy the supply and re-issue the asset",
         onClick: () => navigate(`${PATHS.COMPOSE}/issuance/reset-supply/${asset}`),
       });
     }
 
-    actions.push(
-      {
-        id: "lock-description",
-        title: "Lock Description", 
-        description: "Permanently lock the asset description",
-        onClick: () => navigate(`${PATHS.COMPOSE}/issuance/lock-description/${asset}`),
-      },
-      {
-        id: "update-description",
-        title: "Update Description",
-        description: "Update the asset description",
-        onClick: () => navigate(`${PATHS.COMPOSE}/issuance/update-description/${asset}`),
-      },
-      {
+    // Both write a description, which core refuses once `description_locked` is set: "Cannot
+    // update a locked description". A second lock would be refused for the same reason.
+    if (canReissue && !isDescriptionLocked) {
+      actions.push(
+        {
+          id: "lock-description",
+          title: "Lock Description",
+          description: "Permanently lock the asset description",
+          onClick: () => navigate(`${PATHS.COMPOSE}/issuance/lock-description/${asset}`),
+        },
+        {
+          id: "update-description",
+          title: "Update Description",
+          description: "Update the asset description",
+          onClick: () => navigate(`${PATHS.COMPOSE}/issuance/update-description/${asset}`),
+        }
+      );
+    }
+
+    // A transfer carries no description and no quantity, so neither lock blocks it — only
+    // ownership and the fairminter do.
+    if (canReissue) {
+      actions.push({
         id: "transfer-ownership",
         title: "Transfer Ownership",
         description: "Transfer asset ownership to another address",
         onClick: () => navigate(`${PATHS.COMPOSE}/issuance/transfer-ownership/${asset}`),
-      }
-    );
+      });
+    }
 
     return [{ items: actions }];
   };

--- a/src/pages/compose/issuance/form.tsx
+++ b/src/pages/compose/issuance/form.tsx
@@ -15,6 +15,7 @@ import { isSegwitFormat } from '@/core/bitcoin/address';
 import type { IssuanceOptions } from "@/core/counterparty/compose";
 import { encodeInscriptionContent } from '@/core/counterparty/inscriptionEnvelope';
 import { asDisplayUnits, toBigNumber } from '@/core/numeric';
+import { maxSupplyForDivisibility } from "@/core/validation/amount";
 import { useAssetDetails } from "@/hooks/useAssetDetails";
 
 /** Maximum file size for inscriptions in KB */
@@ -66,20 +67,7 @@ export function IssuanceForm({
   const showAddress = !showAsset && activeAddress && !isInitializing;
   
   // Calculate maximum amount based on divisibility
-  const MAX_INT_STR = "9223372036854775807";
-  const getMaxAmount = () => {
-    if (isDivisible) {
-      // For divisible assets, the actual max quantity is MAX_INT,
-      // but we need to show it in decimal form (divide by 10^8)
-      const maxInt = toBigNumber(MAX_INT_STR);
-      const divisor = toBigNumber("100000000"); // 10^8
-      const maxDivisible = maxInt.dividedBy(divisor);
-      return maxDivisible.toFixed();
-    } else {
-      // For indivisible assets, max is MAX_INT
-      return MAX_INT_STR;
-    }
-  };
+  const getMaxAmount = () => maxSupplyForDivisibility(isDivisible);
 
   
   // Update asset name when initialParentAsset changes

--- a/src/pages/compose/issuance/issue-supply/form.tsx
+++ b/src/pages/compose/issuance/issue-supply/form.tsx
@@ -9,7 +9,8 @@ import { Spinner } from "@/components/ui/spinner";
 import { useComposer } from "@/contexts/composer-context-object";
 import type { IssuanceOptions } from "@/core/counterparty/compose";
 import { formatAmount } from "@/core/format";
-import { asDisplayUnits, toBigNumber } from '@/core/numeric';
+import { asDisplayUnits, fromSatoshis, toBigNumber } from '@/core/numeric';
+import { MAX_SUPPLY } from "@/core/validation/amount";
 import { useAssetInfo } from "@/hooks/useAssetInfo";
 
 /**
@@ -50,21 +51,22 @@ export function IssueSupplyForm({
     const isDivisible = assetInfo.divisible ?? false;
     const currentSupply = toBigNumber(assetInfo.supply || "0");
     
-    // Max int is 2^63 - 1 = 9223372036854775807
-    const maxInt = toBigNumber("9223372036854775807");
-    const maxIssuable = maxInt.minus(currentSupply);
+    // Unlike a reset, an issuance adds to the supply, so the headroom is the ceiling less what
+    // already exists — core checks the sum ("total quantity overflow"), not the addend.
+    const maxIssuable = toBigNumber(MAX_SUPPLY).minus(currentSupply);
     
     if (maxIssuable.isLessThanOrEqualTo(0)) {
       return "0";
     }
     
     // Convert to normalized amount (divide by 10^8 if divisible)
-    const normalizedMax = isDivisible 
-      ? maxIssuable.dividedBy(100000000).toString()
-      : maxIssuable.toString();
+    const normalizedMax = isDivisible ? fromSatoshis(maxIssuable) : maxIssuable.toString();
     
     return formatAmount({
-      value: Number(normalizedMax),
+      // The decimal string, not a double: `MAX_SUPPLY` needs 19 digits and a double carries 15,
+      // so `Number()` here rendered a max the user could not actually reach — the exact trap
+      // `AmountFormatterOptions.value` documents.
+      value: normalizedMax,
       maximumFractionDigits: isDivisible ? 8 : 0,
       minimumFractionDigits: 0
     });

--- a/src/pages/compose/issuance/lock-description/form.tsx
+++ b/src/pages/compose/issuance/lock-description/form.tsx
@@ -22,8 +22,12 @@ interface LockDescriptionFormProps {
 
 /**
  * Form for locking asset description using React 19 Actions.
- * This form creates an issuance transaction with description="LOCK" 
- * which permanently prevents future description changes.
+ *
+ * The transaction is an issuance whose description is the sentinel "LOCK_DESCRIPTION", which
+ * `issuance.parse` matches to set `description_locked` while leaving the stored description
+ * untouched. Note that "LOCK" is a *different* sentinel handled in the same branch: it sets
+ * `lock`, permanently freezing the supply. The two are one `elif` apart and neither is reversible,
+ * so this string is not a label — it is the instruction.
  */
 export function LockDescriptionForm({
   formAction,
@@ -52,9 +56,12 @@ export function LockDescriptionForm({
     return <div className="p-4 text-red-500">Cannot lock description of BTC</div>;
   }
 
-  // Check if description is already locked
+  // The description being frozen here, shown so the user can see what they are freezing.
   const currentDescription = assetInfo?.description || "";
-  const isAlreadyLocked = currentDescription === "LOCK";
+  // Whether the description is locked is its own field. Comparing the description text to "LOCK"
+  // asked whether the sentinel had been stored as the description, which core never does: it
+  // rewrites the description back to the previous one and records the lock in a flag.
+  const isAlreadyLocked = assetInfo?.description_locked ?? false;
 
   if (isAlreadyLocked) {
     return (
@@ -121,7 +128,7 @@ export function LockDescriptionForm({
         {/* Hidden fields for the issuance parameters */}
         <input type="hidden" name="asset" value={asset} />
         <input type="hidden" name="quantity" value="0" />
-        <input type="hidden" name="description" value="LOCK" />
+        <input type="hidden" name="description" value="LOCK_DESCRIPTION" />
         <input type="hidden" name="divisible" value={String(assetInfo?.divisible ?? false)} />
       </Field>
     </ComposerForm>

--- a/src/pages/compose/issuance/lock-description/index.tsx
+++ b/src/pages/compose/issuance/lock-description/index.tsx
@@ -7,7 +7,7 @@ import { ReviewLockDescription } from "@/pages/compose/issuance/lock-description
 
 /**
  * ComposeLockDescription handles the lock description flow for an asset.
- * This creates an issuance transaction with description="LOCK" to permanently
+ * This creates an issuance transaction with description="LOCK_DESCRIPTION" to permanently
  * prevent future description changes.
  */
 function ComposeLockDescriptionPage() {

--- a/src/pages/compose/issuance/reset-supply/__tests__/form.test.tsx
+++ b/src/pages/compose/issuance/reset-supply/__tests__/form.test.tsx
@@ -1,0 +1,222 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AssetInfo } from '@/core/counterparty/api';
+import { asDisplayUnits } from '@/core/numeric';
+import { ResetSupplyForm } from '../form';
+
+const mockUseAssetInfo = vi.fn();
+vi.mock('@/hooks/useAssetInfo', () => ({
+  useAssetInfo: () => mockUseAssetInfo(),
+}));
+
+vi.mock('@/contexts/composer-context-object', () => ({
+  useComposer: () => ({ showHelpText: false, activeAddress: { address: 'bc1qowner' } }),
+}));
+
+// The composer chrome (fee rate, submit button) needs the whole composer context; the form's own
+// fields are what matter here, so it is reduced to a plain form with a submit control.
+vi.mock('@/components/composer/composer-form', () => ({
+  ComposerForm: ({ children, formAction, submitDisabled }: any) => (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        formAction(new FormData(e.target as HTMLFormElement));
+      }}
+    >
+      {children}
+      <button type="submit" disabled={submitDisabled}>
+        Continue
+      </button>
+    </form>
+  ),
+}));
+
+vi.mock('@/components/domain/asset/asset-header', () => ({
+  AssetHeader: () => <div data-testid="asset-header" />,
+}));
+
+// Stands in for the amount input, which carries its own fee/balance machinery.
+vi.mock('@/components/domain/balance/amount-with-max-input', () => ({
+  AmountWithMaxInput: ({ value, onChange, label, isDivisible }: any) => (
+    <label>
+      {label}
+      <input
+        aria-label={label}
+        data-divisible={String(isDivisible)}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      />
+    </label>
+  ),
+}));
+
+function assetInfo(overrides: Partial<AssetInfo> = {}): AssetInfo {
+  return {
+    asset: 'MYASSET',
+    asset_longname: null,
+    description: 'original description',
+    issuer: 'bc1qowner',
+    owner: 'bc1qowner',
+    divisible: false,
+    locked: false,
+    supply: '1000',
+    supply_normalized: asDisplayUnits('1000'),
+    ...overrides,
+  } as AssetInfo;
+}
+
+/** Renders the form and returns the FormData captured on submit. */
+function submitForm(info: AssetInfo, interact: () => void = () => {}): FormData {
+  const formAction = vi.fn();
+  mockUseAssetInfo.mockReturnValue({ isLoading: false, error: null, data: info });
+
+  render(<ResetSupplyForm formAction={formAction} initialFormData={null} asset="MYASSET" />);
+
+  interact();
+  // The confirmation gate must be cleared before the form will submit at all.
+  fireEvent.click(screen.getByLabelText('I understand this cannot be undone'));
+  fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+  expect(formAction).toHaveBeenCalledTimes(1);
+  return formAction.mock.calls[0]![0] as FormData;
+}
+
+describe('ResetSupplyForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('submits a new supply alongside the reset, not a bare burn', () => {
+    // The whole point of the change: core's reset branch destroys the old supply and then credits
+    // `quantity`, so the form has to be able to say what that quantity is.
+    const data = submitForm(assetInfo(), () => {
+      fireEvent.change(screen.getByLabelText('New Supply'), { target: { value: '2026' } });
+    });
+
+    expect(data.get('quantity')).toBe('2026');
+    expect(data.get('reset')).toBe('true');
+    expect(data.get('asset')).toBe('MYASSET');
+  });
+
+  it('sends the divisibility the user chose, which only a reset may change', () => {
+    const data = submitForm(assetInfo({ divisible: false }), () => {
+      fireEvent.click(screen.getByLabelText('Divisible'));
+      fireEvent.change(screen.getByLabelText('New Supply'), { target: { value: '5' } });
+    });
+
+    expect(data.get('divisible')).toBe('true');
+    expect(data.get('quantity')).toBe('5');
+  });
+
+  it('defaults divisibility to the asset\'s current value when untouched', () => {
+    const data = submitForm(assetInfo({ divisible: true }), () => {
+      fireEvent.change(screen.getByLabelText('New Supply'), { target: { value: '1' } });
+    });
+
+    expect(data.get('divisible')).toBe('true');
+  });
+
+  it('tells the amount input which divisibility to accept decimals for', () => {
+    mockUseAssetInfo.mockReturnValue({ isLoading: false, error: null, data: assetInfo({ divisible: false }) });
+    render(<ResetSupplyForm formAction={vi.fn()} initialFormData={null} asset="MYASSET" />);
+
+    expect(screen.getByLabelText('New Supply').getAttribute('data-divisible')).toBe('false');
+    fireEvent.click(screen.getByLabelText('Divisible'));
+    expect(screen.getByLabelText('New Supply').getAttribute('data-divisible')).toBe('true');
+  });
+
+  it('omits an untouched description so the asset keeps the one it has', () => {
+    // A reissuance carrying no description keeps the existing one; restating identical text would
+    // only buy a larger OP_RETURN.
+    const data = submitForm(assetInfo(), () => {
+      fireEvent.change(screen.getByLabelText('New Supply'), { target: { value: '10' } });
+    });
+
+    expect(data.get('description')).toBe('');
+  });
+
+  it('sends an edited description', () => {
+    const data = submitForm(assetInfo(), () => {
+      fireEvent.change(screen.getByLabelText('Description'), {
+        target: { value: 'https://example.com/new.json' },
+      });
+    });
+
+    expect(data.get('description')).toBe('https://example.com/new.json');
+  });
+
+  it('prefills the description with the asset\'s current one', () => {
+    mockUseAssetInfo.mockReturnValue({ isLoading: false, error: null, data: assetInfo() });
+    render(<ResetSupplyForm formAction={vi.fn()} initialFormData={null} asset="MYASSET" />);
+
+    expect(screen.getByLabelText('Description')).toHaveValue('original description');
+  });
+
+  it('can lock the new supply in the same transaction', () => {
+    const data = submitForm(assetInfo(), () => {
+      fireEvent.change(screen.getByLabelText('New Supply'), { target: { value: '1' } });
+      fireEvent.click(screen.getByLabelText('Locked'));
+    });
+
+    expect(data.get('lock')).toBe('true');
+  });
+
+  it('does not lock unless asked', () => {
+    const data = submitForm(assetInfo(), () => {
+      fireEvent.change(screen.getByLabelText('New Supply'), { target: { value: '1' } });
+    });
+
+    expect(data.get('lock')).toBe('false');
+  });
+
+  it('holds submission until the destruction is acknowledged', () => {
+    mockUseAssetInfo.mockReturnValue({ isLoading: false, error: null, data: assetInfo() });
+    render(<ResetSupplyForm formAction={vi.fn()} initialFormData={null} asset="MYASSET" />);
+
+    expect(screen.getByRole('button', { name: 'Continue' })).toBeDisabled();
+    fireEvent.click(screen.getByLabelText('I understand this cannot be undone'));
+    expect(screen.getByRole('button', { name: 'Continue' })).not.toBeDisabled();
+  });
+
+  it('refuses to reset a locked asset', () => {
+    // core: "cannot reset a locked asset".
+    mockUseAssetInfo.mockReturnValue({
+      isLoading: false,
+      error: null,
+      data: assetInfo({ locked: true }),
+    });
+    render(<ResetSupplyForm formAction={vi.fn()} initialFormData={null} asset="MYASSET" />);
+
+    expect(screen.getByText(/supply is locked, so it cannot be reset/)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Continue' })).not.toBeInTheDocument();
+  });
+
+  it('restores the user\'s choices when they come back from review', () => {
+    mockUseAssetInfo.mockReturnValue({ isLoading: false, error: null, data: assetInfo() });
+    render(
+      <ResetSupplyForm
+        formAction={vi.fn()}
+        initialFormData={{
+          sourceAddress: 'bc1qowner',
+          sat_per_vbyte: 1,
+          asset: 'MYASSET',
+          quantity: '42',
+          divisible: true,
+          lock: true,
+          reset: true,
+          description: 'edited earlier',
+        }}
+        asset="MYASSET"
+      />
+    );
+
+    expect(screen.getByLabelText('New Supply')).toHaveValue('42');
+    expect(screen.getByLabelText('Description')).toHaveValue('edited earlier');
+    expect(screen.getByLabelText('Locked')).toBeChecked();
+    expect(screen.getByLabelText('Divisible')).toBeChecked();
+  });
+});

--- a/src/pages/compose/issuance/reset-supply/form.tsx
+++ b/src/pages/compose/issuance/reset-supply/form.tsx
@@ -1,9 +1,16 @@
 import type { ReactElement } from "react";
+import { useState } from "react";
 import { useFormStatus } from "react-dom";
 import { ComposerForm } from "@/components/composer/composer-form";
+import { AssetHeader } from "@/components/domain/asset/asset-header";
+import { AmountWithMaxInput } from "@/components/domain/balance/amount-with-max-input";
 import { CheckboxInput } from "@/components/ui/inputs/checkbox-input";
+import { TextAreaInput } from "@/components/ui/inputs/textarea-input";
+import { Spinner } from "@/components/ui/spinner";
 import { useComposer } from "@/contexts/composer-context-object";
 import type { IssuanceOptions } from "@/core/counterparty/compose";
+import { asDisplayUnits } from "@/core/numeric";
+import { maxSupplyForDivisibility } from "@/core/validation/amount";
 import { useAssetInfo } from "@/hooks/useAssetInfo";
 
 /**
@@ -16,7 +23,17 @@ interface ResetSupplyFormProps {
 }
 
 /**
- * Form for resetting asset supply using React 19 Actions.
+ * Form for re-issuing an asset from scratch.
+ *
+ * A reset is not merely a burn. Core destroys the owner's entire holding and then, in the same
+ * transaction, writes a fresh issuance from the message's own fields — `quantity`, `divisible`,
+ * `description` and `lock` (`messages/issuance.py`, the `reset` branch of `parse`). So this form
+ * asks the same questions the new-asset issuance form does, and describes the asset as it will
+ * exist afterwards rather than only what is being destroyed.
+ *
+ * Divisibility deserves particular note: a reset is the only way to change it. Every other
+ * reissuance is rejected with "cannot change divisibility", a check core explicitly waives when
+ * `reset` is set.
  */
 export function ResetSupplyForm({
   formAction,
@@ -24,46 +41,161 @@ export function ResetSupplyForm({
   asset,
 }: ResetSupplyFormProps): ReactElement {
   // Context hooks
-  useComposer();
-  
+  const { showHelpText, activeAddress } = useComposer();
+
   // Data fetching hooks
-  const { error: assetError, data: assetInfo } = useAssetInfo(asset);
-  
+  const { error: assetError, data: assetInfo, isLoading: assetLoading } = useAssetInfo(asset);
+
   // Form status
   const { pending } = useFormStatus();
 
+  // The asset's present divisibility and description are the starting points, not constraints.
+  // They are held as "unchosen" rather than seeded directly because this component first renders
+  // while `assetInfo` is still loading, and a `useState` initializer only runs once — seeding from
+  // a null asset would latch the defaults to `false` and `""` and never pick the real ones up.
+  const [amount, setAmount] = useState(initialFormData?.quantity?.toString() || "");
+  const [divisibleChoice, setDivisibleChoice] = useState<boolean | null>(
+    initialFormData?.divisible ?? null
+  );
+  const [descriptionChoice, setDescriptionChoice] = useState<string | null>(
+    initialFormData?.description ?? null
+  );
+  const [isLocked, setIsLocked] = useState(initialFormData?.lock ?? false);
+  const [isConfirmed, setIsConfirmed] = useState(false);
+  const [, setError] = useState<string | null>(null);
+
+  const currentDescription = assetInfo?.description ?? "";
+  const isDivisible = divisibleChoice ?? assetInfo?.divisible ?? false;
+  const description = descriptionChoice ?? currentDescription;
+
+  // Calculate maximum amount based on divisibility. A reset overwrites the supply rather than
+  // adding to it, so the whole range is available whatever the asset holds today.
+  const getMaxAmount = () => maxSupplyForDivisibility(isDivisible);
+
+  const processedFormAction = (formData: FormData) => {
+    formData.set("asset", asset);
+    formData.set("reset", "true");
+    // Display units; `normalizeFormData` scales by the divisibility submitted here rather than the
+    // asset's current one, precisely because a reset may change it.
+    formData.set("quantity", amount || "0");
+    formData.set("divisible", String(isDivisible));
+    formData.set("lock", String(isLocked));
+    // An unchanged description is omitted rather than restated: `composeIssuance` drops empty
+    // descriptions, and a reissuance that carries none keeps the asset's existing one, which
+    // costs fewer OP_RETURN bytes than re-sending identical text.
+    formData.set("description", description === currentDescription ? "" : description);
+    formAction(formData);
+  };
+
   // Early returns
+  if (assetLoading) {
+    return <Spinner message="Loading asset details…" />;
+  }
+
   if (assetError || !assetInfo) {
-    return <div className="p-4 text-red-500">Error loading asset details: {assetError?.message}</div>;
+    return (
+      <div className="p-4 text-red-500">
+        Unable to load asset details. Please ensure the asset exists and you have the necessary
+        permissions.
+      </div>
+    );
+  }
+
+  if (asset === "BTC" || asset === "XCP") {
+    return <div className="p-4 text-red-500">Cannot reset {asset}</div>;
+  }
+
+  if (assetInfo.locked) {
+    return (
+      <div className="p-4">
+        <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4 text-center">
+          <p className="text-yellow-800">
+            This asset's supply is locked, so it cannot be reset.
+          </p>
+        </div>
+      </div>
+    );
   }
 
   return (
     <ComposerForm
-      formAction={formAction}
+      formAction={processedFormAction}
+      submitDisabled={!isConfirmed}
+      header={
+        <AssetHeader
+          assetInfo={{
+            asset: asset,
+            asset_longname: assetInfo?.asset_longname ?? null,
+            description: assetInfo?.description,
+            issuer: assetInfo?.issuer,
+            divisible: assetInfo?.divisible ?? false,
+            locked: assetInfo?.locked ?? false,
+            supply: assetInfo?.supply,
+            supply_normalized: asDisplayUnits(assetInfo?.supply_normalized || "0"),
+          }}
+          className="mt-1 mb-5"
+        />
+      }
     >
-      <div className="mb-4 p-3 bg-gray-50 rounded-md">
-        <h2 className="text-sm font-medium text-gray-700">Asset Details</h2>
-        <div className="mt-2 text-sm text-gray-600">
-          <p>Current Supply: {assetInfo?.supply || "0"}</p>
-          <p>Divisible: {assetInfo?.divisible ? "Yes" : "No"}</p>
-          <p>Locked: {assetInfo?.locked ? "Yes" : "No"}</p>
-        </div>
-      </div>
       <div className="bg-yellow-50 border-l-4 border-yellow-400 p-4 mb-4">
         <p className="text-sm text-yellow-700">
-          Resetting destroys all existing {asset}. This cannot be undone.
+          This destroys all {assetInfo?.supply_normalized || "0"} existing {asset} and re-issues the
+          asset with the supply below. It cannot be undone.
         </p>
       </div>
-        <input type="hidden" name="asset" value={asset} />
-        <input type="hidden" name="quantity" value="0" />
-        <input type="hidden" name="reset" value="true" />
-        <input type="hidden" name="divisible" value={String(assetInfo?.divisible ?? false)} />
+
+      <AmountWithMaxInput
+        asset={asset}
+        availableBalance={getMaxAmount()}
+        value={amount}
+        onChange={setAmount}
+        setError={setError}
+        showHelpText={showHelpText}
+        sourceAddress={activeAddress}
+        maxAmount={getMaxAmount()}
+        label="New Supply"
+        name="quantity_display"
+        description={`The quantity of ${asset} to issue after the reset.`}
+        disabled={pending}
+        disableMaxButton={true}
+        isDivisible={isDivisible}
+      />
+
+      <div className="grid grid-cols-3 gap-4">
         <CheckboxInput
-          name="confirm"
-          label="I understand this cannot be undone"
+          name="divisible"
+          label="Divisible"
+          checked={isDivisible}
+          onChange={setDivisibleChoice}
           disabled={pending}
         />
+        <CheckboxInput
+          name="lock"
+          label="Locked"
+          checked={isLocked}
+          onChange={setIsLocked}
+          disabled={pending}
+        />
+      </div>
 
+      <TextAreaInput
+        value={description}
+        onChange={setDescriptionChoice}
+        label="Description"
+        name="description_display"
+        rows={1}
+        disabled={pending}
+        showHelpText={showHelpText}
+        helpText="A textual description for the asset. Leave unchanged to keep the current one."
+      />
+
+      <CheckboxInput
+        name="confirm"
+        label="I understand this cannot be undone"
+        checked={isConfirmed}
+        onChange={setIsConfirmed}
+        disabled={pending}
+      />
     </ComposerForm>
   );
 }

--- a/src/pages/compose/issuance/reset-supply/review.tsx
+++ b/src/pages/compose/issuance/reset-supply/review.tsx
@@ -1,5 +1,7 @@
 import { ReviewScreen } from "@/components/screens/review-screen";
 
+const yesNo = (value: boolean): string => (value ? "Yes" : "No");
+
 interface ReviewIssuanceResetSupplyProps {
   apiResponse: any;
   onSign: () => void;
@@ -8,23 +10,63 @@ interface ReviewIssuanceResetSupplyProps {
   isSigning: boolean;
 }
 
+/**
+ * Review for a reset issuance.
+ *
+ * A reset replaces the asset rather than adjusting it, so the fields are shown as before/after
+ * pairs: what is destroyed, and what exists once the transaction confirms. `asset_info` on the
+ * verbose compose response describes the asset as it stands now; `params` carries what the message
+ * will write.
+ */
 export function ReviewIssuanceResetSupply({
   apiResponse,
   onSign,
   onBack,
   error,
-  isSigning
+  isSigning,
 }: ReviewIssuanceResetSupplyProps) {
   const { result } = apiResponse;
+  const params = result.params;
+  const assetInfo = params.asset_info;
 
-  // Use normalized supply from verbose API response (handles divisibility correctly)
-  const currentSupply = result.params.asset_info?.supply_normalized ?? "0";
+  // Normalized on both sides — the raw `quantity` is base units and would read 1e8 off for a
+  // divisible asset.
+  const currentSupply = assetInfo?.supply_normalized ?? "0";
+  const newSupply = params.quantity_normalized ?? params.quantity ?? "0";
+
+  const wasDivisible = assetInfo?.divisible ?? false;
+  const willBeDivisible = params.divisible ?? wasDivisible;
+
+  // A reissuance that carries no description keeps the existing one, so an omitted description is
+  // reported as unchanged rather than as empty.
+  const newDescription =
+    typeof params.description === "string" && params.description.length > 0
+      ? params.description
+      : (assetInfo?.description ?? "");
 
   const customFields = [
-    { label: "Asset", value: result.params.asset },
-    { label: "Current Supply", value: currentSupply },
-    { label: "Action", value: "Reset Supply" },
+    { label: "Asset", value: params.asset },
+    { label: "Supply Destroyed", value: currentSupply },
+    { label: "New Supply", value: String(newSupply) },
   ];
+
+  // Divisibility is always shown, as an arrow only when the reset is changing it — a reset is the
+  // one issuance that can, so a silent flip would be the easiest thing here to miss.
+  customFields.push({
+    label: "Divisible",
+    value:
+      willBeDivisible === wasDivisible
+        ? yesNo(willBeDivisible)
+        : `${yesNo(wasDivisible)} → ${yesNo(willBeDivisible)}`,
+  });
+
+  if (newDescription !== (assetInfo?.description ?? "")) {
+    customFields.push({ label: "New Description", value: newDescription });
+  }
+
+  if (params.lock === true) {
+    customFields.push({ label: "Lock Supply", value: "Yes — permanent" });
+  }
 
   return (
     <ReviewScreen


### PR DESCRIPTION
The asset page listed nearly every action unconditionally. Six of them — Issue Supply, Lock Supply, Issue Subasset, Lock Description, Update Description, Transfer Ownership — had **no ownership check at all**, and lock state was consulted in only two places. Every action is now gated on the rule counterparty-core validates, with the rule cited beside it.

| Action | Hidden when |
|---|---|
| Start Mint | not owner · locked · fairminter already open |
| Issue Supply / Lock Supply | not owner · locked · fair minting |
| Issue Subasset | not owner · already a subasset |
| Pay Dividend | not owner · BTC/XCP · zero supply |
| Reset Supply | not owner · locked · description locked · fair minting · owner isn't sole holder |
| Lock Description / Update Description | not owner · description locked · fair minting |
| Transfer Ownership | not owner · fair minting |

Two cases that look like they should be gated but aren't: **Issue Subasset** survives a locked or fair-minting parent (a subasset is a new asset with its own empty issuance history — core only checks that you own the parent), and **Pay Dividend** survives fair minting (it isn't an issuance; `dividend.validate` never reads the flag).

## Defects found while checking those rules against core

**Ownership read the wrong field.** `assets_info.issuer` is written once at first issuance and never rewritten; every `ASSET_TRANSFER` moves `owner` alone (`api/apiwatcher.py`). Confirmed on mainnet:

```
A6858513339253895392  issuer 1MmL1kahZpfc9canPPF2kxfFMM9EQdh5r6
                      owner  bc1q6yy9jshvvyzxdqy8j4wv74jgjhzrmppj7u9ful
```

An asset received by transfer showed its new owner nothing to do, while the address that gave it away kept the full menu. The same field backed `lookupAssetOwner`, which resolves a typed asset name to a **send destination** — so it addressed sends to the previous owner.

**Lock Description was locking the supply.** The form submitted `description="LOCK"`. In `issuance.parse` that sentinel sets `lock`. The description sentinel is `LOCK_DESCRIPTION`. Core's own regtest (`scenario_9_issuance.py`) asserts `description_locked: True, locked: False` for the latter, and `issuance_test.py` expects `"cannot lock a non-existent asset"` for the former. Its "already locked?" check also compared the description *text* to `"LOCK"` — a value core never stores — so it never tripped; it now reads `description_locked`.

**`fair_minting` is never present.** `/v2/assets/{asset}` has no such column, so the pre-existing Start Mint gate was inert. Core reads it off the latest issuance row (`last_issuance`), which it keeps current by appending — `close_fairminter` writes a fresh issuance with `fair_minting: false`. New `useAssetLatestIssuance` reads the same row.

## Reset Supply

It was invisible: the gate compared a normalized balance against a base-unit supply, so it could never match for an asset with any supply.

Fixing that exposed that the form misdescribed the operation. A reset destroys the supply and **re-issues from the same message**, carrying `quantity`, `divisible`, `description` and `lock` — and it is the only issuance core lets change divisibility. Real mainnet resets confirm it: MEMEFORCE went indivisible → divisible, TWOSIXPEPE reset to `qty 2026` with a description. The form hardcoded `quantity: 0` and offered none of it.

It now asks what the new-asset issuance form asks, and reuses its components (`CheckboxInput` for Divisible/Locked, `TextAreaInput`, `AmountWithMaxInput`).

**Normalization needed a matching fix.** `normalizeFormData` scaled issuance quantities by the asset's *ledger* divisibility. Resetting an indivisible asset to divisible with supply 5 would have sent `5` base units instead of `500000000` — a supply 1e8 too small, permanently. Reset now scales by the divisibility being chosen, as the fairminter branch already does.

## Incidental

`9223372036854775807` had three spellings; it now has one — `MAX_SUPPLY` in `validation/amount.ts`, with a shared `maxSupplyForDivisibility`. While consolidating, Issue Supply's maximum turned out to render through `Number()`, losing the low-order digits of a 19-digit ceiling and offering a Max no issuance could reach — the exact trap `AmountFormatterOptions.value` documents.

## Tests

4587 passing (up from 4566). New: 19 on action gating, 12 on the reset form, 4 on reset normalization, 3 on the shared helper, 2 on owner-vs-issuer resolution. Each gate was verified load-bearing by reverting it individually.
