### PR TITLE
CI: run E2E in the Playwright image, and move actions off Node 20

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -66,7 +66,7 @@ jobs:
       
       - name: Cache Playwright browsers
         id: pw-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
@@ -113,7 +113,7 @@ jobs:
       
       - name: Upload test artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: nightly-test-results-${{ github.run_number }}
           path: |
@@ -123,7 +123,7 @@ jobs:
       
       - name: Notify on failure
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const { owner, repo } = context.repo;

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -14,6 +14,19 @@ jobs:
   full-test-suite:
     name: Full Test Suite
     runs-on: ubuntu-latest
+    # The official Playwright image ships Chromium and every system library it needs, so the
+    # browser-install and `install-deps` steps below are gone. `playwright install-deps` ran apt
+    # against the runner's Ubuntu mirror on every job and routinely stalled there, timing out
+    # 4-6 batches per run; the retry loop could not help, because the whole loop shared one
+    # `timeout-minutes` budget that a single stalled attempt exhausted.
+    #
+    # The tag MUST track the `@playwright/test` version in package.json. The image's browsers are
+    # built for that exact release, and Playwright refuses to launch a build it did not expect.
+    #
+    # The image runs as root, which Chromium normally refuses — the e2e fixtures already pass
+    # `--no-sandbox` and `--disable-dev-shm-usage`, so no user remapping is needed.
+    container:
+      image: mcr.microsoft.com/playwright:v1.62.1-noble
     timeout-minutes: 120  # Hard backstop so a stalled setup can't burn the 6h job cap
 
     steps:
@@ -63,34 +76,6 @@ jobs:
         env:
           NODE_OPTIONS: --max-old-space-size=6144
         run: npx vitest run src --config vitest.fuzz.config.ts
-      
-      - name: Cache Playwright browsers
-        id: pw-cache
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
-
-      - name: Install Playwright browsers
-        if: steps.pw-cache.outputs.cache-hit != 'true'
-        timeout-minutes: 16
-        run: |
-          # The browser download can stall on the CDN; cap each attempt and retry
-          # so a stall fails in minutes instead of hanging to the job timeout.
-          for attempt in 1 2 3; do
-            echo "Installing Playwright Chromium (attempt $attempt)..."
-            if timeout 300 npx playwright install chromium; then
-              exit 0
-            fi
-            echo "Attempt $attempt stalled or failed; retrying."
-            sleep 5
-          done
-          echo "Playwright browser install failed after 3 attempts" >&2
-          exit 1
-
-      - name: Install Playwright system dependencies
-        timeout-minutes: 5
-        run: npx playwright install-deps chromium
       
       - name: Run all E2E tests
         timeout-minutes: 60

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Check for unpinned dependencies
         run: |
@@ -49,10 +49,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -80,10 +80,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -101,7 +101,7 @@ jobs:
 
       - name: Upload unit test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: unit-test-results-shard-${{ matrix.shard }}
           path: test-results.json
@@ -121,10 +121,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -137,7 +137,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: pw-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
@@ -215,7 +215,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: e2e-test-results-batch-${{ matrix.batch }}
           path: test-results/
@@ -224,7 +224,7 @@ jobs:
 
       - name: Upload playwright report
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: playwright-report-batch-${{ matrix.batch }}
           path: playwright-report/
@@ -268,10 +268,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -110,6 +110,19 @@ jobs:
   e2e-tests:
     name: E2E Tests (Batch ${{ matrix.batch }})
     runs-on: ubuntu-latest
+    # The official Playwright image ships Chromium and every system library it needs, so the
+    # browser-install and `install-deps` steps below are gone. `playwright install-deps` ran apt
+    # against the runner's Ubuntu mirror on every job and routinely stalled there, timing out
+    # 4-6 batches per run; the retry loop could not help, because the whole loop shared one
+    # `timeout-minutes` budget that a single stalled attempt exhausted.
+    #
+    # The tag MUST track the `@playwright/test` version in package.json. The image's browsers are
+    # built for that exact release, and Playwright refuses to launch a build it did not expect.
+    #
+    # The image runs as root, which Chromium normally refuses — the e2e fixtures already pass
+    # `--no-sandbox` and `--disable-dev-shm-usage`, so no user remapping is needed.
+    container:
+      image: mcr.microsoft.com/playwright:v1.62.1-noble
     timeout-minutes: 30  # Hard backstop so a stalled setup can't burn the 6h job cap
     needs: lint-and-type-check
     strategy:
@@ -134,46 +147,6 @@ jobs:
 
       - name: Build extension
         run: npm run build
