### PR TITLE
Release 0.8.9 — asset actions offer only what the node will accept

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "xcp-wallet",
   "description": "Counterparty Web3 Wallet",
   "private": true,
-  "version": "0.8.8",
+  "version": "0.8.9",
   "license": "MIT",
   "type": "module",
   "engines": {


### PR DESCRIPTION
Point release. One user-facing change since v0.8.8 (#316), plus the workflow bump in #317.

## Asset actions offer only what the node will accept

The asset page listed nearly every action unconditionally — six of them had no ownership check at all — so it offered transactions counterparty-core would reject at compose time. Every action is now gated on the rule core validates.

| Action | Hidden when |
|---|---|
| Start Mint | not owner · locked · fairminter already open |
| Issue Supply / Lock Supply | not owner · locked · fair minting |
| Issue Subasset | not owner · already a subasset |
| Pay Dividend | not owner · BTC/XCP · zero supply |
| Reset Supply | not owner · locked · description locked · fair minting · owner isn't sole holder |
| Lock Description / Update Description | not owner · description locked · fair minting |
| Transfer Ownership | not owner · fair minting |

## Three defects fixed

**Lock Description was freezing the supply.** It submitted the sentinel `"LOCK"`, which `issuance.parse` reads as a request to lock the supply. The description sentinel is `"LOCK_DESCRIPTION"` — the two are one `elif` apart and neither is reversible. The screen performed a different permanent action than the one it offered, and left the description unlocked. Its "already locked?" check also compared the description *text* to `"LOCK"`, a value core never stores, so it never tripped.

**Ownership was read from the wrong field.** `assets_info.issuer` is written once at first issuance and never rewritten; every `ASSET_TRANSFER` moves `owner` alone. An asset received by transfer showed its new owner nothing to do, while the address that gave it away kept the full menu. The same field backed the asset-name → send-destination lookup, so it addressed sends to the previous owner.

**Reset Supply was invisible**, because its gate compared a normalized balance against a base-unit supply — it could never match for an asset with any supply.

## Reset Supply, rebuilt

Fixing the gate exposed that the form misdescribed the operation. A reset destroys the supply and **re-issues from the same message**, carrying quantity, divisibility, description and lock — and it is the only issuance core permits to change divisibility. The form hardcoded `quantity: 0` and offered none of it.

It now asks what the new-asset issuance form asks. Normalization was extended to match: a reset scales its quantity by the divisibility being chosen rather than the one on the ledger, which would otherwise have sent a new divisible supply 1e8 short.

## Also

`9223372036854775807` had three spellings and now has one. Issue Supply's maximum rendered through `Number()`, losing the low-order digits of a 19-digit ceiling and offering a Max no issuance could reach.

## Verification

4587 unit tests passing, `tsc` and lint clean. Chrome MV3 zip builds at 784 KB with the manifest reading 0.8.9.