-
-      - name: Cache Playwright browsers
-        id: pw-cache
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
-
-      - name: Install Playwright browsers
-        if: steps.pw-cache.outputs.cache-hit != 'true'
-        timeout-minutes: 16
-        run: |
-          # The browser download can stall on the CDN; cap each attempt and retry
-          # so a stall fails in minutes instead of hanging to the job timeout.
-          for attempt in 1 2 3; do
-            echo "Installing Playwright Chromium (attempt $attempt)..."
-            if timeout 300 npx playwright install chromium; then
-              exit 0
-            fi
-            echo "Attempt $attempt stalled or failed; retrying."
-            sleep 5
-          done
-          echo "Playwright browser install failed after 3 attempts" >&2
-          exit 1
-
-      - name: Install Playwright system dependencies
-        timeout-minutes: 8
-        run: |
-          # apt can stall on a slow Ubuntu mirror while fetching fonts; retry
-          # so a stalled mirror fails in minutes instead of timing out the step.
-          for attempt in 1 2 3; do
-            if npx playwright install-deps chromium; then
-              exit 0
-            fi
-            echo "install-deps attempt $attempt failed; retrying..."
-            sudo apt-get clean || true
-            sleep $((attempt * 10))
-          done
-          echo "install-deps failed after 3 attempts"
-          exit 1
 
       - name: Configure Xvfb (MetaMask style)
         run: |

--- a/.github/workflows/trezor-emulator-tests.yml
+++ b/.github/workflows/trezor-emulator-tests.yml
@@ -43,10 +43,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -100,7 +100,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: pw-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
@@ -285,7 +285,7 @@ jobs:
 
       - name: Upload Playwright test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: trezor-playwright-test-results
           path: |
@@ -300,10 +300,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -321,7 +321,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: hardware-unit-test-results
           path: test-results/


### PR DESCRIPTION
Two CI fixes that have to land together — the second deletes steps the first edits.

## 1. Playwright installs are why merges take three attempts

`playwright install-deps` runs apt against the runner's Ubuntu mirror on every E2E job, and stalls there. It has failed **4–6 of the 20 batches on every run for days** — on `main`, on #316, and twice on this PR.

The step has a retry loop, and the loop is dead code:

```yaml
timeout-minutes: 8          # ← bounds the WHOLE loop
for attempt in 1 2 3; do
  if npx playwright install-deps chromium; then   # ← no per-attempt cap
```

The failure mode is a **stall**, not an error. Attempt 1 hangs, consumes all 8 minutes, and the job is killed before attempt 2 begins. The browser-install step directly above it got this right — `if timeout 300 npx playwright install chromium` — but `install-deps` never got the same treatment.

**Fix:** run the E2E jobs in `mcr.microsoft.com/playwright:v1.62.1-noble`, which ships the browsers and their libraries. All three setup steps go: cache, browser install, install-deps. What apt was stalling on is exactly what the image already contains — Playwright's `install-deps` tool list for noble is `xvfb` plus a dozen font packages.

Verified against the image, not assumed:

- ships **Node 24** — `package.json` requires `>=24 <25`
- browsers preinstalled at `PLAYWRIGHT_BROWSERS_PATH=/ms-playwright`
- **`xvfb` is present**, so the existing `Configure Xvfb` step still works
- runs as **root**, which Chromium refuses without `--no-sandbox` — the e2e fixtures already pass `--no-sandbox` and `--disable-dev-shm-usage`, so no user remapping needed

The tag must track `@playwright/test` in `package.json`; the browsers are built for that exact release. There's a comment at the tag saying so.

**The Trezor workflow is deliberately excluded.** It reaches its emulator through a port-mapped `services:` container on `localhost:21325`, which a containerised job cannot address. It also has no `install-deps` step, so it never had this failure.

## 2. Node 20 deprecation

Every job was warning that `actions/cache@v4`, `actions/checkout@v4`, `actions/setup-node@v4` and `actions/upload-artifact@v4` target Node 20. Warnings now, failures when the runtime is removed.

Each was bumped to the **lowest major declaring `runs.using: node24`**, read from its own `action.yml` at each tag:

| Action | | |
|---|---|---|
| `actions/checkout` | v4 → **v5** | |
| `actions/setup-node` | v4 → **v5** | |
| `actions/upload-artifact` | v4 → **v6** | **v5 is still `node20`**, despite release notes advertising Node 24 support |
| `actions/cache` | v4 → **v5** | |
| `actions/github-script` | v7 → **v8** | also node20; absent from the warning only because no job in that run reached it |

A blanket bump to v5 would have left `upload-artifact` on Node 20 with the warning intact.

Newest majors (`checkout@v7`, `setup-node@v7`, `upload-artifact@v7`, `cache@v6`, `github-script@v9`) were deliberately not taken — each carries behaviour changes beyond the runtime. The one that could have bitten is `setup-node@v5`'s automatic caching, which engages only when `package.json` declares `packageManager`; it doesn't, and every call site sets `cache: 'npm'` explicitly.

All five require runner **v2.327.1**+, which GitHub-hosted runners are well past.

## Self-testing

This PR's own E2E run exercises the container, since `pull_request` uses the workflow from the branch. If it goes green without the flaky step, that's the fix demonstrating itself.
