### PR TITLE
Add proof-based provider signing profiles for 0.9

### DIFF
--- a/PROVIDER.md
+++ b/PROVIDER.md
@@ -241,6 +241,24 @@ is the output sharing the signed input's index; any *other* output paying the
 signer is shown as "may not return to you", the headline reflects that worst
 case, and signing is gated until the signer acknowledges the amount.
 
+The warning copy preserves the same distinction. `ALL | ANYONECANPAY` is an
+informational note that other funding inputs may be added and explicitly says
+that every current output is fixed. `SINGLE | ANYONECANPAY` says that only the
+paired output is fixed; redirectable signer funds escalate to danger. The
+screen does not use the generic and inaccurate “inputs or outputs may be added”
+copy for both flags.
+
+Attached-asset review likewise presents one outcome, not several warnings for
+the same movement. When the destination is resolved, the destination and exact
+asset list share one row: movement to the wallet's own output or a detach back
+to its own address is information, while delivery outside the wallet or a
+signature that leaves delivery flexible is danger. A failed asset lookup
+remains a warning because an unknown UTXO is never treated as asset-free.
+
+When local transaction verification blocks approval, the popup recommends
+retrying or asking the site to rebuild the request. It does not instruct the
+user to disable strict verification from the signing screen.
+
 For a marketplace listing this means:
 
 - Put the seller's proceeds at the **same index as the input being signed**.
@@ -352,7 +370,8 @@ The capability requires all of the following before approval:
 An extra output, substituted address or amount, unreadable output script, OP_RETURN, failed asset
 lookup, or attached asset hard-blocks signing. The approval always appears and shows the full
 destination and amount. The `description`, `reference`, and requesting origin can change wording,
-but can never make an unsafe PSBT signable.
+but can never make an unsafe PSBT signable. A proved payment is shown once in that exact-output
+card; the generic analyzer's truncated payment notice is omitted rather than duplicating it.
 
 The existing permissioned paired-address capability also applies to this method. A payment that
 spends both the same-index Legacy P2PKH and SegWit P2WPKH addresses must name both addresses and

--- a/PROVIDER.md
+++ b/PROVIDER.md
@@ -115,7 +115,8 @@ All signing methods require an active connection and open a popup for user appro
 #### What this wallet will sign
 
 `xcp_signTransaction` and `xcp_signPsbt` are for Counterparty transactions. A request is refused
-outright when it is not one:
+outright when it is not one. Plain Bitcoin website payments use the narrower
+`xcp_signBitcoinPsbt` capability documented below; origins never bypass either policy.
 
 - **No Counterparty content.** The transaction must either carry a Counterparty message or spend an
   input holding attached assets. Both forms count, because spending an attached UTXO moves its
@@ -249,6 +250,49 @@ For a marketplace listing this means:
 
 A listing built that way has nothing at risk and signs with no extra prompt.
 
+**Versioned marketplace intent.** `xcp_signPsbt` accepts an optional `intent` object. It is an
+untrusted claim used to ask for a semantic approval, not permission to skip validation. Version
+0.9 recognizes the `create_listing` family:
+
+```js
+await xcpwallet.request({
+  method: 'xcp_signPsbt',
+  params: [{
+    hex: listingPsbtHex,
+    signInputs: { [seller]: [1] },
+    // Absolute PSBT indices: input 0 is not signed, but occupies slot 0.
+    sighashTypes: [0x01, 0x83],
+    intent: {
+      standard: 'counterparty-marketplace',
+      version: 1,
+      action: 'create_listing',
+      operationId: 'preflight-id',
+      protocolVersion: 'counterparty_attach_listing_v1',
+      assets: [{
+        asset: 'RAREPEPE',
+        quantityRaw: '1',
+        sourceOutpoint: { txid: '<64-char txid>', vout: 0 }
+      }],
+      seller,
+      priceSats: 250000,
+      carrierValueSats: 546,
+      guaranteedSellerPaymentSats: 250546,
+      delivery: { mode: 'buyer_selected_detach' },
+      signingRequestExpiresAt: 1711130400,
+      marketplaceExpiresAt: null,
+      bitcoinExpiresAt: null
+    }
+  }]
+});
+```
+
+The wallet independently checks the two-input/two-output template, null and unsigned buyer slot,
+exact attached outpoint and raw quantity, seller identity and carrier value, only input 1 requested
+with `SINGLE|ANYONECANPAY`, and exact carrier-plus-price payment at output 1. It also states that
+buyer funding and the detach destination remain flexible. A false claim is blocked; an unavailable
+asset lookup asks the user to retry rather than treating the UTXO as empty. Marketplace expiry is
+displayed as service policy, not Bitcoin signature expiry.
+
 **Mixed sighash flags.** When signed inputs carry different flags, the summary
 prices only the outputs that every `ANYONECANPAY` input covers on its own. Such
 an input is detachable — whoever holds the PSBT can keep it, drop the rest, and
@@ -269,6 +313,46 @@ transaction rather than rendered as an ordinary transfer.
 a listing awaiting a buyer's funding inputs — is accepted. No fee is claimed for
 it; the approval screen reports the fee as set by the other party rather than
 showing a figure that cannot be known yet.
+
+#### `xcp_signBitcoinPsbt`
+
+Sign a fully funded, plain-Bitcoin PSBT for an exact website payment. This is intended for flows
+such as funding an Emblem Vault transaction, where no Counterparty message belongs in the funding
+step. It is not a trusted-site mode and it is not available through `xcp_signPsbt`.
+
+```js
+const result = await xcpwallet.request({
+  method: 'xcp_signBitcoinPsbt',
+  params: [{
+    hex: '<fully funded PSBT hex>',
+    signInputs: { 'bc1q...': [0] },
+    sighashTypes: [0x01],
+    intent: {
+      standard: 'xcp-wallet/bitcoin-payment',
+      version: 1,
+      action: 'pay',
+      outputs: [{ address: 'bc1q...', amountSats: 21600 }],
+      description: 'Fund Emblem Vault', // display context only
+      reference: 'vault-63'             // display context only
+    }
+  }]
+});
+// { hex: '<signed PSBT hex>' }
+```
+
+The capability requires all of the following before approval:
+
+- an existing site connection and explicit non-empty `signInputs` owned by the current wallet;
+- an explicit `SIGHASH_ALL` entry for every requested input;
+- a fully funded PSBT with no Counterparty payload or inscription context;
+- an independent successful lookup proving every requested input has no attached assets; and
+- exact multiset equality between the declared external address/amount pairs and decoded PSBT
+  outputs, after excluding wallet-owned change.
+
+An extra output, substituted address or amount, unreadable output script, OP_RETURN, failed asset
+lookup, or attached asset hard-blocks signing. The approval always appears and shows the full
+destination and amount. The `description`, `reference`, and requesting origin can change wording,
+but can never make an unsafe PSBT signable.
 
 ### Broadcasting
 

--- a/PROVIDER.md
+++ b/PROVIDER.md
@@ -354,6 +354,12 @@ lookup, or attached asset hard-blocks signing. The approval always appears and s
 destination and amount. The `description`, `reference`, and requesting origin can change wording,
 but can never make an unsafe PSBT signable.
 
+The existing permissioned paired-address capability also applies to this method. A payment that
+spends both the same-index Legacy P2PKH and SegWit P2WPKH addresses must name both addresses and
+their absolute input indices in `signInputs`, with a `SIGHASH_ALL` entry for each input. Both
+addresses are then recognized as wallet-owned when classifying change. This does not relax the
+per-origin paired-address permission, exact-output proof, or attached-asset checks.
+
 ### Broadcasting
 
 #### `xcp_broadcastTransaction`

--- a/e2e/tests/approval-gallery.spec.ts
+++ b/e2e/tests/approval-gallery.spec.ts
@@ -86,15 +86,35 @@ function opReturnScriptOf(rawTxHex: string): string {
 }
 
 /** Rebuild a fixture so its change output pays `changeAddress`, leaving the payload untouched. */
-/** The dispenser a `dispense` pays. Real dispenses send BTC to the dispenser's address. */
+/**
+ * The external party a `dispense` or `btcpay` pays. Real dispenses send BTC to the dispenser's
+ * address, and a real BTCPay sends it to the order-match counterparty — without that output the
+ * screen shows a payment type that pays nobody, a state no user encounters.
+ */
 const DISPENSER_ADDRESS_SCRIPT = '76a914' + '11'.repeat(20) + '88ac';
 const DISPENSE_PAYMENT_SATS = 10_000;
+const PAYS_EXTERNAL = new Set(['dispense', 'btcpay']);
+/**
+ * A real attach has three outputs — OP_RETURN, the 546-sat carrier the assets attach to, and
+ * change — and its payload targets vout 1, which is where the fixture's attach points. Without
+ * the dedicated carrier the change output doubled as the attached UTXO, a shape no composer
+ * produces. attach-bad-vout is deliberately absent: its payload must keep pointing past the end.
+ */
+const CARRIER_VALUE = 546;
+const HAS_ATTACH_CARRIER = new Set(['attach']);
 
-function rebuildForSigner(rawTxHex: string, changeAddress: string, payDispenser = false): string {
+function rebuildForSigner(
+  rawTxHex: string,
+  changeAddress: string,
+  payExternal = false,
+  attachCarrier = false,
+): string {
   const { txid, vout } = scenarioFixtures.input;
   const txidLe = txid.match(/../g)!.reverse().join('');
   const opReturnScript = opReturnScriptOf(rawTxHex);
   const changeScript = Buffer.from(OutScript.encode(Address().decode(changeAddress))).toString('hex');
+  const extraCount = (payExternal ? 1 : 0) + (attachCarrier ? 1 : 0);
+  const extraValue = (payExternal ? DISPENSE_PAYMENT_SATS : 0) + (attachCarrier ? CARRIER_VALUE : 0);
 
   return [
     le(2, 4),
@@ -103,12 +123,15 @@ function rebuildForSigner(rawTxHex: string, changeAddress: string, payDispenser 
     le(vout, 4),
     '00',
     'ffffffff',
-    payDispenser ? '03' : '02',
+    le(2 + extraCount, 1),
     le(0, 8), le(opReturnScript.length / 2, 1), opReturnScript,
-    ...(payDispenser
+    ...(payExternal
       ? [le(DISPENSE_PAYMENT_SATS, 8), le(DISPENSER_ADDRESS_SCRIPT.length / 2, 1), DISPENSER_ADDRESS_SCRIPT]
       : []),
-    le(CHANGE_VALUE - (payDispenser ? DISPENSE_PAYMENT_SATS : 0), 8),
+    ...(attachCarrier
+      ? [le(CARRIER_VALUE, 8), le(changeScript.length / 2, 1), changeScript]
+      : []),
+    le(CHANGE_VALUE - extraValue, 8),
     le(changeScript.length / 2, 1), changeScript,
     le(0, 4),
   ].join('');
@@ -186,13 +209,12 @@ function toPsbt(rawTxHex: string): string {
  */
 const EXPECTED_WARNINGS: Record<string, RegExp[]> = {
   'sweep-blocked': [/blocked: sweep/i],
-  destroy: [/asset destruction/i],
-  detach: [/moves everything on the utxo/i],
-  // Paying the dispenser, and paying the order-match counterparty, are what these transactions
-  // are. Both are stated rather than flagged; the red danger banner they used to raise fired on
-  // every correct one of them.
-  dispense: [/btc payment/i],
-  btcpay: [/btc payment/i],
+  destroy: [/supply destruction/i],
+  // The fixture detaches to a foreign address, which genuinely deserves attention; a detach to
+  // your own address is routine and raises nothing (its generic note is info-severity now).
+  detach: [/detached to another address/i],
+  // Paying the dispenser or the order-match counterparty is what those transactions are; the
+  // movement rows state the payment and no warning or note fires on a correct one.
   'attach-bad-vout': [/attaches to an output that does not exist/i],
   'utxo-move-foreign-source': [/moves a utxo this transaction does not spend/i],
 };
@@ -200,8 +222,9 @@ const EXPECTED_WARNINGS: Record<string, RegExp[]> = {
 /** Every warning title the safety layer and the approval screens can raise. */
 const ALL_WARNING_PATTERNS: RegExp[] = [
   /blocked: sweep/i,
-  /asset destruction/i,
+  /supply destruction/i,
   /moves everything on the utxo/i,
+  /detached to another address/i,
   /unknown transaction type/i,
   /unrecognized transaction/i,
   /btc sent to external address/i,
@@ -222,6 +245,110 @@ const ALL_WARNING_PATTERNS: RegExp[] = [
 async function warningsOn(page: import('@playwright/test').Page): Promise<RegExp[]> {
   const body = (await page.locator('body').innerText()).replace(/\s+/g, ' ');
   return ALL_WARNING_PATTERNS.filter((re) => re.test(body));
+}
+
+/**
+ * Ledger answers for the states the live ledger cannot produce on demand. The fixture outpoint
+ * carries no attached assets, the fake dispenser address runs no dispenser, and the pool test
+ * assets do not exist — so detach showed no released balances, dispense no payouts, and pool
+ * amounts fell back to the base-units caveat: states no real user of those flows would see.
+ * These stubs answer only those specific lookups; every other request still hits the real API.
+ */
+async function installScenarioStubs(
+  page: import('@playwright/test').Page,
+  name: string
+): Promise<void> {
+  const fixtureOutpoint = `${scenarioFixtures.input.txid}:${scenarioFixtures.input.vout}`;
+  if (name === 'detach') {
+    await page.route(/\/v2\/utxos\//, (route) => {
+      const match = new URL(route.request().url()).pathname.match(/\/v2\/utxos\/([^/]+)\/balances/);
+      if (!match) return route.continue();
+      const utxo = decodeURIComponent(match[1]!);
+      return route.fulfill({
+        json: {
+          result: utxo === fixtureOutpoint
+            ? [
+                { asset: 'RAREPEPE', quantity: '1', quantity_normalized: '1', asset_info: { divisible: false, asset_longname: null } },
+                { asset: 'PEPECASH', quantity: '50000000', quantity_normalized: '0.5', asset_info: { divisible: true, asset_longname: null } },
+              ]
+            : [],
+          next_cursor: null,
+          result_count: utxo === fixtureOutpoint ? 2 : 0,
+        },
+      });
+    });
+  }
+  if (name === 'dispense') {
+    await page.route(/\/dispensers/, (route) => route.fulfill({
+      json: {
+        result: [{
+          asset: 'BAMBOU',
+          status: 0,
+          satoshirate: 1000,
+          give_quantity: 100000000,
+          give_remaining: 2000000000,
+          give_quantity_normalized: '1',
+          asset_info: { divisible: true, asset_longname: null },
+        }],
+        next_cursor: null,
+        result_count: 1,
+      },
+    }));
+  }
+  if (name.startsWith('pool-')) {
+    // The unpack endpoint names an asset its ledger cannot resolve as the literal 0, and the
+    // divisibility enrichment then looks THAT up — so the stub answers both spellings.
+    await page.route(/\/v2\/assets\/(A9542\d+|0)([/?]|$)/, (route) => {
+      const match = new URL(route.request().url()).pathname.match(/\/v2\/assets\/([^/?]+)/);
+      return route.fulfill({
+        json: {
+          result: {
+            asset: decodeURIComponent(match?.[1] ?? ''),
+            divisible: true,
+            asset_longname: null,
+            supply: 10_000_000_000,
+            supply_normalized: '100',
+          },
+        },
+      });
+    });
+    await page.route(/\/v2\/pools\//, (route) => route.fulfill({
+      json: {
+        result: {
+          asset_a: 'XCP',
+          asset_b: 'A95428957068369062',
+          lp_asset: 'A95428957068369099',
+          reserve_a: 0,
+          reserve_b: 0,
+          fee_bps: 50,
+        },
+      },
+    }));
+  }
+}
+
+/**
+ * The approval spreads its statements over two surfaces now: blocking warnings render on the
+ * main screen, and signable cautions wait on the attention screen behind the Review button. A
+ * scan of the main screen alone would call a deliberately deferred caution "missing", so open
+ * the attention screen too, scan both, and capture it alongside the main screenshot.
+ */
+async function collectWarnings(
+  approval: import('@playwright/test').Page,
+  attentionShotPath: string
+): Promise<RegExp[]> {
+  const shown = new Set(await warningsOn(approval));
+
+  const review = approval.getByRole('button', { name: /^review$/i });
+  if (await review.count()) {
+    await review.click();
+    await expect(approval.getByRole('button', { name: 'Back' })).toBeVisible({ timeout: 10_000 });
+    for (const re of await warningsOn(approval)) shown.add(re);
+    await approval.screenshot({ path: attentionShotPath, fullPage: true });
+    await approval.getByRole('button', { name: 'Back' }).click();
+  }
+
+  return ALL_WARNING_PATTERNS.filter((re) => shown.has(re));
 }
 
 walletTest('captures every provider approval screen', async ({ context, page, extensionId }) => {
@@ -252,7 +379,7 @@ walletTest('captures every provider approval screen', async ({ context, page, ex
     );
   };
 
-  const openApproval = async (id: string) => {
+  const openApproval = async (id: string, scenarioName?: string) => {
     await settle(SCREEN_SPACING_MS);
     const approval = await context.newPage();
     // Popup width, because the horizontal-overflow bugs this gallery exists to catch are width
@@ -260,12 +387,13 @@ walletTest('captures every provider approval screen', async ({ context, page, ex
     // captures nothing below the fold and warnings and the recipient list were cut off. A tall
     // viewport puts the whole screen in one image.
     await approval.setViewportSize({ width: 380, height: 1400 });
+    if (scenarioName) await installScenarioStubs(approval, scenarioName);
     await approval.goto(
       `chrome-extension://${extensionId}/popup.html#/requests/transaction/approve?requestId=${id}`
     );
     // The screen decodes and cross-checks before it can describe anything, so wait on the footer
-    // rather than a fixed delay.
-    await expect(approval.getByRole('button', { name: /^(sign|blocked)$/i })).toBeVisible({ timeout: 60_000 });
+    // rather than a fixed delay. A signable request with cautions labels the button Review.
+    await expect(approval.getByRole('button', { name: /^(sign|review|blocked)$/i })).toBeVisible({ timeout: 60_000 });
     return approval;
   };
 
@@ -289,8 +417,8 @@ walletTest('captures every provider approval screen', async ({ context, page, ex
 
   for (const [name, { rawTxHex }] of scenarios) {
     const id = `gallery-${name}`;
-    await seed(id, rebuildForSigner(rawTxHex, signerAddress!, name === 'dispense'));
-    const approval = await openApproval(id);
+    await seed(id, rebuildForSigner(rawTxHex, signerAddress!, PAYS_EXTERNAL.has(name), HAS_ATTACH_CARRIER.has(name)));
+    const approval = await openApproval(id, name);
 
     // Expanded, so inputs, outputs and the mpma recipient list are part of the captured state —
     // for a multi-destination send that panel is the only place the payees appear at all.
@@ -301,7 +429,9 @@ walletTest('captures every provider approval screen', async ({ context, page, ex
     await details.click();
     await expect(approval.getByText(/^Outputs \(/)).toBeVisible({ timeout: 10_000 });
 
-    const shown = (await warningsOn(approval)).map((re) => re.source).sort();
+    const shown = (
+      await collectWarnings(approval, path.join(OUT_DIR, `${name}-attention.png`))
+    ).map((re) => re.source).sort();
     const expected = (EXPECTED_WARNINGS[name] ?? []).map((re) => re.source).sort();
     if (JSON.stringify(shown) !== JSON.stringify(expected)) {
       warningMismatches.push(`${name}
@@ -331,17 +461,18 @@ walletTest('captures every provider approval screen', async ({ context, page, ex
         requestKey: `xcp_signPsbt:${id}`,
         kind: 'sign-psbt',
         status: 'pending',
-        psbtHex: toPsbt(rebuildForSigner(rawTxHex, signerAddress!, name === 'dispense')),
+        psbtHex: toPsbt(rebuildForSigner(rawTxHex, signerAddress!, PAYS_EXTERNAL.has(name), HAS_ATTACH_CARRIER.has(name))),
       }
     );
 
     await settle(SCREEN_SPACING_MS);
     const approval = await context.newPage();
     await approval.setViewportSize({ width: 380, height: 1400 });
+    await installScenarioStubs(approval, name);
     await approval.goto(
       `chrome-extension://${extensionId}/popup.html#/requests/psbt/approve?requestId=${id}`
     );
-    await expect(approval.getByRole('button', { name: /^(sign|blocked)$/i })).toBeVisible({ timeout: 60_000 });
+    await expect(approval.getByRole('button', { name: /^(sign|review|blocked)$/i })).toBeVisible({ timeout: 60_000 });
 
     // Expanded, for the same reason as above: the recipients list and the checks line live in
     // this panel, and they are precisely what was missing from this screen.

--- a/e2e/tests/marketplace-gallery.spec.ts
+++ b/e2e/tests/marketplace-gallery.spec.ts
@@ -1,0 +1,767 @@
+/**
+ * Screenshots every marketplace / provider-safety approval screen the 0.9 work added, one file
+ * per state — the companion to approval-gallery.spec.ts for the surfaces that gallery cannot
+ * reach: proof-based marketplace intents (attach-for-listing, create listing, buy, exact offers,
+ * bulk fan-out), the plain-Bitcoin payment capability, the linked-PSBT bundle screen, and the
+ * blocked / retry gates in front of them.
+ *
+ * The proof analyzer independently re-derives every claim from PSBT bytes, prevouts, and UTXO
+ * balance lookups — so reaching a "proved" state needs transactions whose bytes actually prove
+ * out. The PSBTs here are built from scratch around the live test wallet's address, with real
+ * Counterparty payloads (packed and ARC4-obfuscated the way core does), and the balance lookups
+ * for their fabricated outpoints are answered by a route stub, since no real ledger has ever
+ * seen these outpoints. Everything else still runs the real code path: the same decoder, the
+ * same analyzer, the same screens.
+ *
+ * Output: test-results/marketplace-gallery/*.png
+ */
+
+import { createHash } from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { Address, OutScript } from '@scure/btc-signer';
+import type { Page, Route } from '@playwright/test';
+import { expect, walletTest } from '../fixtures';
+
+const OUT_DIR = 'test-results/marketplace-gallery';
+
+// ---------------------------------------------------------------------------------------------
+// Byte-level builders
+// ---------------------------------------------------------------------------------------------
+
+const le = (value: number | bigint, bytes: number): string => {
+  let hex = '';
+  let remaining = BigInt(value);
+  for (let i = 0; i < bytes; i += 1) {
+    hex += (remaining & 0xffn).toString(16).padStart(2, '0');
+    remaining >>= 8n;
+  }
+  return hex;
+};
+
+const varint = (n: number): string => {
+  if (n < 0xfd) return le(n, 1);
+  if (n <= 0xffff) return 'fd' + le(n, 2);
+  return 'fe' + le(n, 4);
+};
+
+const sha256d = (hex: string): Buffer => {
+  const first = createHash('sha256').update(Buffer.from(hex, 'hex')).digest();
+  return createHash('sha256').update(first).digest();
+};
+
+/** Display-order txid of a raw transaction. */
+const txidOf = (rawTxHex: string): string => sha256d(rawTxHex).reverse().toString('hex');
+
+/** Symmetric ARC4, keyed the way core keys OP_RETURN obfuscation: the first input's txid. */
+function arc4(key: Buffer, data: Buffer): Buffer {
+  const s = Array.from({ length: 256 }, (_, i) => i);
+  let j = 0;
+  for (let i = 0; i < 256; i += 1) {
+    j = (j + s[i]! + key[i % key.length]!) & 0xff;
+    [s[i], s[j]] = [s[j]!, s[i]!];
+  }
+  const out = Buffer.alloc(data.length);
+  let i = 0;
+  j = 0;
+  for (let k = 0; k < data.length; k += 1) {
+    i = (i + 1) & 0xff;
+    j = (j + s[i]!) & 0xff;
+    [s[i], s[j]] = [s[j]!, s[i]!];
+    out[k] = data[k]! ^ s[(s[i]! + s[j]!) & 0xff]!;
+  }
+  return out;
+}
+
+const CNTRPRTY = Buffer.from('CNTRPRTY', 'ascii');
+
+/** attach: `asset|quantity|destination_vout` under type id 101 (core attach.py). */
+const attachPayload = (asset: string, quantity: string, vout: number): Buffer =>
+  Buffer.concat([CNTRPRTY, Buffer.from([101]), Buffer.from(`${asset}|${quantity}|${vout}`, 'utf8')]);
+
+/** detach: the destination address alone under type id 102 (core detach.py). */
+const detachPayload = (destination: string): Buffer =>
+  Buffer.concat([CNTRPRTY, Buffer.from([102]), Buffer.from(destination || '0', 'utf8')]);
+
+/** OP_RETURN script carrying `payload` obfuscated with the first input's display txid. */
+const opReturnScript = (payload: Buffer, firstInputTxid: string): string => {
+  const cipher = arc4(Buffer.from(firstInputTxid, 'hex'), payload);
+  return '6a' + le(cipher.length, 1) + cipher.toString('hex');
+};
+
+const scriptFor = (address: string): string =>
+  Buffer.from(OutScript.encode(Address().decode(address))).toString('hex');
+
+/** A valid bech32 p2wpkh address from a constant hash byte, for counterparties that need one. */
+const fakeAddress = (byte: number): string =>
+  Address().encode({ type: 'wpkh', hash: new Uint8Array(20).fill(byte) });
+
+interface BuiltInput {
+  txid: string; // display order
+  vout: number;
+  /** Address whose p2wpkh script the witness_utxo carries; omitted = empty-script placeholder. */
+  address?: string;
+  value: number;
+  /** Attach a fabricated final witness so the input reads as already signed. */
+  signed?: boolean;
+}
+
+interface BuiltOutput {
+  scriptHex: string;
+  value: number;
+}
+
+/** Version-2, locktime-0 unsigned transaction (exact_offer_v1 pins exactly this header). */
+function buildRawTx(inputs: BuiltInput[], outputs: BuiltOutput[]): string {
+  return [
+    le(2, 4),
+    varint(inputs.length),
+    ...inputs.map(input =>
+      input.txid.match(/../g)!.reverse().join('') + le(input.vout, 4) + '00' + 'ffffffff'
+    ),
+    varint(outputs.length),
+    ...outputs.map(output => le(output.value, 8) + varint(output.scriptHex.length / 2) + output.scriptHex),
+    le(0, 4),
+  ].join('');
+}
+
+/** A plausible final witness (sig-shaped bytes + a compressed-pubkey-shaped key). */
+const FAKE_WITNESS = (() => {
+  const sig = '30440220' + '11'.repeat(32) + '0220' + '22'.repeat(32) + '01';
+  const pubkey = '02' + '33'.repeat(32);
+  return varint(2) + varint(sig.length / 2) + sig + varint(pubkey.length / 2) + pubkey;
+})();
+
+/** Wrap the unsigned tx in a PSBT v0 envelope with witness_utxo (and optional witness) records. */
+function buildPsbt(inputs: BuiltInput[], outputs: BuiltOutput[]): { psbtHex: string; txid: string } {
+  const rawTxHex = buildRawTx(inputs, outputs);
+  const inputMaps = inputs.map(input => {
+    const script = input.address ? scriptFor(input.address) : '';
+    const witnessUtxo = le(input.value, 8) + varint(script.length / 2) + script;
+    return [
+      '01', '01', varint(witnessUtxo.length / 2), witnessUtxo,
+      ...(input.signed ? ['01', '08', varint(FAKE_WITNESS.length / 2), FAKE_WITNESS] : []),
+      '00',
+    ].join('');
+  });
+  const psbtHex = [
+    '70736274ff',
+    '01', '00', varint(rawTxHex.length / 2), rawTxHex,
+    '00',
+    ...inputMaps,
+    '00'.repeat(outputs.length),
+  ].join('');
+  return { psbtHex, txid: txidOf(rawTxHex) };
+}
+
+// ---------------------------------------------------------------------------------------------
+// Balance stubbing
+// ---------------------------------------------------------------------------------------------
+
+interface StubBalance {
+  asset: string;
+  quantity: string;
+  quantity_normalized: string;
+}
+
+/**
+ * Answer every /v2/utxos/{utxo}/balances lookup from the scenario's table: listed outpoints
+ * carry the given assets, 'fail' simulates an unreachable ledger (the retry state), and every
+ * other outpoint is confirmed empty — these outpoints are fabricated, so the real API's answer
+ * for them would be an accident. Everything else still reaches the real API.
+ */
+async function stubUtxoBalances(
+  page: Page,
+  balances: Record<string, StubBalance[] | 'fail'>
+): Promise<void> {
+  await page.route('**/v2/utxos/**', async (route: Route) => {
+    const url = new URL(route.request().url());
+    const match = url.pathname.match(/\/v2\/utxos\/([^/]+)\/balances/);
+    if (!match) return route.continue();
+    const utxo = decodeURIComponent(match[1]!);
+    const entry = balances[utxo];
+    if (entry === 'fail') return route.fulfill({ status: 500, body: 'stubbed ledger outage' });
+    return route.fulfill({
+      json: {
+        result: (entry ?? []).map(balance => ({
+          asset: balance.asset,
+          quantity: balance.quantity,
+          quantity_normalized: balance.quantity_normalized,
+          asset_info: { divisible: balance.quantity !== balance.quantity_normalized, asset_longname: null },
+        })),
+        next_cursor: null,
+        result_count: (entry ?? []).length,
+      },
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------------------------
+// The scenarios
+// ---------------------------------------------------------------------------------------------
+
+const ORIGIN = 'https://marketplace.xcp.io';
+const FUTURE = 2_000_000_000;
+
+/** Read the live wallet address the same way ux-visual-check does. */
+async function readActiveAddress(page: Page): Promise<string> {
+  await page.goto(page.url().replace(/\/(index|requests|addresses).*/, '/addresses/details'));
+  await page.waitForLoadState('networkidle');
+  const address = await page.evaluate(() => {
+    for (const el of Array.from(document.querySelectorAll('*'))) {
+      const m = (el.textContent || '').match(/(bc1|tb1)[0-9a-z]{30,}/);
+      if (m) return m[0];
+    }
+    return '';
+  });
+  expect(address, 'should read the full active address').toMatch(/^(bc1|tb1)/);
+  return address;
+}
+
+interface Scenario {
+  name: string;
+  /** popup.html#<route>?requestId=… */
+  route: '/requests/psbt/approve' | '/requests/psbts/approve';
+  record: Record<string, unknown>;
+  balances: Record<string, StubBalance[] | 'fail'>;
+  /** The footer state this scenario is expected to reach — a drifting state fails the run. */
+  expectFooter: 'Sign' | 'Review' | 'Blocked';
+}
+
+function buildScenarios(wallet: string): Scenario[] {
+  const SELLER_A = fakeAddress(0x11);
+  const SELLER_B = fakeAddress(0x22);
+  const BUYER_EXT = fakeAddress(0x33);
+  const PLATFORM = fakeAddress(0x44);
+
+  const ASSET_TXID = 'ab'.repeat(32);
+  const ASSET_TXID_TWO = 'cd'.repeat(32);
+  const FUNDING_TXID = '11'.repeat(32);
+  const BID_TXID = '19'.repeat(32);
+  const FANOUT_FUNDING_TXID = '21'.repeat(32);
+
+  const scenarios: Scenario[] = [];
+  const seedRecord = (
+    id: string,
+    fields: Record<string, unknown>,
+  ): Record<string, unknown> => ({
+    id,
+    origin: ORIGIN,
+    timestamp: Date.now(),
+    address: wallet,
+    walletId: '',
+    status: 'pending',
+    ...fields,
+  });
+
+  // --- attach_for_listing (caution: block-dependent XCP fee) --------------------------------
+  {
+    const funding: BuiltInput = { txid: '15'.repeat(32), vout: 0, address: wallet, value: 100_000 };
+    const payload = attachPayload('RAREPEPE', '1', 0);
+    const outputs: BuiltOutput[] = [
+      { scriptHex: scriptFor(wallet), value: 546 },
+      { scriptHex: opReturnScript(payload, funding.txid), value: 0 },
+      { scriptHex: scriptFor(wallet), value: 98_454 },
+    ];
+    const { psbtHex, txid } = buildPsbt([funding], outputs);
+    scenarios.push({
+      name: 'listing-attach-caution',
+      route: '/requests/psbt/approve',
+      expectFooter: 'Sign',
+      record: seedRecord('mk-attach', {
+        requestKey: 'xcp_signPsbt:mk-attach',
+        kind: 'sign-psbt',
+        psbtHex,
+        signInputs: { [wallet]: [0] },
+        sighashTypes: [0x01],
+        marketplaceIntent: {
+          standard: 'counterparty-marketplace',
+          version: 1,
+          action: 'attach_for_listing',
+          operationId: 'attach-1',
+          protocolVersion: 'counterparty_attach_listing_v1',
+          assets: [{ asset: 'RAREPEPE', quantityRaw: '1' }],
+          seller: wallet,
+          expectedAttachedOutpoint: { txid, vout: 0 },
+          carrierAddress: wallet,
+          carrierValueSats: 546,
+          networkFeeSats: 1_000,
+          protocolFee: {
+            asset: 'XCP',
+            quotedAmountRaw: '25000000',
+            actualAmountRaw: null,
+            observedBlock: 900_000,
+            variableUntilConfirmed: true,
+          },
+          operationExpiresAt: FUTURE,
+        },
+      }),
+      balances: {},
+    });
+  }
+
+  // --- create_listing (caution: buyer-selected detach stays flexible) -----------------------
+  {
+    const placeholder: BuiltInput = { txid: '00'.repeat(32), vout: 0, value: 0 };
+    const assetInput: BuiltInput = { txid: ASSET_TXID, vout: 7, address: wallet, value: 546 };
+    const outputs: BuiltOutput[] = [
+      { scriptHex: scriptFor(wallet), value: 546 },
+      { scriptHex: scriptFor(wallet), value: 250_546 },
+    ];
+    const { psbtHex } = buildPsbt([placeholder, assetInput], outputs);
+    const intent = {
+      standard: 'counterparty-marketplace',
+      version: 1,
+      action: 'create_listing',
+      operationId: 'listing-1',
+      protocolVersion: 'counterparty_attach_listing_v1',
+      assets: [{
+        asset: 'RAREPEPE',
+        quantityRaw: '100000000',
+        sourceOutpoint: { txid: ASSET_TXID, vout: 7 },
+      }],
+      seller: wallet,
+      priceSats: 250_000,
+      carrierValueSats: 546,
+      guaranteedSellerPaymentSats: 250_546,
+      delivery: { mode: 'buyer_selected_detach' },
+      signingRequestExpiresAt: FUTURE,
+      marketplaceExpiresAt: FUTURE + 3_600,
+      bitcoinExpiresAt: null,
+    };
+    scenarios.push({
+      name: 'listing-create-caution',
+      route: '/requests/psbt/approve',
+      expectFooter: 'Review',
+      record: seedRecord('mk-listing', {
+        requestKey: 'xcp_signPsbt:mk-listing',
+        kind: 'sign-psbt',
+        psbtHex,
+        signInputs: { [wallet]: [1] },
+        sighashTypes: [0x01, 0x83],
+        marketplaceIntent: intent,
+      }),
+      balances: {
+        [`${ASSET_TXID}:7`]: [{ asset: 'RAREPEPE', quantity: '100000000', quantity_normalized: '1' }],
+      },
+    });
+
+    // Same listing, but the ledger cannot answer for the attached outpoint → retry gate.
+    scenarios.push({
+      name: 'listing-create-retry',
+      route: '/requests/psbt/approve',
+      expectFooter: 'Blocked',
+      record: seedRecord('mk-listing-retry', {
+        requestKey: 'xcp_signPsbt:mk-listing-retry',
+        kind: 'sign-psbt',
+        psbtHex,
+        signInputs: { [wallet]: [1] },
+        sighashTypes: [0x01, 0x83],
+        marketplaceIntent: intent,
+      }),
+      balances: { [`${ASSET_TXID}:7`]: 'fail' },
+    });
+  }
+
+  // --- buy_listings (proved) and its tampered twin (blocked) --------------------------------
+  {
+    const buildBuy = (seller1Payment: number) => {
+      const inputs: BuiltInput[] = [
+        { txid: FUNDING_TXID, vout: 0, address: wallet, value: 400_000 },
+        { txid: ASSET_TXID, vout: 7, address: SELLER_A, value: 546 },
+        { txid: ASSET_TXID_TWO, vout: 3, address: SELLER_B, value: 330 },
+      ];
+      const outputs: BuiltOutput[] = [
+        { scriptHex: opReturnScript(detachPayload(wallet), FUNDING_TXID), value: 0 },
+        { scriptHex: scriptFor(SELLER_A), value: seller1Payment },
+        { scriptHex: scriptFor(SELLER_B), value: 200_330 },
+        { scriptHex: scriptFor(PLATFORM), value: 5_000 },
+        { scriptHex: scriptFor(wallet), value: 94_000 },
+      ];
+      return buildPsbt(inputs, outputs);
+    };
+    const intentFor = (txid: string) => ({
+      standard: 'counterparty-marketplace',
+      version: 1,
+      action: 'buy_listings',
+      operationId: 'checkout-1',
+      protocolVersion: 'direct_v1',
+      assets: [
+        { asset: 'RAREPEPE', quantityRaw: '1', sourceOutpoint: { txid: ASSET_TXID, vout: 7 } },
+        { asset: 'SPELLS', quantityRaw: '100000000', sourceOutpoint: { txid: ASSET_TXID_TWO, vout: 3 } },
+      ],
+      buyer: wallet,
+      items: [
+        {
+          asset: 'RAREPEPE',
+          quantityRaw: '1',
+          sourceOutpoint: { txid: ASSET_TXID, vout: 7 },
+          listingId: 'listing-1',
+          seller: SELLER_A,
+          carrierValueSats: 546,
+          priceSats: 100_000,
+          sellerPaymentSats: 100_546,
+        },
+        {
+          asset: 'SPELLS',
+          quantityRaw: '100000000',
+          sourceOutpoint: { txid: ASSET_TXID_TWO, vout: 3 },
+          listingId: 'listing-2',
+          seller: SELLER_B,
+          carrierValueSats: 330,
+          priceSats: 200_000,
+          sellerPaymentSats: 200_330,
+        },
+      ],
+      subtotalSats: 300_000,
+      networkFeeSats: 1_000,
+      platformFeeSats: 5_000,
+      totalSats: 306_000,
+      expectedTxid: txid,
+      delivery: { mode: 'detached', address: wallet },
+      marketplaceExpiresAt: FUTURE + 3_600,
+    });
+    const buyBalances = {
+      [`${ASSET_TXID}:7`]: [{ asset: 'RAREPEPE', quantity: '1', quantity_normalized: '1' }],
+      [`${ASSET_TXID_TWO}:3`]: [{ asset: 'SPELLS', quantity: '100000000', quantity_normalized: '1' }],
+    };
+
+    const proved = buildBuy(100_546);
+    scenarios.push({
+      name: 'checkout-buy-proved',
+      route: '/requests/psbt/approve',
+      expectFooter: 'Sign',
+      record: seedRecord('mk-buy', {
+        requestKey: 'xcp_signPsbt:mk-buy',
+        kind: 'sign-psbt',
+        psbtHex: proved.psbtHex,
+        signInputs: { [wallet]: [0] },
+        sighashTypes: [0x01],
+        marketplaceIntent: intentFor(proved.txid),
+      }),
+      balances: buyBalances,
+    });
+
+    // A tampered seller payment: the site's claim no longer matches the bytes.
+    const tampered = buildBuy(100_545);
+    scenarios.push({
+      name: 'checkout-buy-tampered-blocked',
+      route: '/requests/psbt/approve',
+      expectFooter: 'Blocked',
+      record: seedRecord('mk-buy-bad', {
+        requestKey: 'xcp_signPsbt:mk-buy-bad',
+        kind: 'sign-psbt',
+        psbtHex: tampered.psbtHex,
+        signInputs: { [wallet]: [0] },
+        sighashTypes: [0x01],
+        // The intent still claims the original payment, so the mismatch must block.
+        marketplaceIntent: intentFor(tampered.txid),
+      }),
+      balances: buyBalances,
+    });
+  }
+
+  // --- exact offers: buyer authorization (caution) and seller acceptance (proved) -----------
+  {
+    const offer = (accepting: boolean) => {
+      const buyerAddr = accepting ? BUYER_EXT : wallet;
+      const sellerAddr = accepting ? wallet : SELLER_A;
+      const inputs: BuiltInput[] = [
+        { txid: BID_TXID, vout: 4, address: buyerAddr, value: 250_000, signed: accepting },
+        { txid: ASSET_TXID, vout: 7, address: sellerAddr, value: 546 },
+      ];
+      const outputs: BuiltOutput[] = [
+        { scriptHex: opReturnScript(detachPayload(buyerAddr), BID_TXID), value: 0 },
+        { scriptHex: scriptFor(sellerAddr), value: 250_046 },
+      ];
+      const { psbtHex, txid } = buildPsbt(inputs, outputs);
+      const intent = {
+        standard: 'counterparty-marketplace',
+        version: 1,
+        action: accepting ? 'accept_exact_offer' : 'authorize_exact_offer',
+        operationId: 'authorization-1',
+        protocolVersion: 'exact_offer_v1',
+        assets: [{
+          asset: 'RAREPEPE',
+          quantityRaw: '1',
+          sourceOutpoint: { txid: ASSET_TXID, vout: 7 },
+        }],
+        authorizationId: 'authorization-1',
+        bidder: buyerAddr,
+        seller: sellerAddr,
+        priceSats: 250_000,
+        carrierValueSats: 546,
+        sellerProceedsSats: 250_046,
+        networkFeeSats: 500,
+        expectedTxid: txid,
+        delivery: { mode: 'detached', address: buyerAddr },
+        marketplaceExpiresAt: FUTURE + 3_600,
+        bitcoinExpiresAt: null,
+        bitcoinInvalidation: {
+          type: 'spend_funding_outpoint',
+          outpoint: { txid: BID_TXID, vout: 4 },
+        },
+      };
+      return { psbtHex, txid, intent };
+    };
+
+    const authorize = offer(false);
+    scenarios.push({
+      name: 'offer-authorize-caution',
+      route: '/requests/psbt/approve',
+      expectFooter: 'Review',
+      record: seedRecord('mk-authorize', {
+        requestKey: 'xcp_signPsbt:mk-authorize',
+        kind: 'sign-psbt',
+        psbtHex: authorize.psbtHex,
+        signInputs: { [wallet]: [0] },
+        sighashTypes: [0x01],
+        marketplaceIntent: authorize.intent,
+      }),
+      balances: {
+        [`${ASSET_TXID}:7`]: [{ asset: 'RAREPEPE', quantity: '1', quantity_normalized: '1' }],
+      },
+    });
+
+    const accept = offer(true);
+    scenarios.push({
+      name: 'offer-accept-proved',
+      route: '/requests/psbt/approve',
+      expectFooter: 'Sign',
+      record: seedRecord('mk-accept', {
+        requestKey: 'xcp_signPsbt:mk-accept',
+        kind: 'sign-psbt',
+        psbtHex: accept.psbtHex,
+        signInputs: { [wallet]: [1] },
+        sighashTypes: [0x01, 0x01],
+        marketplaceIntent: accept.intent,
+      }),
+      balances: {
+        [`${ASSET_TXID}:7`]: [{ asset: 'RAREPEPE', quantity: '1', quantity_normalized: '1' }],
+      },
+    });
+
+    // The acceptance again, now linked to its CPFP fee-bump child on the bundle screen.
+    const child = buildPsbt(
+      [{ txid: accept.txid, vout: 1, address: wallet, value: 250_046 }],
+      [{ scriptHex: scriptFor(wallet), value: 249_046 }],
+    );
+    scenarios.push({
+      name: 'bundle-accept-cpfp-proved',
+      route: '/requests/psbts/approve',
+      expectFooter: 'Sign',
+      record: seedRecord('mk-bundle', {
+        requestKey: 'xcp_signPsbts:mk-bundle',
+        kind: 'sign-psbts',
+        bundleKind: 'acceptance-cpfp',
+        items: [
+          {
+            psbtHex: accept.psbtHex,
+            signInputs: { [wallet]: [1] },
+            sighashTypes: [0x01, 0x01],
+            marketplaceIntent: accept.intent,
+          },
+          {
+            psbtHex: child.psbtHex,
+            signInputs: { [wallet]: [0] },
+            sighashTypes: [0x01],
+            marketplaceIntent: {
+              standard: 'counterparty-marketplace',
+              version: 1,
+              action: 'bump_acceptance_fee',
+              operationId: 'authorization-1',
+              protocolVersion: 'exact_offer_v1',
+              assets: [{
+                asset: 'RAREPEPE',
+                quantityRaw: '1',
+                sourceOutpoint: { txid: ASSET_TXID, vout: 7 },
+              }],
+              authorizationId: 'authorization-1',
+              seller: wallet,
+              parentExpectedTxid: accept.txid,
+              childExpectedTxid: child.txid,
+              parentSellerProceedsVout: 1,
+              parentSellerProceedsSats: 250_046,
+              parentNetworkFeeSats: 500,
+              childNetworkFeeSats: 1_000,
+              packageFeeSats: 1_500,
+              packageFeeRate: 5,
+              finalSellerProceedsSats: 249_046,
+            },
+          },
+        ],
+      }),
+      balances: {
+        [`${ASSET_TXID}:7`]: [{ asset: 'RAREPEPE', quantity: '1', quantity_normalized: '1' }],
+      },
+    });
+  }
+
+  // --- prepare_bulk_fanout (proved). Plain BTC never signs as a single xcp_signPsbt — the
+  // Counterparty-only gate blocks it there — so the fan-out phase exists only as a bundle. -----
+  {
+    const parents = ['31', '32'].map((seed, index) => {
+      const fundingTxid = seed.repeat(32);
+      const { psbtHex, txid } = buildPsbt(
+        [{ txid: fundingTxid, vout: 2, address: wallet, value: 100_000 }],
+        [
+          { scriptHex: scriptFor(wallet), value: 10_000 },
+          { scriptHex: scriptFor(wallet), value: 10_000 },
+          { scriptHex: scriptFor(wallet), value: 79_000 },
+        ],
+      );
+      return {
+        psbtHex,
+        signInputs: { [wallet]: [0] },
+        sighashTypes: [0x01],
+        marketplaceIntent: {
+          standard: 'counterparty-marketplace',
+          version: 1,
+          action: 'prepare_bulk_fanout',
+          operationId: 'bulk-1',
+          protocolVersion: 'counterparty_bulk_attach_v1',
+          assets: [],
+          batchIndex: index,
+          seller: wallet,
+          fundingOutpoint: { txid: fundingTxid, vout: 2 },
+          fundingValueSats: 100_000,
+          slotCount: 2,
+          slotValueSats: 10_000,
+          networkFeeSats: 1_000,
+          changeSats: 79_000,
+          expectedTxid: txid,
+          operationExpiresAt: FUTURE,
+        },
+      };
+    });
+    scenarios.push({
+      name: 'bundle-bulk-fanout-proved',
+      route: '/requests/psbts/approve',
+      expectFooter: 'Sign',
+      record: seedRecord('mk-fanout', {
+        requestKey: 'xcp_signPsbts:mk-fanout',
+        kind: 'sign-psbts',
+        bundleKind: 'bulk-fanout',
+        items: parents,
+      }),
+      balances: {},
+    });
+  }
+
+  // --- xcp_signBitcoinPsbt: exact website payment (proved) and its tampered twin ------------
+  {
+    const buildPay = (declaredSats: number) => buildPsbt(
+      [{ txid: '31'.repeat(32), vout: 0, address: wallet, value: 100_000 }],
+      [
+        { scriptHex: scriptFor(BUYER_EXT), value: 21_600 },
+        { scriptHex: scriptFor(wallet), value: 77_400 },
+      ],
+    ).psbtHex;
+    const payIntent = (amountSats: number) => ({
+      standard: 'xcp-wallet/bitcoin-payment',
+      version: 1,
+      action: 'pay',
+      outputs: [{ address: BUYER_EXT, amountSats }],
+      description: 'Fund Emblem Vault',
+      reference: 'vault-63',
+    });
+    scenarios.push({
+      name: 'bitcoin-pay-proved',
+      route: '/requests/psbt/approve',
+      expectFooter: 'Sign',
+      record: seedRecord('mk-pay', {
+        requestKey: 'xcp_signBitcoinPsbt:mk-pay',
+        kind: 'sign-psbt',
+        psbtHex: buildPay(21_600),
+        signInputs: { [wallet]: [0] },
+        sighashTypes: [0x01],
+        signingPurpose: 'bitcoin-payment',
+        bitcoinPaymentIntent: payIntent(21_600),
+      }),
+      balances: {},
+    });
+    scenarios.push({
+      name: 'bitcoin-pay-mismatch-blocked',
+      route: '/requests/psbt/approve',
+      expectFooter: 'Blocked',
+      record: seedRecord('mk-pay-bad', {
+        requestKey: 'xcp_signBitcoinPsbt:mk-pay-bad',
+        kind: 'sign-psbt',
+        psbtHex: buildPay(21_600),
+        signInputs: { [wallet]: [0] },
+        sighashTypes: [0x01],
+        signingPurpose: 'bitcoin-payment',
+        // The site declares a different amount than the PSBT pays.
+        bitcoinPaymentIntent: payIntent(21_599),
+      }),
+      balances: {},
+    });
+  }
+
+  return scenarios;
+}
+
+// ---------------------------------------------------------------------------------------------
+// The run
+// ---------------------------------------------------------------------------------------------
+
+// Same deliberate pacing as approval-gallery: the balance lookups are stubbed here, but each
+// screen still makes real decode calls against shared public infrastructure.
+const SCREEN_SPACING_MS = 2_000;
+const settle = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+walletTest('captures every marketplace and provider-safety approval screen', async ({ context, page, extensionId }) => {
+  walletTest.setTimeout(300_000);
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+
+  const wallet = await readActiveAddress(page);
+  const scenarios = buildScenarios(wallet);
+  const captured: string[] = [];
+  const stateMismatches: string[] = [];
+
+  for (const scenario of scenarios) {
+    await settle(SCREEN_SPACING_MS);
+    await page.evaluate(async (record) => {
+      await chrome.storage.session.set({ pending_sign_flow: [record] });
+    }, scenario.record);
+
+    const approval = await context.newPage();
+    await approval.setViewportSize({ width: 380, height: 1400 });
+    await stubUtxoBalances(approval, scenario.balances);
+    await approval.goto(
+      `chrome-extension://${extensionId}/popup.html#${scenario.route}?requestId=${scenario.record.id}`
+    );
+
+    const footer = approval.getByRole('button', { name: /^(sign|review|blocked)$/i });
+    await expect(footer).toBeVisible({ timeout: 60_000 });
+    const footerLabel = (await footer.textContent())?.trim() ?? '';
+    if (footerLabel.toLowerCase() !== scenario.expectFooter.toLowerCase()) {
+      stateMismatches.push(`${scenario.name}: footer reads "${footerLabel}", expected "${scenario.expectFooter}"`);
+    }
+
+    // Open every progressive-disclosure surface so the captured state is the full statement.
+    for (const title of [/^Transaction Details$/, /^Linked Transaction Details$/]) {
+      const toggle = approval.getByText(title);
+      if (await toggle.count()) await toggle.first().click();
+    }
+    await approval.screenshot({ path: path.join(OUT_DIR, `${scenario.name}.png`), fullPage: true });
+
+    const review = approval.getByRole('button', { name: /^review$/i });
+    if (await review.count()) {
+      await review.click();
+      await expect(approval.getByRole('button', { name: 'Back' })).toBeVisible({ timeout: 10_000 });
+      await approval.screenshot({
+        path: path.join(OUT_DIR, `${scenario.name}-attention.png`),
+        fullPage: true,
+      });
+      await approval.getByRole('button', { name: 'Back' }).click();
+    }
+
+    captured.push(scenario.name);
+    await approval.close();
+  }
+
+  expect(stateMismatches, 'scenarios did not reach their expected approval states').toEqual([]);
+  expect(captured).toEqual(scenarios.map((scenario) => scenario.name));
+  console.log(`\nMarketplace gallery: ${captured.length} screens in ${OUT_DIR}\n`);
+});

--- a/e2e/tests/ux-visual-check.spec.ts
+++ b/e2e/tests/ux-visual-check.spec.ts
@@ -5,9 +5,10 @@
  * of each for human review. Intentionally assertion-based rather than pixel
  * golden-image diffing: the app renders in a browser extension and CI (Linux)
  * vs local (Windows) font rendering differs, which would make pixel baselines
- * flaky. These checks fail on real regressions (a missing banner, the amber
- * fee caption disappearing, the Advanced disclosure breaking) without that
- * fragility, and the attached screenshots let a human eyeball the result.
+ * flaky. These checks fail on real regressions (a missing caution on the
+ * attention screen, the Review step disappearing, the Advanced disclosure
+ * breaking) without that fragility, and the attached screenshots let a human
+ * eyeball the result.
  *
  * The approval screen is reached by seeding a pending request into
  * chrome.storage.session (its PSBT decode is local, no dApp connection needed);
@@ -69,9 +70,10 @@ async function seedPsbtAndOpenApproval(page: Page, psbtHex: string, origin = 'ht
   );
   // The PSBT decode is async and its API-enrichment calls fail-and-retry in the
   // test (no dApp backend), so networkidle never settles. Wait for the screen
-  // itself to resolve to either the signable view or an error gate.
+  // itself to resolve to either the signable view or an error gate. A signable
+  // request with cautions labels its footer button Review rather than Sign.
   await expect(
-    page.getByRole('button', { name: 'Sign' }).or(page.getByText('Request Expired'))
+    page.getByRole('button', { name: /^(Sign|Review)$/ }).or(page.getByText('Request Expired'))
   ).toBeVisible({ timeout: 20000 });
 }
 
@@ -96,21 +98,29 @@ walletTest.describe('UX visual check', () => {
     });
   });
 
-  walletTest('approval screen: extracted chrome, amber high-fee caption, severity banner', async ({ page }, testInfo) => {
+  walletTest('approval screen: extracted chrome, Review step with high-fee and severity cautions', async ({ page }, testInfo) => {
     await seedPsbtAndOpenApproval(page, HIGH_FEE_PSBT);
 
-    // Extracted chrome (wallet header dot + site bar + footer).
+    // Extracted chrome (wallet header dot + site bar + footer). The high-fee and
+    // BTC-to-external cautions defer signing behind a Review step, so the footer
+    // reads Review rather than Sign and the main screen stays visually quiet.
     await expect(page.getByText('app.example.com', { exact: true })).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Sign' })).toBeVisible();
+    const review = page.getByRole('button', { name: 'Review' });
+    await expect(review).toBeVisible();
     await expect(page.getByRole('button', { name: 'Cancel' })).toBeVisible();
 
-    // High-fee signal is the amber caption (the standalone banner was removed).
-    await expect(page.getByText(/unusually high/i)).toBeVisible();
+    await testInfo.attach('approval-high-fee', {
+      body: await page.screenshot({ fullPage: true }),
+      contentType: 'image/png',
+    });
 
-    // A severity banner renders through WarningStack/Banner.
+    // The cautions themselves live on the attention screen behind Review: the
+    // high-fee item and the BTC-to-external severity item.
+    await review.click();
+    await expect(page.getByText(/unusually high network fee/i)).toBeVisible();
     await expect(page.getByText(/BTC Sent to External Address/i)).toBeVisible();
 
-    await testInfo.attach('approval-high-fee', {
+    await testInfo.attach('approval-high-fee-attention', {
       body: await page.screenshot({ fullPage: true }),
       contentType: 'image/png',
     });

--- a/src/components/domain/approval/__tests__/approval-warnings.test.ts
+++ b/src/components/domain/approval/__tests__/approval-warnings.test.ts
@@ -77,13 +77,13 @@ describe('buildApprovalWarnings', () => {
       expect(item?.description).toContain('not an address you control');
     });
 
-    it('is a warning when they land on your own output', () => {
+    it('is calm information when they land on your own output', () => {
       const [item] = buildApprovalWarnings({
         ...EMPTY,
         attachedAssetDestination: destination({}),
       });
 
-      expect(item?.severity).toBe('warning');
+      expect(item?.severity).toBe('info');
       expect(item?.title).toBe('Attached assets move to your own output');
       expect(item?.description).not.toContain('not an address you control');
     });
@@ -95,8 +95,31 @@ describe('buildApprovalWarnings', () => {
       });
 
       expect(item?.title).toBe('Attached assets are detached to your address');
+      expect(item?.severity).toBe('info');
       expect(item?.description).toContain('credited back to your address');
       expect(item?.description).not.toContain('output #');
+    });
+
+    it('deduplicates the generic detach warning and includes the exact assets in the destination', () => {
+      const items = buildApprovalWarnings({
+        ...EMPTY,
+        safetyWarnings: [{
+          code: 'detach_all',
+          severity: 'warning',
+          title: 'Moves Everything on the UTXO',
+          message: 'Every asset moves.',
+        }],
+        attachedAssetDestination: destination({ detaches: true }),
+        signedInputsWithAssets: [{
+          inputIndex: 0,
+          utxo: 'a:0',
+          assets: [{ asset: 'RAREPEPE', quantity_normalized: '1' }],
+        }] as unknown as ApprovalWarningInput['signedInputsWithAssets'],
+      });
+
+      expect(items).toHaveLength(1);
+      expect(items[0]?.key).toBe('attached-destination');
+      expect(items[0]?.children).toBeDefined();
     });
 
     it('does not present a SINGLE|ANYONECANPAY placeholder as guaranteed delivery', () => {
@@ -193,7 +216,6 @@ describe('buildApprovalWarnings', () => {
       'safety-0',
       'attached-destination',
       'structure-0',
-      'attached-assets',
       'unknown-status',
     ]);
   });

--- a/src/components/domain/approval/__tests__/approval-warnings.test.ts
+++ b/src/components/domain/approval/__tests__/approval-warnings.test.ts
@@ -25,6 +25,8 @@ const destination = (over: Record<string, unknown>) =>
     sourceInputs: [0],
     destinationVout: 1,
     destinationAddress: undefined,
+    destinationCommitted: true,
+    mode: 'implicit-output',
     ...over,
   }) as ApprovalWarningInput['attachedAssetDestination'];
 
@@ -95,6 +97,38 @@ describe('buildApprovalWarnings', () => {
       expect(item?.title).toBe('Attached assets are detached to your address');
       expect(item?.description).toContain('credited back to your address');
       expect(item?.description).not.toContain('output #');
+    });
+
+    it('does not present a SINGLE|ANYONECANPAY placeholder as guaranteed delivery', () => {
+      const [item] = buildApprovalWarnings({
+        ...EMPTY,
+        attachedAssetDestination: destination({
+          destinationCommitted: false,
+          mode: 'flexible',
+          destinationVout: 0,
+          destinationAddress: 'bc1qplaceholder',
+        }),
+      });
+
+      expect(item?.severity).toBe('danger');
+      expect(item?.title).toBe('Asset delivery is flexible');
+      expect(item?.description).toContain('does not fix the asset destination');
+      expect(item?.description).not.toContain('credited to output');
+    });
+
+    it('names the destination proved by an explicit detach', () => {
+      const [item] = buildApprovalWarnings({
+        ...EMPTY,
+        attachedAssetDestination: destination({
+          detaches: true,
+          mode: 'explicit-detach',
+          destinationVout: null,
+          destinationAddress: 'bc1qbuyer',
+          leavesWallet: true,
+        }),
+      });
+
+      expect(item?.description).toContain('detached to bc1qbuyer');
     });
 
     it('pluralises the source inputs', () => {

--- a/src/components/domain/approval/__tests__/order-card.test.tsx
+++ b/src/components/domain/approval/__tests__/order-card.test.tsx
@@ -96,7 +96,7 @@ describe('OrderCard', () => {
     mockFetchPoolQuote.mockResolvedValue(quote(10_526_400_000));
     render(<OrderCard order={order()} />);
 
-    expect(await screen.findByText(/accepts up to 5\.0% less/)).toBeInTheDocument();
+    expect(await screen.findByText(/Accepts up to 5\.0% below/)).toBeInTheDocument();
   });
 
   it('stays quiet just under the threshold', async () => {

--- a/src/components/domain/approval/approval-attention.test.tsx
+++ b/src/components/domain/approval/approval-attention.test.tsx
@@ -1,0 +1,73 @@
+import '@testing-library/jest-dom/vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { WarningItem } from '@/components/ui/warning-stack';
+import {
+  ApprovalAttentionScreen,
+  ApprovalNotes,
+  highFeeAttentionItem,
+  partitionApprovalItems,
+  verificationAttentionItem,
+} from './approval-attention';
+
+vi.mock('@/components/icons', () => ({
+  FiAlertTriangle: (props: any) => <span {...props} />,
+  FiChevronDown: (props: any) => <span {...props} />,
+  FiInfo: (props: any) => <span {...props} />,
+}));
+
+const items: WarningItem[] = [
+  { key: 'routine', severity: 'info', title: 'Other inputs may be added' },
+  { key: 'scope', severity: 'warning', title: 'Authorization remains valid' },
+  { key: 'loss', severity: 'danger', title: 'BTC is not guaranteed back' },
+];
+
+describe('approval attention presentation', () => {
+  it('partitions routine information away from decision friction', () => {
+    expect(partitionApprovalItems(items)).toEqual({
+      informational: [items[0]],
+      attention: [items[1], items[2]],
+    });
+  });
+
+  it('keeps routine mechanics behind a neutral disclosure', () => {
+    render(<ApprovalNotes items={[items[0]!]} />);
+    expect(screen.getByRole('button', { name: /how this transaction works/i })).toBeInTheDocument();
+    expect(screen.queryByText('Other inputs may be added')).not.toBeInTheDocument();
+  });
+
+  it('requires a separate action-specific confirmation', () => {
+    const onBack = vi.fn();
+    const onConfirm = vi.fn();
+    render(
+      <ApprovalAttentionScreen
+        title="Review authorization"
+        description="Confirm the reusable authorization."
+        items={[items[1]!]}
+        confirmLabel="Authorize offer"
+        busy={false}
+        isHardware={false}
+        onBack={onBack}
+        onConfirm={onConfirm}
+      />
+    );
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Authorization remains valid')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Authorize offer' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+    expect(onConfirm).toHaveBeenCalledOnce();
+    expect(onBack).toHaveBeenCalledOnce();
+  });
+
+  it('uses shared, quantified copy for provider exceptions', () => {
+    expect(highFeeAttentionItem(120_000, 200)).toMatchObject({
+      title: 'Unusually high network fee',
+      description: expect.stringContaining('600 sat/vB'),
+    });
+    expect(verificationAttentionItem('Quantity differs')).toMatchObject({
+      title: expect.stringMatching(/could not reproduce/i),
+      description: expect.stringContaining('Quantity differs'),
+    });
+  });
+});

--- a/src/components/domain/approval/approval-attention.test.tsx
+++ b/src/components/domain/approval/approval-attention.test.tsx
@@ -4,7 +4,6 @@ import { describe, expect, it, vi } from 'vitest';
 import type { WarningItem } from '@/components/ui/warning-stack';
 import {
   ApprovalAttentionScreen,
-  ApprovalNotes,
   highFeeAttentionItem,
   partitionApprovalItems,
   verificationAttentionItem,
@@ -23,17 +22,10 @@ const items: WarningItem[] = [
 ];
 
 describe('approval attention presentation', () => {
-  it('partitions routine information away from decision friction', () => {
+  it('keeps only decision friction, dropping routine information entirely', () => {
     expect(partitionApprovalItems(items)).toEqual({
-      informational: [items[0]],
       attention: [items[1], items[2]],
     });
-  });
-
-  it('keeps routine mechanics behind a neutral disclosure', () => {
-    render(<ApprovalNotes items={[items[0]!]} />);
-    expect(screen.getByRole('button', { name: /how this transaction works/i })).toBeInTheDocument();
-    expect(screen.queryByText('Other inputs may be added')).not.toBeInTheDocument();
   });
 
   it('requires a separate action-specific confirmation', () => {

--- a/src/components/domain/approval/approval-attention.tsx
+++ b/src/components/domain/approval/approval-attention.tsx
@@ -1,0 +1,139 @@
+import type { ReactNode } from 'react';
+import { FiAlertTriangle, FiInfo } from '@/components/icons';
+import { Button } from '@/components/ui/button';
+import { Collapsible } from '@/components/ui/collapsible';
+import type { WarningItem } from '@/components/ui/warning-stack';
+import { divide, roundUp } from '@/core/numeric';
+
+interface ApprovalAttentionScreenProps {
+  title: string;
+  description: string;
+  items: WarningItem[];
+  confirmLabel: string;
+  busy: boolean;
+  isHardware: boolean;
+  onBack: () => void;
+  onConfirm: () => void;
+}
+
+/**
+ * A deliberate second step for an exceptional, but knowingly signable, authorization.
+ *
+ * The ordinary review page stays visually quiet. Only after the user chooses Review does this
+ * screen interrupt the flow and name the consequences that need a second decision. The cards are
+ * deliberately neutral: one danger icon and an action-specific confirmation carry the hierarchy,
+ * instead of painting every independently detected fact red or amber.
+ */
+export function ApprovalAttentionScreen({
+  title,
+  description,
+  items,
+  confirmLabel,
+  busy,
+  isHardware,
+  onBack,
+  onConfirm,
+}: ApprovalAttentionScreenProps) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex h-dvh flex-col bg-gray-50"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="approval-attention-title"
+    >
+      <div className="flex-1 overflow-y-auto p-4">
+        <div className="mx-auto max-w-md space-y-4">
+          <div className="py-3 text-center">
+            <div className="mx-auto mb-3 flex size-10 items-center justify-center rounded-full bg-warning-100">
+              <FiAlertTriangle className="size-5 text-warning-700" aria-hidden="true" />
+            </div>
+            <h1 id="approval-attention-title" className="text-lg font-semibold text-gray-900">
+              {title}
+            </h1>
+            <p className="mx-auto mt-1 max-w-[300px] text-sm text-gray-600">{description}</p>
+          </div>
+
+          <div className="space-y-3">
+            {items.map(item => (
+              <section key={item.key} className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+                <h2 className="text-sm font-semibold text-gray-900">{item.title}</h2>
+                {item.description && (
+                  <p className="mt-1 text-sm leading-5 text-gray-600">{item.description}</p>
+                )}
+                {item.children && <div className="mt-2 text-gray-700">{item.children}</div>}
+              </section>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="border-t border-gray-200 bg-white p-4">
+        <div className="mx-auto grid max-w-md grid-cols-2 gap-3">
+          <Button color="gray" onClick={onBack} disabled={busy} fullWidth>
+            Back
+          </Button>
+          <Button color="blue" onClick={onConfirm} disabled={busy} fullWidth>
+            {busy ? (isHardware ? 'Confirm on device…' : 'Signing…') : confirmLabel}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Routine mechanics stay available without competing visually with real warnings.
+ */
+export function ApprovalNotes({ items }: { items: WarningItem[] }) {
+  if (items.length === 0) return null;
+  return (
+    <Collapsible variant="card" title="How this transaction works">
+      <div className="space-y-3">
+        {items.map(item => (
+          <div key={item.key} className="flex items-start gap-2 text-xs text-gray-600">
+            <FiInfo className="mt-0.5 size-4 flex-shrink-0 text-gray-400" aria-hidden="true" />
+            <div>
+              <p className="font-medium text-gray-700">{item.title}</p>
+              {item.description && <p className="mt-0.5 leading-5">{item.description}</p>}
+              {item.children as ReactNode}
+            </div>
+          </div>
+        ))}
+      </div>
+    </Collapsible>
+  );
+}
+
+/** Preserve the analyzer's fixed ordering while separating routine notes from decision friction. */
+export function partitionApprovalItems(items: WarningItem[]) {
+  return {
+    informational: items.filter(item => item.severity === 'info' || item.severity === 'success'),
+    attention: items.filter(item => item.severity === 'warning' || item.severity === 'danger'),
+  };
+}
+
+/** Keep the fee consequence and its wording identical on raw-transaction and PSBT approvals. */
+export function highFeeAttentionItem(feeSats: number, vsize?: number): WarningItem {
+  const feeRate = vsize && vsize > 0 ? roundUp(divide(feeSats, vsize)).toFixed(0) : null;
+  return {
+    key: 'high-fee',
+    severity: 'warning',
+    title: 'Unusually high network fee',
+    description:
+      `This transaction pays ${feeSats.toLocaleString()} sats` +
+      `${feeRate === null ? '' : ` (about ${feeRate} sat/vB)`}. ` +
+      'Confirm that this fee is intentional.',
+  };
+}
+
+/** A user-disabled decoder check becomes deliberate friction, never a silent fast path. */
+export function verificationAttentionItem(message?: string): WarningItem {
+  return {
+    key: 'verification-warning',
+    severity: 'warning',
+    title: 'The wallet could not reproduce every transaction field',
+    description: message
+      ? `${message} Review this exception before signing.`
+      : 'Strict verification is disabled. Review this exception before signing.',
+  };
+}

--- a/src/components/domain/approval/approval-attention.tsx
+++ b/src/components/domain/approval/approval-attention.tsx
@@ -1,7 +1,5 @@
-import type { ReactNode } from 'react';
-import { FiAlertTriangle, FiInfo } from '@/components/icons';
+import { FiAlertTriangle } from '@/components/icons';
 import { Button } from '@/components/ui/button';
-import { Collapsible } from '@/components/ui/collapsible';
 import type { WarningItem } from '@/components/ui/warning-stack';
 import { divide, roundUp } from '@/core/numeric';
 
@@ -82,32 +80,12 @@ export function ApprovalAttentionScreen({
 }
 
 /**
- * Routine mechanics stay available without competing visually with real warnings.
+ * The items that earn decision friction. Info- and success-severity statements are dropped from
+ * the approval screens entirely — a routine mechanical note next to a signature request reads as
+ * a warning whether or not it is one.
  */
-export function ApprovalNotes({ items }: { items: WarningItem[] }) {
-  if (items.length === 0) return null;
-  return (
-    <Collapsible variant="card" title="How this transaction works">
-      <div className="space-y-3">
-        {items.map(item => (
-          <div key={item.key} className="flex items-start gap-2 text-xs text-gray-600">
-            <FiInfo className="mt-0.5 size-4 flex-shrink-0 text-gray-400" aria-hidden="true" />
-            <div>
-              <p className="font-medium text-gray-700">{item.title}</p>
-              {item.description && <p className="mt-0.5 leading-5">{item.description}</p>}
-              {item.children as ReactNode}
-            </div>
-          </div>
-        ))}
-      </div>
-    </Collapsible>
-  );
-}
-
-/** Preserve the analyzer's fixed ordering while separating routine notes from decision friction. */
 export function partitionApprovalItems(items: WarningItem[]) {
   return {
-    informational: items.filter(item => item.severity === 'info' || item.severity === 'success'),
     attention: items.filter(item => item.severity === 'warning' || item.severity === 'danger'),
   };
 }

--- a/src/components/domain/approval/approval-chrome.test.tsx
+++ b/src/components/domain/approval/approval-chrome.test.tsx
@@ -48,6 +48,9 @@ describe('ApprovalFooter', () => {
 
     rerender(<ApprovalFooter {...base} busy isHardware />);
     expect(screen.getByRole('button', { name: 'Confirm on device…' })).toBeInTheDocument();
+
+    rerender(<ApprovalFooter {...base} signLabel="Review" />);
+    expect(screen.getByRole('button', { name: 'Review' })).toBeInTheDocument();
   });
 
   it('wires cancel and sign handlers', () => {

--- a/src/components/domain/approval/approval-chrome.tsx
+++ b/src/components/domain/approval/approval-chrome.tsx
@@ -105,12 +105,15 @@ export function ApprovalFooter({
   busy,
   blocked,
   isHardware,
+  signLabel = 'Sign',
 }: {
   onCancel: () => void;
   onSign: () => void;
   busy: boolean;
   blocked: boolean;
   isHardware: boolean;
+  /** Use "Review" when signing first opens a focused consequence screen. */
+  signLabel?: string;
 }) {
   return (
     <div className="bg-white border-t border-gray-200 p-4">
@@ -119,7 +122,7 @@ export function ApprovalFooter({
           Cancel
         </Button>
         <Button color="blue" onClick={onSign} disabled={busy || blocked} fullWidth>
-          {busy ? (isHardware ? 'Confirm on device…' : 'Signing…') : blocked ? 'Blocked' : 'Sign'}
+          {busy ? (isHardware ? 'Confirm on device…' : 'Signing…') : blocked ? 'Blocked' : signLabel}
         </Button>
       </div>
     </div>

--- a/src/components/domain/approval/approval-summary-card.test.tsx
+++ b/src/components/domain/approval/approval-summary-card.test.tsx
@@ -8,7 +8,7 @@ const movement = (over: Partial<MoneyMovement> = {}): MoneyMovement => ({
   spent: 100000, backToYou: 5000, atRisk: 0, external: [{ address: 'bc1qexternaldest', value: 90000 }], fee: 5000, net: -95000, incomplete: false, ...over,
 });
 
-const base = { movement: movement(), flexible: false, hasHighFee: false, protocolFeeXcp: null } as const;
+const base = { movement: movement(), hasHighFee: false, protocolFeeXcp: null } as const;
 
 describe('ApprovalSummaryCard', () => {
   it('leads with the Counterparty action and shows money-movement beneath (no BTC headline)', () => {

--- a/src/components/domain/approval/approval-summary-card.tsx
+++ b/src/components/domain/approval/approval-summary-card.tsx
@@ -36,6 +36,8 @@ interface ApprovalSummaryCardProps {
   /** The exact flexibility left by the requested ANYONECANPAY signatures. */
   flexibility?: PsbtFlexibilityKind;
   hasHighFee: boolean;
+  /** The footer opens a focused Review step for caution details. */
+  deferCautions?: boolean;
   /** Outputs exceed inputs; the fee depends on inputs the counterparty has yet to add. */
   unfunded?: boolean;
   /** Counterparty protocol (XCP) fee in sats, if any. */
@@ -55,6 +57,7 @@ export function ApprovalSummaryCard({
   movement,
   flexibility,
   hasHighFee,
+  deferCautions,
   unfunded,
   protocolFeeXcp,
 }: ApprovalSummaryCardProps) {
@@ -78,7 +81,14 @@ export function ApprovalSummaryCard({
           })()}
         </div>
       )}
-      <MoneyMovementView movement={movement} flexibility={flexibility} hasHighFee={hasHighFee} unfunded={unfunded} showHeadline={!txAction && !order} />
+      <MoneyMovementView
+        movement={movement}
+        flexibility={flexibility}
+        hasHighFee={hasHighFee}
+        deferCautions={deferCautions}
+        unfunded={unfunded}
+        showHeadline={!txAction && !order}
+      />
       {protocolFeeXcp != null && protocolFeeXcp > 0 && (
         <div className="mt-1.5 flex items-center justify-center gap-2 text-xs">
           <span className="text-gray-500">Protocol Fee:</span>

--- a/src/components/domain/approval/approval-summary-card.tsx
+++ b/src/components/domain/approval/approval-summary-card.tsx
@@ -13,14 +13,25 @@ import { fromSatoshis } from '@/core/numeric';
  * the destination out of view — on the line that says where the money goes. Truncating instead
  * would reintroduce the lookalike-grinding problem the outputs list deliberately avoids.
  *
+ * With the address on its own line the sentence's trailing "to" dangles ("Send 1 XCP to"), so it
+ * is dropped — the mono line beneath already reads as the destination.
+ *
+ * A description may also carry its own second line ("ASSET\nIssue 1,000"); that comes back as
+ * `subline`, set like the address line but in the text face.
+ *
  * Lives here because both approval screens render this headline, and it was once fixed inline on
  * the transaction screen only, so the PSBT screen kept overflowing.
  */
-export function splitTrailingAddress(description: string): { sentence: string; address?: string } {
-  const match = description.match(
+export function splitTrailingAddress(
+  description: string
+): { sentence: string; address?: string; subline?: string } {
+  const [first, ...rest] = description.split('\n');
+  const subline = rest.length > 0 ? rest.join(' ') : undefined;
+  const match = first!.match(
     /^(.*?)\s((?:bc1|tb1)[023456789acdefghjklmnpqrstuvwxyz]{20,}|[13][1-9A-HJ-NP-Za-km-z]{25,34})$/
   );
-  return match ? { sentence: match[1]!, address: match[2]! } : { sentence: description };
+  if (!match) return { sentence: first!, subline };
+  return { sentence: match[1]!.replace(/\s+to$/, ''), address: match[2]!, subline };
 }
 
 interface ApprovalSummaryCardProps {
@@ -40,6 +51,12 @@ interface ApprovalSummaryCardProps {
   deferCautions?: boolean;
   /** Outputs exceed inputs; the fee depends on inputs the counterparty has yet to add. */
   unfunded?: boolean;
+  /**
+   * Skip the money-movement block. For an unfunded marketplace authorization nothing is moving
+   * yet, and rendering the movement resolves to an alarming "Couldn't be determined" for a state
+   * the semantic facts already describe precisely.
+   */
+  hideMovement?: boolean;
   /** Counterparty protocol (XCP) fee in sats, if any. */
   protocolFeeXcp: number | null;
 }
@@ -59,18 +76,21 @@ export function ApprovalSummaryCard({
   hasHighFee,
   deferCautions,
   unfunded,
+  hideMovement,
   protocolFeeXcp,
 }: ApprovalSummaryCardProps) {
   return (
     <div className="bg-white rounded-lg shadow-sm p-5">
       {order ? <OrderCard order={order} /> : txAction && (
-        <div className="text-center mb-3">
-          <p className="text-xs text-gray-500 mb-1">{txAction.label}</p>
+        <div className={`text-center ${hideMovement ? '' : 'mb-3'}`}>
+          {/* No eyebrow when the page header already names the action (marketplace screens). */}
+          {txAction.label && <p className="text-xs text-gray-500 mb-1">{txAction.label}</p>}
           {(() => {
-            const { sentence, address } = splitTrailingAddress(txAction.description);
+            const { sentence, address, subline } = splitTrailingAddress(txAction.description);
             return (
               <>
                 <p className="text-lg font-bold text-gray-900 break-words">{sentence}</p>
+                {subline && <p className="mt-1 text-sm text-gray-700 break-words">{subline}</p>}
                 {address && (
                   <p className="mt-1 text-sm font-medium font-mono text-gray-700 break-all">
                     {address}
@@ -81,14 +101,16 @@ export function ApprovalSummaryCard({
           })()}
         </div>
       )}
-      <MoneyMovementView
-        movement={movement}
-        flexibility={flexibility}
-        hasHighFee={hasHighFee}
-        deferCautions={deferCautions}
-        unfunded={unfunded}
-        showHeadline={!txAction && !order}
-      />
+      {!hideMovement && (
+        <MoneyMovementView
+          movement={movement}
+          flexibility={flexibility}
+          hasHighFee={hasHighFee}
+          deferCautions={deferCautions}
+          unfunded={unfunded}
+          showHeadline={!txAction && !order}
+        />
+      )}
       {protocolFeeXcp != null && protocolFeeXcp > 0 && (
         <div className="mt-1.5 flex items-center justify-center gap-2 text-xs">
           <span className="text-gray-500">Protocol Fee:</span>

--- a/src/components/domain/approval/approval-summary-card.tsx
+++ b/src/components/domain/approval/approval-summary-card.tsx
@@ -1,6 +1,7 @@
 import type { MoneyMovement } from '@/components/domain/approval/money-movement';
 import { MoneyMovementView } from '@/components/domain/approval/money-movement-view';
 import { type OrderAction, OrderCard } from '@/components/domain/approval/order-card';
+import type { PsbtFlexibilityKind } from '@/components/domain/approval/psbt-flexibility';
 import { formatAmount } from '@/core/format';
 import { fromSatoshis } from '@/core/numeric';
 
@@ -32,8 +33,8 @@ interface ApprovalSummaryCardProps {
   order?: OrderAction | null;
   /** Structural net effect on the signer's wallet. */
   movement: MoneyMovement;
-  /** ANYONECANPAY — the movement can change after signing. */
-  flexible: boolean;
+  /** The exact flexibility left by the requested ANYONECANPAY signatures. */
+  flexibility?: PsbtFlexibilityKind;
   hasHighFee: boolean;
   /** Outputs exceed inputs; the fee depends on inputs the counterparty has yet to add. */
   unfunded?: boolean;
@@ -52,7 +53,7 @@ export function ApprovalSummaryCard({
   txAction,
   order,
   movement,
-  flexible,
+  flexibility,
   hasHighFee,
   unfunded,
   protocolFeeXcp,
@@ -77,7 +78,7 @@ export function ApprovalSummaryCard({
           })()}
         </div>
       )}
-      <MoneyMovementView movement={movement} flexible={flexible} hasHighFee={hasHighFee} unfunded={unfunded} showHeadline={!txAction && !order} />
+      <MoneyMovementView movement={movement} flexibility={flexibility} hasHighFee={hasHighFee} unfunded={unfunded} showHeadline={!txAction && !order} />
       {protocolFeeXcp != null && protocolFeeXcp > 0 && (
         <div className="mt-1.5 flex items-center justify-center gap-2 text-xs">
           <span className="text-gray-500">Protocol Fee:</span>

--- a/src/components/domain/approval/approval-transaction-details.test.tsx
+++ b/src/components/domain/approval/approval-transaction-details.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest';
 import { ApprovalTransactionDetails } from './approval-transaction-details';
 
 describe('ApprovalTransactionDetails', () => {
-  it('shows the same money, asset, recipient, and decoder facts for every signing path', () => {
+  it('shows the same money, asset, and decoder facts for every signing path', () => {
     render(
       <ApprovalTransactionDetails
         txid={'ab'.repeat(32)}
@@ -16,7 +16,6 @@ describe('ApprovalTransactionDetails', () => {
           address: 'bc1qinput',
         }]}
         outputs={[{ index: 0, value: 10_000, type: 'op_return' }]}
-        recipients={[{ asset: 'RAREPEPE', quantity: '1', address: 'bc1qrecipient' }]}
         attachedAssets={[{
           inputIndex: 0,
           utxo: `${'cd'.repeat(32)}:1`,
@@ -33,8 +32,7 @@ describe('ApprovalTransactionDetails', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Transaction Details' }));
 
     expect(screen.getByText('0.00050000 BTC')).toBeInTheDocument();
-    expect(screen.getAllByText('RAREPEPE')).toHaveLength(2);
-    expect(screen.getByText('bc1qrecipient')).toBeInTheDocument();
+    expect(screen.getAllByText('RAREPEPE')).toHaveLength(1);
     expect(screen.getByText('Destination formatting differs')).toBeInTheDocument();
   });
 
@@ -43,7 +41,6 @@ describe('ApprovalTransactionDetails', () => {
       <ApprovalTransactionDetails
         inputs={[{ index: 0, txid: 'ef'.repeat(32), vout: 0 }]}
         outputs={[]}
-        recipients={[]}
         attachedAssets={[{
           inputIndex: 0,
           utxo: `${'ef'.repeat(32)}:0`,

--- a/src/components/domain/approval/approval-transaction-details.test.tsx
+++ b/src/components/domain/approval/approval-transaction-details.test.tsx
@@ -1,0 +1,59 @@
+import '@testing-library/jest-dom/vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ApprovalTransactionDetails } from './approval-transaction-details';
+
+describe('ApprovalTransactionDetails', () => {
+  it('shows the same money, asset, recipient, and decoder facts for every signing path', () => {
+    render(
+      <ApprovalTransactionDetails
+        txid={'ab'.repeat(32)}
+        inputs={[{
+          index: 0,
+          txid: 'cd'.repeat(32),
+          vout: 1,
+          value: 50_000,
+          address: 'bc1qinput',
+        }]}
+        outputs={[{ index: 0, value: 10_000, type: 'op_return' }]}
+        recipients={[{ asset: 'RAREPEPE', quantity: '1', address: 'bc1qrecipient' }]}
+        attachedAssets={[{
+          inputIndex: 0,
+          utxo: `${'cd'.repeat(32)}:1`,
+          assets: [{ asset: 'RAREPEPE', quantity_normalized: '1' }],
+        }]}
+        verification={{
+          passed: false,
+          comparedAgainstApi: true,
+          repackProved: true,
+          mismatches: ['Destination formatting differs'],
+        }}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Transaction Details' }));
+
+    expect(screen.getByText('0.00050000 BTC')).toBeInTheDocument();
+    expect(screen.getAllByText('RAREPEPE')).toHaveLength(2);
+    expect(screen.getByText('bc1qrecipient')).toBeInTheDocument();
+    expect(screen.getByText('Destination formatting differs')).toBeInTheDocument();
+  });
+
+  it('marks unresolved attached-asset status explicitly', () => {
+    render(
+      <ApprovalTransactionDetails
+        inputs={[{ index: 0, txid: 'ef'.repeat(32), vout: 0 }]}
+        outputs={[]}
+        recipients={[]}
+        attachedAssets={[{
+          inputIndex: 0,
+          utxo: `${'ef'.repeat(32)}:0`,
+          assets: [],
+          lookupFailed: true,
+        }]}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Transaction Details' }));
+
+    expect(screen.getByText('Asset status unavailable')).toBeInTheDocument();
+  });
+});

--- a/src/components/domain/approval/approval-transaction-details.tsx
+++ b/src/components/domain/approval/approval-transaction-details.tsx
@@ -20,27 +20,22 @@ interface ApprovalDetailOutput {
   type: string;
 }
 
-interface ApprovalDetailRecipient {
-  asset: string;
-  quantity: string;
-  address: string;
-}
-
 /** The byte-derived transaction facts shared by raw-transaction and PSBT approvals. */
 export function ApprovalTransactionDetails({
   txid,
   inputs,
   outputs,
-  recipients,
   attachedAssets,
   verification,
+  attachVout,
 }: {
   txid?: string;
   inputs: ApprovalDetailInput[];
   outputs: ApprovalDetailOutput[];
-  recipients: ApprovalDetailRecipient[];
   attachedAssets: InputAttachedAssets[];
   verification?: ProviderVerificationResult;
+  /** The output an attach turns into the new asset-bearing UTXO, so the list can mark it. */
+  attachVout?: number;
 }) {
   const attachedByInput = new Map(attachedAssets.map((entry) => [entry.inputIndex, entry]));
 
@@ -110,7 +105,10 @@ export function ApprovalTransactionDetails({
           {outputs.map((output) => (
             <div key={output.index} className="rounded bg-gray-50 p-2 text-xs">
               <div className="flex justify-between">
-                <span className={output.type === 'op_return' ? 'text-purple-600' : 'text-gray-600'}>
+                {/* Counterparty pink, not a warning color: the data output is the protocol
+                    working as designed. Indexed so "New UTXO …:1" maps to a row here. */}
+                <span className={output.type === 'op_return' ? 'text-pink-600' : 'text-gray-600'}>
+                  #{output.index}{' '}
                   {output.type === 'op_return' ? 'OP_RETURN' : output.type.toUpperCase()}
                 </span>
                 <span className="font-medium text-gray-900">
@@ -122,39 +120,22 @@ export function ApprovalTransactionDetails({
                   BTC
                 </span>
               </div>
+              {output.type === 'op_return' && verification?.localUnpack?.success && (
+                <div className="mt-0.5 text-gray-500">Counterparty protocol message</div>
+              )}
               {/* Destinations are shown in full: short address fragments are grindable. */}
               {output.address && (
                 <div className="break-all font-mono text-gray-500" title={output.address}>
                   {formatAddress(output.address, false)}
                 </div>
               )}
+              {attachVout === output.index && (
+                <div className="mt-1 text-purple-700">Assets attach to this output</div>
+              )}
             </div>
           ))}
         </div>
       </div>
-
-      {recipients.length > 0 && (
-        <div>
-          <h4 className="mb-2 text-xs font-medium uppercase text-gray-500">
-            Recipients ({recipients.length})
-          </h4>
-          <div className="space-y-2">
-            {recipients.map((recipient, index) => (
-              <div key={`${recipient.address}-${index}`} className="rounded bg-gray-50 p-2 text-xs">
-                <div className="flex justify-between gap-2">
-                  <span className="truncate text-gray-600">{recipient.asset}</span>
-                  <span className="flex-shrink-0 font-medium text-gray-900">
-                    {recipient.quantity}
-                  </span>
-                </div>
-                <div className="break-all font-mono text-gray-500" title={recipient.address}>
-                  {recipient.address}
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
 
       <VerificationDetails verification={verification} />
     </Collapsible>

--- a/src/components/domain/approval/approval-transaction-details.tsx
+++ b/src/components/domain/approval/approval-transaction-details.tsx
@@ -105,9 +105,9 @@ export function ApprovalTransactionDetails({
           {outputs.map((output) => (
             <div key={output.index} className="rounded bg-gray-50 p-2 text-xs">
               <div className="flex justify-between">
-                {/* Counterparty pink, not a warning color: the data output is the protocol
+                {/* The buttons' blue, not a warning color: the data output is the protocol
                     working as designed. Indexed so "New UTXO …:1" maps to a row here. */}
-                <span className={output.type === 'op_return' ? 'text-pink-600' : 'text-gray-600'}>
+                <span className={output.type === 'op_return' ? 'text-blue-500' : 'text-gray-600'}>
                   #{output.index}{' '}
                   {output.type === 'op_return' ? 'OP_RETURN' : output.type.toUpperCase()}
                 </span>
@@ -121,7 +121,7 @@ export function ApprovalTransactionDetails({
                 </span>
               </div>
               {output.type === 'op_return' && verification?.localUnpack?.success && (
-                <div className="mt-0.5 text-gray-500">Counterparty protocol message</div>
+                <div className="mt-0.5 text-gray-500">Counterparty protocol</div>
               )}
               {/* Destinations are shown in full: short address fragments are grindable. */}
               {output.address && (

--- a/src/components/domain/approval/approval-transaction-details.tsx
+++ b/src/components/domain/approval/approval-transaction-details.tsx
@@ -1,0 +1,162 @@
+import { Collapsible } from '@/components/ui/collapsible';
+import type { InputAttachedAssets } from '@/core/counterparty/inputAssets';
+import type { ProviderVerificationResult } from '@/core/counterparty/unpack/providerVerify';
+import { formatAddress, formatAmount } from '@/core/format';
+import { fromSatoshis } from '@/core/numeric';
+import { VerificationDetails } from './verification-details';
+
+interface ApprovalDetailInput {
+  index: number;
+  txid: string;
+  vout: number;
+  value?: number;
+  address?: string;
+}
+
+interface ApprovalDetailOutput {
+  index: number;
+  value: number;
+  address?: string;
+  type: string;
+}
+
+interface ApprovalDetailRecipient {
+  asset: string;
+  quantity: string;
+  address: string;
+}
+
+/** The byte-derived transaction facts shared by raw-transaction and PSBT approvals. */
+export function ApprovalTransactionDetails({
+  txid,
+  inputs,
+  outputs,
+  recipients,
+  attachedAssets,
+  verification,
+}: {
+  txid?: string;
+  inputs: ApprovalDetailInput[];
+  outputs: ApprovalDetailOutput[];
+  recipients: ApprovalDetailRecipient[];
+  attachedAssets: InputAttachedAssets[];
+  verification?: ProviderVerificationResult;
+}) {
+  const attachedByInput = new Map(attachedAssets.map((entry) => [entry.inputIndex, entry]));
+
+  return (
+    <Collapsible variant="card" title="Transaction Details">
+      {txid && (
+        <div>
+          <h4 className="mb-2 text-xs font-medium uppercase text-gray-500">TX Hash</h4>
+          <div className="break-all rounded bg-gray-50 p-2 text-xs text-gray-600">{txid}</div>
+        </div>
+      )}
+
+      <div>
+        <h4 className="mb-2 text-xs font-medium uppercase text-gray-500">
+          Inputs ({inputs.length})
+        </h4>
+        <div className="space-y-2">
+          {inputs.map((input) => {
+            const inputAssets = attachedByInput.get(input.index);
+            return (
+              <div key={input.index} className="rounded bg-gray-50 p-2 text-xs">
+                <div className="flex justify-between">
+                  <span className="text-gray-600">#{input.index}</span>
+                  {input.value !== undefined && (
+                    <span className="font-medium text-gray-900">
+                      {formatAmount({
+                        value: fromSatoshis(input.value, true),
+                        minimumFractionDigits: 8,
+                        maximumFractionDigits: 8,
+                      })}{' '}
+                      BTC
+                    </span>
+                  )}
+                </div>
+                {input.address && (
+                  <div className="truncate text-gray-500" title={input.address}>
+                    {formatAddress(input.address, true)}
+                  </div>
+                )}
+                <div className="truncate text-gray-400" title={input.txid}>
+                  {input.txid.slice(0, 8)}...:{input.vout}
+                </div>
+                {inputAssets?.assets.map((asset) => (
+                  <div key={asset.asset} className="mt-1 flex justify-between text-purple-700">
+                    <span className="truncate" title={asset.asset_longname ?? asset.asset}>
+                      {asset.asset_longname ?? asset.asset}
+                    </span>
+                    <span className="ml-2 flex-shrink-0 font-medium">
+                      {asset.quantity_normalized}
+                    </span>
+                  </div>
+                ))}
+                {inputAssets?.lookupFailed && (
+                  <div className="mt-1 text-amber-600">Asset status unavailable</div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      <div>
+        <h4 className="mb-2 text-xs font-medium uppercase text-gray-500">
+          Outputs ({outputs.length})
+        </h4>
+        <div className="space-y-2">
+          {outputs.map((output) => (
+            <div key={output.index} className="rounded bg-gray-50 p-2 text-xs">
+              <div className="flex justify-between">
+                <span className={output.type === 'op_return' ? 'text-purple-600' : 'text-gray-600'}>
+                  {output.type === 'op_return' ? 'OP_RETURN' : output.type.toUpperCase()}
+                </span>
+                <span className="font-medium text-gray-900">
+                  {formatAmount({
+                    value: fromSatoshis(output.value, true),
+                    minimumFractionDigits: 8,
+                    maximumFractionDigits: 8,
+                  })}{' '}
+                  BTC
+                </span>
+              </div>
+              {/* Destinations are shown in full: short address fragments are grindable. */}
+              {output.address && (
+                <div className="break-all font-mono text-gray-500" title={output.address}>
+                  {formatAddress(output.address, false)}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {recipients.length > 0 && (
+        <div>
+          <h4 className="mb-2 text-xs font-medium uppercase text-gray-500">
+            Recipients ({recipients.length})
+          </h4>
+          <div className="space-y-2">
+            {recipients.map((recipient, index) => (
+              <div key={`${recipient.address}-${index}`} className="rounded bg-gray-50 p-2 text-xs">
+                <div className="flex justify-between gap-2">
+                  <span className="truncate text-gray-600">{recipient.asset}</span>
+                  <span className="flex-shrink-0 font-medium text-gray-900">
+                    {recipient.quantity}
+                  </span>
+                </div>
+                <div className="break-all font-mono text-gray-500" title={recipient.address}>
+                  {recipient.address}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <VerificationDetails verification={verification} />
+    </Collapsible>
+  );
+}

--- a/src/components/domain/approval/approval-warnings.tsx
+++ b/src/components/domain/approval/approval-warnings.tsx
@@ -38,7 +38,13 @@ export function buildApprovalWarnings({
   signedInputsWithAssets,
   signedInputsUnknownStatus,
 }: ApprovalWarningInput): WarningItem[] {
-  const warningItems: WarningItem[] = safetyWarnings.map((warning, idx) => ({
+  // A resolved attached destination below says where every attached balance goes. The generic
+  // detach warning says only that every balance moves, so showing both turns one fact into two
+  // alarms and makes a routine detach look more suspicious than it is.
+  const presentedSafetyWarnings = attachedAssetDestination
+    ? safetyWarnings.filter((warning) => warning.code !== 'detach_all')
+    : safetyWarnings;
+  const warningItems: WarningItem[] = presentedSafetyWarnings.map((warning, idx) => ({
     key: `safety-${idx}`,
     severity: warning.severity === 'block' ? 'danger' : warning.severity,
     title: warning.title,
@@ -48,6 +54,18 @@ export function buildApprovalWarnings({
   // Where the attached assets land. Spending an attached UTXO moves its balances with no
   // Counterparty message, so without this the screen can say only that assets move, never where —
   // and for an atomic swap that is the whole question.
+  const attachedAssetList = signedInputsWithAssets.length > 0 ? (
+    <ul className="mt-2 space-y-1 text-xs font-medium">
+      {signedInputsWithAssets.flatMap(entry =>
+        entry.assets.map(asset => (
+          <li key={`${entry.inputIndex}-${asset.asset}`}>
+            Input #{entry.inputIndex}: {asset.quantity_normalized} {asset.asset_longname ?? asset.asset}
+          </li>
+        ))
+      )}
+    </ul>
+  ) : undefined;
+
   if (attachedAssetDestination) {
     const dest = attachedAssetDestination;
     if (!dest.destinationCommitted) {
@@ -60,11 +78,12 @@ export function buildApprovalWarnings({
           `${dest.sourceInputs.map((i) => `#${i}`).join(', ')} does not fix the asset destination. ` +
           'Whoever completes this PSBT may choose an explicit detach address or a different first ' +
           'output. Review the exact authorization below.',
+        children: attachedAssetList,
       });
     } else {
     warningItems.push({
       key: 'attached-destination',
-      severity: dest.leavesWallet ? 'danger' : 'warning',
+      severity: dest.leavesWallet ? 'danger' : 'info',
       title: dest.detaches
         ? 'Attached assets are detached to your address'
         : dest.leavesWallet
@@ -81,6 +100,7 @@ export function buildApprovalWarnings({
           `${dest.sourceInputs.map((i) => `#${i}`).join(', ')} is credited to output ` +
           `#${dest.destinationVout}${dest.destinationAddress ? ` (${dest.destinationAddress})` : ''}` +
           `${dest.leavesWallet ? ', which is not an address you control.' : '.'}`,
+      children: attachedAssetList,
     });
     }
   }
@@ -97,23 +117,13 @@ export function buildApprovalWarnings({
     });
   }
 
-  if (signedInputsWithAssets.length > 0) {
+  if (!attachedAssetDestination && signedInputsWithAssets.length > 0) {
     warningItems.push({
       key: 'attached-assets',
       severity: 'warning',
       title: 'Spends UTXOs holding Counterparty assets',
       description: 'Inputs you are signing carry attached assets. Signing moves them, not just BTC.',
-      children: (
-        <ul className="mt-2 space-y-1 text-xs font-medium">
-          {signedInputsWithAssets.flatMap(entry =>
-            entry.assets.map(asset => (
-              <li key={`${entry.inputIndex}-${asset.asset}`}>
-                Input #{entry.inputIndex}: {asset.quantity_normalized} {asset.asset_longname ?? asset.asset}
-              </li>
-            ))
-          )}
-        </ul>
-      ),
+      children: attachedAssetList,
     });
   }
 

--- a/src/components/domain/approval/approval-warnings.tsx
+++ b/src/components/domain/approval/approval-warnings.tsx
@@ -50,6 +50,18 @@ export function buildApprovalWarnings({
   // and for an atomic swap that is the whole question.
   if (attachedAssetDestination) {
     const dest = attachedAssetDestination;
+    if (!dest.destinationCommitted) {
+      warningItems.push({
+        key: 'attached-destination',
+        severity: 'danger',
+        title: 'Asset delivery is flexible',
+        description:
+          `The signature for attached input${dest.sourceInputs.length === 1 ? '' : 's'} ` +
+          `${dest.sourceInputs.map((i) => `#${i}`).join(', ')} does not fix the asset destination. ` +
+          'Whoever completes this PSBT may choose an explicit detach address or a different first ' +
+          'output. Review the exact authorization below.',
+      });
+    } else {
     warningItems.push({
       key: 'attached-destination',
       severity: dest.leavesWallet ? 'danger' : 'warning',
@@ -59,13 +71,18 @@ export function buildApprovalWarnings({
           ? 'Attached assets leave your wallet'
           : 'Attached assets move to your own output',
       description: dest.detaches
-        ? 'This transaction has no ordinary output, so every asset attached to the inputs you are ' +
-          'signing is credited back to your address.'
+        ? dest.mode === 'explicit-detach'
+          ? `Every asset attached to input${dest.sourceInputs.length === 1 ? '' : 's'} ` +
+            `${dest.sourceInputs.map((i) => `#${i}`).join(', ')} is detached to ` +
+            `${dest.destinationAddress ?? 'the source address'}.`
+          : 'This transaction has no ordinary output, so every asset attached to the inputs you are ' +
+            'signing is credited back to your address.'
         : `Every asset attached to input${dest.sourceInputs.length === 1 ? '' : 's'} ` +
           `${dest.sourceInputs.map((i) => `#${i}`).join(', ')} is credited to output ` +
           `#${dest.destinationVout}${dest.destinationAddress ? ` (${dest.destinationAddress})` : ''}` +
           `${dest.leavesWallet ? ', which is not an address you control.' : '.'}`,
     });
+    }
   }
 
   // The message's own references to this transaction, where they do not resolve against it. A

--- a/src/components/domain/approval/approval-warnings.tsx
+++ b/src/components/domain/approval/approval-warnings.tsx
@@ -85,7 +85,9 @@ export function buildApprovalWarnings({
       key: 'attached-destination',
       severity: dest.leavesWallet ? 'danger' : 'info',
       title: dest.detaches
-        ? 'Attached assets are detached to your address'
+        ? dest.leavesWallet
+          ? 'Assets are detached to another address'
+          : 'Attached assets are detached to your address'
         : dest.leavesWallet
           ? 'Attached assets leave your wallet'
           : 'Attached assets move to your own output',

--- a/src/components/domain/approval/bitcoin-payment-card.test.tsx
+++ b/src/components/domain/approval/bitcoin-payment-card.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import type { BitcoinPaymentIntentV1 } from '@/core/bitcoin/providerPayment';
+import { BitcoinPaymentCard } from './bitcoin-payment-card';
+
+const ADDRESS = 'bc1qglv8hh3l23y0qu5uw4zu7e8q4td0gcjsa8f3tq';
+const intent: BitcoinPaymentIntentV1 = {
+  standard: 'xcp-wallet/bitcoin-payment',
+  version: 1,
+  action: 'pay',
+  outputs: [{ address: ADDRESS, amountSats: 21_600 }],
+  description: 'Fund Emblem Vault',
+  reference: 'vault-63',
+};
+
+describe('BitcoinPaymentCard', () => {
+  it('shows a proved site-described payment with its full output terms', () => {
+    render(<BitcoinPaymentCard intent={intent} proof={{
+      proved: true,
+      errors: [],
+      outputs: [{ index: 0, address: ADDRESS, amountSats: 21_600 }],
+      totalSats: 21_600,
+    }} />);
+
+    expect(screen.getByText('Bitcoin payment outputs verified')).toBeInTheDocument();
+    expect(screen.getByText('Site description: Fund Emblem Vault')).toBeInTheDocument();
+    expect(screen.getByText('Reference: vault-63')).toBeInTheDocument();
+    expect(screen.getByText(ADDRESS)).toBeInTheDocument();
+    expect(screen.getByText(/0\.00021600 BTC/)).toBeInTheDocument();
+    expect(screen.getByText(/site name and description are context/i)).toBeInTheDocument();
+  });
+
+  it('never presents an unproved request as verified', () => {
+    render(<BitcoinPaymentCard intent={intent} proof={{
+      proved: false,
+      errors: ['destination differs'],
+      outputs: [],
+      totalSats: 0,
+    }} />);
+
+    expect(screen.getByText('Bitcoin payment did not verify')).toBeInTheDocument();
+    expect(screen.queryByText(ADDRESS)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/domain/approval/bitcoin-payment-card.test.tsx
+++ b/src/components/domain/approval/bitcoin-payment-card.test.tsx
@@ -31,15 +31,26 @@ describe('BitcoinPaymentCard', () => {
     expect(screen.getByText(/site name and description are context/i)).toBeInTheDocument();
   });
 
-  it('never presents an unproved request as verified', () => {
-    render(<BitcoinPaymentCard intent={intent} proof={{
-      proved: false,
-      errors: ['destination differs'],
-      outputs: [],
-      totalSats: 0,
-    }} />);
+  it('shows the claim beside the bytes when the payment does not verify', () => {
+    render(<BitcoinPaymentCard
+      intent={intent}
+      proof={{
+        proved: false,
+        errors: ['the external payment outputs do not exactly match the site intent'],
+        outputs: [{ index: 0, address: ADDRESS, amountSats: 21_599 }],
+        totalSats: 21_599,
+      }}
+      failure={['the external payment outputs do not exactly match the site intent']}
+    />);
 
     expect(screen.getByText('Bitcoin payment did not verify')).toBeInTheDocument();
-    expect(screen.queryByText(ADDRESS)).not.toBeInTheDocument();
+    // The mismatch is inspectable: the declared amount and the actual amount both render.
+    expect(screen.getByText('Site declared')).toBeInTheDocument();
+    expect(screen.getByText(/0\.00021600 BTC/)).toBeInTheDocument();
+    expect(screen.getByText('Transaction pays')).toBeInTheDocument();
+    expect(screen.getByText(/0\.00021599 BTC/)).toBeInTheDocument();
+    expect(screen.getByText(/do not exactly match/)).toBeInTheDocument();
+    // No boilerplate framing — the heading and the reasons carry it.
+    expect(screen.queryByText(/cannot be proved/)).not.toBeInTheDocument();
   });
 });

--- a/src/components/domain/approval/bitcoin-payment-card.tsx
+++ b/src/components/domain/approval/bitcoin-payment-card.tsx
@@ -15,7 +15,9 @@ const btc = (sats: number) => formatAmount({
  * Semantic context for the dedicated plain-Bitcoin provider capability.
  *
  * In the failure state this card is the screen's one voice: the approval page suppresses its
- * generic warning stack for the payment gate, so the concrete reason must be carried here.
+ * generic warning stack for the payment gate, so the concrete reasons must be carried here —
+ * and the mismatch must be inspectable, which means showing the site's claim beside what the
+ * transaction actually pays.
  */
 export function BitcoinPaymentCard({
   intent,
@@ -24,8 +26,8 @@ export function BitcoinPaymentCard({
 }: {
   intent: BitcoinPaymentIntentV1;
   proof: BitcoinPaymentProof | undefined;
-  /** The gating message from the analyzer, when the payment could not be proved. */
-  failure?: string;
+  /** The gating reasons from the analyzer, when the payment could not be proved. */
+  failure?: string[];
 }) {
   return (
     <div className={`rounded-lg border p-4 ${
@@ -65,9 +67,46 @@ export function BitcoinPaymentCard({
           not authority to sign.
         </p>
       ) : (
-        <p className="mt-3 text-xs leading-5 text-danger-800">
-          {failure ?? 'The wallet could not match the declared payment to the PSBT, so signing is blocked.'}
-        </p>
+        <>
+          {/* The claim beside the bytes, so the mismatch is inspectable rather than asserted. */}
+          <div className="mt-3 space-y-2 border-t border-danger-200 pt-3 text-xs text-danger-950">
+            <p className="font-semibold">Site declared</p>
+            {intent.outputs.map((output, index) => (
+              <div key={`declared-${index}`}>
+                <div className="flex justify-between gap-3">
+                  <span>Payment</span>
+                  <span className="font-semibold">{btc(output.amountSats)} BTC</span>
+                </div>
+                <p className="mt-0.5 break-all font-mono text-danger-800">
+                  {formatAddress(output.address, false)}
+                </p>
+              </div>
+            ))}
+            <p className="pt-1 font-semibold">Transaction pays</p>
+            {proof && proof.outputs.length > 0 ? (
+              proof.outputs.map((output) => (
+                <div key={`actual-${output.index}`}>
+                  <div className="flex justify-between gap-3">
+                    <span>Output #{output.index}</span>
+                    <span className="font-semibold">{btc(output.amountSats)} BTC</span>
+                  </div>
+                  <p className="mt-0.5 break-all font-mono text-danger-800">
+                    {formatAddress(output.address, false)}
+                  </p>
+                </div>
+              ))
+            ) : (
+              <p className="text-danger-800">No external payment output</p>
+            )}
+          </div>
+          {failure && failure.length > 0 && (
+            <ul className="mt-3 space-y-1 border-t border-danger-200 pt-3 text-xs leading-5 text-danger-800">
+              {failure.map((reason) => (
+                <li key={reason}>• {reason}</li>
+              ))}
+            </ul>
+          )}
+        </>
       )}
     </div>
   );

--- a/src/components/domain/approval/bitcoin-payment-card.tsx
+++ b/src/components/domain/approval/bitcoin-payment-card.tsx
@@ -1,0 +1,60 @@
+import type {
+  BitcoinPaymentIntentV1,
+  BitcoinPaymentProof,
+} from '@/core/bitcoin/providerPayment';
+import { formatAddress, formatAmount } from '@/core/format';
+import { fromSatoshis } from '@/core/numeric';
+
+const btc = (sats: number) => formatAmount({
+  value: fromSatoshis(sats, true),
+  minimumFractionDigits: 8,
+  maximumFractionDigits: 8,
+});
+
+/** Semantic context for the dedicated plain-Bitcoin provider capability. */
+export function BitcoinPaymentCard({
+  intent,
+  proof,
+}: {
+  intent: BitcoinPaymentIntentV1;
+  proof: BitcoinPaymentProof | undefined;
+}) {
+  return (
+    <div className={`rounded-lg border p-4 ${
+      proof?.proved ? 'border-blue-200 bg-blue-50' : 'border-danger-200 bg-danger-50'
+    }`}>
+      <p className={`text-sm font-semibold ${proof?.proved ? 'text-blue-900' : 'text-danger-900'}`}>
+        {proof?.proved ? 'Bitcoin payment outputs verified' : 'Bitcoin payment did not verify'}
+      </p>
+      {intent.description && (
+        <p className={`mt-1 text-xs ${proof?.proved ? 'text-blue-800' : 'text-danger-800'}`}>
+          Site description: {intent.description}
+        </p>
+      )}
+      {intent.reference && (
+        <p className={`mt-1 text-xs ${proof?.proved ? 'text-blue-700' : 'text-danger-700'}`}>
+          Reference: {intent.reference}
+        </p>
+      )}
+      {proof?.proved && (
+        <div className="mt-3 space-y-2 border-t border-blue-200 pt-3">
+          {proof.outputs.map((output) => (
+            <div key={output.index} className="text-xs text-blue-950">
+              <div className="flex justify-between gap-3">
+                <span>Payment output #{output.index}</span>
+                <span className="font-semibold">{btc(output.amountSats)} BTC</span>
+              </div>
+              <p className="mt-1 break-all font-mono text-blue-800">
+                {formatAddress(output.address, false)}
+              </p>
+            </div>
+          ))}
+        </div>
+      )}
+      <p className={`mt-3 text-xs ${proof?.proved ? 'text-blue-700' : 'text-danger-700'}`}>
+        The wallet matched these terms to the PSBT. The site name and description are context,
+        not authority to sign.
+      </p>
+    </div>
+  );
+}

--- a/src/components/domain/approval/bitcoin-payment-card.tsx
+++ b/src/components/domain/approval/bitcoin-payment-card.tsx
@@ -11,13 +11,21 @@ const btc = (sats: number) => formatAmount({
   maximumFractionDigits: 8,
 });
 
-/** Semantic context for the dedicated plain-Bitcoin provider capability. */
+/**
+ * Semantic context for the dedicated plain-Bitcoin provider capability.
+ *
+ * In the failure state this card is the screen's one voice: the approval page suppresses its
+ * generic warning stack for the payment gate, so the concrete reason must be carried here.
+ */
 export function BitcoinPaymentCard({
   intent,
   proof,
+  failure,
 }: {
   intent: BitcoinPaymentIntentV1;
   proof: BitcoinPaymentProof | undefined;
+  /** The gating message from the analyzer, when the payment could not be proved. */
+  failure?: string;
 }) {
   return (
     <div className={`rounded-lg border p-4 ${
@@ -51,10 +59,16 @@ export function BitcoinPaymentCard({
           ))}
         </div>
       )}
-      <p className={`mt-3 text-xs ${proof?.proved ? 'text-blue-700' : 'text-danger-700'}`}>
-        The wallet matched these terms to the PSBT. The site name and description are context,
-        not authority to sign.
-      </p>
+      {proof?.proved ? (
+        <p className="mt-3 text-xs text-blue-700">
+          The wallet matched these terms to the PSBT. The site name and description are context,
+          not authority to sign.
+        </p>
+      ) : (
+        <p className="mt-3 text-xs leading-5 text-danger-800">
+          {failure ?? 'The wallet could not match the declared payment to the PSBT, so signing is blocked.'}
+        </p>
+      )}
     </div>
   );
 }

--- a/src/components/domain/approval/counterparty-details-card.tsx
+++ b/src/components/domain/approval/counterparty-details-card.tsx
@@ -15,28 +15,65 @@ import type { ProtocolField } from '@/core/counterparty/describe';
  */
 const OWN_LINE_LENGTH = 32;
 
-export function CounterpartyDetailsCard({ fields }: { fields: ProtocolField[] }) {
-  if (fields.length === 0) return null;
+/** An mpma_send recipient: destinations travel in the payload, so this list is the only account of who is paid. */
+export interface CounterpartyDetailRecipient {
+  asset: string;
+  quantity: string;
+  address: string;
+}
+
+export function CounterpartyDetailsCard({
+  fields,
+  recipients = [],
+}: {
+  fields: ProtocolField[];
+  recipients?: CounterpartyDetailRecipient[];
+}) {
+  if (fields.length === 0 && recipients.length === 0) return null;
 
   return (
     <div className="bg-white rounded-lg shadow-sm p-4">
       <h3 className="text-xs font-medium text-gray-500 uppercase mb-2">Counterparty Details</h3>
       <div className="space-y-1.5">
-        {fields.map((field) =>
+        {/* Keyed by label + index: repeated labels are legitimate (one "Detached" row per asset). */}
+        {fields.map((field, index) =>
           field.value.length > OWN_LINE_LENGTH ? (
             // Monospace on its own line, where the digits line up and can be compared.
-            <div key={field.label} className="text-sm">
+            <div key={`${field.label}-${index}`} className="text-sm">
               <div className="text-gray-500">{field.label}</div>
               <div className="text-gray-900 font-mono text-xs break-all mt-0.5">{field.value}</div>
             </div>
           ) : (
-            <div key={field.label} className="flex justify-between gap-3 text-sm">
+            <div key={`${field.label}-${index}`} className="flex justify-between gap-3 text-sm">
               <span className="text-gray-500 flex-shrink-0">{field.label}</span>
               <span className="text-gray-900 font-medium text-right break-all">{field.value}</span>
             </div>
           )
         )}
       </div>
+      {recipients.length > 0 && (
+        <div className={fields.length > 0 ? 'mt-3' : ''}>
+          <h4 className="mb-2 text-xs font-medium uppercase text-gray-500">
+            Recipients ({recipients.length})
+          </h4>
+          <div className="space-y-2">
+            {recipients.map((recipient, index) => (
+              <div key={`${recipient.address}-${index}`} className="rounded bg-gray-50 p-2 text-xs">
+                <div className="flex justify-between gap-2">
+                  <span className="truncate text-gray-600">{recipient.asset}</span>
+                  <span className="flex-shrink-0 font-medium text-gray-900">
+                    {recipient.quantity}
+                  </span>
+                </div>
+                {/* Shown in full: short address fragments are grindable for lookalikes. */}
+                <div className="break-all font-mono text-gray-500" title={recipient.address}>
+                  {recipient.address}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/domain/approval/marketplace-review-card.test.tsx
+++ b/src/components/domain/approval/marketplace-review-card.test.tsx
@@ -20,10 +20,10 @@ describe('MarketplaceReviewCard', () => {
       blockers: [],
     }} />);
 
-    expect(screen.getByText('Terms verified — review authorization')).toBeInTheDocument();
+    expect(screen.getByText('List 1 RAREPEPE for 0.00250000 BTC')).toBeInTheDocument();
+    expect(screen.queryByText('Terms verified — review authorization')).not.toBeInTheDocument();
     expect(screen.getByText('250,546 sats')).toBeInTheDocument();
     expect(screen.getByText(/buyer may add funding inputs/i)).toBeInTheDocument();
-    expect(screen.getByText(/wallet independently checked the transaction bytes/i)).toBeInTheDocument();
   });
 
   it('shows an exact checkout as proved rather than as a scary generic detach', () => {
@@ -42,9 +42,9 @@ describe('MarketplaceReviewCard', () => {
       blockers: [],
     }} />);
 
-    expect(screen.getByText('Marketplace terms verified')).toBeInTheDocument();
+    expect(screen.queryByText('Marketplace terms verified')).not.toBeInTheDocument();
     expect(screen.getByText('306,000 sats')).toBeInTheDocument();
-    expect(screen.getByText(/SIGHASH_ALL fixes every input/i)).toBeInTheDocument();
+    expect(screen.queryByText(/SIGHASH_ALL fixes every input/i)).not.toBeInTheDocument();
   });
 
   it('separates a variable XCP attach quote from wallet-proved Bitcoin terms', () => {
@@ -64,7 +64,7 @@ describe('MarketplaceReviewCard', () => {
     }} />);
 
     expect(screen.getByText('0.25 XCP')).toBeInTheDocument();
-    expect(screen.getByText(/website supplied the label and XCP estimate/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Terms verified/i)).not.toBeInTheDocument();
     expect(screen.getByText(/recomputes it at the block/i)).toBeInTheDocument();
   });
 

--- a/src/components/domain/approval/marketplace-review-card.test.tsx
+++ b/src/components/domain/approval/marketplace-review-card.test.tsx
@@ -78,9 +78,9 @@ describe('MarketplaceReviewCard', () => {
       blockers: ['Asset status is required before signing.'],
     }} />);
 
-    expect(screen.getByText('Verification incomplete — retry required')).toBeInTheDocument();
+    expect(screen.getByText('Verification incomplete — retry')).toBeInTheDocument();
     expect(screen.queryByText('Marketplace terms did not verify')).not.toBeInTheDocument();
-    expect(screen.getByText(/Signing remains blocked until/i)).toBeInTheDocument();
+    expect(screen.getByText(/retry in a moment/i)).toBeInTheDocument();
   });
 
   it('keeps a proved mismatch visually distinct from a retry', () => {

--- a/src/components/domain/approval/marketplace-review-card.test.tsx
+++ b/src/components/domain/approval/marketplace-review-card.test.tsx
@@ -1,0 +1,28 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { MarketplaceReviewCard } from './marketplace-review-card';
+
+describe('MarketplaceReviewCard', () => {
+  it('explains a proved flexible listing without a generic drain warning', () => {
+    render(<MarketplaceReviewCard review={{
+      status: 'caution',
+      family: 'create_listing',
+      title: 'List 1 RAREPEPE for 0.00250000 BTC',
+      facts: [
+        { label: 'Seller receives', value: '250,546 sats' },
+        { label: 'Delivery', value: 'Detached to the eventual buyer' },
+      ],
+      notices: [{
+        severity: 'warning',
+        message: 'The buyer may add funding inputs and choose the detach destination.',
+      }],
+      blockers: [],
+    }} />);
+
+    expect(screen.getByText('Marketplace terms verified')).toBeInTheDocument();
+    expect(screen.getByText('250,546 sats')).toBeInTheDocument();
+    expect(screen.getByText(/buyer may add funding inputs/i)).toBeInTheDocument();
+    expect(screen.getByText(/wallet proved the outpoint/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/domain/approval/marketplace-review-card.test.tsx
+++ b/src/components/domain/approval/marketplace-review-card.test.tsx
@@ -20,7 +20,7 @@ describe('MarketplaceReviewCard', () => {
       blockers: [],
     }} />);
 
-    expect(screen.getByText('Marketplace terms verified')).toBeInTheDocument();
+    expect(screen.getByText('Terms verified — review authorization')).toBeInTheDocument();
     expect(screen.getByText('250,546 sats')).toBeInTheDocument();
     expect(screen.getByText(/buyer may add funding inputs/i)).toBeInTheDocument();
     expect(screen.getByText(/wallet independently checked the transaction bytes/i)).toBeInTheDocument();
@@ -66,5 +66,34 @@ describe('MarketplaceReviewCard', () => {
     expect(screen.getByText('0.25 XCP')).toBeInTheDocument();
     expect(screen.getByText(/website supplied the label and XCP estimate/i)).toBeInTheDocument();
     expect(screen.getByText(/recomputes it at the block/i)).toBeInTheDocument();
+  });
+
+  it('distinguishes a retryable incomplete lookup from a proved mismatch', () => {
+    render(<MarketplaceReviewCard review={{
+      status: 'retry',
+      family: 'buy_listings',
+      title: 'Attached-asset lookup is temporarily unavailable',
+      facts: [],
+      notices: [{ severity: 'warning', message: 'Retry after the indexer responds.' }],
+      blockers: ['Asset status is required before signing.'],
+    }} />);
+
+    expect(screen.getByText('Verification incomplete — retry required')).toBeInTheDocument();
+    expect(screen.queryByText('Marketplace terms did not verify')).not.toBeInTheDocument();
+    expect(screen.getByText(/Signing remains blocked until/i)).toBeInTheDocument();
+  });
+
+  it('keeps a proved mismatch visually distinct from a retry', () => {
+    render(<MarketplaceReviewCard review={{
+      status: 'blocked',
+      family: 'buy_listings',
+      title: 'Seller payment does not match the signed listing',
+      facts: [],
+      notices: [],
+      blockers: ['Seller payment differs.'],
+    }} />);
+
+    expect(screen.getByText('Marketplace terms did not verify')).toBeInTheDocument();
+    expect(screen.getByText(/Signing is blocked/i)).toBeInTheDocument();
   });
 });

--- a/src/components/domain/approval/marketplace-review-card.test.tsx
+++ b/src/components/domain/approval/marketplace-review-card.test.tsx
@@ -23,6 +23,27 @@ describe('MarketplaceReviewCard', () => {
     expect(screen.getByText('Marketplace terms verified')).toBeInTheDocument();
     expect(screen.getByText('250,546 sats')).toBeInTheDocument();
     expect(screen.getByText(/buyer may add funding inputs/i)).toBeInTheDocument();
-    expect(screen.getByText(/wallet proved the outpoint/i)).toBeInTheDocument();
+    expect(screen.getByText(/wallet independently checked the transaction bytes/i)).toBeInTheDocument();
+  });
+
+  it('shows an exact checkout as proved rather than as a scary generic detach', () => {
+    render(<MarketplaceReviewCard review={{
+      status: 'proved',
+      family: 'buy_listings',
+      title: 'Buy 2 collectibles for 0.00306000 BTC',
+      facts: [
+        { label: 'You pay', value: '306,000 sats' },
+        { label: 'Delivery', value: 'Detached to bc1qbuyer' },
+      ],
+      notices: [{
+        severity: 'info',
+        message: 'SIGHASH_ALL fixes every input, seller payment, fee, change output, and destination.',
+      }],
+      blockers: [],
+    }} />);
+
+    expect(screen.getByText('Marketplace terms verified')).toBeInTheDocument();
+    expect(screen.getByText('306,000 sats')).toBeInTheDocument();
+    expect(screen.getByText(/SIGHASH_ALL fixes every input/i)).toBeInTheDocument();
   });
 });

--- a/src/components/domain/approval/marketplace-review-card.test.tsx
+++ b/src/components/domain/approval/marketplace-review-card.test.tsx
@@ -46,4 +46,25 @@ describe('MarketplaceReviewCard', () => {
     expect(screen.getByText('306,000 sats')).toBeInTheDocument();
     expect(screen.getByText(/SIGHASH_ALL fixes every input/i)).toBeInTheDocument();
   });
+
+  it('separates a variable XCP attach quote from wallet-proved Bitcoin terms', () => {
+    render(<MarketplaceReviewCard review={{
+      status: 'caution',
+      family: 'attach_for_listing',
+      title: 'Attach 1 raw unit of RAREPEPE',
+      facts: [
+        { label: 'Network fee', value: '1,000 sats' },
+        { label: 'Quoted XCP fee', value: '0.25 XCP' },
+      ],
+      notices: [{
+        severity: 'warning',
+        message: 'Counterparty recomputes it at the block that confirms this transaction.',
+      }],
+      blockers: [],
+    }} />);
+
+    expect(screen.getByText('0.25 XCP')).toBeInTheDocument();
+    expect(screen.getByText(/website supplied the label and XCP estimate/i)).toBeInTheDocument();
+    expect(screen.getByText(/recomputes it at the block/i)).toBeInTheDocument();
+  });
 });

--- a/src/components/domain/approval/marketplace-review-card.tsx
+++ b/src/components/domain/approval/marketplace-review-card.tsx
@@ -33,7 +33,7 @@ export function MarketplaceReviewCard({ review }: { review: MarketplaceApprovalR
     <div className={`rounded-lg border p-4 ${palette.box}`}>
       {!showFacts && (
         <p className={`text-sm font-semibold ${palette.heading}`}>
-          {retry ? 'Verification incomplete — retry required' : 'Marketplace terms did not verify'}
+          {retry ? 'Verification incomplete — retry' : 'Marketplace terms did not verify'}
         </p>
       )}
       <p className={`${showFacts ? 'font-semibold' : 'mt-1'} text-sm ${palette.heading}`}>
@@ -56,12 +56,23 @@ export function MarketplaceReviewCard({ review }: { review: MarketplaceApprovalR
           {notice.message}
         </p>
       ))}
+      {/* The one and only failure surface: the approval screens suppress their generic warning
+          stacks and error alerts when this card gates signing, so it must say everything. */}
       {!showFacts && (
-        <p className={`mt-3 text-xs ${palette.muted}`}>
-          {retry
-            ? 'The wallet could not complete every required check. Signing remains blocked until the missing facts are available.'
-            : 'The wallet checked the transaction bytes and found marketplace terms it could not prove. Signing is blocked.'}
-        </p>
+        <>
+          <p className={`mt-3 text-xs ${palette.muted}`}>
+            {retry
+              ? "The wallet couldn't verify this against the ledger. Nothing looks wrong with the request — retry in a moment."
+              : 'The wallet checked the transaction bytes and found marketplace terms it could not prove. Signing is blocked.'}
+          </p>
+          {review.blockers.length > 0 && (
+            <ul className={`mt-2 space-y-1 text-xs ${palette.body}`}>
+              {review.blockers.map((blocker) => (
+                <li key={blocker}>• {blocker}</li>
+              ))}
+            </ul>
+          )}
+        </>
       )}
     </div>
   );

--- a/src/components/domain/approval/marketplace-review-card.tsx
+++ b/src/components/domain/approval/marketplace-review-card.tsx
@@ -3,34 +3,58 @@ import type { MarketplaceApprovalReview } from '@/core/counterparty/marketplaceI
 /** Semantic review shown only after the wallet has independently proved the marketplace family. */
 export function MarketplaceReviewCard({ review }: { review: MarketplaceApprovalReview }) {
   const healthy = review.status === 'proved' || review.status === 'caution';
+  const proved = review.status === 'proved';
+  const palette = proved
+    ? {
+        box: 'border-blue-200 bg-blue-50',
+        heading: 'text-blue-950',
+        body: 'text-blue-900',
+        border: 'border-blue-200',
+        muted: 'text-blue-700',
+      }
+    : healthy
+      ? {
+          box: 'border-amber-200 bg-amber-50',
+          heading: 'text-amber-950',
+          body: 'text-amber-900',
+          border: 'border-amber-200',
+          muted: 'text-amber-700',
+        }
+      : {
+          box: 'border-danger-200 bg-danger-50',
+          heading: 'text-danger-900',
+          body: 'text-danger-800',
+          border: 'border-danger-200',
+          muted: 'text-danger-700',
+        };
   return (
-    <div className={`rounded-lg border p-4 ${
-      healthy ? 'border-amber-200 bg-amber-50' : 'border-danger-200 bg-danger-50'
-    }`}>
-      <p className={`text-sm font-semibold ${healthy ? 'text-amber-950' : 'text-danger-900'}`}>
+    <div className={`rounded-lg border p-4 ${palette.box}`}>
+      <p className={`text-sm font-semibold ${palette.heading}`}>
         {healthy ? 'Marketplace terms verified' : 'Marketplace terms did not verify'}
       </p>
-      <p className={`mt-1 text-sm ${healthy ? 'text-amber-900' : 'text-danger-800'}`}>
+      <p className={`mt-1 text-sm ${palette.body}`}>
         {review.title}
       </p>
       {healthy && (
-        <dl className="mt-3 space-y-2 border-t border-amber-200 pt-3 text-xs">
+        <dl className={`mt-3 space-y-2 border-t pt-3 text-xs ${palette.border}`}>
           {review.facts.map((fact) => (
             <div key={fact.label} className="flex justify-between gap-3">
-              <dt className="text-amber-700">{fact.label}</dt>
-              <dd className="max-w-[65%] text-right font-medium text-amber-950">{fact.value}</dd>
+              <dt className={palette.muted}>{fact.label}</dt>
+              <dd className={`max-w-[65%] break-all text-right font-medium ${palette.heading}`}>
+                {fact.value}
+              </dd>
             </div>
           ))}
         </dl>
       )}
       {review.notices.map((notice, index) => (
-        <p key={`${notice.severity}-${index}`} className="mt-3 text-xs text-amber-800">
+        <p key={`${notice.severity}-${index}`} className={`mt-3 text-xs ${palette.body}`}>
           {notice.message}
         </p>
       ))}
-      <p className={`mt-3 text-xs ${healthy ? 'text-amber-700' : 'text-danger-700'}`}>
-        The website supplied the label. The wallet proved the outpoint, asset, signature scope,
-        and exact seller payment from the PSBT and independent balance lookup.
+      <p className={`mt-3 text-xs ${palette.muted}`}>
+        The website supplied the label. The wallet independently checked the transaction bytes,
+        signer scope, attached assets, payments, fees, and delivery terms that apply to this action.
       </p>
     </div>
   );

--- a/src/components/domain/approval/marketplace-review-card.tsx
+++ b/src/components/domain/approval/marketplace-review-card.tsx
@@ -53,8 +53,9 @@ export function MarketplaceReviewCard({ review }: { review: MarketplaceApprovalR
         </p>
       ))}
       <p className={`mt-3 text-xs ${palette.muted}`}>
-        The website supplied the label. The wallet independently checked the transaction bytes,
-        signer scope, attached assets, payments, fees, and delivery terms that apply to this action.
+        {review.family === 'attach_for_listing'
+          ? 'The website supplied the label and XCP estimate. The wallet independently checked the transaction bytes, signer scope, carrier output, Bitcoin fee, and attach terms.'
+          : 'The website supplied the label. The wallet independently checked the transaction bytes, signer scope, attached assets, payments, fees, and delivery terms that apply to this action.'}
       </p>
     </div>
   );

--- a/src/components/domain/approval/marketplace-review-card.tsx
+++ b/src/components/domain/approval/marketplace-review-card.tsx
@@ -6,15 +6,15 @@ export function MarketplaceReviewCard({ review }: { review: MarketplaceApprovalR
   const caution = review.status === 'caution';
   const retry = review.status === 'retry';
   const showFacts = proved || caution;
-  const palette = proved
+  const palette = proved || caution
     ? {
-        box: 'border-blue-200 bg-blue-50',
-        heading: 'text-blue-950',
-        body: 'text-blue-900',
-        border: 'border-blue-200',
-        muted: 'text-blue-700',
+        box: 'border-gray-100 bg-white shadow-sm',
+        heading: 'text-gray-900',
+        body: 'text-gray-600',
+        border: 'border-gray-100',
+        muted: 'text-gray-500',
       }
-    : caution || retry
+    : retry
       ? {
           box: 'border-amber-200 bg-amber-50',
           heading: 'text-amber-950',
@@ -31,16 +31,12 @@ export function MarketplaceReviewCard({ review }: { review: MarketplaceApprovalR
         };
   return (
     <div className={`rounded-lg border p-4 ${palette.box}`}>
-      <p className={`text-sm font-semibold ${palette.heading}`}>
-        {proved
-          ? 'Marketplace terms verified'
-          : caution
-            ? 'Terms verified — review authorization'
-            : retry
-              ? 'Verification incomplete — retry required'
-              : 'Marketplace terms did not verify'}
-      </p>
-      <p className={`mt-1 text-sm ${palette.body}`}>
+      {!showFacts && (
+        <p className={`text-sm font-semibold ${palette.heading}`}>
+          {retry ? 'Verification incomplete — retry required' : 'Marketplace terms did not verify'}
+        </p>
+      )}
+      <p className={`${showFacts ? 'font-semibold' : 'mt-1'} text-sm ${palette.heading}`}>
         {review.title}
       </p>
       {showFacts && (
@@ -55,20 +51,18 @@ export function MarketplaceReviewCard({ review }: { review: MarketplaceApprovalR
           ))}
         </dl>
       )}
-      {review.notices.map((notice, index) => (
-        <p key={`${notice.severity}-${index}`} className={`mt-3 text-xs ${palette.body}`}>
+      {caution && review.notices.map((notice, index) => (
+        <p key={`${notice.severity}-${index}`} className={`mt-3 border-t pt-3 text-xs leading-5 ${palette.border} ${palette.body}`}>
           {notice.message}
         </p>
       ))}
-      <p className={`mt-3 text-xs ${palette.muted}`}>
-        {retry
-          ? 'The wallet could not complete every required check. Signing remains blocked until the missing facts are available.'
-          : review.status === 'blocked'
-            ? 'The wallet checked the transaction bytes and found marketplace terms it could not prove. Signing is blocked.'
-            : review.family === 'attach_for_listing'
-          ? 'The website supplied the label and XCP estimate. The wallet independently checked the transaction bytes, signer scope, carrier output, Bitcoin fee, and attach terms.'
-          : 'The website supplied the label. The wallet independently checked the transaction bytes, signer scope, attached assets, payments, fees, and delivery terms that apply to this action.'}
-      </p>
+      {!showFacts && (
+        <p className={`mt-3 text-xs ${palette.muted}`}>
+          {retry
+            ? 'The wallet could not complete every required check. Signing remains blocked until the missing facts are available.'
+            : 'The wallet checked the transaction bytes and found marketplace terms it could not prove. Signing is blocked.'}
+        </p>
+      )}
     </div>
   );
 }

--- a/src/components/domain/approval/marketplace-review-card.tsx
+++ b/src/components/domain/approval/marketplace-review-card.tsx
@@ -1,0 +1,37 @@
+import type { MarketplaceApprovalReview } from '@/core/counterparty/marketplaceIntent';
+
+/** Semantic review shown only after the wallet has independently proved the marketplace family. */
+export function MarketplaceReviewCard({ review }: { review: MarketplaceApprovalReview }) {
+  const healthy = review.status === 'proved' || review.status === 'caution';
+  return (
+    <div className={`rounded-lg border p-4 ${
+      healthy ? 'border-amber-200 bg-amber-50' : 'border-danger-200 bg-danger-50'
+    }`}>
+      <p className={`text-sm font-semibold ${healthy ? 'text-amber-950' : 'text-danger-900'}`}>
+        {healthy ? 'Marketplace terms verified' : 'Marketplace terms did not verify'}
+      </p>
+      <p className={`mt-1 text-sm ${healthy ? 'text-amber-900' : 'text-danger-800'}`}>
+        {review.title}
+      </p>
+      {healthy && (
+        <dl className="mt-3 space-y-2 border-t border-amber-200 pt-3 text-xs">
+          {review.facts.map((fact) => (
+            <div key={fact.label} className="flex justify-between gap-3">
+              <dt className="text-amber-700">{fact.label}</dt>
+              <dd className="max-w-[65%] text-right font-medium text-amber-950">{fact.value}</dd>
+            </div>
+          ))}
+        </dl>
+      )}
+      {review.notices.map((notice, index) => (
+        <p key={`${notice.severity}-${index}`} className="mt-3 text-xs text-amber-800">
+          {notice.message}
+        </p>
+      ))}
+      <p className={`mt-3 text-xs ${healthy ? 'text-amber-700' : 'text-danger-700'}`}>
+        The website supplied the label. The wallet proved the outpoint, asset, signature scope,
+        and exact seller payment from the PSBT and independent balance lookup.
+      </p>
+    </div>
+  );
+}

--- a/src/components/domain/approval/marketplace-review-card.tsx
+++ b/src/components/domain/approval/marketplace-review-card.tsx
@@ -1,9 +1,11 @@
 import type { MarketplaceApprovalReview } from '@/core/counterparty/marketplaceIntent';
 
-/** Semantic review shown only after the wallet has independently proved the marketplace family. */
+/** Semantic review produced after the wallet independently evaluates the marketplace family. */
 export function MarketplaceReviewCard({ review }: { review: MarketplaceApprovalReview }) {
-  const healthy = review.status === 'proved' || review.status === 'caution';
   const proved = review.status === 'proved';
+  const caution = review.status === 'caution';
+  const retry = review.status === 'retry';
+  const showFacts = proved || caution;
   const palette = proved
     ? {
         box: 'border-blue-200 bg-blue-50',
@@ -12,7 +14,7 @@ export function MarketplaceReviewCard({ review }: { review: MarketplaceApprovalR
         border: 'border-blue-200',
         muted: 'text-blue-700',
       }
-    : healthy
+    : caution || retry
       ? {
           box: 'border-amber-200 bg-amber-50',
           heading: 'text-amber-950',
@@ -30,12 +32,18 @@ export function MarketplaceReviewCard({ review }: { review: MarketplaceApprovalR
   return (
     <div className={`rounded-lg border p-4 ${palette.box}`}>
       <p className={`text-sm font-semibold ${palette.heading}`}>
-        {healthy ? 'Marketplace terms verified' : 'Marketplace terms did not verify'}
+        {proved
+          ? 'Marketplace terms verified'
+          : caution
+            ? 'Terms verified — review authorization'
+            : retry
+              ? 'Verification incomplete — retry required'
+              : 'Marketplace terms did not verify'}
       </p>
       <p className={`mt-1 text-sm ${palette.body}`}>
         {review.title}
       </p>
-      {healthy && (
+      {showFacts && (
         <dl className={`mt-3 space-y-2 border-t pt-3 text-xs ${palette.border}`}>
           {review.facts.map((fact) => (
             <div key={fact.label} className="flex justify-between gap-3">
@@ -53,7 +61,11 @@ export function MarketplaceReviewCard({ review }: { review: MarketplaceApprovalR
         </p>
       ))}
       <p className={`mt-3 text-xs ${palette.muted}`}>
-        {review.family === 'attach_for_listing'
+        {retry
+          ? 'The wallet could not complete every required check. Signing remains blocked until the missing facts are available.'
+          : review.status === 'blocked'
+            ? 'The wallet checked the transaction bytes and found marketplace terms it could not prove. Signing is blocked.'
+            : review.family === 'attach_for_listing'
           ? 'The website supplied the label and XCP estimate. The wallet independently checked the transaction bytes, signer scope, carrier output, Bitcoin fee, and attach terms.'
           : 'The website supplied the label. The wallet independently checked the transaction bytes, signer scope, attached assets, payments, fees, and delivery terms that apply to this action.'}
       </p>

--- a/src/components/domain/approval/money-movement-view.test.tsx
+++ b/src/components/domain/approval/money-movement-view.test.tsx
@@ -74,4 +74,19 @@ describe('MoneyMovementView', () => {
     render(<MoneyMovementView movement={movement({ net: 10000 })} flexibility="outputs-flexible" />);
     expect(screen.getByText(/inputs or outputs may be added or changed/i)).toBeInTheDocument();
   });
+
+  it('keeps quantified cautions neutral when a focused review step presents the warning', () => {
+    render(
+      <MoneyMovementView
+        movement={movement({ net: -50_000, atRisk: 50_000, fee: 1_000 })}
+        flexibility="outputs-flexible"
+        hasHighFee
+        deferCautions
+      />
+    );
+
+    expect(screen.getByText('Not guaranteed back')).toHaveClass('text-gray-500');
+    expect(screen.queryByText(/unusually high/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/may be added or changed/i)).not.toBeInTheDocument();
+  });
 });

--- a/src/components/domain/approval/money-movement-view.test.tsx
+++ b/src/components/domain/approval/money-movement-view.test.tsx
@@ -64,8 +64,14 @@ describe('MoneyMovementView', () => {
     expect(screen.getByText('You send')).toBeInTheDocument();
   });
 
-  it('shows the flexible (ANYONECANPAY) caveat when set', () => {
-    render(<MoneyMovementView movement={movement({ net: 10000 })} flexible />);
-    expect(screen.getByText(/may be added after you sign/i)).toBeInTheDocument();
+  it('says ALL|ANYONECANPAY fixes every current output', () => {
+    render(<MoneyMovementView movement={movement({ net: 10000 })} flexibility="inputs-only" />);
+    expect(screen.getByText(/every current output is fixed/i)).toBeInTheDocument();
+    expect(screen.queryByText(/outputs may be added/i)).not.toBeInTheDocument();
+  });
+
+  it('distinguishes output-flexible signatures', () => {
+    render(<MoneyMovementView movement={movement({ net: 10000 })} flexibility="outputs-flexible" />);
+    expect(screen.getByText(/inputs or outputs may be added or changed/i)).toBeInTheDocument();
   });
 });

--- a/src/components/domain/approval/money-movement-view.tsx
+++ b/src/components/domain/approval/money-movement-view.tsx
@@ -1,4 +1,5 @@
 import type { MoneyMovement } from '@/components/domain/approval/money-movement';
+import type { PsbtFlexibilityKind } from '@/components/domain/approval/psbt-flexibility';
 import { formatAddress, formatAmount } from '@/core/format';
 import { fromSatoshis } from '@/core/numeric';
 
@@ -7,8 +8,8 @@ const btc = (sats: number) =>
 
 interface MoneyMovementViewProps {
   movement: MoneyMovement;
-  /** ANYONECANPAY: inputs/outputs may be added after signing, so the net can change. */
-  flexible?: boolean;
+  /** The exact flexibility left by the requested ANYONECANPAY signatures. */
+  flexibility?: PsbtFlexibilityKind;
   /** Highlight the network fee as unusually high. */
   hasHighFee?: boolean;
   /** The outputs exceed the inputs, so the fee depends on inputs someone else has yet to add. */
@@ -28,7 +29,7 @@ interface MoneyMovementViewProps {
  * would just re-create habituation); genuine anomalies escalate via the warning
  * stack, not here.
  */
-export function MoneyMovementView({ movement, flexible, hasHighFee, unfunded, showHeadline = true }: MoneyMovementViewProps) {
+export function MoneyMovementView({ movement, flexibility, hasHighFee, unfunded, showHeadline = true }: MoneyMovementViewProps) {
   const { net, external, backToYou, atRisk, fee, incomplete } = movement;
   const sending = net < 0;
 
@@ -92,7 +93,7 @@ export function MoneyMovementView({ movement, flexible, hasHighFee, unfunded, sh
           <p className="text-warning-600 text-center">Unusually high — double-check before signing.</p>
         )}
       </div>
-      {(incomplete || flexible || atRisk > 0) && (
+      {(incomplete || flexibility || atRisk > 0) && (
         <div className="mt-2 space-y-1 text-center text-xs">
           {incomplete && (
             <p className="text-warning-600">Some amounts couldn't be determined — review the details.</p>
@@ -102,8 +103,15 @@ export function MoneyMovementView({ movement, flexible, hasHighFee, unfunded, sh
               This can be sent elsewhere after you sign, so the total above counts it as leaving.
             </p>
           )}
-          {flexible && atRisk === 0 && (
-            <p className="text-gray-400">More inputs or outputs may be added after you sign.</p>
+          {flexibility === 'inputs-only' && atRisk === 0 && (
+            <p className="text-gray-400">
+              Other inputs may be added; every current output is fixed by your signature.
+            </p>
+          )}
+          {flexibility === 'outputs-flexible' && atRisk === 0 && (
+            <p className="text-warning-600">
+              Other inputs or outputs may be added or changed after you sign.
+            </p>
           )}
         </div>
       )}

--- a/src/components/domain/approval/money-movement-view.tsx
+++ b/src/components/domain/approval/money-movement-view.tsx
@@ -12,6 +12,8 @@ interface MoneyMovementViewProps {
   flexibility?: PsbtFlexibilityKind;
   /** Highlight the network fee as unusually high. */
   hasHighFee?: boolean;
+  /** A focused Review step presents cautions after the first click; keep this summary neutral. */
+  deferCautions?: boolean;
   /** The outputs exceed the inputs, so the fee depends on inputs someone else has yet to add. */
   unfunded?: boolean;
   /**
@@ -29,7 +31,14 @@ interface MoneyMovementViewProps {
  * would just re-create habituation); genuine anomalies escalate via the warning
  * stack, not here.
  */
-export function MoneyMovementView({ movement, flexibility, hasHighFee, unfunded, showHeadline = true }: MoneyMovementViewProps) {
+export function MoneyMovementView({
+  movement,
+  flexibility,
+  hasHighFee,
+  deferCautions = false,
+  unfunded,
+  showHeadline = true,
+}: MoneyMovementViewProps) {
   const { net, external, backToYou, atRisk, fee, incomplete } = movement;
   const sending = net < 0;
 
@@ -71,13 +80,15 @@ export function MoneyMovementView({ movement, flexibility, hasHighFee, unfunded,
         ))}
         {atRisk > 0 && (
           <div className="flex items-center justify-between gap-2">
-            <span className="text-danger-600">May not return to you</span>
-            <span className="text-danger-600 font-medium flex-shrink-0">{btc(atRisk)} BTC</span>
+            <span className={deferCautions ? 'text-gray-500' : 'text-danger-600'}>Not guaranteed back</span>
+            <span className={`${deferCautions ? 'text-gray-900' : 'text-danger-600'} font-medium flex-shrink-0`}>
+              {btc(atRisk)} BTC
+            </span>
           </div>
         )}
         <div className="flex items-center justify-between gap-2">
           <span className="text-gray-500">Network fee</span>
-          <span className={`font-medium flex-shrink-0 ${hasHighFee ? 'text-warning-600' : 'text-gray-900'}`}>
+          <span className={`font-medium flex-shrink-0 ${hasHighFee && !deferCautions ? 'text-warning-600' : 'text-gray-900'}`}>
             {unfunded ? 'Set by the other party' : `${btc(fee)} BTC`}
           </span>
         </div>
@@ -89,16 +100,18 @@ export function MoneyMovementView({ movement, flexibility, hasHighFee, unfunded,
             <span className="text-gray-400 font-medium flex-shrink-0">{btc(backToYou)} BTC</span>
           </div>
         )}
-        {hasHighFee && (
+        {hasHighFee && !deferCautions && (
           <p className="text-warning-600 text-center">Unusually high — double-check before signing.</p>
         )}
       </div>
-      {(incomplete || flexibility || atRisk > 0) && (
+      {(incomplete
+        || flexibility === 'inputs-only'
+        || (!deferCautions && (flexibility === 'outputs-flexible' || atRisk > 0))) && (
         <div className="mt-2 space-y-1 text-center text-xs">
           {incomplete && (
             <p className="text-warning-600">Some amounts couldn't be determined — review the details.</p>
           )}
-          {atRisk > 0 && (
+          {atRisk > 0 && !deferCautions && (
             <p className="text-danger-600">
               This can be sent elsewhere after you sign, so the total above counts it as leaving.
             </p>
@@ -108,7 +121,7 @@ export function MoneyMovementView({ movement, flexibility, hasHighFee, unfunded,
               Other inputs may be added; every current output is fixed by your signature.
             </p>
           )}
-          {flexibility === 'outputs-flexible' && atRisk === 0 && (
+          {flexibility === 'outputs-flexible' && atRisk === 0 && !deferCautions && (
             <p className="text-warning-600">
               Other inputs or outputs may be added or changed after you sign.
             </p>

--- a/src/components/domain/approval/order-card.tsx
+++ b/src/components/domain/approval/order-card.tsx
@@ -305,8 +305,8 @@ export function OrderCard({ order }: { order: OrderAction }) {
         )}
         {impliedSlippage !== null && impliedSlippage >= 0.05 && (
           <p className="text-xs text-amber-600 mt-1.5">
-            This order accepts up to {(impliedSlippage * 100).toFixed(1)}% less than the wallet's
-            own estimate. Make sure that is the slippage you chose.
+            Accepts up to {(impliedSlippage * 100).toFixed(1)}% below the wallet's estimate —
+            confirm this matches your slippage.
           </p>
         )}
       </div>

--- a/src/components/domain/approval/psbt-flexibility.test.ts
+++ b/src/components/domain/approval/psbt-flexibility.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { describePsbtFlexibility } from './psbt-flexibility';
+
+describe('describePsbtFlexibility', () => {
+  it('is silent when the requested signatures are not ANYONECANPAY', () => {
+    expect(describePsbtFlexibility([{ index: 0, sighashType: 0x01 }], 0)).toBeNull();
+  });
+
+  it('explains that ALL|ANYONECANPAY fixes every current output', () => {
+    expect(describePsbtFlexibility([{ index: 0, sighashType: 0x81 }], 0)).toMatchObject({
+      kind: 'inputs-only',
+      severity: 'info',
+      title: 'Other funding inputs may be added',
+    });
+  });
+
+  it('treats a surviving SINGLE|ANYONECANPAY authorization as output-flexible', () => {
+    expect(describePsbtFlexibility([
+      { index: 0, sighashType: 0x81 },
+      { index: 1, sighashType: 0x83 },
+    ], 0)).toMatchObject({
+      kind: 'outputs-flexible',
+      severity: 'warning',
+      title: 'Only paired outputs are fixed',
+    });
+  });
+
+  it('escalates funds that can be redirected to danger', () => {
+    expect(describePsbtFlexibility([{ index: 1, sighashType: 0x83 }], 50_000)).toMatchObject({
+      kind: 'outputs-flexible',
+      severity: 'danger',
+      title: 'Some of your funds can be redirected',
+    });
+  });
+});

--- a/src/components/domain/approval/psbt-flexibility.ts
+++ b/src/components/domain/approval/psbt-flexibility.ts
@@ -1,0 +1,57 @@
+export type PsbtFlexibilityKind = 'inputs-only' | 'outputs-flexible';
+
+export interface PsbtFlexibilityReview {
+  kind: PsbtFlexibilityKind;
+  severity: 'info' | 'warning' | 'danger';
+  title: string;
+  description: string;
+}
+
+/**
+ * Describe what the signatures requested from this wallet can still authorize after signing.
+ *
+ * ALL|ANYONECANPAY fixes every current output and only permits other inputs to be added.
+ * SINGLE|ANYONECANPAY fixes its same-index output; because an individual ACP input and signature
+ * can survive after the rest are dropped, the weaker detachable signature determines the warning.
+ */
+export function describePsbtFlexibility(
+  signedInputs: Array<{ index: number; sighashType: number }>,
+  atRiskSats: number
+): PsbtFlexibilityReview | null {
+  const anyoneCanPay = signedInputs.filter(({ sighashType }) => (sighashType & 0x80) !== 0);
+  if (anyoneCanPay.length === 0) return null;
+
+  const hasOutputFlexibleSignature = anyoneCanPay.some(
+    ({ sighashType }) => (sighashType & 0x1f) !== 0x01
+  );
+
+  if (atRiskSats > 0) {
+    return {
+      kind: 'outputs-flexible',
+      severity: 'danger',
+      title: 'Some of your funds can be redirected',
+      description:
+        'Part of the amount shown returning to your wallet can be sent somewhere else after you sign.',
+    };
+  }
+
+  if (hasOutputFlexibleSignature) {
+    return {
+      kind: 'outputs-flexible',
+      severity: 'warning',
+      title: 'Only paired outputs are fixed',
+      description:
+        'Each SINGLE|ANYONECANPAY signature fixes only the output with the same index. Other inputs ' +
+        'or outputs may be added or changed after you sign.',
+    };
+  }
+
+  return {
+    kind: 'inputs-only',
+    severity: 'info',
+    title: 'Other funding inputs may be added',
+    description:
+      'Your ALL|ANYONECANPAY signature fixes every current output. It allows other funding inputs ' +
+      'to be added without changing those payments.',
+  };
+}

--- a/src/components/domain/approval/verification-details.test.tsx
+++ b/src/components/domain/approval/verification-details.test.tsx
@@ -1,0 +1,50 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type { ProviderVerificationResult } from '@/core/counterparty/unpack/providerVerify';
+import { VerificationDetails } from './verification-details';
+
+function verification(
+  overrides: Partial<ProviderVerificationResult>,
+): ProviderVerificationResult {
+  return {
+    passed: false,
+    comparedAgainstApi: true,
+    repackProved: false,
+    mismatches: [],
+    ...overrides,
+  };
+}
+
+describe('VerificationDetails', () => {
+  it('is silent when the decoders found no differences', () => {
+    const { container } = render(<VerificationDetails verification={verification({})} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('quietly explains differences that an exact payload rebuild resolved', () => {
+    render(
+      <VerificationDetails
+        verification={verification({
+          repackProved: true,
+          mismatches: ['Quantity: local=1, API=100000000'],
+        })}
+      />,
+    );
+
+    expect(screen.getByText('Decoder differences')).toBeInTheDocument();
+    expect(screen.getByText(/do not block signing/i)).toBeInTheDocument();
+    expect(screen.getByText(/Quantity: local=1/)).toBeInTheDocument();
+  });
+
+  it('does not reassure when the local decode could not be rebuilt', () => {
+    render(
+      <VerificationDetails
+        verification={verification({ mismatches: ['Destination differs'] })}
+      />,
+    );
+
+    expect(screen.getByText(/could not rebuild/i)).toBeInTheDocument();
+    expect(screen.queryByText(/do not block signing/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/domain/approval/verification-details.tsx
+++ b/src/components/domain/approval/verification-details.tsx
@@ -1,0 +1,33 @@
+import type { ProviderVerificationResult } from '@/core/counterparty/unpack/providerVerify';
+
+/**
+ * Keeps decoder disagreements available for an expert review without turning a
+ * successfully rebuilt payload into an alarming top-level warning.
+ */
+export function VerificationDetails({
+  verification,
+}: {
+  verification?: ProviderVerificationResult;
+}) {
+  if (!verification || verification.mismatches.length === 0) return null;
+
+  return (
+    <div>
+      <h4 className="mb-2 text-xs font-medium uppercase text-gray-500">Decoder differences</h4>
+      <div className="rounded bg-gray-50 p-2 text-xs text-gray-600">
+        <p>
+          {verification.repackProved
+            ? 'The Counterparty service described some fields differently. The wallet rebuilt its local decode to the exact payload bytes, so these differences do not block signing.'
+            : 'The wallet and Counterparty service described some fields differently, and the wallet could not rebuild its local decode to the exact payload bytes.'}
+        </p>
+        <ul className="mt-2 list-disc space-y-1 pl-4">
+          {verification.mismatches.map((mismatch, index) => (
+            <li key={`${index}-${mismatch}`} className="break-words">
+              {mismatch}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/src/components/domain/tx/tx-action-info.test.ts
+++ b/src/components/domain/tx/tx-action-info.test.ts
@@ -94,20 +94,20 @@ describe('getTxActionInfo merges what each decoder knows', () => {
     ));
 
     expect(info?.description).toBe(
-      'Deposit liquidity: 1.00000000 XCP and 2.00000000 A95428957068369062'
+      '1.00000000 XCP / 2.00000000 A95428957068369062\n1 XCP = 2 A95428957068369062'
     );
   });
 
-  it('says the decimals are unconfirmed when the API cannot supply divisibility either', () => {
+  it('labels base units when the API cannot supply divisibility either', () => {
     const info = getTxActionInfo(withBoth(
       'pooldeposit',
       { assetA: 'XCP', quantityA: asBaseUnits(100000000), assetB: 'MYSTERY', quantityB: asBaseUnits(200000000) },
       { asset_a: 'XCP', asset_a_info: { divisible: true }, asset_b: 0 },
     ));
 
-    // "base units" is this codebase's vocabulary, not the reader's; the screen says the digits are
-    // right and their scale is not established.
-    expect(info?.description).toContain('200,000,000 (decimals unconfirmed) MYSTERY');
+    // The digits are right and their scale is not established; "base units" is the count that is
+    // correct whichever way the divisibility resolves.
+    expect(info?.description).toContain('200,000,000 (base units) MYSTERY');
   });
 
   it('uses the API description when there is no local unpack to merge with', () => {

--- a/src/components/domain/tx/tx-action-info.ts
+++ b/src/components/domain/tx/tx-action-info.ts
@@ -70,8 +70,9 @@ export function normalizeQuantity(
   // this is reached for every asset but BTC and XCP — and precisely when the API decode failed and
   // the wallet is relying on its own bytes. Printing the bare integer reads as a quantity and is
   // off by 1e8 for any divisible asset: 1.5 PEPECASH as "150,000,000 PEPECASH". Label it so an
-  // unknown is visibly an unknown rather than a confident wrong number.
-  return `${val.toLocaleString()} (decimals unconfirmed)`;
+  // unknown is visibly an unknown rather than a confident wrong number — "base units" because
+  // that count is correct whichever way the divisibility resolves.
+  return `${val.toLocaleString()} (base units)`;
 }
 
 /**
@@ -153,6 +154,24 @@ export function getTxActionInfo(
 }
 
 /**
+ * The output index an attach targets, so the details list can mark which output becomes the new
+ * asset-bearing UTXO. Undefined for non-attach messages and for an attach that leaves the index
+ * to core's default.
+ */
+export function attachDestinationVout(source: TxActionSource): number | undefined {
+  const unpack = source.verification?.localUnpack;
+  if (unpack?.success && unpack.messageType === 'attach') {
+    const vout = (unpack.data as { destinationVout?: number }).destinationVout;
+    if (typeof vout === 'number') return vout;
+  }
+  if (source.counterpartyMessage?.messageType === 'attach') {
+    const raw = source.counterpartyMessage.messageData?.destination_vout;
+    if (raw != null && Number.isFinite(Number(raw))) return Number(raw);
+  }
+  return undefined;
+}
+
+/**
  * Adapt a local unpack into the shared describer's view.
  *
  * The unpacker uses camelCase and carries asset names but no divisibility, so quantities are
@@ -217,6 +236,9 @@ function fromLocalUnpack(
       : undefined,
     feeRequired: data.feeRequired,
     lpAsset: data.lpAsset as string | undefined,
+    minLpQuantity: data.minLpQuantity,
+    minQuantityA: data.minQuantityA,
+    minQuantityB: data.minQuantityB,
     recipients: sends as { asset?: string; destination: string; quantity: unknown }[] | undefined,
     dispenserStatus: data.status as number | undefined,
     format: (quantity, asset) => {
@@ -224,7 +246,7 @@ function fromLocalUnpack(
       const divisible = divisibilityOf(asset);
       if (divisible === true) return fromSatoshis(String(quantity), { removeTrailingZeros: false });
       if (divisible === false) return BigInt(String(quantity)).toLocaleString();
-      return `${BigInt(String(quantity)).toLocaleString()} (decimals unconfirmed)`;
+      return `${BigInt(String(quantity)).toLocaleString()} (base units)`;
     },
     // The same value with nothing added, for the figures that get divided rather than displayed.
     // Undefined where divisibility is unknown: a derived rate computed on a guessed scale is wrong

--- a/src/components/domain/tx/verification-status.test.tsx
+++ b/src/components/domain/tx/verification-status.test.tsx
@@ -25,6 +25,8 @@ describe('VerificationStatus', () => {
 
     expect(screen.getByText(/signing blocked/i)).toBeInTheDocument();
     expect(screen.getByText('Quantity differs')).toBeInTheDocument();
+    expect(screen.getByText(/ask the site to rebuild/i)).toBeInTheDocument();
+    expect(screen.queryByText(/disable|settings.*advanced/i)).not.toBeInTheDocument();
   });
 
   it('warns rather than blocks when strict mode is off', () => {

--- a/src/components/domain/tx/verification-status.tsx
+++ b/src/components/domain/tx/verification-status.tsx
@@ -69,8 +69,8 @@ export function VerificationStatus({
           {warning && <p className="text-xs mt-1">{warning}</p>}
           {shouldBlock && (
             <p className="text-xs mt-2">
-              Strict transaction verification is enabled. You can disable this in
-              Settings &gt; Advanced to proceed with warnings only.
+              Retry the request or ask the site to rebuild it. Do not approve a replacement
+              transaction you cannot verify.
             </p>
           )}
         </div>

--- a/src/components/domain/tx/verification-status.tsx
+++ b/src/components/domain/tx/verification-status.tsx
@@ -46,7 +46,8 @@ export function VerificationStatus({
   //
   // Silence also happens to be the most honest option available: it claims nothing at all, which
   // is the right claim to make whether the decode was proved complete or merely not contradicted.
-  // The outcome is still reported, quietly, inside Transaction Details for anyone who looks.
+  // Any decoder disagreement is still reported, quietly, inside Transaction Details for anyone
+  // who looks.
   if (passed === true) {
     return null;
   }

--- a/src/core/bitcoin/__tests__/providerPayment.test.ts
+++ b/src/core/bitcoin/__tests__/providerPayment.test.ts
@@ -5,6 +5,7 @@ import {
 } from '../providerPayment';
 
 const SIGNER = 'bc1qvux25709r4uw6rzc8wyl7wwecjdhrx085hm5ty';
+const LEGACY_SIGNER = '1FvyAqqELFiQyaEWdhFbWF8MZapKPZS8J7';
 const VAULT = 'bc1qglv8hh3l23y0qu5uw4zu7e8q4td0gcjsa8f3tq';
 
 const intent = () => parseBitcoinPaymentIntent({
@@ -46,6 +47,19 @@ describe('plain Bitcoin provider intent', () => {
       { index: 0, value: 21_600, type: 'witness_v0_keyhash', address: VAULT },
       { index: 1, value: 28_982, type: 'witness_v0_keyhash', address: SIGNER.toUpperCase() },
     ], [SIGNER])).toEqual({
+      proved: true,
+      errors: [],
+      outputs: [{ index: 0, address: VAULT, amountSats: 21_600 }],
+      totalSats: 21_600,
+    });
+  });
+
+  it('excludes change to both permissioned Legacy and SegWit signer addresses', () => {
+    expect(proveBitcoinPaymentIntent(intent(), [
+      { index: 0, value: 21_600, type: 'witness_v0_keyhash', address: VAULT },
+      { index: 1, value: 10_000, type: 'pubkeyhash', address: LEGACY_SIGNER },
+      { index: 2, value: 18_982, type: 'witness_v0_keyhash', address: SIGNER },
+    ], [LEGACY_SIGNER, SIGNER])).toEqual({
       proved: true,
       errors: [],
       outputs: [{ index: 0, address: VAULT, amountSats: 21_600 }],

--- a/src/core/bitcoin/__tests__/providerPayment.test.ts
+++ b/src/core/bitcoin/__tests__/providerPayment.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import {
+  parseBitcoinPaymentIntent,
+  proveBitcoinPaymentIntent,
+} from '../providerPayment';
+
+const SIGNER = 'bc1qvux25709r4uw6rzc8wyl7wwecjdhrx085hm5ty';
+const VAULT = 'bc1qglv8hh3l23y0qu5uw4zu7e8q4td0gcjsa8f3tq';
+
+const intent = () => parseBitcoinPaymentIntent({
+  standard: 'xcp-wallet/bitcoin-payment',
+  version: 1,
+  action: 'pay',
+  outputs: [{ address: VAULT, amountSats: 21_600 }],
+  description: 'Fund Emblem Vault',
+  reference: 'vault-63',
+});
+
+describe('plain Bitcoin provider intent', () => {
+  it('parses a bounded, versioned claim without treating its label as proof', () => {
+    expect(intent()).toEqual({
+      standard: 'xcp-wallet/bitcoin-payment',
+      version: 1,
+      action: 'pay',
+      outputs: [{ address: VAULT, amountSats: 21_600 }],
+      description: 'Fund Emblem Vault',
+      reference: 'vault-63',
+    });
+  });
+
+  it.each([
+    null,
+    {},
+    { standard: 'other', version: 1, action: 'pay', outputs: [] },
+    { standard: 'xcp-wallet/bitcoin-payment', version: 1, action: 'pay', outputs: [] },
+    {
+      standard: 'xcp-wallet/bitcoin-payment', version: 1, action: 'pay',
+      outputs: [{ address: VAULT, amountSats: Number.MAX_SAFE_INTEGER + 1 }],
+    },
+  ])('rejects malformed wire claims (%j)', (candidate) => {
+    expect(() => parseBitcoinPaymentIntent(candidate)).toThrow();
+  });
+
+  it('proves the exact external output while excluding wallet change', () => {
+    expect(proveBitcoinPaymentIntent(intent(), [
+      { index: 0, value: 21_600, type: 'witness_v0_keyhash', address: VAULT },
+      { index: 1, value: 28_982, type: 'witness_v0_keyhash', address: SIGNER.toUpperCase() },
+    ], [SIGNER])).toEqual({
+      proved: true,
+      errors: [],
+      outputs: [{ index: 0, address: VAULT, amountSats: 21_600 }],
+      totalSats: 21_600,
+    });
+  });
+
+  it.each([
+    {
+      name: 'amount substitution',
+      outputs: [{ index: 0, value: 21_601, type: 'witness_v0_keyhash', address: VAULT }],
+    },
+    {
+      name: 'address substitution',
+      outputs: [{ index: 0, value: 21_600, type: 'witness_v0_keyhash', address: SIGNER }],
+    },
+    {
+      name: 'hidden second payment',
+      outputs: [
+        { index: 0, value: 21_600, type: 'witness_v0_keyhash', address: VAULT },
+        { index: 1, value: 1_000, type: 'witness_v0_keyhash', address: '1AttackerAddressxxxxxxxxxxxxxx' },
+      ],
+    },
+    {
+      name: 'unreviewable script',
+      outputs: [{ index: 0, value: 21_600, type: 'unknown' }],
+    },
+    {
+      name: 'data output',
+      outputs: [
+        { index: 0, value: 21_600, type: 'witness_v0_keyhash', address: VAULT },
+        { index: 1, value: 0, type: 'op_return' },
+      ],
+    },
+  ])('blocks $name', ({ outputs }) => {
+    expect(proveBitcoinPaymentIntent(intent(), outputs, [SIGNER]).proved).toBe(false);
+  });
+});

--- a/src/core/bitcoin/__tests__/psbt.test.ts
+++ b/src/core/bitcoin/__tests__/psbt.test.ts
@@ -170,6 +170,11 @@ describe('parsePSBT', () => {
 });
 
 describe('extractPsbtDetails', () => {
+  it('computes the unsigned transaction id locally from the PSBT', () => {
+    const psbtHex = createTestPsbt();
+    expect(extractPsbtDetails(psbtHex).transactionId).toBe(parsePSBT(psbtHex).id);
+  });
+
   it('should extract inputs from PSBT', () => {
     const psbtHex = createTestPsbt();
     const details = extractPsbtDetails(psbtHex);

--- a/src/core/bitcoin/__tests__/psbt.test.ts
+++ b/src/core/bitcoin/__tests__/psbt.test.ts
@@ -175,6 +175,12 @@ describe('extractPsbtDetails', () => {
     expect(extractPsbtDetails(psbtHex).transactionId).toBe(parsePSBT(psbtHex).id);
   });
 
+  it('extracts the transaction version and locktime from the PSBT', () => {
+    const details = extractPsbtDetails(createTestPsbt());
+    expect(details.transactionVersion).toBe(2);
+    expect(details.lockTime).toBe(0);
+  });
+
   it('should extract inputs from PSBT', () => {
     const psbtHex = createTestPsbt();
     const details = extractPsbtDetails(psbtHex);

--- a/src/core/bitcoin/__tests__/saneFeeRate.test.ts
+++ b/src/core/bitcoin/__tests__/saneFeeRate.test.ts
@@ -37,6 +37,18 @@ describe('exceedsSaneFeeRate', () => {
     expect(exceedsSaneFeeRate(HIGH_FEE_RATE_WARNING * 200 + 200, 200)).toBe(true);
   });
 
+  it('uses a current network quote without warning about ordinary urgency', () => {
+    // At a 75 sat/vB fastest quote, the relative 750 sat/vB threshold replaces the 500 sat/vB
+    // fallback. A 600 sat/vB CPFP is expensive but not ten times the current urgent rate.
+    expect(exceedsSaneFeeRate(120_000, 200, 75)).toBe(false);
+    expect(exceedsSaneFeeRate(160_000, 200, 75)).toBe(true);
+  });
+
+  it('keeps a floor when the mempool is quiet', () => {
+    expect(exceedsSaneFeeRate(20_000, 200, 1)).toBe(false); // exactly 100 sat/vB
+    expect(exceedsSaneFeeRate(20_200, 200, 1)).toBe(true);
+  });
+
   it('says nothing when the fee or size is unknown', () => {
     // An unresolvable fee is not evidence of an absurd one; other checks cover that case.
     expect(exceedsSaneFeeRate(null, 200)).toBe(false);

--- a/src/core/bitcoin/address.ts
+++ b/src/core/bitcoin/address.ts
@@ -38,9 +38,12 @@ export const AddressFormat = {
  */
 export type AddressFormat = typeof AddressFormat[keyof typeof AddressFormat];
 
-/** Normalize only Bech32 addresses; Base58 addresses remain case-sensitive. */
+/** Normalize only Bech32/Bech32m addresses; Base58 addresses remain case-sensitive. */
 export function normalizeAddressForComparison(address: string): string {
-  return address.toLowerCase().startsWith('bc1') ? address.toLowerCase() : address;
+  const lower = address.toLowerCase();
+  return lower.startsWith('bc1') || lower.startsWith('tb1') || lower.startsWith('bcrt1')
+    ? lower
+    : address;
 }
 
 /**

--- a/src/core/bitcoin/feeVerification.ts
+++ b/src/core/bitcoin/feeVerification.ts
@@ -42,6 +42,10 @@ export const MAX_SANE_FEE_RATE = 5000;
  * reasons the wallet cannot see (see `transaction/approve.tsx`).
  */
 export const HIGH_FEE_RATE_WARNING = 500;
+/** Never warn below this rate merely because the current mempool is unusually quiet. */
+export const HIGH_FEE_RATE_WARNING_FLOOR = 100;
+/** A site-selected rate this many times the fastest current quote deserves a second look. */
+export const NETWORK_FEE_RATE_WARNING_MULTIPLIER = 10;
 /** When the user chose a fee rate, reject fees beyond this multiple of it. */
 export const USER_FEE_RATE_TOLERANCE = 10;
 /** Absolute floor so tiny transactions aren't rejected by rate rounding. */
@@ -59,10 +63,22 @@ const MIN_BOUND_SATS = 10_000;
  * @param fee - Miner fee in sats, or null when it could not be established.
  * @param vsize - Transaction virtual size in vbytes.
  */
-export function exceedsSaneFeeRate(fee: number | null | undefined, vsize: number | undefined): boolean {
+export function exceedsSaneFeeRate(
+  fee: number | null | undefined,
+  vsize: number | undefined,
+  fastestFeeRate?: number | null,
+): boolean {
   if (fee == null || !Number.isFinite(fee) || fee <= 0) return false;
   if (!vsize || !Number.isFinite(vsize) || vsize <= 0) return false;
-  return fee / vsize > HIGH_FEE_RATE_WARNING;
+  const relativeThreshold = fastestFeeRate != null
+    && Number.isFinite(fastestFeeRate)
+    && fastestFeeRate > 0
+    ? Math.max(
+        HIGH_FEE_RATE_WARNING_FLOOR,
+        fastestFeeRate * NETWORK_FEE_RATE_WARNING_MULTIPLIER,
+      )
+    : HIGH_FEE_RATE_WARNING;
+  return fee / vsize > relativeThreshold;
 }
 
 export interface FeeCheckInput {

--- a/src/core/bitcoin/providerPayment.ts
+++ b/src/core/bitcoin/providerPayment.ts
@@ -1,0 +1,139 @@
+import { normalizeAddressForComparison } from '@/core/bitcoin/address';
+
+export const BITCOIN_PAYMENT_INTENT_STANDARD = 'xcp-wallet/bitcoin-payment' as const;
+export const BITCOIN_PAYMENT_INTENT_VERSION = 1 as const;
+
+export interface BitcoinPaymentIntentV1 {
+  standard: typeof BITCOIN_PAYMENT_INTENT_STANDARD;
+  version: typeof BITCOIN_PAYMENT_INTENT_VERSION;
+  action: 'pay';
+  outputs: Array<{ address: string; amountSats: number }>;
+  /** Site-supplied context. Displayed as a claim, never used as proof. */
+  description?: string;
+  /** Optional site reference such as an Emblem vault id. */
+  reference?: string;
+}
+
+export interface BitcoinPaymentOutput {
+  index: number;
+  value: number;
+  type: string;
+  address?: string;
+}
+
+export interface BitcoinPaymentProof {
+  proved: boolean;
+  errors: string[];
+  outputs: Array<{ index: number; address: string; amountSats: number }>;
+  totalSats: number;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+/**
+ * Validate the provider wire shape before persisting it. The result is still an
+ * untrusted claim; proveBitcoinPaymentIntent binds it to the decoded PSBT.
+ */
+export function parseBitcoinPaymentIntent(value: unknown): BitcoinPaymentIntentV1 {
+  if (!isRecord(value)) throw new Error('intent must be an object');
+  if (value.standard !== BITCOIN_PAYMENT_INTENT_STANDARD || value.version !== 1) {
+    throw new Error(`intent must use ${BITCOIN_PAYMENT_INTENT_STANDARD} version 1`);
+  }
+  if (value.action !== 'pay') throw new Error('intent action must be pay');
+  if (!Array.isArray(value.outputs) || value.outputs.length < 1 || value.outputs.length > 20) {
+    throw new Error('intent outputs must contain 1 to 20 payments');
+  }
+
+  const outputs = value.outputs.map((candidate, index) => {
+    if (!isRecord(candidate)) throw new Error(`intent output ${index} must be an object`);
+    if (typeof candidate.address !== 'string' || candidate.address.length < 8 || candidate.address.length > 128) {
+      throw new Error(`intent output ${index} has an invalid address`);
+    }
+    if (
+      typeof candidate.amountSats !== 'number'
+      || !Number.isSafeInteger(candidate.amountSats)
+      || candidate.amountSats <= 0
+    ) {
+      throw new Error(`intent output ${index} amountSats must be a positive safe integer`);
+    }
+    return { address: candidate.address, amountSats: candidate.amountSats };
+  });
+
+  const optionalText = (field: 'description' | 'reference', max: number): string | undefined => {
+    const candidate = value[field];
+    if (candidate === undefined) return undefined;
+    if (typeof candidate !== 'string' || candidate.length < 1 || candidate.length > max) {
+      throw new Error(`intent ${field} must be a non-empty string of at most ${max} characters`);
+    }
+    return candidate;
+  };
+
+  return {
+    standard: BITCOIN_PAYMENT_INTENT_STANDARD,
+    version: BITCOIN_PAYMENT_INTENT_VERSION,
+    action: 'pay',
+    outputs,
+    ...(value.description === undefined ? {} : { description: optionalText('description', 120) }),
+    ...(value.reference === undefined ? {} : { reference: optionalText('reference', 160) }),
+  };
+}
+
+const paymentKey = (address: string, amountSats: number): string =>
+  `${normalizeAddressForComparison(address)}\u0000${amountSats}`;
+
+/**
+ * Prove the exact external-output set. Wallet-owned outputs are change; every
+ * other output must be addressable and appear exactly once in the claim.
+ */
+export function proveBitcoinPaymentIntent(
+  intent: BitcoinPaymentIntentV1,
+  outputs: BitcoinPaymentOutput[],
+  signerAddresses: string[],
+): BitcoinPaymentProof {
+  const errors: string[] = [];
+  const own = new Set(signerAddresses.map(normalizeAddressForComparison));
+  const external: BitcoinPaymentProof['outputs'] = [];
+
+  for (const output of outputs) {
+    if (output.type === 'op_return') {
+      errors.push(`output ${output.index} carries data; plain Bitcoin payments may not`);
+      continue;
+    }
+    if (!output.address) {
+      errors.push(`output ${output.index} has no reviewable Bitcoin address`);
+      continue;
+    }
+    if (!own.has(normalizeAddressForComparison(output.address))) {
+      external.push({ index: output.index, address: output.address, amountSats: output.value });
+    }
+  }
+
+  if (external.length === 0) errors.push('the PSBT has no external payment output');
+
+  const claimedCounts = new Map<string, number>();
+  for (const output of intent.outputs) {
+    const key = paymentKey(output.address, output.amountSats);
+    claimedCounts.set(key, (claimedCounts.get(key) ?? 0) + 1);
+  }
+  const actualCounts = new Map<string, number>();
+  for (const output of external) {
+    const key = paymentKey(output.address, output.amountSats);
+    actualCounts.set(key, (actualCounts.get(key) ?? 0) + 1);
+  }
+
+  const keys = new Set([...claimedCounts.keys(), ...actualCounts.keys()]);
+  for (const key of keys) {
+    if ((claimedCounts.get(key) ?? 0) !== (actualCounts.get(key) ?? 0)) {
+      errors.push('the external payment outputs do not exactly match the site intent');
+      break;
+    }
+  }
+
+  return {
+    proved: errors.length === 0,
+    errors,
+    outputs: external,
+    totalSats: external.reduce((sum, output) => sum + output.amountSats, 0),
+  };
+}

--- a/src/core/bitcoin/psbt.ts
+++ b/src/core/bitcoin/psbt.ts
@@ -179,6 +179,8 @@ export interface DecodedInput {
   address?: string;
   value?: number;          // in satoshis, if known from witnessUtxo
   sighashType?: number;    // sighash type from PSBT input (e.g. 0x83 for SINGLE|ANYONECANPAY)
+  /** Existing signature/finalization material, used to prove marketplace placeholder slots empty. */
+  hasSignatures?: boolean;
   /**
    * Tapleaf scripts this input would reveal, hex, leaf-version byte stripped. An inscription
    * reveal carries its ord envelope — and therefore its Counterparty message — here rather than
@@ -368,6 +370,12 @@ export function extractPsbtDetails(psbtHex: string): PsbtDetails {
         address,
         value,
         sighashType: input.sighashType,
+        hasSignatures: Boolean(
+          input.tapKeySig
+          || input.partialSig?.length
+          || input.finalScriptSig?.length
+          || input.finalScriptWitness?.length
+        ),
         ...(tapLeafScripts && tapLeafScripts.length > 0 ? { tapLeafScripts } : {}),
       });
     }

--- a/src/core/bitcoin/psbt.ts
+++ b/src/core/bitcoin/psbt.ts
@@ -193,6 +193,8 @@ export interface DecodedInput {
  * Basic PSBT details extracted via pure Bitcoin parsing
  */
 export interface PsbtDetails {
+  /** Unsigned transaction id computed locally from the PSBT transaction bytes. */
+  transactionId: string;
   /** Raw transaction hex (if extractable) */
   rawTxHex: string;
   inputs: DecodedInput[];
@@ -426,6 +428,7 @@ export function extractPsbtDetails(psbtHex: string): PsbtDetails {
   const fee = totalInputValue > 0 && !unfunded ? totalInputValue - totalOutputValue : 0;
 
   return {
+    transactionId: tx.id,
     rawTxHex,
     inputs,
     outputs,

--- a/src/core/bitcoin/psbt.ts
+++ b/src/core/bitcoin/psbt.ts
@@ -195,6 +195,10 @@ export interface DecodedInput {
 export interface PsbtDetails {
   /** Unsigned transaction id computed locally from the PSBT transaction bytes. */
   transactionId: string;
+  /** Bitcoin transaction version committed to by the PSBT. */
+  transactionVersion: number;
+  /** Bitcoin transaction locktime committed to by the PSBT. */
+  lockTime: number;
   /** Raw transaction hex (if extractable) */
   rawTxHex: string;
   inputs: DecodedInput[];
@@ -429,6 +433,8 @@ export function extractPsbtDetails(psbtHex: string): PsbtDetails {
 
   return {
     transactionId: tx.id,
+    transactionVersion: tx.version,
+    lockTime: tx.lockTime,
     rawTxHex,
     inputs,
     outputs,

--- a/src/core/bitcoin/psbtApprovalDecoder.ts
+++ b/src/core/bitcoin/psbtApprovalDecoder.ts
@@ -1,0 +1,94 @@
+/** Shared PSBT decoding and safety analysis used by single and atomic provider approvals. */
+
+import type { BitcoinPaymentIntentV1 } from '@/core/bitcoin/providerPayment';
+import {
+  extractPsbtDetails,
+  type PsbtDetails,
+  resolvePsbtSighashType,
+} from '@/core/bitcoin/psbt';
+import { fetchInputsAttachedAssets } from '@/core/counterparty/inputAssets';
+import type { MarketplaceIntentClaimV1 } from '@/core/counterparty/marketplaceIntent';
+import {
+  type InscriptionCommitContext,
+  resolveRevealMessage,
+} from '@/core/counterparty/providerInscriptions';
+import {
+  analyzeSignRequest,
+  type SignRequestAnalysis,
+} from '@/core/counterparty/signRequestAnalysis';
+import { decodeRawTransaction } from '@/core/counterparty/transaction';
+import { extractPayloadFromOutputs } from '@/core/counterparty/unpack/opReturn';
+
+export interface DecodedPsbtInfo extends SignRequestAnalysis {
+  psbtDetails: PsbtDetails;
+  /** Unsigned transaction ID computed locally from the PSBT. */
+  txid?: string;
+}
+
+export async function decodePsbtForApproval(
+  psbtHex: string,
+  signerAddresses?: string[],
+  signedInputIndices?: number[],
+  requestedSighashTypes?: number[],
+  inscriptionContext?: InscriptionCommitContext,
+  signingPurpose: 'counterparty' | 'bitcoin-payment' = 'counterparty',
+  bitcoinPaymentIntent?: BitcoinPaymentIntentV1,
+  marketplaceIntent?: MarketplaceIntentClaimV1,
+): Promise<DecodedPsbtInfo> {
+  const psbtDetails = extractPsbtDetails(psbtHex);
+  const attachedAssetsPromise = fetchInputsAttachedAssets(psbtDetails.inputs, signedInputIndices);
+  let txid: string | undefined = psbtDetails.transactionId;
+  let counterpartyDataHex: string | undefined;
+
+  const firstInputTxid = psbtDetails.inputs[0]?.txid;
+  if (firstInputTxid) {
+    counterpartyDataHex = extractPayloadFromOutputs(
+      psbtDetails.outputs.map(output => output.script ?? ''),
+      firstInputTxid,
+    ) ?? undefined;
+  }
+  if (!counterpartyDataHex) {
+    const reveal = resolveRevealMessage(psbtDetails.inputs, psbtDetails.outputs);
+    if (reveal) counterpartyDataHex = reveal.messageHex;
+  }
+
+  if (psbtDetails.rawTxHex) {
+    try {
+      const decoded = await decodeRawTransaction(psbtDetails.rawTxHex, true);
+      txid ??= decoded.txid;
+      for (const vout of decoded.vout) {
+        const output = psbtDetails.outputs.find(candidate => candidate.index === vout.n);
+        // Remote decoding may fill an address the local decoder could not establish, never replace
+        // a local address used by the money-movement and safety classifiers (ADR-019).
+        if (output && !output.address && vout.scriptPubKey.address) {
+          output.address = vout.scriptPubKey.address;
+        }
+      }
+    } catch (error) {
+      console.warn('Failed to decode transaction via API:', error);
+    }
+  }
+
+  const analysis = await analyzeSignRequest({
+    counterpartyDataHex,
+    inputs: psbtDetails.inputs,
+    outputs: psbtDetails.outputs,
+    signerAddresses: signerAddresses ?? [],
+    signedInputIndices: signedInputIndices ?? [],
+    signedInputs: (signedInputIndices ?? []).map(index => ({
+      index,
+      sighashType: resolvePsbtSighashType(
+        requestedSighashTypes?.[index],
+        psbtDetails.inputs[index]?.sighashType,
+      ),
+    })),
+    transactionId: txid,
+    attachedAssets: attachedAssetsPromise,
+    inscriptionContext,
+    signingPurpose,
+    bitcoinPaymentIntent,
+    marketplaceIntent,
+  });
+
+  return { psbtDetails, txid, ...analysis };
+}

--- a/src/core/counterparty/__tests__/attachedAssetMovement.test.ts
+++ b/src/core/counterparty/__tests__/attachedAssetMovement.test.ts
@@ -12,6 +12,7 @@ import {
 
 const MINE = 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4';
 const THEIRS = '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa';
+const all = (index = 0) => [{ index, sighashType: 0x01 }];
 
 const withAssets = (inputIndex: number) => ({
   inputIndex,
@@ -36,7 +37,8 @@ describe('where attached assets go', () => {
       ],
       [withAssets(0)],
       [0],
-      [MINE]
+      [MINE],
+      all()
     );
 
     expect(result?.destinationVout).toBe(1);
@@ -51,7 +53,8 @@ describe('where attached assets go', () => {
       [{ index: 0, type: 'p2pkh', address: THEIRS }],
       [withAssets(0)],
       [0],
-      [MINE]
+      [MINE],
+      all()
     );
 
     expect(result?.destinationVout).toBe(0);
@@ -63,7 +66,8 @@ describe('where attached assets go', () => {
       [{ index: 0, type: 'unknown' }],
       [withAssets(0)],
       [0],
-      [MINE]
+      [MINE],
+      all()
     );
 
     expect(result?.destinationAddress).toBeUndefined();
@@ -77,7 +81,8 @@ describe('where attached assets go', () => {
       [{ index: 0, type: 'op_return' }],
       [withAssets(0)],
       [0],
-      [MINE]
+      [MINE],
+      all()
     );
 
     expect(result?.detaches).toBe(true);
@@ -91,7 +96,8 @@ describe('where attached assets go', () => {
       [{ index: 0, type: 'p2wpkh', address: MINE }],
       [withAssets(1)],
       [0],
-      [MINE]
+      [MINE],
+      all()
     );
 
     expect(result).toBeNull();
@@ -103,9 +109,65 @@ describe('where attached assets go', () => {
         [{ index: 0, type: 'p2wpkh', address: MINE }],
         [empty(0)],
         [0],
-        [MINE]
+        [MINE],
+        all()
       )
     ).toBeNull();
+  });
+
+  it('uses a locally decoded detach destination instead of the first ordinary output', () => {
+    const result = resolveAttachedAssetDestination(
+      [
+        { index: 0, type: 'op_return' },
+        { index: 1, type: 'p2wpkh', address: MINE },
+      ],
+      [withAssets(1)],
+      [1],
+      [MINE],
+      all(1),
+      { messageType: 'detach', data: { destination: THEIRS } }
+    );
+
+    expect(result).toMatchObject({
+      detaches: true,
+      mode: 'explicit-detach',
+      destinationCommitted: true,
+      destinationVout: null,
+      destinationAddress: THEIRS,
+      leavesWallet: true,
+    });
+  });
+
+  it('does not claim a listing placeholder fixes delivery under SINGLE|ANYONECANPAY', () => {
+    const result = resolveAttachedAssetDestination(
+      [
+        { index: 0, type: 'p2wpkh', address: MINE },
+        { index: 1, type: 'p2pkh', address: MINE },
+      ],
+      [withAssets(1)],
+      [1],
+      [MINE],
+      [{ index: 1, sighashType: 0x83 }]
+    );
+
+    expect(result).toMatchObject({
+      mode: 'flexible',
+      destinationCommitted: false,
+      leavesWallet: true,
+    });
+  });
+
+  it('treats a missing effective sighash as flexible, never as implicit ALL', () => {
+    const result = resolveAttachedAssetDestination(
+      [{ index: 0, type: 'p2wpkh', address: MINE }],
+      [withAssets(0)],
+      [0],
+      [MINE],
+      []
+    );
+
+    expect(result?.destinationCommitted).toBe(false);
+    expect(result?.mode).toBe('flexible');
   });
 });
 

--- a/src/core/counterparty/__tests__/inputAssets.test.ts
+++ b/src/core/counterparty/__tests__/inputAssets.test.ts
@@ -61,6 +61,19 @@ describe('fetchInputsAttachedAssets', () => {
     expect(assets[0]!.assets[0]!.asset_longname).toBe('MYPROJECT.RARE');
   });
 
+  it('preserves the exact raw quantity for marketplace proofs', async () => {
+    mockedFetch.mockResolvedValue(
+      page([{
+        asset: 'RAREPEPE',
+        quantity: '100000000',
+        quantity_normalized: asDisplayUnits('1.00000000'),
+      }])
+    );
+
+    const assets = await fetchInputsAttachedAssets([input(0)]);
+    expect(assets[0]?.assets[0]?.quantity).toBe('100000000');
+  });
+
   it('reports a failed lookup as unknown status, not as clean', async () => {
     mockedFetch.mockRejectedValue(new Error('indexer down'));
 

--- a/src/core/counterparty/__tests__/marketplaceBatch.test.ts
+++ b/src/core/counterparty/__tests__/marketplaceBatch.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import {
+  analyzeMarketplaceBatch,
+  parseMarketplaceBatchIntents,
+} from '@/core/counterparty/marketplaceBatch';
+import type {
+  MarketplaceApprovalReview,
+  PrepareBulkFanoutIntentClaim,
+} from '@/core/counterparty/marketplaceIntent';
+
+const SELLER = 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4';
+
+const fanout = (batchIndex: number): PrepareBulkFanoutIntentClaim => ({
+  standard: 'counterparty-marketplace',
+  version: 1,
+  action: 'prepare_bulk_fanout',
+  operationId: 'bulk-1',
+  protocolVersion: 'counterparty_bulk_attach_v1',
+  assets: [],
+  batchIndex,
+  seller: SELLER,
+  fundingOutpoint: { txid: (batchIndex === 0 ? '11' : '12').repeat(32), vout: batchIndex },
+  fundingValueSats: 100_000,
+  slotCount: 2,
+  slotValueSats: 10_000,
+  networkFeeSats: 1_000,
+  changeSats: 79_000,
+  expectedTxid: (batchIndex === 0 ? '21' : '22').repeat(32),
+  operationExpiresAt: 2_000_000_000,
+});
+
+const proved = (overrides: Partial<MarketplaceApprovalReview> = {}): MarketplaceApprovalReview => ({
+  status: 'proved',
+  family: 'prepare_bulk_fanout',
+  title: 'Prepare funding slots',
+  facts: [],
+  notices: [],
+  blockers: [],
+  ...overrides,
+});
+
+describe('homogeneous marketplace batch parser', () => {
+  it('accepts ordered independent fan-out parents for one operation', () => {
+    expect(parseMarketplaceBatchIntents([fanout(0), fanout(1)])).toEqual({
+      kind: 'bulk-fanout',
+      intents: [fanout(0), fanout(1)],
+    });
+  });
+
+  it.each([
+    ['empty', []],
+    ['mixed actions', [fanout(0), { ...fanout(1), action: 'attach_for_listing' }]],
+    ['different operation', [fanout(0), { ...fanout(1), operationId: 'bulk-2' }]],
+    ['wrong order', [fanout(1), fanout(0)]],
+    ['duplicate funding', [fanout(0), { ...fanout(1), fundingOutpoint: fanout(0).fundingOutpoint }]],
+  ])('refuses a %s batch', (_label, intents) => {
+    expect(() => parseMarketplaceBatchIntents(intents)).toThrow();
+  });
+});
+
+describe('marketplace batch aggregate proof', () => {
+  it('shows exact aggregate slot and fee totals', () => {
+    const intents = [fanout(0), fanout(1)];
+    const review = analyzeMarketplaceBatch('bulk-fanout', intents, [proved(), proved()]);
+
+    expect(review).toMatchObject({
+      status: 'proved',
+      family: 'marketplace_batch',
+      blockers: [],
+    });
+    expect(review.facts).toContainEqual({ label: 'Attach slots', value: '4' });
+    expect(review.facts).toContainEqual({ label: 'Total network fees', value: '2,000 sats' });
+  });
+
+  it.each([
+    ['caution', proved({ status: 'caution' })],
+    ['retry', proved({ status: 'retry', blockers: ['lookup failed'] })],
+    ['blocked', proved({ status: 'blocked', blockers: ['output changed'] })],
+  ] as const)('never weakens an item-level %s result', (status, secondReview) => {
+    const review = analyzeMarketplaceBatch(
+      'bulk-fanout',
+      [fanout(0), fanout(1)],
+      [proved(), secondReview],
+    );
+    expect(review.status).toBe(status);
+    if (status === 'retry' || status === 'blocked') {
+      expect(review.blockers[0]).toMatch(/item 2/i);
+    }
+  });
+});

--- a/src/core/counterparty/__tests__/marketplaceBundle.test.ts
+++ b/src/core/counterparty/__tests__/marketplaceBundle.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from 'vitest';
+import {
+  analyzeAcceptanceCpfpBundle,
+  parseAcceptanceCpfpBundleIntents,
+} from '@/core/counterparty/marketplaceBundle';
+
+const SELLER = 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4';
+const BUYER = 'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq';
+const ASSET_TXID = 'ab'.repeat(32);
+const PARENT_TXID = 'cd'.repeat(32);
+const CHILD_TXID = 'ef'.repeat(32);
+
+const parentIntent = {
+  standard: 'counterparty-marketplace',
+  version: 1,
+  action: 'accept_exact_offer',
+  operationId: 'authorization-1',
+  protocolVersion: 'exact_offer_v1',
+  assets: [{
+    asset: 'RAREPEPE',
+    quantityRaw: '1',
+    sourceOutpoint: { txid: ASSET_TXID, vout: 4 },
+  }],
+  authorizationId: 'authorization-1',
+  bidder: BUYER,
+  seller: SELLER,
+  priceSats: 250_000,
+  carrierValueSats: 546,
+  sellerProceedsSats: 250_046,
+  networkFeeSats: 500,
+  expectedTxid: PARENT_TXID,
+  delivery: { mode: 'detached', address: BUYER },
+  marketplaceExpiresAt: 2_000_003_600,
+  bitcoinExpiresAt: null,
+  bitcoinInvalidation: {
+    type: 'spend_funding_outpoint',
+    outpoint: { txid: '12'.repeat(32), vout: 1 },
+  },
+} as const;
+
+const childIntent = {
+  standard: 'counterparty-marketplace',
+  version: 1,
+  action: 'bump_acceptance_fee',
+  operationId: 'authorization-1',
+  protocolVersion: 'exact_offer_v1',
+  assets: [{
+    asset: 'RAREPEPE',
+    quantityRaw: '1',
+    sourceOutpoint: { txid: ASSET_TXID, vout: 4 },
+  }],
+  authorizationId: 'authorization-1',
+  seller: SELLER,
+  parentExpectedTxid: PARENT_TXID,
+  childExpectedTxid: CHILD_TXID,
+  parentSellerProceedsVout: 1,
+  parentSellerProceedsSats: 250_046,
+  parentNetworkFeeSats: 500,
+  childNetworkFeeSats: 1_000,
+  packageFeeSats: 1_500,
+  packageFeeRate: 5,
+  finalSellerProceedsSats: 249_046,
+} as const;
+
+const intents = () => parseAcceptanceCpfpBundleIntents(parentIntent, childIntent);
+
+const base = () => {
+  const parsed = intents();
+  return {
+    parentIntent: parsed.parent,
+    parentReview: {
+      status: 'proved' as const,
+      family: 'accept_exact_offer' as const,
+      title: 'Accept exact offer',
+      facts: [],
+      notices: [],
+      blockers: [],
+    },
+    childIntent: parsed.child,
+    childInputs: [{
+      index: 0,
+      txid: PARENT_TXID,
+      vout: 1,
+      address: SELLER,
+      value: 250_046,
+      hasSignatures: false,
+    }],
+    childOutputs: [{ index: 0, type: 'p2wpkh', address: SELLER, value: 249_046 }],
+    childSignedInputs: [{ index: 0, sighashType: 0x01 }],
+    childSignerAddresses: [SELLER],
+    childTransactionId: CHILD_TXID,
+    childHasCounterpartyPayload: false,
+  };
+};
+
+describe('exact acceptance plus CPFP bundle intent parser', () => {
+  it('accepts only the linked exact parent and fee-bump child shape', () => {
+    expect(intents()).toEqual({ parent: parentIntent, child: childIntent });
+  });
+
+  it.each([
+    ['wrong parent action', { ...parentIntent, action: 'authorize_exact_offer' }, childIntent],
+    ['wrong child action', parentIntent, { ...childIntent, action: 'buy_listings' }],
+    ['wrong child protocol', parentIntent, { ...childIntent, protocolVersion: 'direct_v1' }],
+    ['wrong parent vout', parentIntent, { ...childIntent, parentSellerProceedsVout: 0 }],
+    ['bad package rate', parentIntent, { ...childIntent, packageFeeRate: 0 }],
+  ])('refuses %s', (_label, parent, child) => {
+    expect(() => parseAcceptanceCpfpBundleIntents(parent, child)).toThrow();
+  });
+});
+
+describe('exact acceptance plus CPFP atomic proof', () => {
+  it('proves the child spends only seller proceeds back to the seller', () => {
+    const review = analyzeAcceptanceCpfpBundle(base());
+
+    expect(review).toMatchObject({
+      status: 'proved',
+      family: 'accept_exact_offer_with_cpfp',
+      blockers: [],
+    });
+    expect(review.facts).toContainEqual({ label: 'Added child fee', value: '1,000 sats' });
+    expect(review.facts).toContainEqual({ label: 'Final seller proceeds', value: '249,046 sats' });
+    expect(review.notices[0]?.message).toMatch(/before either signature/i);
+  });
+
+  it.each([
+    ['unproved parent', {
+      parentReview: { ...base().parentReview, status: 'blocked' as const },
+    }],
+    ['authorization id', {
+      childIntent: { ...base().childIntent, authorizationId: 'other' },
+    }],
+    ['asset', {
+      childIntent: {
+        ...base().childIntent,
+        assets: [{
+          ...base().childIntent.assets[0],
+          asset: 'SPELLS',
+        }] as ReturnType<typeof intents>['child']['assets'],
+      },
+    }],
+    ['parent txid', {
+      childInputs: [{ ...base().childInputs[0]!, txid: '13'.repeat(32) }],
+    }],
+    ['parent value', {
+      childInputs: [{ ...base().childInputs[0]!, value: 250_045 }],
+    }],
+    ['external output', {
+      childOutputs: [{ ...base().childOutputs[0]!, address: BUYER }],
+    }],
+    ['final proceeds', {
+      childOutputs: [{ ...base().childOutputs[0]!, value: 249_045 }],
+    }],
+    ['signature scope', { childSignedInputs: [{ index: 0, sighashType: 0x81 }] }],
+    ['signer', { childSignerAddresses: [BUYER] }],
+    ['existing signature', {
+      childInputs: [{ ...base().childInputs[0]!, hasSignatures: true }],
+    }],
+    ['Counterparty payload', { childHasCounterpartyPayload: true }],
+    ['child txid', { childTransactionId: '14'.repeat(32) }],
+    ['package arithmetic', {
+      childIntent: { ...base().childIntent, packageFeeSats: 1_499 },
+    }],
+  ])('blocks a mutation of %s', (_label, override) => {
+    const review = analyzeAcceptanceCpfpBundle({ ...base(), ...override });
+    expect(review.status).toBe('blocked');
+    expect(review.blockers.length).toBeGreaterThan(0);
+  });
+
+  it('requires retry when the parent proof is waiting on independent asset truth', () => {
+    const request = base();
+    const review = analyzeAcceptanceCpfpBundle({
+      ...request,
+      parentReview: {
+        ...request.parentReview,
+        status: 'retry',
+        blockers: ['asset lookup failed'],
+      },
+    });
+
+    expect(review.status).toBe('retry');
+    expect(review.blockers.join(' ')).toMatch(/parent.*lookup/i);
+  });
+});

--- a/src/core/counterparty/__tests__/marketplaceIntent.test.ts
+++ b/src/core/counterparty/__tests__/marketplaceIntent.test.ts
@@ -6,6 +6,7 @@ import {
   analyzeMarketplaceIntent,
   type BuyListingsIntentClaim,
   type CreateListingIntentClaim,
+  type PrepareBulkFanoutIntentClaim,
   parseMarketplaceIntent,
 } from '@/core/counterparty/marketplaceIntent';
 
@@ -19,6 +20,8 @@ const BUY_TXID = 'ef'.repeat(32);
 const ATTACH_TXID = '14'.repeat(32);
 const EXACT_TXID = '18'.repeat(32);
 const BID_TXID = '19'.repeat(32);
+const FANOUT_TXID = '20'.repeat(32);
+const FANOUT_FUNDING_TXID = '21'.repeat(32);
 
 const intent: CreateListingIntentClaim = {
   standard: 'counterparty-marketplace',
@@ -264,6 +267,48 @@ const exactBase = (accepting = false) => ({
   localCounterpartyMessage: { messageType: 'detach', data: { destination: BUYER } },
 });
 
+const fanoutIntent: PrepareBulkFanoutIntentClaim = {
+  standard: 'counterparty-marketplace',
+  version: 1,
+  action: 'prepare_bulk_fanout',
+  operationId: 'bulk-1',
+  protocolVersion: 'counterparty_bulk_attach_v1',
+  assets: [],
+  batchIndex: 0,
+  seller: SELLER,
+  fundingOutpoint: { txid: FANOUT_FUNDING_TXID, vout: 2 },
+  fundingValueSats: 100_000,
+  slotCount: 2,
+  slotValueSats: 10_000,
+  networkFeeSats: 1_000,
+  changeSats: 79_000,
+  expectedTxid: FANOUT_TXID,
+  operationExpiresAt: 2_000_000_000,
+};
+
+const fanoutBase = () => ({
+  intent: fanoutIntent,
+  inputs: [{
+    index: 0,
+    txid: FANOUT_FUNDING_TXID,
+    vout: 2,
+    address: SELLER,
+    value: 100_000,
+    hasSignatures: false,
+  }],
+  outputs: [
+    { index: 0, type: 'p2wpkh', address: SELLER, value: 10_000 },
+    { index: 1, type: 'p2wpkh', address: SELLER, value: 10_000 },
+    { index: 2, type: 'p2wpkh', address: SELLER, value: 79_000 },
+  ],
+  signedInputs: [{ index: 0, sighashType: 0x01 }],
+  signerAddresses: [SELLER],
+  attachedAssets: [{ inputIndex: 0, utxo: `${FANOUT_FUNDING_TXID}:2`, assets: [] }],
+  attachedAssetDestination: null,
+  hasCounterpartyPayload: false,
+  transactionId: FANOUT_TXID,
+});
+
 describe('marketplace intent wire parser', () => {
   it('copies a bounded create-listing claim', () => {
     expect(parseMarketplaceIntent(intent)).toEqual(intent);
@@ -280,6 +325,10 @@ describe('marketplace intent wire parser', () => {
   it('copies bounded exact-offer authorization and acceptance claims', () => {
     expect(parseMarketplaceIntent(authorizeExactIntent)).toEqual(authorizeExactIntent);
     expect(parseMarketplaceIntent(acceptExactIntent)).toEqual(acceptExactIntent);
+  });
+
+  it('copies a bounded plain-Bitcoin bulk fan-out claim', () => {
+    expect(parseMarketplaceIntent(fanoutIntent)).toEqual(fanoutIntent);
   });
 
   it.each([
@@ -626,5 +675,68 @@ describe('exact-offer authorization and unilateral acceptance proof', () => {
 
     expect(review.status).toBe('retry');
     expect(review.blockers.join(' ')).toMatch(/lookup/i);
+  });
+});
+
+describe('bulk fan-out funding proof', () => {
+  it('proves that every plain-Bitcoin output remains controlled by the seller', () => {
+    const review = analyzeMarketplaceIntent(fanoutBase());
+
+    expect(review).toMatchObject({
+      status: 'proved',
+      family: 'prepare_bulk_fanout',
+      blockers: [],
+    });
+    expect(review.facts).toContainEqual({ label: 'Attach slots', value: '2 × 10,000 sats' });
+    expect(review.notices[0]?.message).toMatch(/no asset moves/i);
+  });
+
+  it.each([
+    ['funding outpoint', {
+      inputs: [{ ...fanoutBase().inputs[0]!, vout: 3 }],
+    }],
+    ['funding value', {
+      inputs: [{ ...fanoutBase().inputs[0]!, value: 99_999 }],
+    }],
+    ['external output', {
+      outputs: fanoutBase().outputs.map(output => output.index === 1
+        ? { ...output, address: BUYER }
+        : output),
+    }],
+    ['slot value', {
+      outputs: fanoutBase().outputs.map(output => output.index === 0
+        ? { ...output, value: 9_999 }
+        : output),
+    }],
+    ['signature scope', { signedInputs: [{ index: 0, sighashType: 0x81 }] }],
+    ['signer', { signerAddresses: [BUYER] }],
+    ['payload', { hasCounterpartyPayload: true }],
+    ['existing signature', {
+      inputs: [{ ...fanoutBase().inputs[0]!, hasSignatures: true }],
+    }],
+    ['attached asset', {
+      attachedAssets: [{
+        inputIndex: 0,
+        utxo: `${FANOUT_FUNDING_TXID}:2`,
+        assets: [{ asset: 'XCP', quantity: '1', quantity_normalized: '0.00000001' }],
+      }],
+    }],
+  ])('blocks a mutation of %s', (_label, override) => {
+    const review = analyzeMarketplaceIntent({ ...fanoutBase(), ...override });
+    expect(review.status).toBe('blocked');
+    expect(review.blockers.length).toBeGreaterThan(0);
+  });
+
+  it('requires retry when clean-funding status cannot be proved', () => {
+    const review = analyzeMarketplaceIntent({
+      ...fanoutBase(),
+      attachedAssets: [{
+        inputIndex: 0,
+        utxo: `${FANOUT_FUNDING_TXID}:2`,
+        assets: [],
+        lookupFailed: true,
+      }],
+    });
+    expect(review.status).toBe('retry');
   });
 });

--- a/src/core/counterparty/__tests__/marketplaceIntent.test.ts
+++ b/src/core/counterparty/__tests__/marketplaceIntent.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  type AttachForListingIntentClaim,
   analyzeMarketplaceIntent,
   type BuyListingsIntentClaim,
   type CreateListingIntentClaim,
@@ -13,6 +14,7 @@ const PLATFORM = 'bc1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq9e75rs';
 const TXID = 'ab'.repeat(32);
 const TXID_TWO = 'cd'.repeat(32);
 const BUY_TXID = 'ef'.repeat(32);
+const ATTACH_TXID = '14'.repeat(32);
 
 const intent: CreateListingIntentClaim = {
   standard: 'counterparty-marketplace',
@@ -140,6 +142,54 @@ const buyBase = () => ({
   localCounterpartyMessage: { messageType: 'detach', data: { destination: BUYER } },
 });
 
+const attachIntent: AttachForListingIntentClaim = {
+  standard: 'counterparty-marketplace',
+  version: 1,
+  action: 'attach_for_listing',
+  operationId: 'attach-1',
+  protocolVersion: 'counterparty_attach_listing_v1',
+  assets: [{ asset: 'RAREPEPE', quantityRaw: '1' }],
+  seller: SELLER,
+  expectedAttachedOutpoint: { txid: ATTACH_TXID, vout: 0 },
+  carrierAddress: SELLER,
+  carrierValueSats: 546,
+  networkFeeSats: 1_000,
+  protocolFee: {
+    asset: 'XCP',
+    quotedAmountRaw: '25000000',
+    actualAmountRaw: null,
+    observedBlock: 900_000,
+    variableUntilConfirmed: true,
+  },
+  operationExpiresAt: 2_000_000_000,
+};
+
+const attachBase = () => ({
+  intent: attachIntent,
+  inputs: [
+    { index: 0, txid: '15'.repeat(32), vout: 0, address: SELLER, value: 100_000, hasSignatures: false },
+    { index: 1, txid: '16'.repeat(32), vout: 1, address: SELLER_TWO, value: 100_000, hasSignatures: false },
+  ],
+  outputs: [
+    { index: 0, type: 'p2wpkh', address: SELLER, value: 546 },
+    { index: 1, type: 'op_return', value: 0 },
+    { index: 2, type: 'p2wpkh', address: SELLER_TWO, value: 198_454 },
+  ],
+  signedInputs: [
+    { index: 0, sighashType: 0x01 },
+    { index: 1, sighashType: 0x01 },
+  ],
+  signerAddresses: [SELLER, SELLER_TWO],
+  attachedAssets: [],
+  attachedAssetDestination: null,
+  hasCounterpartyPayload: true,
+  transactionId: ATTACH_TXID,
+  localCounterpartyMessage: {
+    messageType: 'attach',
+    data: { asset: 'RAREPEPE', quantity: 1n, destinationVout: 0 },
+  },
+});
+
 describe('marketplace intent wire parser', () => {
   it('copies a bounded create-listing claim', () => {
     expect(parseMarketplaceIntent(intent)).toEqual(intent);
@@ -149,6 +199,10 @@ describe('marketplace intent wire parser', () => {
     expect(parseMarketplaceIntent(buyIntent)).toEqual(buyIntent);
   });
 
+  it('copies a bounded attach-for-listing claim with a variable XCP fee', () => {
+    expect(parseMarketplaceIntent(attachIntent)).toEqual(attachIntent);
+  });
+
   it.each([
     { ...intent, version: 2 },
     { ...intent, action: 'buy_listings' },
@@ -156,6 +210,108 @@ describe('marketplace intent wire parser', () => {
     { ...intent, assets: [] },
   ])('refuses an unsupported or malformed claim', (candidate) => {
     expect(() => parseMarketplaceIntent(candidate)).toThrow();
+  });
+});
+
+describe('attach-for-listing proof', () => {
+  it('proves the attach transaction while labeling the block-dependent XCP fee', () => {
+    const review = analyzeMarketplaceIntent(attachBase());
+
+    expect(review.status).toBe('caution');
+    expect(review.family).toBe('attach_for_listing');
+    expect(review.blockers).toEqual([]);
+    expect(review.facts).toContainEqual({ label: 'Quoted XCP fee', value: '0.25 XCP' });
+    expect(review.notices[0]?.message).toMatch(/recomputes it at the block/i);
+  });
+
+  it('distinguishes the Counterparty source from a paired carrier address', () => {
+    const request = attachBase();
+    const review = analyzeMarketplaceIntent({
+      ...request,
+      intent: { ...attachIntent, carrierAddress: SELLER_TWO },
+      outputs: request.outputs.map(output => output.index === 0
+        ? { ...output, address: SELLER_TWO }
+        : output),
+    });
+
+    expect(review.status).toBe('caution');
+    expect(review.blockers).toEqual([]);
+  });
+
+  it.each([
+    ['message asset', {
+      localCounterpartyMessage: {
+        messageType: 'attach',
+        data: { asset: 'SPELLS', quantity: 1n, destinationVout: 0 },
+      },
+    }],
+    ['message quantity', {
+      localCounterpartyMessage: {
+        messageType: 'attach',
+        data: { asset: 'RAREPEPE', quantity: 2n, destinationVout: 0 },
+      },
+    }],
+    ['destination vout', {
+      localCounterpartyMessage: {
+        messageType: 'attach',
+        data: { asset: 'RAREPEPE', quantity: 1n, destinationVout: 2 },
+      },
+    }],
+    ['source', {
+      inputs: [{ ...attachBase().inputs[0]!, address: BUYER }, attachBase().inputs[1]!],
+    }],
+    ['carrier value', {
+      outputs: attachBase().outputs.map(output => output.index === 0
+        ? { ...output, value: 545 }
+        : output),
+    }],
+    ['signature scope', {
+      signedInputs: [{ index: 0, sighashType: 0x01 }, { index: 1, sighashType: 0x81 }],
+    }],
+    ['external output', {
+      outputs: attachBase().outputs.map(output => output.index === 2
+        ? { ...output, address: BUYER }
+        : output),
+    }],
+    ['attached funding asset', {
+      attachedAssets: [{
+        inputIndex: 1,
+        utxo: `${'16'.repeat(32)}:1`,
+        assets: [{ asset: 'BONUS', quantity: '1', quantity_normalized: '1' }],
+      }],
+    }],
+    ['fixed-fee label', {
+      intent: {
+        ...attachIntent,
+        protocolFee: { ...attachIntent.protocolFee, variableUntilConfirmed: false },
+      },
+    }],
+    ['premature actual XCP fee', {
+      intent: {
+        ...attachIntent,
+        protocolFee: { ...attachIntent.protocolFee, actualAmountRaw: '25000000' },
+      },
+    }],
+    ['transaction id', { transactionId: '17'.repeat(32) }],
+  ])('blocks a mutation of %s', (_label, override) => {
+    const review = analyzeMarketplaceIntent({ ...attachBase(), ...override });
+    expect(review.status).toBe('blocked');
+    expect(review.blockers.length).toBeGreaterThan(0);
+  });
+
+  it('requires a retry when a signed funding input asset lookup fails', () => {
+    const review = analyzeMarketplaceIntent({
+      ...attachBase(),
+      attachedAssets: [{
+        inputIndex: 0,
+        utxo: `${'15'.repeat(32)}:0`,
+        assets: [],
+        lookupFailed: true,
+      }],
+    });
+
+    expect(review.status).toBe('retry');
+    expect(review.blockers.join(' ')).toMatch(/lookup/i);
   });
 });
 

--- a/src/core/counterparty/__tests__/marketplaceIntent.test.ts
+++ b/src/core/counterparty/__tests__/marketplaceIntent.test.ts
@@ -6,6 +6,7 @@ import {
   analyzeMarketplaceIntent,
   type BuyListingsIntentClaim,
   type CreateListingIntentClaim,
+  marketplaceTransactionHeaderProblem,
   type PrepareBulkFanoutIntentClaim,
   parseMarketplaceIntent,
 } from '@/core/counterparty/marketplaceIntent';
@@ -325,6 +326,12 @@ describe('marketplace intent wire parser', () => {
   it('copies bounded exact-offer authorization and acceptance claims', () => {
     expect(parseMarketplaceIntent(authorizeExactIntent)).toEqual(authorizeExactIntent);
     expect(parseMarketplaceIntent(acceptExactIntent)).toEqual(acceptExactIntent);
+  });
+
+  it('pins exact-offer transactions to version 2 with locktime 0', () => {
+    expect(marketplaceTransactionHeaderProblem(authorizeExactIntent, 2, 0)).toBeNull();
+    expect(marketplaceTransactionHeaderProblem(acceptExactIntent, 3, 0)).toMatch(/version 2/);
+    expect(marketplaceTransactionHeaderProblem(acceptExactIntent, 2, 1)).toMatch(/locktime 0/);
   });
 
   it('copies a bounded plain-Bitcoin bulk fan-out claim', () => {

--- a/src/core/counterparty/__tests__/marketplaceIntent.test.ts
+++ b/src/core/counterparty/__tests__/marketplaceIntent.test.ts
@@ -1,12 +1,18 @@
 import { describe, expect, it } from 'vitest';
 import {
   analyzeMarketplaceIntent,
+  type BuyListingsIntentClaim,
   type CreateListingIntentClaim,
   parseMarketplaceIntent,
 } from '@/core/counterparty/marketplaceIntent';
 
 const SELLER = 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4';
+const SELLER_TWO = 'bc1qglv8hh3l23y0qu5uw4zu7e8q4td0gcjsa8f3tq';
+const BUYER = 'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq';
+const PLATFORM = 'bc1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq9e75rs';
 const TXID = 'ab'.repeat(32);
+const TXID_TWO = 'cd'.repeat(32);
+const BUY_TXID = 'ef'.repeat(32);
 
 const intent: CreateListingIntentClaim = {
   standard: 'counterparty-marketplace',
@@ -58,9 +64,89 @@ const base = () => ({
   hasCounterpartyPayload: false,
 });
 
+const buyIntent: BuyListingsIntentClaim = {
+  standard: 'counterparty-marketplace',
+  version: 1,
+  action: 'buy_listings',
+  operationId: 'checkout-1',
+  protocolVersion: 'direct_v1',
+  assets: [
+    { asset: 'RAREPEPE', quantityRaw: '1', sourceOutpoint: { txid: TXID, vout: 7 } },
+    { asset: 'SPELLS', quantityRaw: '100000000', sourceOutpoint: { txid: TXID_TWO, vout: 3 } },
+  ],
+  buyer: BUYER,
+  items: [
+    {
+      asset: 'RAREPEPE',
+      quantityRaw: '1',
+      sourceOutpoint: { txid: TXID, vout: 7 },
+      listingId: 'listing-1',
+      seller: SELLER,
+      carrierValueSats: 546,
+      priceSats: 100_000,
+      sellerPaymentSats: 100_546,
+    },
+    {
+      asset: 'SPELLS',
+      quantityRaw: '100000000',
+      sourceOutpoint: { txid: TXID_TWO, vout: 3 },
+      listingId: 'listing-2',
+      seller: SELLER_TWO,
+      carrierValueSats: 330,
+      priceSats: 200_000,
+      sellerPaymentSats: 200_330,
+    },
+  ],
+  subtotalSats: 300_000,
+  networkFeeSats: 1_000,
+  platformFeeSats: 5_000,
+  totalSats: 306_000,
+  expectedTxid: BUY_TXID,
+  delivery: { mode: 'detached', address: BUYER },
+  marketplaceExpiresAt: 2_000_003_600,
+};
+
+const buyBase = () => ({
+  intent: buyIntent,
+  inputs: [
+    { index: 0, txid: '11'.repeat(32), vout: 0, address: BUYER, value: 400_000, hasSignatures: false },
+    { index: 1, txid: TXID, vout: 7, address: SELLER, value: 546, hasSignatures: false },
+    { index: 2, txid: TXID_TWO, vout: 3, address: SELLER_TWO, value: 330, hasSignatures: false },
+  ],
+  outputs: [
+    { index: 0, type: 'op_return', value: 0 },
+    { index: 1, type: 'p2wpkh', address: SELLER, value: 100_546 },
+    { index: 2, type: 'p2wpkh', address: SELLER_TWO, value: 200_330 },
+    { index: 3, type: 'p2wpkh', address: PLATFORM, value: 5_000 },
+    { index: 4, type: 'p2wpkh', address: BUYER, value: 94_000 },
+  ],
+  signedInputs: [{ index: 0, sighashType: 0x01 }],
+  signerAddresses: [BUYER],
+  attachedAssets: [
+    {
+      inputIndex: 1,
+      utxo: `${TXID}:7`,
+      assets: [{ asset: 'RAREPEPE', quantity: '1', quantity_normalized: '1' }],
+    },
+    {
+      inputIndex: 2,
+      utxo: `${TXID_TWO}:3`,
+      assets: [{ asset: 'SPELLS', quantity: '100000000', quantity_normalized: '1' }],
+    },
+  ],
+  attachedAssetDestination: null,
+  hasCounterpartyPayload: true,
+  transactionId: BUY_TXID,
+  localCounterpartyMessage: { messageType: 'detach', data: { destination: BUYER } },
+});
+
 describe('marketplace intent wire parser', () => {
   it('copies a bounded create-listing claim', () => {
     expect(parseMarketplaceIntent(intent)).toEqual(intent);
+  });
+
+  it('copies a bounded multi-item buy claim', () => {
+    expect(parseMarketplaceIntent(buyIntent)).toEqual(buyIntent);
   });
 
   it.each([
@@ -119,5 +205,78 @@ describe('create-listing proof', () => {
 
     expect(review.status).toBe('retry');
     expect(review.blockers.join(' ')).toMatch(/raw attached quantity/i);
+  });
+});
+
+describe('buy-listings proof', () => {
+  it('proves the complete atomic checkout and detached delivery', () => {
+    const review = analyzeMarketplaceIntent(buyBase());
+
+    expect(review.status).toBe('proved');
+    expect(review.family).toBe('buy_listings');
+    expect(review.blockers).toEqual([]);
+    expect(review.title).toContain('2 collectibles');
+    expect(review.facts).toContainEqual({ label: 'You pay', value: '306,000 sats' });
+    expect(review.facts).toContainEqual({ label: 'Delivery', value: `Detached to ${BUYER}` });
+  });
+
+  it.each([
+    ['detach destination', {
+      localCounterpartyMessage: { messageType: 'detach', data: { destination: SELLER } },
+    }],
+    ['seller payment', {
+      outputs: buyBase().outputs.map(output => output.index === 1 ? { ...output, value: 100_545 } : output),
+    }],
+    ['seller outpoint', {
+      inputs: buyBase().inputs.map(transactionInput => transactionInput.index === 2
+        ? { ...transactionInput, txid: '12'.repeat(32) }
+        : transactionInput),
+    }],
+    ['signature scope', { signedInputs: [{ index: 0, sighashType: 0x83 }] }],
+    ['signer', { signerAddresses: [SELLER] }],
+    ['transaction id', { transactionId: '13'.repeat(32) }],
+    ['duplicate input', {
+      inputs: buyBase().inputs.map(transactionInput => transactionInput.index === 2
+        ? { ...transactionInput, txid: TXID, vout: 7 }
+        : transactionInput),
+    }],
+    ['platform fee', {
+      outputs: buyBase().outputs.map(output => output.index === 3 ? { ...output, value: 4_999 } : output),
+    }],
+    ['unexpected output', {
+      outputs: [...buyBase().outputs, { index: 5, type: 'p2wpkh', address: BUYER, value: 1 }],
+    }],
+    ['attached buyer asset', {
+      attachedAssets: [
+        ...buyBase().attachedAssets,
+        {
+          inputIndex: 0,
+          utxo: `${'11'.repeat(32)}:0`,
+          assets: [{ asset: 'XCP', quantity: '1', quantity_normalized: '0.00000001' }],
+        },
+      ],
+    }],
+  ])('blocks a mutation of %s', (_label, override) => {
+    const review = analyzeMarketplaceIntent({ ...buyBase(), ...override });
+    expect(review.status).toBe('blocked');
+    expect(review.blockers.length).toBeGreaterThan(0);
+  });
+
+  it.each([
+    ['seller balance', {
+      attachedAssets: buyBase().attachedAssets.map(entry => entry.inputIndex === 1
+        ? { ...entry, assets: [], lookupFailed: true }
+        : entry),
+    }],
+    ['raw quantity', {
+      attachedAssets: buyBase().attachedAssets.map(entry => entry.inputIndex === 2
+        ? { ...entry, assets: [{ asset: 'SPELLS', quantity_normalized: '1' }] }
+        : entry),
+    }],
+    ['transaction id', { transactionId: undefined }],
+  ])('requires a retry when %s cannot be proved', (_label, override) => {
+    const review = analyzeMarketplaceIntent({ ...buyBase(), ...override });
+    expect(review.status).toBe('retry');
+    expect(review.blockers.length).toBeGreaterThan(0);
   });
 });

--- a/src/core/counterparty/__tests__/marketplaceIntent.test.ts
+++ b/src/core/counterparty/__tests__/marketplaceIntent.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
+  type AcceptExactOfferIntentClaim,
   type AttachForListingIntentClaim,
+  type AuthorizeExactOfferIntentClaim,
   analyzeMarketplaceIntent,
   type BuyListingsIntentClaim,
   type CreateListingIntentClaim,
@@ -15,6 +17,8 @@ const TXID = 'ab'.repeat(32);
 const TXID_TWO = 'cd'.repeat(32);
 const BUY_TXID = 'ef'.repeat(32);
 const ATTACH_TXID = '14'.repeat(32);
+const EXACT_TXID = '18'.repeat(32);
+const BID_TXID = '19'.repeat(32);
 
 const intent: CreateListingIntentClaim = {
   standard: 'counterparty-marketplace',
@@ -190,6 +194,76 @@ const attachBase = () => ({
   },
 });
 
+const authorizeExactIntent: AuthorizeExactOfferIntentClaim = {
+  standard: 'counterparty-marketplace',
+  version: 1,
+  action: 'authorize_exact_offer',
+  operationId: 'authorization-1',
+  protocolVersion: 'exact_offer_v1',
+  assets: [{
+    asset: 'RAREPEPE',
+    quantityRaw: '1',
+    sourceOutpoint: { txid: TXID, vout: 7 },
+  }],
+  authorizationId: 'authorization-1',
+  bidder: BUYER,
+  seller: SELLER,
+  priceSats: 250_000,
+  carrierValueSats: 546,
+  sellerProceedsSats: 250_046,
+  networkFeeSats: 500,
+  expectedTxid: EXACT_TXID,
+  delivery: { mode: 'detached', address: BUYER },
+  marketplaceExpiresAt: 2_000_003_600,
+  bitcoinExpiresAt: null,
+  bitcoinInvalidation: {
+    type: 'spend_funding_outpoint',
+    outpoint: { txid: BID_TXID, vout: 4 },
+  },
+};
+
+const acceptExactIntent: AcceptExactOfferIntentClaim = {
+  ...authorizeExactIntent,
+  action: 'accept_exact_offer',
+};
+
+const exactBase = (accepting = false) => ({
+  intent: accepting ? acceptExactIntent : authorizeExactIntent,
+  inputs: [
+    {
+      index: 0,
+      txid: BID_TXID,
+      vout: 4,
+      address: BUYER,
+      value: 250_000,
+      hasSignatures: accepting,
+    },
+    {
+      index: 1,
+      txid: TXID,
+      vout: 7,
+      address: SELLER,
+      value: 546,
+      hasSignatures: false,
+    },
+  ],
+  outputs: [
+    { index: 0, type: 'op_return', value: 0 },
+    { index: 1, type: 'p2wpkh', address: SELLER, value: 250_046 },
+  ],
+  signedInputs: [{ index: accepting ? 1 : 0, sighashType: 0x01 }],
+  signerAddresses: [accepting ? SELLER : BUYER],
+  attachedAssets: [{
+    inputIndex: 1,
+    utxo: `${TXID}:7`,
+    assets: [{ asset: 'RAREPEPE', quantity: '1', quantity_normalized: '1' }],
+  }],
+  attachedAssetDestination: null,
+  hasCounterpartyPayload: true,
+  transactionId: EXACT_TXID,
+  localCounterpartyMessage: { messageType: 'detach', data: { destination: BUYER } },
+});
+
 describe('marketplace intent wire parser', () => {
   it('copies a bounded create-listing claim', () => {
     expect(parseMarketplaceIntent(intent)).toEqual(intent);
@@ -201,6 +275,11 @@ describe('marketplace intent wire parser', () => {
 
   it('copies a bounded attach-for-listing claim with a variable XCP fee', () => {
     expect(parseMarketplaceIntent(attachIntent)).toEqual(attachIntent);
+  });
+
+  it('copies bounded exact-offer authorization and acceptance claims', () => {
+    expect(parseMarketplaceIntent(authorizeExactIntent)).toEqual(authorizeExactIntent);
+    expect(parseMarketplaceIntent(acceptExactIntent)).toEqual(acceptExactIntent);
   });
 
   it.each([
@@ -434,5 +513,118 @@ describe('buy-listings proof', () => {
     const review = analyzeMarketplaceIntent({ ...buyBase(), ...override });
     expect(review.status).toBe('retry');
     expect(review.blockers.length).toBeGreaterThan(0);
+  });
+});
+
+describe('exact-offer authorization and unilateral acceptance proof', () => {
+  it('proves the buyer authorization while clearly labeling shared-slot authority', () => {
+    const review = analyzeMarketplaceIntent(exactBase());
+
+    expect(review).toMatchObject({
+      status: 'caution',
+      family: 'authorize_exact_offer',
+      blockers: [],
+    });
+    expect(review.facts).toContainEqual({ label: 'Offer price', value: '250,000 sats' });
+    expect(review.notices[0]?.message).toMatch(/without another approval/i);
+    expect(review.notices[0]?.message).toMatch(/first confirmed spend wins/i);
+  });
+
+  it('proves that the seller signature completes the exact sale without a buyer callback', () => {
+    const review = analyzeMarketplaceIntent(exactBase(true));
+
+    expect(review).toMatchObject({
+      status: 'proved',
+      family: 'accept_exact_offer',
+      blockers: [],
+    });
+    expect(review.notices[0]?.message).toMatch(/without a buyer callback/i);
+    expect(review.notices[0]?.message).toMatch(/asset remains yours/i);
+  });
+
+  it.each([
+    ['detach destination', {
+      localCounterpartyMessage: { messageType: 'detach', data: { destination: SELLER } },
+    }],
+    ['funding outpoint', {
+      inputs: exactBase().inputs.map(transactionInput => transactionInput.index === 0
+        ? { ...transactionInput, vout: 5 }
+        : transactionInput),
+    }],
+    ['asset outpoint', {
+      inputs: exactBase().inputs.map(transactionInput => transactionInput.index === 1
+        ? { ...transactionInput, txid: TXID_TWO }
+        : transactionInput),
+    }],
+    ['buyer value', {
+      inputs: exactBase().inputs.map(transactionInput => transactionInput.index === 0
+        ? { ...transactionInput, value: 249_999 }
+        : transactionInput),
+    }],
+    ['carrier value', {
+      inputs: exactBase().inputs.map(transactionInput => transactionInput.index === 1
+        ? { ...transactionInput, value: 545 }
+        : transactionInput),
+    }],
+    ['seller proceeds', {
+      outputs: [exactBase().outputs[0]!, { ...exactBase().outputs[1]!, value: 250_045 }],
+    }],
+    ['signature scope', { signedInputs: [{ index: 0, sighashType: 0x81 }] }],
+    ['signer', { signerAddresses: [SELLER] }],
+    ['transaction id', { transactionId: TXID_TWO }],
+    ['attached buyer asset', {
+      attachedAssets: [
+        ...exactBase().attachedAssets,
+        {
+          inputIndex: 0,
+          utxo: `${BID_TXID}:4`,
+          assets: [{ asset: 'XCP', quantity: '1', quantity_normalized: '0.00000001' }],
+        },
+      ],
+    }],
+    ['asset quantity', {
+      attachedAssets: [{
+        ...exactBase().attachedAssets[0]!,
+        assets: [{ asset: 'RAREPEPE', quantity: '2', quantity_normalized: '2' }],
+      }],
+    }],
+  ])('blocks an authorization mutation of %s', (_label, override) => {
+    const review = analyzeMarketplaceIntent({ ...exactBase(), ...override });
+    expect(review.status).toBe('blocked');
+    expect(review.blockers.length).toBeGreaterThan(0);
+  });
+
+  it.each([
+    ['missing buyer authorization', {
+      inputs: exactBase(true).inputs.map(transactionInput => transactionInput.index === 0
+        ? { ...transactionInput, hasSignatures: false }
+        : transactionInput),
+    }],
+    ['already-signed seller input', {
+      inputs: exactBase(true).inputs.map(transactionInput => transactionInput.index === 1
+        ? { ...transactionInput, hasSignatures: true }
+        : transactionInput),
+    }],
+    ['buyer input requested again', { signedInputs: [{ index: 0, sighashType: 0x01 }] }],
+    ['wrong seller signer', { signerAddresses: [BUYER] }],
+  ])('blocks a seller-acceptance mutation of %s', (_label, override) => {
+    const review = analyzeMarketplaceIntent({ ...exactBase(true), ...override });
+    expect(review.status).toBe('blocked');
+    expect(review.blockers.length).toBeGreaterThan(0);
+  });
+
+  it('requires retry rather than trusting the label when the target asset lookup fails', () => {
+    const review = analyzeMarketplaceIntent({
+      ...exactBase(),
+      attachedAssets: [{
+        inputIndex: 1,
+        utxo: `${TXID}:7`,
+        assets: [],
+        lookupFailed: true,
+      }],
+    });
+
+    expect(review.status).toBe('retry');
+    expect(review.blockers.join(' ')).toMatch(/lookup/i);
   });
 });

--- a/src/core/counterparty/__tests__/marketplaceIntent.test.ts
+++ b/src/core/counterparty/__tests__/marketplaceIntent.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+import {
+  analyzeMarketplaceIntent,
+  type CreateListingIntentClaim,
+  parseMarketplaceIntent,
+} from '@/core/counterparty/marketplaceIntent';
+
+const SELLER = 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4';
+const TXID = 'ab'.repeat(32);
+
+const intent: CreateListingIntentClaim = {
+  standard: 'counterparty-marketplace',
+  version: 1,
+  action: 'create_listing',
+  operationId: 'listing-preflight-1',
+  protocolVersion: 'counterparty_attach_listing_v1',
+  assets: [{
+    asset: 'RAREPEPE',
+    quantityRaw: '100000000',
+    sourceOutpoint: { txid: TXID, vout: 7 },
+  }],
+  seller: SELLER,
+  priceSats: 250_000,
+  carrierValueSats: 546,
+  guaranteedSellerPaymentSats: 250_546,
+  delivery: { mode: 'buyer_selected_detach' },
+  signingRequestExpiresAt: 2_000_000_000,
+  marketplaceExpiresAt: 2_000_003_600,
+  bitcoinExpiresAt: null,
+};
+
+const base = () => ({
+  intent,
+  inputs: [
+    { index: 0, txid: '0'.repeat(64), vout: 0, value: 0, hasSignatures: false },
+    { index: 1, txid: TXID, vout: 7, address: SELLER, value: 546, hasSignatures: false },
+  ],
+  outputs: [
+    { index: 0, type: 'p2wpkh', address: SELLER, value: 546 },
+    { index: 1, type: 'p2wpkh', address: SELLER, value: 250_546 },
+  ],
+  signedInputs: [{ index: 1, sighashType: 0x83 }],
+  signerAddresses: [SELLER],
+  attachedAssets: [{
+    inputIndex: 1,
+    utxo: `${TXID}:7`,
+    assets: [{ asset: 'RAREPEPE', quantity: '100000000', quantity_normalized: '1' }],
+  }],
+  attachedAssetDestination: {
+    sourceInputs: [1],
+    destinationVout: 0,
+    destinationAddress: SELLER,
+    detaches: false,
+    mode: 'flexible' as const,
+    destinationCommitted: false,
+    leavesWallet: true,
+  },
+  hasCounterpartyPayload: false,
+});
+
+describe('marketplace intent wire parser', () => {
+  it('copies a bounded create-listing claim', () => {
+    expect(parseMarketplaceIntent(intent)).toEqual(intent);
+  });
+
+  it.each([
+    { ...intent, version: 2 },
+    { ...intent, action: 'buy_listings' },
+    { ...intent, bitcoinExpiresAt: 2_000_000_000 },
+    { ...intent, assets: [] },
+  ])('refuses an unsupported or malformed claim', (candidate) => {
+    expect(() => parseMarketplaceIntent(candidate)).toThrow();
+  });
+});
+
+describe('create-listing proof', () => {
+  it('proves exact seller payment while stating buyer-selected detach flexibility', () => {
+    const review = analyzeMarketplaceIntent(base());
+
+    expect(review.status).toBe('caution');
+    expect(review.blockers).toEqual([]);
+    expect(review.title).toContain('RAREPEPE');
+    expect(review.facts).toContainEqual({ label: 'Seller receives', value: '250,546 sats' });
+    expect(review.notices[0]?.message).toContain('choose the detach destination');
+  });
+
+  it.each([
+    ['seller payment', { outputs: [base().outputs[0]!, { ...base().outputs[1]!, value: 250_545 }] }],
+    ['source outpoint', { inputs: [base().inputs[0]!, { ...base().inputs[1]!, txid: 'cd'.repeat(32) }] }],
+    ['signature scope', { signedInputs: [{ index: 1, sighashType: 0x01 }] }],
+    ['unproven placeholder signature state', {
+      inputs: [{ ...base().inputs[0]!, hasSignatures: undefined }, base().inputs[1]!],
+    }],
+    ['payload', { hasCounterpartyPayload: true }],
+    ['extra asset', {
+      attachedAssets: [{
+        ...base().attachedAssets[0]!,
+        assets: [
+          ...base().attachedAssets[0]!.assets,
+          { asset: 'BONUS', quantity: '1', quantity_normalized: '1' },
+        ],
+      }],
+    }],
+  ])('blocks a mutation of %s', (_label, override) => {
+    const review = analyzeMarketplaceIntent({ ...base(), ...override });
+    expect(review.status).toBe('blocked');
+    expect(review.blockers.length).toBeGreaterThan(0);
+  });
+
+  it('requires a retry when exact raw quantity is unavailable', () => {
+    const request = base();
+    const review = analyzeMarketplaceIntent({
+      ...request,
+      attachedAssets: [{
+        ...request.attachedAssets[0]!,
+        assets: [{ asset: 'RAREPEPE', quantity_normalized: '1' }],
+      }],
+    });
+
+    expect(review.status).toBe('retry');
+    expect(review.blockers.join(' ')).toMatch(/raw attached quantity/i);
+  });
+});

--- a/src/core/counterparty/__tests__/marketplaceIntent.test.ts
+++ b/src/core/counterparty/__tests__/marketplaceIntent.test.ts
@@ -355,8 +355,12 @@ describe('attach-for-listing proof', () => {
     expect(review.status).toBe('caution');
     expect(review.family).toBe('attach_for_listing');
     expect(review.blockers).toEqual([]);
-    expect(review.facts).toContainEqual({ label: 'Quoted XCP fee', value: '0.25 XCP' });
-    expect(review.notices[0]?.message).toMatch(/recomputes it at the block/i);
+    expect(review.facts).toContainEqual({
+      label: 'Quoted XCP fee',
+      value: '0.25 XCP (finalized at confirmation)',
+    });
+    // The block-dependence lives in the fact row itself; the attach carries no extra notice.
+    expect(review.notices).toEqual([]);
   });
 
   it('distinguishes the Counterparty source from a paired carrier address', () => {

--- a/src/core/counterparty/__tests__/signRequestAnalysis.test.ts
+++ b/src/core/counterparty/__tests__/signRequestAnalysis.test.ts
@@ -9,7 +9,9 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { parseBitcoinPaymentIntent } from '@/core/bitcoin/providerPayment';
 import type { InputAttachedAssets } from '../inputAssets';
+import { parseMarketplaceIntent } from '../marketplaceIntent';
 import type { ProtocolContext } from '../protocolContext';
 import { type AnalyzedOutput, analyzeSignRequest } from '../signRequestAnalysis';
 
@@ -38,6 +40,35 @@ const OUTPUTS: AnalyzedOutput[] = [
 ];
 
 const INPUTS = [{ txid: 'a'.repeat(64), vout: 0 }];
+const VAULT = 'bc1qglv8hh3l23y0qu5uw4zu7e8q4td0gcjsa8f3tq';
+const PAYMENT_INTENT = parseBitcoinPaymentIntent({
+  standard: 'xcp-wallet/bitcoin-payment',
+  version: 1,
+  action: 'pay',
+  outputs: [{ address: VAULT, amountSats: 21_600 }],
+  description: 'Fund Emblem Vault',
+});
+const LISTING_TXID = 'ab'.repeat(32);
+const LISTING_INTENT = parseMarketplaceIntent({
+  standard: 'counterparty-marketplace',
+  version: 1,
+  action: 'create_listing',
+  operationId: 'preflight-1',
+  protocolVersion: 'counterparty_attach_listing_v1',
+  assets: [{
+    asset: 'RAREPEPE',
+    quantityRaw: '1',
+    sourceOutpoint: { txid: LISTING_TXID, vout: 4 },
+  }],
+  seller: SIGNER,
+  priceSats: 250_000,
+  carrierValueSats: 546,
+  guaranteedSellerPaymentSats: 250_546,
+  delivery: { mode: 'buyer_selected_detach' },
+  signingRequestExpiresAt: 2_000_000_000,
+  marketplaceExpiresAt: null,
+  bitcoinExpiresAt: null,
+});
 
 /** An input carrying assets, at the given index. */
 function withAssets(inputIndex: number): InputAttachedAssets {
@@ -55,6 +86,7 @@ function run(overrides: Partial<Parameters<typeof analyzeSignRequest>[0]> = {}) 
     outputs: OUTPUTS,
     signerAddresses: [SIGNER],
     signedInputIndices: [0],
+    signedInputs: [{ index: 0, sighashType: 0x01 }],
     transactionId: undefined,
     attachedAssets: Promise.resolve([]),
     ...overrides,
@@ -104,6 +136,126 @@ describe('the not-a-Counterparty-transaction gate', () => {
 
     expect(analysis.safety.blocked).toBe(true);
     expect(blockedOnNotCounterparty(analysis.safety.warnings)).toBe(true);
+  });
+});
+
+describe('the separate plain Bitcoin payment capability', () => {
+  beforeEach(() => {
+    vi.mocked(verifyProviderTransaction).mockReturnValue({ localUnpack: undefined } as never);
+    vi.mocked(resolveProtocolContext).mockResolvedValue({
+      context: {} as ProtocolContext,
+      warnings: [],
+    });
+  });
+
+  const payment = (overrides: Partial<Parameters<typeof analyzeSignRequest>[0]> = {}) => run({
+    signingPurpose: 'bitcoin-payment',
+    bitcoinPaymentIntent: PAYMENT_INTENT,
+    outputs: [
+      { index: 0, value: 21_600, type: 'witness_v0_keyhash', address: VAULT },
+      { index: 1, value: 28_982, type: 'witness_v0_keyhash', address: SIGNER },
+    ],
+    ...overrides,
+  });
+
+  it('allows an exact declared payment after proving clean signed inputs', async () => {
+    const analysis = await payment();
+
+    expect(analysis.safety.blocked).toBe(false);
+    expect(analysis.bitcoinPaymentProof).toMatchObject({
+      proved: true,
+      totalSats: 21_600,
+      outputs: [{ index: 0, address: VAULT, amountSats: 21_600 }],
+    });
+    expect(analysis.safety.warnings).toContainEqual(expect.objectContaining({
+      severity: 'info',
+      title: 'Bitcoin Payment',
+    }));
+  });
+
+  it.each([
+    {
+      name: 'changed destination',
+      overrides: {
+        outputs: [{
+          index: 0, value: 21_600, type: 'witness_v0_keyhash',
+          address: 'bc1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq9e75rs',
+        }],
+      },
+    },
+    {
+      name: 'Counterparty payload',
+      overrides: { counterpartyDataHex: '434e5452505254590a00' },
+    },
+    {
+      name: 'attached asset',
+      overrides: { attachedAssets: Promise.resolve([withAssets(0)]) },
+    },
+    {
+      name: 'unknown asset status',
+      overrides: {
+        attachedAssets: Promise.resolve([{
+          inputIndex: 0, utxo: `${'a'.repeat(64)}:0`, assets: [], lookupFailed: true,
+        }]),
+      },
+    },
+  ])('blocks $name rather than trusting the site or origin', async ({ overrides }) => {
+    const analysis = await payment(overrides);
+    expect(analysis.safety.blocked).toBe(true);
+    expect(analysis.safety.warnings[0]?.severity).toBe('block');
+  });
+});
+
+describe('the marketplace intent proof', () => {
+  const listing = (overrides: Partial<Parameters<typeof analyzeSignRequest>[0]> = {}) => run({
+    marketplaceIntent: LISTING_INTENT,
+    inputs: [
+      { index: 0, txid: '0'.repeat(64), vout: 0, hasSignatures: false },
+      { index: 1, txid: LISTING_TXID, vout: 4, address: SIGNER, value: 546 },
+    ],
+    outputs: [
+      { index: 0, value: 546, type: 'witness_v0_keyhash', address: SIGNER },
+      { index: 1, value: 250_546, type: 'witness_v0_keyhash', address: SIGNER },
+    ],
+    signedInputIndices: [1],
+    signedInputs: [{ index: 1, sighashType: 0x83 }],
+    attachedAssets: Promise.resolve([{
+      inputIndex: 1,
+      utxo: `${LISTING_TXID}:4`,
+      assets: [{
+        asset: 'RAREPEPE',
+        quantity: '1',
+        quantity_normalized: '1',
+      }],
+    }]),
+    ...overrides,
+  });
+
+  it('allows the proved listing and returns semantic terms', async () => {
+    const analysis = await listing();
+
+    expect(analysis.safety.blocked).toBe(false);
+    expect(analysis.marketplaceReview).toMatchObject({
+      status: 'caution',
+      family: 'create_listing',
+      blockers: [],
+    });
+    expect(analysis.attachedAssetDestination).toMatchObject({
+      destinationCommitted: false,
+      mode: 'flexible',
+    });
+  });
+
+  it('hard-blocks a site claim whose seller payment differs from the PSBT', async () => {
+    const analysis = await listing({
+      outputs: [
+        { index: 0, value: 546, type: 'witness_v0_keyhash', address: SIGNER },
+        { index: 1, value: 250_545, type: 'witness_v0_keyhash', address: SIGNER },
+      ],
+    });
+
+    expect(analysis.safety.blocked).toBe(true);
+    expect(analysis.safety.warnings[0]?.title).toBe('Blocked: Marketplace Intent Mismatch');
   });
 });
 

--- a/src/core/counterparty/__tests__/signRequestAnalysis.test.ts
+++ b/src/core/counterparty/__tests__/signRequestAnalysis.test.ts
@@ -167,8 +167,7 @@ describe('the separate plain Bitcoin payment capability', () => {
       totalSats: 21_600,
       outputs: [{ index: 0, address: VAULT, amountSats: 21_600 }],
     });
-    expect(analysis.safety.warnings).toContainEqual(expect.objectContaining({
-      severity: 'info',
+    expect(analysis.safety.warnings).not.toContainEqual(expect.objectContaining({
       title: 'Bitcoin Payment',
     }));
   });

--- a/src/core/counterparty/__tests__/signRequestAnalysis.test.ts
+++ b/src/core/counterparty/__tests__/signRequestAnalysis.test.ts
@@ -69,6 +69,28 @@ const LISTING_INTENT = parseMarketplaceIntent({
   marketplaceExpiresAt: null,
   bitcoinExpiresAt: null,
 });
+const ATTACH_TXID = 'bc'.repeat(32);
+const ATTACH_INTENT = parseMarketplaceIntent({
+  standard: 'counterparty-marketplace',
+  version: 1,
+  action: 'attach_for_listing',
+  operationId: 'attach-1',
+  protocolVersion: 'counterparty_attach_listing_v1',
+  assets: [{ asset: 'RAREPEPE', quantityRaw: '1' }],
+  seller: SIGNER,
+  expectedAttachedOutpoint: { txid: ATTACH_TXID, vout: 0 },
+  carrierAddress: SIGNER,
+  carrierValueSats: 546,
+  networkFeeSats: 1_000,
+  protocolFee: {
+    asset: 'XCP',
+    quotedAmountRaw: '25000000',
+    actualAmountRaw: null,
+    observedBlock: 900_000,
+    variableUntilConfirmed: true,
+  },
+  operationExpiresAt: 2_000_000_000,
+});
 const CHECKOUT_TXID = 'cd'.repeat(32);
 const CHECKOUT_INTENT = parseMarketplaceIntent({
   standard: 'counterparty-marketplace',
@@ -237,6 +259,42 @@ describe('the separate plain Bitcoin payment capability', () => {
 });
 
 describe('the marketplace intent proof', () => {
+  const attach = (overrides: Partial<Parameters<typeof analyzeSignRequest>[0]> = {}) => run({
+    counterpartyDataHex: '434e5452505254590000006552415245504550457c317c30',
+    marketplaceIntent: ATTACH_INTENT,
+    inputs: [
+      {
+        index: 0,
+        txid: '18'.repeat(32),
+        vout: 0,
+        address: SIGNER,
+        value: 100_000,
+        hasSignatures: false,
+      },
+      {
+        index: 1,
+        txid: '19'.repeat(32),
+        vout: 1,
+        address: VAULT,
+        value: 100_000,
+        hasSignatures: false,
+      },
+    ],
+    outputs: [
+      { index: 0, value: 546, type: 'witness_v0_keyhash', address: SIGNER },
+      { index: 1, value: 0, type: 'op_return' },
+      { index: 2, value: 198_454, type: 'witness_v0_keyhash', address: VAULT },
+    ],
+    signerAddresses: [SIGNER, VAULT],
+    signedInputIndices: [0, 1],
+    signedInputs: [
+      { index: 0, sighashType: 0x01 },
+      { index: 1, sighashType: 0x01 },
+    ],
+    transactionId: ATTACH_TXID,
+    attachedAssets: Promise.resolve([]),
+    ...overrides,
+  });
   const listing = (overrides: Partial<Parameters<typeof analyzeSignRequest>[0]> = {}) => run({
     marketplaceIntent: LISTING_INTENT,
     inputs: [
@@ -315,6 +373,29 @@ describe('the marketplace intent proof', () => {
     expect(analysis.attachedAssetDestination).toMatchObject({
       destinationCommitted: false,
       mode: 'flexible',
+    });
+  });
+
+  it('allows a proved attach while preserving the variable XCP-fee caution', async () => {
+    vi.mocked(verifyProviderTransaction).mockReturnValue({
+      localUnpack: {
+        success: true,
+        messageType: 'attach',
+        data: { asset: 'RAREPEPE', quantity: 1n, destinationVout: 0 },
+      },
+    } as never);
+
+    const analysis = await attach();
+
+    expect(analysis.safety.blocked).toBe(false);
+    expect(analysis.marketplaceReview).toMatchObject({
+      status: 'caution',
+      family: 'attach_for_listing',
+      blockers: [],
+    });
+    expect(analysis.marketplaceReview?.facts).toContainEqual({
+      label: 'Quoted XCP fee',
+      value: '0.25 XCP',
     });
   });
 

--- a/src/core/counterparty/__tests__/signRequestAnalysis.test.ts
+++ b/src/core/counterparty/__tests__/signRequestAnalysis.test.ts
@@ -122,6 +122,39 @@ const CHECKOUT_INTENT = parseMarketplaceIntent({
   delivery: { mode: 'detached', address: SIGNER },
   marketplaceExpiresAt: 2_000_003_600,
 });
+const EXACT_TXID = 'de'.repeat(32);
+const EXACT_FUNDING_TXID = 'ef'.repeat(32);
+const EXACT_AUTHORIZATION_INTENT = parseMarketplaceIntent({
+  standard: 'counterparty-marketplace',
+  version: 1,
+  action: 'authorize_exact_offer',
+  operationId: 'authorization-1',
+  protocolVersion: 'exact_offer_v1',
+  assets: [{
+    asset: 'RAREPEPE',
+    quantityRaw: '1',
+    sourceOutpoint: { txid: LISTING_TXID, vout: 4 },
+  }],
+  authorizationId: 'authorization-1',
+  bidder: SIGNER,
+  seller: VAULT,
+  priceSats: 250_000,
+  carrierValueSats: 546,
+  sellerProceedsSats: 250_046,
+  networkFeeSats: 500,
+  expectedTxid: EXACT_TXID,
+  delivery: { mode: 'detached', address: SIGNER },
+  marketplaceExpiresAt: 2_000_003_600,
+  bitcoinExpiresAt: null,
+  bitcoinInvalidation: {
+    type: 'spend_funding_outpoint',
+    outpoint: { txid: EXACT_FUNDING_TXID, vout: 1 },
+  },
+});
+const EXACT_ACCEPTANCE_INTENT = parseMarketplaceIntent({
+  ...EXACT_AUTHORIZATION_INTENT,
+  action: 'accept_exact_offer',
+});
 
 /** An input carrying assets, at the given index. */
 function withAssets(inputIndex: number): InputAttachedAssets {
@@ -360,6 +393,45 @@ describe('the marketplace intent proof', () => {
     }]),
     ...overrides,
   });
+  const exact = (
+    accepting: boolean,
+    overrides: Partial<Parameters<typeof analyzeSignRequest>[0]> = {},
+  ) => run({
+    counterpartyDataHex: '434e5452505254590000006600',
+    marketplaceIntent: accepting ? EXACT_ACCEPTANCE_INTENT : EXACT_AUTHORIZATION_INTENT,
+    inputs: [
+      {
+        index: 0,
+        txid: EXACT_FUNDING_TXID,
+        vout: 1,
+        address: SIGNER,
+        value: 250_000,
+        hasSignatures: accepting,
+      },
+      {
+        index: 1,
+        txid: LISTING_TXID,
+        vout: 4,
+        address: VAULT,
+        value: 546,
+        hasSignatures: false,
+      },
+    ],
+    outputs: [
+      { index: 0, value: 0, type: 'op_return' },
+      { index: 1, value: 250_046, type: 'witness_v0_keyhash', address: VAULT },
+    ],
+    signerAddresses: [accepting ? VAULT : SIGNER],
+    signedInputIndices: [accepting ? 1 : 0],
+    signedInputs: [{ index: accepting ? 1 : 0, sighashType: 0x01 }],
+    transactionId: EXACT_TXID,
+    attachedAssets: Promise.resolve([{
+      inputIndex: 1,
+      utxo: `${LISTING_TXID}:4`,
+      assets: [{ asset: 'RAREPEPE', quantity: '1', quantity_normalized: '1' }],
+    }]),
+    ...overrides,
+  });
 
   it('allows the proved listing and returns semantic terms', async () => {
     const analysis = await listing();
@@ -449,6 +521,34 @@ describe('the marketplace intent proof', () => {
 
     expect(analysis.safety.blocked).toBe(true);
     expect(analysis.safety.warnings[0]?.title).toBe('Blocked: Marketplace Intent Mismatch');
+  });
+
+  it.each([
+    { accepting: false, status: 'caution', family: 'authorize_exact_offer' },
+    { accepting: true, status: 'proved', family: 'accept_exact_offer' },
+  ])('allows exact-offer $family and replaces generic alarms with proved terms', async ({
+    accepting,
+    status,
+    family,
+  }) => {
+    vi.mocked(verifyProviderTransaction).mockReturnValue({
+      localUnpack: {
+        success: true,
+        messageType: 'detach',
+        data: { destination: SIGNER },
+      },
+    } as never);
+
+    const analysis = await exact(accepting);
+
+    expect(analysis.safety.blocked).toBe(false);
+    expect(analysis.marketplaceReview).toMatchObject({ status, family, blockers: [] });
+    expect(analysis.safety.warnings).not.toContainEqual(expect.objectContaining({
+      code: 'detach_all',
+    }));
+    expect(analysis.safety.warnings).not.toContainEqual(expect.objectContaining({
+      code: 'external_btc_output',
+    }));
   });
 });
 

--- a/src/core/counterparty/__tests__/signRequestAnalysis.test.ts
+++ b/src/core/counterparty/__tests__/signRequestAnalysis.test.ts
@@ -69,6 +69,37 @@ const LISTING_INTENT = parseMarketplaceIntent({
   marketplaceExpiresAt: null,
   bitcoinExpiresAt: null,
 });
+const CHECKOUT_TXID = 'cd'.repeat(32);
+const CHECKOUT_INTENT = parseMarketplaceIntent({
+  standard: 'counterparty-marketplace',
+  version: 1,
+  action: 'buy_listings',
+  operationId: 'checkout-1',
+  protocolVersion: 'direct_v1',
+  assets: [{
+    asset: 'RAREPEPE',
+    quantityRaw: '1',
+    sourceOutpoint: { txid: LISTING_TXID, vout: 4 },
+  }],
+  buyer: SIGNER,
+  items: [{
+    asset: 'RAREPEPE',
+    quantityRaw: '1',
+    sourceOutpoint: { txid: LISTING_TXID, vout: 4 },
+    listingId: 'listing-1',
+    seller: VAULT,
+    carrierValueSats: 546,
+    priceSats: 250_000,
+    sellerPaymentSats: 250_546,
+  }],
+  subtotalSats: 250_000,
+  networkFeeSats: 2_000,
+  platformFeeSats: 5_000,
+  totalSats: 257_000,
+  expectedTxid: CHECKOUT_TXID,
+  delivery: { mode: 'detached', address: SIGNER },
+  marketplaceExpiresAt: 2_000_003_600,
+});
 
 /** An input carrying assets, at the given index. */
 function withAssets(inputIndex: number): InputAttachedAssets {
@@ -229,6 +260,48 @@ describe('the marketplace intent proof', () => {
     }]),
     ...overrides,
   });
+  const checkout = (overrides: Partial<Parameters<typeof analyzeSignRequest>[0]> = {}) => run({
+    counterpartyDataHex: '434e5452505254590000006600',
+    marketplaceIntent: CHECKOUT_INTENT,
+    inputs: [
+      {
+        index: 0,
+        txid: '11'.repeat(32),
+        vout: 0,
+        address: SIGNER,
+        value: 400_000,
+        hasSignatures: false,
+      },
+      {
+        index: 1,
+        txid: LISTING_TXID,
+        vout: 4,
+        address: VAULT,
+        value: 546,
+        hasSignatures: false,
+      },
+    ],
+    outputs: [
+      { index: 0, value: 0, type: 'op_return' },
+      { index: 1, value: 250_546, type: 'witness_v0_keyhash', address: VAULT },
+      {
+        index: 2,
+        value: 5_000,
+        type: 'witness_v0_keyhash',
+        address: 'bc1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq9e75rs',
+      },
+      { index: 3, value: 143_000, type: 'witness_v0_keyhash', address: SIGNER },
+    ],
+    signedInputIndices: [0],
+    signedInputs: [{ index: 0, sighashType: 0x01 }],
+    transactionId: CHECKOUT_TXID,
+    attachedAssets: Promise.resolve([{
+      inputIndex: 1,
+      utxo: `${LISTING_TXID}:4`,
+      assets: [{ asset: 'RAREPEPE', quantity: '1', quantity_normalized: '1' }],
+    }]),
+    ...overrides,
+  });
 
   it('allows the proved listing and returns semantic terms', async () => {
     const analysis = await listing();
@@ -252,6 +325,46 @@ describe('the marketplace intent proof', () => {
         { index: 1, value: 250_545, type: 'witness_v0_keyhash', address: SIGNER },
       ],
     });
+
+    expect(analysis.safety.blocked).toBe(true);
+    expect(analysis.safety.warnings[0]?.title).toBe('Blocked: Marketplace Intent Mismatch');
+  });
+
+  it('allows a proved checkout and replaces the generic detach alarm with exact semantic terms', async () => {
+    vi.mocked(verifyProviderTransaction).mockReturnValue({
+      localUnpack: {
+        success: true,
+        messageType: 'detach',
+        data: { destination: SIGNER },
+      },
+    } as never);
+
+    const analysis = await checkout();
+
+    expect(analysis.safety.blocked).toBe(false);
+    expect(analysis.marketplaceReview).toMatchObject({
+      status: 'proved',
+      family: 'buy_listings',
+      blockers: [],
+    });
+    expect(analysis.safety.warnings).not.toContainEqual(expect.objectContaining({
+      code: 'detach_all',
+    }));
+    expect(analysis.safety.warnings).not.toContainEqual(expect.objectContaining({
+      code: 'external_btc_output',
+    }));
+  });
+
+  it('hard-blocks checkout when the locally decoded detach differs from the site claim', async () => {
+    vi.mocked(verifyProviderTransaction).mockReturnValue({
+      localUnpack: {
+        success: true,
+        messageType: 'detach',
+        data: { destination: VAULT },
+      },
+    } as never);
+
+    const analysis = await checkout();
 
     expect(analysis.safety.blocked).toBe(true);
     expect(analysis.safety.warnings[0]?.title).toBe('Blocked: Marketplace Intent Mismatch');

--- a/src/core/counterparty/__tests__/signRequestAnalysis.test.ts
+++ b/src/core/counterparty/__tests__/signRequestAnalysis.test.ts
@@ -467,7 +467,7 @@ describe('the marketplace intent proof', () => {
     });
     expect(analysis.marketplaceReview?.facts).toContainEqual({
       label: 'Quoted XCP fee',
-      value: '0.25 XCP',
+      value: '0.25 XCP (finalized at confirmation)',
     });
   });
 

--- a/src/core/counterparty/__tests__/transaction.test.ts
+++ b/src/core/counterparty/__tests__/transaction.test.ts
@@ -246,26 +246,28 @@ describe('describeCounterpartyMessage', () => {
     expect(desc).toContain('FAIRTOKEN');
   });
 
-  it('describes pooldeposit', () => {
+  it('describes pooldeposit as its two legs', () => {
     const desc = describeCounterpartyMessage('pooldeposit', {
       asset_a: 'XCP',
       asset_b: 'POOLTEST',
       quantity_a: 100000000,
       quantity_b: 500000000,
+      asset_a_info: { divisible: true },
+      asset_b_info: { divisible: true },
     });
-    expect(desc).toContain('Deposit liquidity');
-    expect(desc).toContain('XCP');
-    expect(desc).toContain('POOLTEST');
+    expect(desc).toContain('1.00000000 XCP / 5.00000000 POOLTEST');
+    // The implied price reads on the second line.
+    expect(desc).toContain('1 XCP = 5 POOLTEST');
   });
 
-  it('describes poolwithdraw', () => {
+  it('describes poolwithdraw as the LP burn over the pool pair', () => {
     const desc = describeCounterpartyMessage('poolwithdraw', {
       asset_a: 'XCP',
       asset_b: 'POOLTEST',
       quantity: asBaseUnits(1000000),
     });
-    expect(desc).toContain('Withdraw liquidity');
-    expect(desc).toContain('XCP/POOLTEST');
+    expect(desc).toContain('Destroy 0.01000000 LP Tokens');
+    expect(desc).toContain('POOLTEST / XCP');
   });
 
   it('describes attach', () => {

--- a/src/core/counterparty/__tests__/transactionSafety.test.ts
+++ b/src/core/counterparty/__tests__/transactionSafety.test.ts
@@ -108,15 +108,16 @@ describe('message type safety', () => {
     expect(result.warnings).toHaveLength(0);
   });
 
-  it('warns on detach, which moves every asset on the UTXO', () => {
+  it('states the detach-moves-everything fact as information, not friction', () => {
     // detach credits EVERY balance on the source UTXO to the destination (core detach.py), so the
-    // message states no amount. It was listed as safe and raised nothing, while sweep — the same
-    // idea at address scope — is blocked outright. Not blocked here, because the scope is one
-    // UTXO and a detach without a valid destination credits back to the UTXO owner.
+    // message states no amount — but a detach doing exactly that is routine, and the details list
+    // names each released balance. A detach whose assets leave the wallet escalates through the
+    // attached-asset destination warning instead.
     const result = analyzeTransactionSafety('detach', normalOutputs, SIGNER);
     expect(result.blocked).toBe(false);
     expect(result.warnings).toHaveLength(1);
     expect(result.warnings[0]!.title).toMatch(/moves everything/i);
+    expect(result.warnings[0]!.severity).toBe('info');
   });
 
   it('should allow mpma_send without warnings', () => {

--- a/src/core/counterparty/__tests__/transactionSafety.test.ts
+++ b/src/core/counterparty/__tests__/transactionSafety.test.ts
@@ -207,6 +207,21 @@ describe('suspicious output detection', () => {
     expect(result.warnings[0]!.message).toContain('2 addresses');
   });
 
+  it('renders externally paid BTC as information only for the separate payment capability', () => {
+    const outputs = makeOutputs(
+      { value: 21_600, address: 'bc1qglv8hh3l23y0qu5uw4zu7e8q4td0gcjsa8f3tq' },
+      { value: 28_982, address: SIGNER },
+    );
+    const result = analyzeTransactionSafety(undefined, outputs, SIGNER, {
+      plainBitcoinPayment: true,
+    });
+    expect(result.blocked).toBe(false);
+    expect(result.warnings).toEqual([expect.objectContaining({
+      severity: 'info',
+      title: 'Bitcoin Payment',
+    })]);
+  });
+
   it('should be case-insensitive when comparing Bech32 signer addresses', () => {
     const signer = 'bc1qvux25709r4uw6rzc8wyl7wwecjdhrx085hm5ty';
     const outputs = makeOutputs(

--- a/src/core/counterparty/attachedAssetMovement.ts
+++ b/src/core/counterparty/attachedAssetMovement.ts
@@ -35,6 +35,17 @@ export interface AttachedAssetDestination {
   /** True when there is no non-OP_RETURN output, so core detaches to the source address. */
   detaches: boolean;
   /**
+   * How Counterparty resolves the movement. A flexible authorization deliberately does not fix
+   * whether fulfillment uses an explicit detach or the ordinary first-output rule.
+   */
+  mode: 'explicit-detach' | 'implicit-output' | 'implicit-source' | 'flexible';
+  /**
+   * Whether every signature over an attached source input fixes the complete output set.
+   * SINGLE|ANYONECANPAY never does: even when it covers the current first output, a holder can add
+   * an explicit detach message and change delivery without invalidating that signature.
+   */
+  destinationCommitted: boolean;
+  /**
    * True when the destination is an address the signer does not control.
    *
    * The legitimate case for a swap — the buyer receives the asset — and the dangerous case for an
@@ -50,6 +61,23 @@ interface OutputLike {
   address?: string;
 }
 
+interface SignedInputLike {
+  index: number;
+  sighashType: number;
+}
+
+interface CounterpartyMovementMessage {
+  messageType?: string;
+  data?: unknown;
+}
+
+const detachDestination = (message?: CounterpartyMovementMessage): string | undefined | null => {
+  if (message?.messageType !== 'detach') return null;
+  if (typeof message.data !== 'object' || message.data === null) return undefined;
+  const destination = (message.data as Record<string, unknown>).destination;
+  return typeof destination === 'string' ? destination : undefined;
+};
+
 /**
  * @param attachedAssets - per-input lookup results; only entries with assets count as sources
  * @param signedInputIndices - the inputs this wallet is being asked to sign; assets on inputs it
@@ -60,7 +88,9 @@ export function resolveAttachedAssetDestination(
   outputs: OutputLike[],
   attachedAssets: InputAttachedAssets[],
   signedInputIndices: number[],
-  signerAddresses: string[]
+  signerAddresses: string[],
+  signedInputs: SignedInputLike[],
+  counterpartyMessage?: CounterpartyMovementMessage
 ): AttachedAssetDestination | null {
   const signed = new Set(signedInputIndices);
   const sourceInputs = attachedAssets
@@ -70,11 +100,42 @@ export function resolveAttachedAssetDestination(
 
   if (sourceInputs.length === 0) return null;
 
+  const sighashByInput = new Map(signedInputs.map(input => [input.index, input.sighashType]));
+  // ALL and ALL|ANYONECANPAY both bind every output and therefore also bind the absence of an
+  // overriding detach message. A missing effective sighash is unknown, never optimistically ALL.
+  const destinationCommitted = sourceInputs.every(inputIndex =>
+    ((sighashByInput.get(inputIndex) ?? -1) & 0x1f) === 0x01
+  );
+
+  const explicitDestination = detachDestination(counterpartyMessage);
+  if (explicitDestination !== null) {
+    const mine = new Set(signerAddresses.map(normalizeAddressForComparison));
+    const leavesWallet = explicitDestination
+      ? !mine.has(normalizeAddressForComparison(explicitDestination))
+      : false;
+    return {
+      sourceInputs,
+      destinationVout: null,
+      ...(explicitDestination ? { destinationAddress: explicitDestination } : {}),
+      detaches: true,
+      mode: destinationCommitted ? 'explicit-detach' : 'flexible',
+      destinationCommitted,
+      leavesWallet: destinationCommitted ? leavesWallet : true,
+    };
+  }
+
   // Core's destination rule, verbatim: the first output that is not an OP_RETURN.
   const destination = outputs.find((output) => output.type !== 'op_return');
 
   if (!destination) {
-    return { sourceInputs, destinationVout: null, detaches: true, leavesWallet: false };
+    return {
+      sourceInputs,
+      destinationVout: null,
+      detaches: true,
+      mode: destinationCommitted ? 'implicit-source' : 'flexible',
+      destinationCommitted,
+      leavesWallet: !destinationCommitted,
+    };
   }
 
   const mine = new Set(signerAddresses.map(normalizeAddressForComparison));
@@ -89,7 +150,9 @@ export function resolveAttachedAssetDestination(
     destinationVout: destination.index,
     ...(destination.address ? { destinationAddress: destination.address } : {}),
     detaches: false,
-    leavesWallet,
+    mode: destinationCommitted ? 'implicit-output' : 'flexible',
+    destinationCommitted,
+    leavesWallet: destinationCommitted ? leavesWallet : true,
   };
 }
 

--- a/src/core/counterparty/describe.ts
+++ b/src/core/counterparty/describe.ts
@@ -21,14 +21,17 @@
 import {
   type DisplayUnits,
   divide,
+  fromSatoshis,
   isGreaterThan,
   isLessThan,
   isLessThanOrEqualTo,
   multiply,
   roundDown,
+  subtract,
   toBigNumber,
   toGroupedString,
 } from '@/core/numeric';
+import { getTradingPair } from '@/core/tradingPair';
 
 /**
  * A decoded message in the shape the describer reads, independent of which decoder produced it.
@@ -88,6 +91,11 @@ export interface DescribableMessage {
   feeRequired?: unknown;
   /** The pool an LP operation belongs to. */
   lpAsset?: string;
+  /** A pool deposit's LP floor: the deposit fails below this many LP tokens minted. */
+  minLpQuantity?: unknown;
+  /** A pool withdrawal's floors: the withdrawal fails below these amounts back. */
+  minQuantityA?: unknown;
+  minQuantityB?: unknown;
   /** MPMA recipients, which travel in the payload rather than in outputs. */
   recipients?: { asset?: string; destination: string; quantity: unknown }[];
   /**
@@ -115,7 +123,7 @@ export interface DescribableMessage {
    * A quantity in display units as a plain number string — no separators, no unit, no caveat.
    *
    * Derived figures (an order's price, a destroy's share of supply) need arithmetic, and `format`'s
-   * output is not a valid input for it: separators must be stripped and the "(decimals unconfirmed)"
+   * output is not a valid input for it: separators must be stripped and the "(base units)"
    * caveat parses to NaN.
    *
    * Returns undefined when divisibility is not established — a derived figure must be withheld
@@ -137,7 +145,8 @@ const DISPENSER_STATUS_CLOSED = 10;
 const TYPE_LABELS: Record<string, string> = {
   enhanced_send: 'Send',
   mpma_send: 'Multi-Send',
-  btcpay: 'BTC Payment',
+  // The protocol's own name for the message type.
+  btcpay: 'BTC Pay',
   lr_issuance: 'Issuance',
   lr_subasset: 'Subasset Issuance',
   pooldeposit: 'Pool Deposit',
@@ -199,9 +208,12 @@ export function describeMessage(
       if (m.dispenserStatus === DISPENSER_STATUS_CLOSED) {
         return `Close the ${n(m.asset)} dispenser`;
       }
-      // giveQuantity, not quantity: a dispenser's payout per trigger. Reading `quantity` here
-      // rendered every dispenser as "? XCP".
-      return `${q(m.giveQuantity, m.asset)} ${n(m.asset)} per ${toGroupedString((m.mainchainrate ?? 0) as string | number, 0)} sats`;
+      // The escrow is the headline — it is what leaves the wallet — with the rate beneath it.
+      // giveQuantity, not quantity: a dispenser's payout per trigger.
+      return m.escrowQuantity != null
+        ? `${q(m.escrowQuantity, m.asset)} ${n(m.asset)}\n` +
+          `${q(m.giveQuantity, m.asset)} ${n(m.asset)} @ ${fromSatoshis(String(m.mainchainrate ?? 0), { removeTrailingZeros: false })} BTC`
+        : `${q(m.giveQuantity, m.asset)} ${n(m.asset)} per ${toGroupedString((m.mainchainrate ?? 0) as string | number, 0)} sats`;
 
     case 'dispense':
       // The payload is a marker byte; which dispenser is triggered is decided by the outputs,
@@ -213,13 +225,23 @@ export function describeMessage(
     case 'lr_issuance':
     case 'lr_subasset': {
       const asset = m.subassetLongname || n(m.asset);
-      return m.quantity != null && m.quantity !== 0n && m.quantity !== 0
-        ? `${asset} — issue ${q(m.quantity, m.asset)}`
-        : `${asset} — no new supply`;
+      // The message itself carries the divisible switch, so the quantity never needs the
+      // unknown-divisibility caveat here: scale by the flag being signed rather than a lookup.
+      const issued = m.quantity != null && m.quantity !== 0n && m.quantity !== 0
+        ? m.divisible === undefined
+          ? q(m.quantity, m.asset)
+          : m.divisible
+            ? fromSatoshis(String(m.quantity), { removeTrailingZeros: false })
+            : BigInt(String(m.quantity)).toLocaleString()
+        : null;
+      // Two lines: the asset is the headline, the amount reads beneath it — a numeric asset
+      // name and a quantity in one sentence are two long tokens fighting for the same line.
+      return issued !== null ? `${asset}\nIssue ${issued}` : `${asset}\nNo new supply`;
     }
 
     case 'dividend':
-      return `${q(m.quantityPerUnit, m.dividendAsset)} ${n(m.dividendAsset)} per ${n(m.asset)}`;
+      // The rate is the headline; who it is paid across reads beneath it.
+      return `${q(m.quantityPerUnit, m.dividendAsset)} ${n(m.dividendAsset)}\nAll ${n(m.asset)} holders`;
 
     case 'btcpay':
       // Not "BTC Pay for Order Match": that is the label above it, and the eyebrow repeating the
@@ -240,14 +262,35 @@ export function describeMessage(
       // to state, name the asset rather than formatting nothing as "?".
       return m.quantity == null ? n(m.asset) : `${q(m.quantity, m.asset)} ${n(m.asset)}`;
 
-    case 'pooldeposit':
-      return `Deposit liquidity: ${q(m.quantityA, m.assetA)} ${n(m.assetA)} and ${q(m.quantityB, m.assetB)} ${n(m.assetB)}`;
+    case 'pooldeposit': {
+      // The two legs are the headline; the price they imply reads beneath. The ratio is withheld
+      // when either side's divisibility is unknown — a rate on a guessed scale is wrong by 1e8.
+      const legs = `${q(m.quantityA, m.assetA)} ${n(m.assetA)} / ${q(m.quantityB, m.assetB)} ${n(m.assetB)}`;
+      const a = m.numeric?.(m.quantityA, m.assetA);
+      const b = m.numeric?.(m.quantityB, m.assetB);
+      const ratio =
+        a !== undefined && b !== undefined
+        && toBigNumber(a).isFinite() && toBigNumber(b).isFinite()
+        && isGreaterThan(a, 0)
+          ? `1 ${n(m.assetA)} = ${toGroupedString(divide(b, a))} ${n(m.assetB)}`
+          : null;
+      return ratio ? `${legs}\n${ratio}` : legs;
+    }
 
-    case 'poolwithdraw':
-      return `Withdraw liquidity: burn ${q(m.quantity, undefined)} LP tokens from ${n(m.assetA)}/${n(m.assetB)}`;
+    case 'poolwithdraw': {
+      // LP tokens are always divisible (core's own comment in verbose.py), so the burn amount
+      // never needs the unknown-divisibility caveat. The pair beneath uses the same base/quote
+      // order as the market pages, so one pool reads the same way everywhere.
+      const pair = getTradingPair(m.assetA ?? '', m.assetB ?? '').map(n).join(' / ');
+      return m.quantity != null
+        ? `Destroy ${fromSatoshis(String(m.quantity), { removeTrailingZeros: false })} LP Tokens\n${pair}`
+        : `Withdraw liquidity\n${pair}`;
+    }
 
     case 'attach':
-      return `Attach ${q(m.quantity, m.asset)} ${n(m.asset)} to UTXO`;
+      // "to UTXO" says nothing an attach does not already imply; the created outpoint is named
+      // in the detail list.
+      return `Attach ${q(m.quantity, m.asset)} ${n(m.asset)}`;
 
     case 'detach':
       // The payload carries one field — where everything on the UTXO goes.
@@ -320,6 +363,12 @@ export interface ProtocolContext {
   dispensePayouts?: string[];
   /** XCP a dividend costs beyond the distributed asset: core charges a per-holder fee. */
   dividendFeeXcp?: string;
+  /** The LP asset of the pool an LP operation belongs to, when the pool could be resolved. */
+  poolLpAsset?: string;
+  /** The pool's swap fee as a display percentage (e.g. "0.5%"), when the pool exposes one. */
+  poolFeeRate?: string;
+  /** Where a fairmint's XCP payment goes: burned, seeded into a pool, or paid to the issuer. */
+  fairmintPaymentModel?: 'burned' | 'pool' | 'paid';
 }
 
 /** A labelled field of the Counterparty message, for the protocol detail list. */
@@ -433,13 +482,9 @@ export function protocolFields(
       break;
 
     case 'mpma_send':
-      // The headline can only state a count, because the recipients are in the payload rather than
-      // in outputs - so this list is the only account of who is paid. One row per recipient in the
-      // same shape as every other row: the label names the field, the value carries the data.
-      for (const r of m.recipients ?? []) {
-        const paid = amount(r.quantity, r.asset);
-        if (paid) add('Recipient', `${paid} to ${r.destination}`);
-      }
+      // Recipients travel in the payload rather than in outputs, but a label/value row is the
+      // wrong shape for asset + amount + address — the details card renders them as its own
+      // recipient list instead (CounterpartyDetailsCard `recipients`).
       break;
 
     case 'order':
@@ -457,6 +502,10 @@ export function protocolFields(
       // describe the opening case only.
       if (m.dispenserStatus !== DISPENSER_STATUS_CLOSED) {
         add('Escrow', amount(m.escrowQuantity, m.asset));
+        add('Dispense', amount(m.giveQuantity, m.asset));
+        if (m.mainchainrate != null && isGreaterThan(String(m.mainchainrate), 0)) {
+          add('Per dispense', `${fromSatoshis(String(m.mainchainrate), { removeTrailingZeros: false })} BTC`);
+        }
         add('Dispenses', dispensesAvailable(m));
       }
       break;
@@ -477,10 +526,17 @@ export function protocolFields(
       break;
 
     case 'fairmint':
-      // Headline: the amount being minted. Not in it: what it costs. "XCP price" rather than
-      // "Cost", because this is a purchase price and the same screen uses "XCP fee" for the
-      // protocol charge on attach, detach and dividend - one name per concept.
-      add('XCP price', context.protocolFeeXcp ? `${context.protocolFeeXcp} XCP` : undefined);
+      // Headline: the amount being minted. Not in it: what it costs, and where the payment goes —
+      // a fairminter burns the XCP, seeds a liquidity pool with it, or pays it to the issuer, and
+      // those are different acts to agree to. A BTC-fee-only mint has no row at all.
+      add(
+        context.fairmintPaymentModel === 'burned'
+          ? 'XCP burned'
+          : context.fairmintPaymentModel === 'pool'
+            ? 'XCP to pool'
+            : 'XCP price',
+        context.protocolFeeXcp ? `${context.protocolFeeXcp} XCP` : undefined
+      );
       break;
 
     case 'issuance':
@@ -497,25 +553,37 @@ export function protocolFields(
       break;
 
     case 'dividend':
-      // Headline: the rate. Here: the bill, before the supply it is measured against.
+      // Headline: the rate. Here: the bill.
       add(
-        'Total payout',
+        'Total dividend',
         context.dividendTotal ? `${context.dividendTotal} ${n(m.dividendAsset)}` : undefined
       );
       add('XCP fee', context.dividendFeeXcp ? `${context.dividendFeeXcp} XCP` : undefined);
-      add('Supply', context.assetSupply ? `${context.assetSupply} ${n(m.asset)}` : undefined);
       break;
 
-    case 'destroy':
+    case 'destroy': {
       // Headline: the amount. Without the supply it has no sense of scale - destroying 1,000 of
-      // 1,000 is a very different act from destroying 1,000 of a billion.
-      add('Share of supply', shareOfSupply(m, context.assetSupply));
+      // 1,000 is a very different act from destroying 1,000 of a billion. Before/after states the
+      // ledger's supply is the pre-burn figure, which "Total supply" alone left ambiguous.
       add(
-        'Total supply',
+        'Supply before',
         context.assetSupply ? `${context.assetSupply} ${n(m.asset)}` : undefined
       );
+      const destroyed = m.numeric?.(m.quantity, m.asset);
+      if (context.assetSupply && destroyed !== undefined) {
+        const total = context.assetSupply.replace(/,/g, '');
+        if (
+          toBigNumber(total).isFinite() &&
+          toBigNumber(destroyed).isFinite() &&
+          !isLessThan(subtract(total, destroyed), 0)
+        ) {
+          add('Supply after', `${toGroupedString(subtract(total, destroyed))} ${n(m.asset)}`);
+        }
+      }
+      add('Share destroyed', shareOfSupply(m, context.assetSupply));
       add('Tag', m.memo);
       break;
+    }
 
     case 'sweep':
       // Headline: the destination. Not in it: what actually moves, which is the whole question -
@@ -559,10 +627,28 @@ export function protocolFields(
       add('Order hash', m.offerHash);
       break;
 
-    case 'pooldeposit':
+    case 'pooldeposit': {
+      // Both amounts are the headline; the pool they belong to, its fee, and the slippage floor
+      // being signed are not.
+      add('Pool', m.lpAsset ? n(m.lpAsset) : context.poolLpAsset);
+      add('Pool fee', context.poolFeeRate);
+      // LP tokens are always divisible; a zero floor means no slippage protection was set.
+      if (m.minLpQuantity != null && isGreaterThan(String(m.minLpQuantity), 0)) {
+        add('Min LP received', `${fromSatoshis(String(m.minLpQuantity))} LP`);
+      }
+      break;
+    }
+
     case 'poolwithdraw':
-      // Both amounts are the headline; the pool they belong to is not.
-      add('Pool', m.lpAsset ? n(m.lpAsset) : undefined);
+      add('Pool', m.lpAsset ? n(m.lpAsset) : context.poolLpAsset);
+      add('Pool fee', context.poolFeeRate);
+      // The withdrawal's slippage floors: it fails below these amounts back.
+      if (m.minQuantityA != null && isGreaterThan(String(m.minQuantityA), 0)) {
+        add(`Min ${n(m.assetA)} back`, amount(m.minQuantityA, m.assetA, ''));
+      }
+      if (m.minQuantityB != null && isGreaterThan(String(m.minQuantityB), 0)) {
+        add(`Min ${n(m.assetB)} back`, amount(m.minQuantityB, m.assetB, ''));
+      }
       break;
 
     case 'attach':
@@ -579,14 +665,15 @@ export function protocolFields(
 
     case 'detach':
       // The destination is in the headline. What is not is which balances come back.
-      for (const asset of context.detachingAssets ?? []) add('Released', asset);
+      for (const asset of context.detachingAssets ?? []) add('Detached', asset);
       add('XCP fee', context.protocolFeeXcp ? `${context.protocolFeeXcp} XCP` : undefined);
       break;
 
     case 'utxo':
     case 'utxo_move':
-      // Asset, amount and destination are the headline; which UTXO is being emptied is not.
+      // Asset and amount are the headline; the endpoints of the move are not.
       add('From UTXO', m.sourceUtxo);
+      add('To', m.destination);
       break;
 
     default:

--- a/src/core/counterparty/inputAssets.ts
+++ b/src/core/counterparty/inputAssets.ts
@@ -24,6 +24,8 @@ export interface InputAttachedAssets {
   lookupFailed?: boolean;
   assets: Array<{
     asset: string;
+    /** Exact Counterparty base-unit quantity, preserved as decimal text when the API supplies it. */
+    quantity?: string;
     quantity_normalized: string;
     asset_longname?: string | null;
   }>;
@@ -61,6 +63,7 @@ export async function fetchInputsAttachedAssets(
           .filter((b) => b.asset && b.quantity_normalized)
           .map((b) => ({
             asset: b.asset,
+            ...(b.quantity !== undefined ? { quantity: String(b.quantity) } : {}),
             quantity_normalized: b.quantity_normalized,
             asset_longname: b.asset_info?.asset_longname ?? null,
           }));

--- a/src/core/counterparty/marketplaceBatch.ts
+++ b/src/core/counterparty/marketplaceBatch.ts
@@ -1,0 +1,160 @@
+/** Homogeneous multi-PSBT marketplace phases. Every item proves independently first. */
+
+import { normalizeAddressForComparison } from '@/core/bitcoin/address';
+import {
+  type AttachForListingIntentClaim,
+  type CreateListingIntentClaim,
+  type MarketplaceApprovalReview,
+  type PrepareBulkFanoutIntentClaim,
+  parseMarketplaceIntent,
+} from '@/core/counterparty/marketplaceIntent';
+import { sum, toSafeInteger } from '@/core/numeric';
+
+export type MarketplaceBatchIntent =
+  | PrepareBulkFanoutIntentClaim
+  | AttachForListingIntentClaim
+  | CreateListingIntentClaim;
+
+export type MarketplaceBatchKind = 'bulk-fanout' | 'bulk-attach' | 'bulk-listing';
+
+const sameAddress = (left: string, right: string): boolean =>
+  normalizeAddressForComparison(left) === normalizeAddressForComparison(right);
+
+/** Parse an untrusted request array and admit only bounded homogeneous signing phases. */
+export function parseMarketplaceBatchIntents(values: unknown[]): {
+  kind: MarketplaceBatchKind;
+  intents: MarketplaceBatchIntent[];
+} {
+  if (values.length < 1 || values.length > 8) {
+    throw new Error('marketplace batch must contain 1..8 requests');
+  }
+  const parsed = values.map(parseMarketplaceIntent);
+  const action = parsed[0]!.action;
+  if (!parsed.every(intent => intent.action === action)) {
+    throw new Error('marketplace batch requests must use one semantic action');
+  }
+  if (!['prepare_bulk_fanout', 'attach_for_listing', 'create_listing'].includes(action)) {
+    throw new Error('marketplace action is not supported in a multi-PSBT phase');
+  }
+  const intents = parsed as MarketplaceBatchIntent[];
+  const seller = intents[0]!.seller;
+  if (!intents.every(intent => sameAddress(intent.seller, seller))) {
+    throw new Error('marketplace batch requests must use one seller identity');
+  }
+  if (new Set(intents.map(intent => intent.operationId)).size !== intents.length) {
+    if (action !== 'prepare_bulk_fanout') {
+      throw new Error('marketplace batch contains a duplicate operation id');
+    }
+  }
+
+  if (action === 'prepare_bulk_fanout') {
+    if (intents.length > 5) throw new Error('bulk fan-out phase supports at most 5 parents');
+    const fanouts = intents as PrepareBulkFanoutIntentClaim[];
+    const operationId = fanouts[0]!.operationId;
+    if (!fanouts.every(intent => intent.operationId === operationId)) {
+      throw new Error('bulk fan-out parents must belong to one operation');
+    }
+    if (fanouts.some((intent, index) => intent.batchIndex !== index)) {
+      throw new Error('bulk fan-out batch indices must be ordered from zero');
+    }
+    if (new Set(fanouts.map(intent => intent.fundingOutpoint.txid + ':' + intent.fundingOutpoint.vout)).size
+      !== fanouts.length) {
+      throw new Error('bulk fan-out parents must spend distinct funding outpoints');
+    }
+    return { kind: 'bulk-fanout', intents: fanouts };
+  }
+  const semanticTargets = action === 'attach_for_listing'
+    ? (intents as AttachForListingIntentClaim[]).map(intent =>
+        `${intent.expectedAttachedOutpoint.txid}:${intent.expectedAttachedOutpoint.vout}`)
+    : (intents as CreateListingIntentClaim[]).map(intent => {
+        const target = intent.assets[0].sourceOutpoint;
+        return `${target.txid}:${target.vout}`;
+      });
+  if (new Set(semanticTargets).size !== semanticTargets.length) {
+    throw new Error('marketplace batch contains a duplicate transaction target');
+  }
+  return {
+    kind: action === 'attach_for_listing' ? 'bulk-attach' : 'bulk-listing',
+    intents,
+  };
+}
+
+const exactSafeSum = (values: number[], label: string): number => {
+  const total = toSafeInteger(sum(values).toFixed(0));
+  if (total === undefined) throw new Error(`${label} exceeds the safe integer range`);
+  return total;
+};
+
+const formatXcpRaw = (values: string[]): string => {
+  const raw = sum(values).toFixed(0);
+  const padded = raw.padStart(9, '0');
+  const whole = padded.slice(0, -8);
+  const fraction = padded.slice(-8).replace(/0+$/, '');
+  return fraction ? `${whole}.${fraction} XCP` : `${whole} XCP`;
+};
+
+/** Aggregate already-independent item proofs without weakening any item status. */
+export function analyzeMarketplaceBatch(
+  kind: MarketplaceBatchKind,
+  intents: MarketplaceBatchIntent[],
+  reviews: MarketplaceApprovalReview[],
+): MarketplaceApprovalReview {
+  if (intents.length !== reviews.length || intents.length < 1) {
+    throw new Error('marketplace batch proof count does not match its intents');
+  }
+  const blockers = reviews.flatMap((review, index) =>
+    review.blockers.map(problem => `item ${index + 1}: ${problem}`));
+  const status = reviews.some(review => review.status === 'blocked')
+    ? 'blocked'
+    : reviews.some(review => review.status === 'retry')
+      ? 'retry'
+      : reviews.some(review => review.status === 'caution')
+        ? 'caution'
+        : 'proved';
+  const seller = intents[0]!.seller;
+  const facts: MarketplaceApprovalReview['facts'] = [
+    { label: 'Transactions', value: intents.length.toLocaleString() },
+    { label: 'Seller wallet', value: seller },
+  ];
+  let title: string;
+  let notice: string;
+
+  if (kind === 'bulk-fanout') {
+    const fanouts = intents as PrepareBulkFanoutIntentClaim[];
+    const slots = exactSafeSum(fanouts.map(intent => intent.slotCount), 'slot count');
+    const fees = exactSafeSum(fanouts.map(intent => intent.networkFeeSats), 'network fee');
+    title = `Prepare ${slots} listing funding slots`;
+    facts.push(
+      { label: 'Attach slots', value: slots.toLocaleString() },
+      { label: 'Total network fees', value: `${fees.toLocaleString()} sats` },
+    );
+    notice = 'Every fan-out input and same-wallet output was proved before this batch can sign. No Counterparty asset moves in this phase.';
+  } else if (kind === 'bulk-attach') {
+    const attaches = intents as AttachForListingIntentClaim[];
+    const fees = exactSafeSum(attaches.map(intent => intent.networkFeeSats), 'network fee');
+    title = `Attach ${attaches.length} collectibles for listing`;
+    facts.push(
+      { label: 'Total network fees', value: `${fees.toLocaleString()} sats` },
+      {
+        label: 'Total quoted XCP fees',
+        value: formatXcpRaw(attaches.map(intent => intent.protocolFee.quotedAmountRaw)),
+      },
+    );
+    notice = 'Every attach proves its source, clean funding, carrier output, miner fee, and local Counterparty message. XCP fees remain block-dependent until confirmation.';
+  } else {
+    const listings = intents as CreateListingIntentClaim[];
+    const gross = exactSafeSum(listings.map(intent => intent.priceSats), 'listing prices');
+    title = `Authorize ${listings.length} marketplace listings`;
+    facts.push({ label: 'Combined asking prices', value: `${gross.toLocaleString()} sats` });
+    notice = 'Every listing independently guarantees its seller payment. Each flexible signature remains valid until its attached asset outpoint is spent.';
+  }
+
+  return {
+    status,
+    family: 'marketplace_batch',
+    title,
+    facts,
+    notices: blockers.length > 0 ? [] : [{ severity: status === 'caution' ? 'warning' : 'info', message: notice }],
+    blockers,
+  };
+}

--- a/src/core/counterparty/marketplaceBundle.ts
+++ b/src/core/counterparty/marketplaceBundle.ts
@@ -311,8 +311,8 @@ export function analyzeAcceptanceCpfpBundle(
     status,
     family: 'accept_exact_offer_with_cpfp',
     title:
-      `Accept ${(parentIntent.priceSats / 100_000_000).toFixed(8)} BTC for `
-      + `${claim.quantityRaw} raw units of ${claim.asset} with fee bump`,
+      `Accept ${(parentIntent.priceSats / 100_000_000).toFixed(8)} BTC for ${claim.asset}`
+      + ' with fee bump',
     facts: [
       { label: 'Offer price', value: `${parentIntent.priceSats.toLocaleString()} sats` },
       {

--- a/src/core/counterparty/marketplaceBundle.ts
+++ b/src/core/counterparty/marketplaceBundle.ts
@@ -1,0 +1,341 @@
+/** Atomic wallet proof for an exact-offer acceptance parent and its seller-funded CPFP child. */
+
+import { normalizeAddressForComparison } from '@/core/bitcoin/address';
+import {
+  type AcceptExactOfferIntentClaim,
+  type MarketplaceApprovalReview,
+  type MarketplaceAssetClaim,
+  parseMarketplaceIntent,
+} from '@/core/counterparty/marketplaceIntent';
+import { toFiniteNumber } from '@/core/numeric';
+
+export interface BumpAcceptanceFeeIntentClaim {
+  standard: 'counterparty-marketplace';
+  version: 1;
+  action: 'bump_acceptance_fee';
+  operationId: string;
+  protocolVersion: 'exact_offer_v1';
+  assets: [MarketplaceAssetClaim];
+  authorizationId: string;
+  seller: string;
+  parentExpectedTxid: string;
+  childExpectedTxid: string;
+  parentSellerProceedsVout: 1;
+  parentSellerProceedsSats: number;
+  parentNetworkFeeSats: number;
+  childNetworkFeeSats: number;
+  packageFeeSats: number;
+  packageFeeRate: number;
+  finalSellerProceedsSats: number;
+}
+
+interface InputLike {
+  index: number;
+  txid: string;
+  vout: number;
+  address?: string;
+  value?: number;
+  hasSignatures?: boolean;
+}
+
+interface OutputLike {
+  index: number;
+  type: string;
+  address?: string;
+  value: number;
+}
+
+export interface AcceptanceCpfpBundleAnalysisInput {
+  parentIntent: AcceptExactOfferIntentClaim;
+  parentReview: MarketplaceApprovalReview;
+  childIntent: BumpAcceptanceFeeIntentClaim;
+  childInputs: InputLike[];
+  childOutputs: OutputLike[];
+  childSignedInputs: Array<{ index: number; sighashType: number }>;
+  childSignerAddresses: string[];
+  childTransactionId?: string;
+  childHasCounterpartyPayload: boolean;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const boundedString = (value: unknown, label: string, max = 160): string => {
+  if (typeof value !== 'string' || value.length < 1 || value.length > max) {
+    throw new Error(`${label} must be a non-empty string of at most ${max} characters`);
+  }
+  return value;
+};
+
+const positiveInteger = (value: unknown, label: string): number => {
+  if (!Number.isSafeInteger(value) || Number(value) <= 0) {
+    throw new Error(`${label} must be a positive safe integer`);
+  }
+  return Number(value);
+};
+
+const nonNegativeInteger = (value: unknown, label: string): number => {
+  if (!Number.isSafeInteger(value) || Number(value) < 0) {
+    throw new Error(`${label} must be a non-negative safe integer`);
+  }
+  return Number(value);
+};
+
+const txid = (value: unknown, label: string): string => {
+  const parsed = boundedString(value, label, 64).toLowerCase();
+  if (!/^[0-9a-f]{64}$/.test(parsed)) throw new Error(`${label} must be 32-byte hex`);
+  return parsed;
+};
+
+const parseAsset = (value: unknown): MarketplaceAssetClaim => {
+  if (!isRecord(value) || !isRecord(value.sourceOutpoint)) {
+    throw new Error('bumpAcceptanceFee.assets[0] must carry a source outpoint');
+  }
+  const quantityRaw = boundedString(value.quantityRaw, 'quantityRaw', 24);
+  if (!/^[1-9][0-9]*$/.test(quantityRaw)) {
+    throw new Error('quantityRaw must be a positive base-unit integer string');
+  }
+  const vout = nonNegativeInteger(value.sourceOutpoint.vout, 'sourceOutpoint.vout');
+  return {
+    asset: boundedString(value.asset, 'asset', 250),
+    quantityRaw,
+    sourceOutpoint: {
+      txid: txid(value.sourceOutpoint.txid, 'sourceOutpoint.txid'),
+      vout,
+    },
+  };
+};
+
+/** Parse both untrusted request labels and require the only supported atomic bundle shape. */
+export function parseAcceptanceCpfpBundleIntents(
+  parentValue: unknown,
+  childValue: unknown,
+): {
+  parent: AcceptExactOfferIntentClaim;
+  child: BumpAcceptanceFeeIntentClaim;
+} {
+  const parent = parseMarketplaceIntent(parentValue);
+  if (parent.action !== 'accept_exact_offer') {
+    throw new Error('bundle request 0 must be accept_exact_offer');
+  }
+  if (!isRecord(childValue)) throw new Error('bundle request 1 intent must be an object');
+  if (
+    childValue.standard !== 'counterparty-marketplace'
+    || childValue.version !== 1
+    || childValue.action !== 'bump_acceptance_fee'
+    || childValue.protocolVersion !== 'exact_offer_v1'
+  ) {
+    throw new Error('bundle request 1 must be counterparty-marketplace bump_acceptance_fee v1');
+  }
+  if (!Array.isArray(childValue.assets) || childValue.assets.length !== 1) {
+    throw new Error('bump_acceptance_fee must claim exactly one asset');
+  }
+  if (childValue.parentSellerProceedsVout !== 1) {
+    throw new Error('bump_acceptance_fee must spend parent seller-proceeds output 1');
+  }
+  const packageFeeRate = toFiniteNumber(childValue.packageFeeRate);
+  if (packageFeeRate === undefined || packageFeeRate <= 0 || packageFeeRate > 500) {
+    throw new Error('packageFeeRate must be a finite rate in (0, 500]');
+  }
+
+  return {
+    parent,
+    child: {
+      standard: 'counterparty-marketplace',
+      version: 1,
+      action: 'bump_acceptance_fee',
+      operationId: boundedString(childValue.operationId, 'operationId'),
+      protocolVersion: 'exact_offer_v1',
+      assets: [parseAsset(childValue.assets[0])],
+      authorizationId: boundedString(childValue.authorizationId, 'authorizationId'),
+      seller: boundedString(childValue.seller, 'seller', 128),
+      parentExpectedTxid: txid(childValue.parentExpectedTxid, 'parentExpectedTxid'),
+      childExpectedTxid: txid(childValue.childExpectedTxid, 'childExpectedTxid'),
+      parentSellerProceedsVout: 1,
+      parentSellerProceedsSats: positiveInteger(
+        childValue.parentSellerProceedsSats,
+        'parentSellerProceedsSats',
+      ),
+      parentNetworkFeeSats: nonNegativeInteger(
+        childValue.parentNetworkFeeSats,
+        'parentNetworkFeeSats',
+      ),
+      childNetworkFeeSats: positiveInteger(
+        childValue.childNetworkFeeSats,
+        'childNetworkFeeSats',
+      ),
+      packageFeeSats: positiveInteger(childValue.packageFeeSats, 'packageFeeSats'),
+      packageFeeRate,
+      finalSellerProceedsSats: positiveInteger(
+        childValue.finalSellerProceedsSats,
+        'finalSellerProceedsSats',
+      ),
+    },
+  };
+}
+
+const sameAddress = (left: string | undefined, right: string): boolean =>
+  left !== undefined
+  && normalizeAddressForComparison(left) === normalizeAddressForComparison(right);
+
+const sameAsset = (left: MarketplaceAssetClaim, right: MarketplaceAssetClaim): boolean =>
+  left.asset === right.asset
+  && left.quantityRaw === right.quantityRaw
+  && left.sourceOutpoint.txid === right.sourceOutpoint.txid
+  && left.sourceOutpoint.vout === right.sourceOutpoint.vout;
+
+/** Prove both transactions before the approval page invokes either signer. */
+export function analyzeAcceptanceCpfpBundle(
+  input: AcceptanceCpfpBundleAnalysisInput,
+): MarketplaceApprovalReview {
+  const { parentIntent, parentReview, childIntent } = input;
+  const blockers: string[] = [];
+  const retry: string[] = [];
+
+  if (parentReview.status === 'retry') {
+    retry.push(...parentReview.blockers.map(problem => `parent: ${problem}`));
+  } else if (parentReview.status !== 'proved' || parentReview.family !== 'accept_exact_offer') {
+    blockers.push(...(
+      parentReview.blockers.length > 0
+        ? parentReview.blockers.map(problem => `parent: ${problem}`)
+        : ['the parent exact-offer acceptance did not independently prove']
+    ));
+  }
+  if (
+    childIntent.operationId !== parentIntent.operationId
+    || childIntent.authorizationId !== parentIntent.authorizationId
+  ) {
+    blockers.push('parent and child do not identify the same exact authorization');
+  }
+  if (!sameAsset(childIntent.assets[0], parentIntent.assets[0])) {
+    blockers.push('parent and child do not identify the same attached asset');
+  }
+  if (!sameAddress(childIntent.seller, parentIntent.seller)) {
+    blockers.push('parent and child do not identify the same seller');
+  }
+  if (childIntent.parentExpectedTxid !== parentIntent.expectedTxid) {
+    blockers.push('the child does not spend the exact reviewed parent transaction');
+  }
+  if (childIntent.parentSellerProceedsSats !== parentIntent.sellerProceedsSats) {
+    blockers.push('the child parent value differs from the reviewed seller proceeds');
+  }
+  if (childIntent.parentNetworkFeeSats !== parentIntent.networkFeeSats) {
+    blockers.push('the package parent fee differs from the reviewed acceptance fee');
+  }
+
+  if (input.childHasCounterpartyPayload) {
+    blockers.push('the CPFP child must be an ordinary Bitcoin transaction with no Counterparty payload');
+  }
+  if (!input.childTransactionId) {
+    retry.push('the wallet could not establish the child transaction id');
+  } else if (input.childTransactionId.toLowerCase() !== childIntent.childExpectedTxid) {
+    blockers.push('the child transaction id differs from the package claim');
+  }
+  if (input.childInputs.length !== 1 || input.childOutputs.length !== 1) {
+    blockers.push(
+      `expected a 1-input/1-output CPFP child, got ${input.childInputs.length}/${input.childOutputs.length}`,
+    );
+  }
+  if (
+    input.childSignedInputs.length !== 1
+    || input.childSignedInputs[0]?.index !== 0
+    || input.childSignedInputs[0]?.sighashType !== 0x01
+  ) {
+    blockers.push('the wallet must sign only child input 0 with ALL (0x01)');
+  }
+  if (
+    input.childSignerAddresses.length !== 1
+    || !sameAddress(input.childSignerAddresses[0], childIntent.seller)
+  ) {
+    blockers.push('the requested child signer is not exactly the accepting seller');
+  }
+
+  const childInput = input.childInputs[0];
+  if (!childInput) {
+    blockers.push('the CPFP child input is missing');
+  } else {
+    if (
+      childInput.txid.toLowerCase() !== childIntent.parentExpectedTxid
+      || childInput.vout !== childIntent.parentSellerProceedsVout
+    ) {
+      blockers.push('the child input is not parent seller-proceeds output 1');
+    }
+    if (!sameAddress(childInput.address, childIntent.seller)) {
+      blockers.push('the child input is not controlled by the accepting seller');
+    }
+    if (childInput.value === undefined) {
+      retry.push('the child input has no authenticated parent-output value');
+    } else if (childInput.value !== childIntent.parentSellerProceedsSats) {
+      blockers.push('the child input value differs from parent seller proceeds');
+    }
+    if (childInput.hasSignatures !== false) {
+      blockers.push('the child input must be proven unsigned before bundle approval');
+    }
+  }
+
+  const childOutput = input.childOutputs[0];
+  if (!childOutput) {
+    blockers.push('the seller-returning child output is missing');
+  } else {
+    if (childOutput.type === 'op_return' || !sameAddress(childOutput.address, childIntent.seller)) {
+      blockers.push('the child output does not return to the accepting seller');
+    }
+    if (childOutput.value !== childIntent.finalSellerProceedsSats) {
+      blockers.push('the child output differs from final seller proceeds');
+    }
+  }
+
+  if (
+    childIntent.parentSellerProceedsSats - childIntent.finalSellerProceedsSats
+    !== childIntent.childNetworkFeeSats
+  ) {
+    blockers.push('the child fee does not equal parent proceeds minus final proceeds');
+  }
+  if (
+    childIntent.parentNetworkFeeSats + childIntent.childNetworkFeeSats
+    !== childIntent.packageFeeSats
+  ) {
+    blockers.push('the package fee does not equal parent plus child fees');
+  }
+  if (childInput?.value !== undefined && childOutput) {
+    const actualChildFee = childInput.value - childOutput.value;
+    if (actualChildFee < 0 || actualChildFee !== childIntent.childNetworkFeeSats) {
+      blockers.push('the actual child miner fee differs from the package claim');
+    }
+  }
+
+  const allProblems = [...retry, ...blockers];
+  const status = blockers.length > 0 ? 'blocked' : retry.length > 0 ? 'retry' : 'proved';
+  const claim = parentIntent.assets[0];
+  return {
+    status,
+    family: 'accept_exact_offer_with_cpfp',
+    title:
+      `Accept ${(parentIntent.priceSats / 100_000_000).toFixed(8)} BTC for `
+      + `${claim.quantityRaw} raw units of ${claim.asset} with fee bump`,
+    facts: [
+      { label: 'Offer price', value: `${parentIntent.priceSats.toLocaleString()} sats` },
+      {
+        label: 'Parent seller proceeds',
+        value: `${childIntent.parentSellerProceedsSats.toLocaleString()} sats`,
+      },
+      { label: 'Parent fee', value: `${childIntent.parentNetworkFeeSats.toLocaleString()} sats` },
+      { label: 'Added child fee', value: `${childIntent.childNetworkFeeSats.toLocaleString()} sats` },
+      { label: 'Package fee', value: `${childIntent.packageFeeSats.toLocaleString()} sats` },
+      { label: 'Quoted package rate', value: `${childIntent.packageFeeRate.toFixed(2)} sat/vB` },
+      {
+        label: 'Final seller proceeds',
+        value: `${childIntent.finalSellerProceedsSats.toLocaleString()} sats`,
+      },
+      { label: 'Delivery', value: `Detached to ${parentIntent.delivery.address}` },
+    ],
+    notices: allProblems.length > 0
+      ? []
+      : [{
+          severity: 'info',
+          message:
+            'The parent completes the exact sale and the child spends only your parent proceeds back to you. Both transactions were proved before either signature is requested.',
+        }],
+    blockers: allProblems,
+  };
+}

--- a/src/core/counterparty/marketplaceIntent.ts
+++ b/src/core/counterparty/marketplaceIntent.ts
@@ -117,12 +117,32 @@ export interface AuthorizeExactOfferIntentClaim
 export interface AcceptExactOfferIntentClaim
   extends ExactOfferIntentBase<'accept_exact_offer'> {}
 
+export interface PrepareBulkFanoutIntentClaim {
+  standard: typeof MARKETPLACE_INTENT_STANDARD;
+  version: typeof MARKETPLACE_INTENT_VERSION;
+  action: 'prepare_bulk_fanout';
+  operationId: string;
+  protocolVersion: 'counterparty_bulk_attach_v1';
+  assets: [];
+  batchIndex: number;
+  seller: string;
+  fundingOutpoint: MarketplaceOutpointClaim;
+  fundingValueSats: number;
+  slotCount: number;
+  slotValueSats: number;
+  networkFeeSats: number;
+  changeSats: number;
+  expectedTxid: string;
+  operationExpiresAt: number;
+}
+
 export type MarketplaceIntentClaimV1 =
   | AttachForListingIntentClaim
   | CreateListingIntentClaim
   | BuyListingsIntentClaim
   | AuthorizeExactOfferIntentClaim
-  | AcceptExactOfferIntentClaim;
+  | AcceptExactOfferIntentClaim
+  | PrepareBulkFanoutIntentClaim;
 
 export interface MarketplaceApprovalReview {
   status: 'proved' | 'caution' | 'retry' | 'blocked';
@@ -132,7 +152,9 @@ export interface MarketplaceApprovalReview {
     | 'buy_listings'
     | 'authorize_exact_offer'
     | 'accept_exact_offer'
-    | 'accept_exact_offer_with_cpfp';
+    | 'accept_exact_offer_with_cpfp'
+    | 'prepare_bulk_fanout'
+    | 'marketplace_batch';
   title: string;
   facts: Array<{ label: string; value: string }>;
   notices: Array<{ severity: 'info' | 'warning' | 'danger'; message: string }>;
@@ -250,6 +272,7 @@ export function parseMarketplaceIntent(value: unknown): MarketplaceIntentClaimV1
     throw new Error(`marketplace intent must use ${MARKETPLACE_INTENT_STANDARD} version 1`);
   }
   if (value.action === 'attach_for_listing') return parseAttachForListingIntent(value);
+  if (value.action === 'prepare_bulk_fanout') return parsePrepareBulkFanoutIntent(value);
   if (value.action === 'buy_listings') return parseBuyListingsIntent(value);
   if (value.action === 'authorize_exact_offer' || value.action === 'accept_exact_offer') {
     return parseExactOfferIntent(value, value.action);
@@ -293,6 +316,51 @@ export function parseMarketplaceIntent(value: unknown): MarketplaceIntentClaimV1
     bitcoinExpiresAt: null,
   };
 }
+
+const parsePrepareBulkFanoutIntent = (
+  value: Record<string, unknown>,
+): PrepareBulkFanoutIntentClaim => {
+  if (value.protocolVersion !== 'counterparty_bulk_attach_v1') {
+    throw new Error('prepare_bulk_fanout intent has the wrong protocolVersion');
+  }
+  if (!Array.isArray(value.assets) || value.assets.length !== 0) {
+    throw new Error('prepare_bulk_fanout must not claim attached assets');
+  }
+  const expectedTxid = boundedString(value.expectedTxid, 'expectedTxid', 64).toLowerCase();
+  if (!/^[0-9a-f]{64}$/.test(expectedTxid)) {
+    throw new Error('expectedTxid must be 32-byte hex');
+  }
+  const batchIndex = safeInteger(value.batchIndex, 'batchIndex');
+  const slotCount = safeInteger(value.slotCount, 'slotCount', { positive: true });
+  if (batchIndex === null || batchIndex < 0) {
+    throw new Error('batchIndex must be a non-negative safe integer');
+  }
+  if (slotCount === null || slotCount > 24) {
+    throw new Error('slotCount must be 1..24');
+  }
+  return {
+    standard: MARKETPLACE_INTENT_STANDARD,
+    version: MARKETPLACE_INTENT_VERSION,
+    action: 'prepare_bulk_fanout',
+    operationId: boundedString(value.operationId, 'operationId'),
+    protocolVersion: 'counterparty_bulk_attach_v1',
+    assets: [],
+    batchIndex,
+    seller: boundedString(value.seller, 'seller', 128),
+    fundingOutpoint: outpoint(value.fundingOutpoint, 'fundingOutpoint'),
+    fundingValueSats: safeInteger(value.fundingValueSats, 'fundingValueSats', {
+      positive: true,
+    })!,
+    slotCount,
+    slotValueSats: safeInteger(value.slotValueSats, 'slotValueSats', { positive: true })!,
+    networkFeeSats: nonNegativeSafeInteger(value.networkFeeSats, 'networkFeeSats'),
+    changeSats: nonNegativeSafeInteger(value.changeSats, 'changeSats'),
+    expectedTxid,
+    operationExpiresAt: safeInteger(value.operationExpiresAt, 'operationExpiresAt', {
+      positive: true,
+    })!,
+  };
+};
 
 const parseAttachForListingIntent = (
   value: Record<string, unknown>,
@@ -1289,6 +1357,132 @@ function analyzeExactOfferIntent(
   };
 }
 
+/** Prove a clean-BTC parent that creates same-owner attach funding slots. */
+function analyzePrepareBulkFanoutIntent(
+  input: MarketplaceAnalysisInput,
+  intent: PrepareBulkFanoutIntentClaim,
+): MarketplaceApprovalReview {
+  const {
+    inputs,
+    outputs,
+    signedInputs,
+    signerAddresses,
+    attachedAssets,
+    hasCounterpartyPayload,
+    transactionId,
+  } = input;
+  const blockers: string[] = [];
+  const retry: string[] = [];
+
+  if (!transactionId) {
+    retry.push('the wallet could not establish the fan-out transaction id');
+  } else if (transactionId.toLowerCase() !== intent.expectedTxid) {
+    blockers.push('the fan-out transaction id differs from the claim');
+  }
+  if (hasCounterpartyPayload) {
+    blockers.push('a funding fan-out must not carry a Counterparty payload');
+  }
+  if (inputs.length !== 1) {
+    blockers.push(`expected exactly one fan-out funding input, got ${inputs.length}`);
+  }
+  if (
+    signedInputs.length !== 1
+    || signedInputs[0]?.index !== 0
+    || signedInputs[0]?.sighashType !== 0x01
+  ) {
+    blockers.push('the wallet must sign only fan-out input 0 with ALL (0x01)');
+  }
+  if (signerAddresses.length !== 1 || !sameAddress(signerAddresses[0], intent.seller)) {
+    blockers.push('the requested fan-out signer is not exactly the claimed seller');
+  }
+
+  const fundingInput = inputs[0];
+  if (!fundingInput) {
+    blockers.push('the fan-out funding input is missing');
+  } else {
+    if (!sameOutpoint(fundingInput, intent.fundingOutpoint)) {
+      blockers.push('the fan-out input differs from the claimed funding outpoint');
+    }
+    if (!sameAddress(fundingInput.address, intent.seller)) {
+      blockers.push('the fan-out input is not controlled by the claimed seller');
+    }
+    if (fundingInput.value === undefined) {
+      retry.push('the fan-out input has no authenticated value');
+    } else if (fundingInput.value !== intent.fundingValueSats) {
+      blockers.push('the fan-out input value differs from the claim');
+    }
+    if (fundingInput.hasSignatures !== false) {
+      blockers.push('the fan-out input must be proven unsigned before approval');
+    }
+  }
+
+  const fundingAssets = attachedAssets.find(entry => entry.inputIndex === 0);
+  if (fundingAssets?.lookupFailed) {
+    retry.push('the attached-asset lookup for the fan-out input failed');
+  } else if (fundingAssets && fundingAssets.assets.length > 0) {
+    blockers.push('the fan-out funding input already carries Counterparty assets');
+  }
+
+  const expectedOutputCount = intent.slotCount + (intent.changeSats > 0 ? 1 : 0);
+  if (outputs.length !== expectedOutputCount) {
+    blockers.push(`expected ${expectedOutputCount} fan-out outputs, got ${outputs.length}`);
+  }
+  for (let outputIndex = 0; outputIndex < outputs.length; outputIndex += 1) {
+    const output = outputs[outputIndex]!;
+    const expectedValue = outputIndex < intent.slotCount
+      ? intent.slotValueSats
+      : intent.changeSats;
+    if (output.type === 'op_return' || !sameAddress(output.address, intent.seller)) {
+      blockers.push(`fan-out output ${outputIndex} does not return to the seller`);
+    }
+    if (output.value !== expectedValue) {
+      blockers.push(`fan-out output ${outputIndex} value differs from the plan`);
+    }
+  }
+
+  const slotTotal = safeSum(Array.from({ length: intent.slotCount }, () => intent.slotValueSats));
+  const outputTotal = slotTotal === null ? null : safeSum([slotTotal, intent.changeSats]);
+  const claimedFee = outputTotal === null ? null : intent.fundingValueSats - outputTotal;
+  if (claimedFee === null || claimedFee < 0 || claimedFee !== intent.networkFeeSats) {
+    blockers.push('the claimed fan-out fee does not equal funding minus outputs');
+  }
+  if (fundingInput?.value !== undefined) {
+    const actualOutputTotal = safeSum(outputs.map(output => output.value));
+    const actualFee = actualOutputTotal === null ? null : fundingInput.value - actualOutputTotal;
+    if (actualFee === null || actualFee < 0 || actualFee !== intent.networkFeeSats) {
+      blockers.push('the actual fan-out fee differs from the claim');
+    }
+  }
+
+  const allProblems = [...retry, ...blockers];
+  return {
+    status: blockers.length > 0 ? 'blocked' : retry.length > 0 ? 'retry' : 'proved',
+    family: 'prepare_bulk_fanout',
+    title: `Prepare ${intent.slotCount} listing funding slot${intent.slotCount === 1 ? '' : 's'}`,
+    facts: [
+      { label: 'Funding input', value: `${intent.fundingValueSats.toLocaleString()} sats` },
+      {
+        label: 'Attach slots',
+        value: `${intent.slotCount} × ${intent.slotValueSats.toLocaleString()} sats`,
+      },
+      { label: 'Change', value: `${intent.changeSats.toLocaleString()} sats` },
+      { label: 'Network fee', value: `${intent.networkFeeSats.toLocaleString()} sats` },
+      {
+        label: 'Operation expiry',
+        value: new Date(intent.operationExpiresAt * 1000).toLocaleString(),
+      },
+    ],
+    notices: allProblems.length > 0
+      ? []
+      : [{
+          severity: 'info',
+          message:
+            'Every output remains controlled by this wallet. These plain-Bitcoin slots fund later Counterparty attach transactions; no asset moves in this phase.',
+        }],
+    blockers: allProblems,
+  };
+}
+
 export function analyzeMarketplaceIntent(input: MarketplaceAnalysisInput): MarketplaceApprovalReview {
   switch (input.intent.action) {
     case 'attach_for_listing':
@@ -1300,5 +1494,7 @@ export function analyzeMarketplaceIntent(input: MarketplaceAnalysisInput): Marke
     case 'authorize_exact_offer':
     case 'accept_exact_offer':
       return analyzeExactOfferIntent(input, input.intent);
+    case 'prepare_bulk_fanout':
+      return analyzePrepareBulkFanoutIntent(input, input.intent);
   }
 }

--- a/src/core/counterparty/marketplaceIntent.ts
+++ b/src/core/counterparty/marketplaceIntent.ts
@@ -41,11 +41,35 @@ export interface CreateListingIntentClaim {
   bitcoinExpiresAt: null;
 }
 
-export type MarketplaceIntentClaimV1 = CreateListingIntentClaim;
+export interface BuyListingsIntentClaim {
+  standard: typeof MARKETPLACE_INTENT_STANDARD;
+  version: typeof MARKETPLACE_INTENT_VERSION;
+  action: 'buy_listings';
+  operationId: string;
+  protocolVersion: 'direct_v1';
+  assets: MarketplaceAssetClaim[];
+  buyer: string;
+  items: Array<MarketplaceAssetClaim & {
+    listingId: string;
+    seller: string;
+    carrierValueSats: number;
+    priceSats: number;
+    sellerPaymentSats: number;
+  }>;
+  subtotalSats: number;
+  networkFeeSats: number;
+  platformFeeSats: number;
+  totalSats: number;
+  expectedTxid: string;
+  delivery: { mode: 'detached'; address: string };
+  marketplaceExpiresAt: number;
+}
+
+export type MarketplaceIntentClaimV1 = CreateListingIntentClaim | BuyListingsIntentClaim;
 
 export interface MarketplaceApprovalReview {
   status: 'proved' | 'caution' | 'retry' | 'blocked';
-  family: 'create_listing';
+  family: 'create_listing' | 'buy_listings';
   title: string;
   facts: Array<{ label: string; value: string }>;
   notices: Array<{ severity: 'info' | 'warning' | 'danger'; message: string }>;
@@ -77,6 +101,8 @@ export interface MarketplaceAnalysisInput {
   attachedAssets: InputAttachedAssets[];
   attachedAssetDestination: AttachedAssetDestination | null;
   hasCounterpartyPayload: boolean;
+  transactionId?: string;
+  localCounterpartyMessage?: { messageType: string; data: unknown };
 }
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -99,6 +125,14 @@ const safeInteger = (
     throw new Error(`${label} must be ${options.positive ? 'a positive ' : 'a '}safe integer`);
   }
   return Number(value);
+};
+
+const nonNegativeSafeInteger = (value: unknown, label: string): number => {
+  const parsed = safeInteger(value, label);
+  if (parsed === null || parsed < 0) {
+    throw new Error(`${label} must be a non-negative safe integer`);
+  }
+  return parsed;
 };
 
 const outpoint = (value: unknown, label: string): MarketplaceOutpointClaim => {
@@ -129,6 +163,7 @@ export function parseMarketplaceIntent(value: unknown): MarketplaceIntentClaimV1
   if (value.standard !== MARKETPLACE_INTENT_STANDARD || value.version !== 1) {
     throw new Error(`marketplace intent must use ${MARKETPLACE_INTENT_STANDARD} version 1`);
   }
+  if (value.action === 'buy_listings') return parseBuyListingsIntent(value);
   if (value.action !== 'create_listing') {
     throw new Error('marketplace intent action is not supported by this wallet version');
   }
@@ -169,13 +204,82 @@ export function parseMarketplaceIntent(value: unknown): MarketplaceIntentClaimV1
   };
 }
 
+const parseBuyListingsIntent = (value: Record<string, unknown>): BuyListingsIntentClaim => {
+  if (value.protocolVersion !== 'direct_v1') {
+    throw new Error('buy_listings intent has the wrong protocolVersion');
+  }
+  if (
+    !Array.isArray(value.assets)
+    || !Array.isArray(value.items)
+    || value.items.length < 1
+    || value.items.length > 20
+    || value.assets.length !== value.items.length
+  ) {
+    throw new Error('buy_listings intent must claim 1..20 aligned assets and items');
+  }
+  if (
+    !isRecord(value.delivery)
+    || value.delivery.mode !== 'detached'
+  ) {
+    throw new Error('buy_listings delivery must be detached');
+  }
+
+  const items = value.items.map((itemValue, index) => {
+    if (!isRecord(itemValue)) throw new Error(`items[${index}] must be an object`);
+    return {
+      ...asset(itemValue, `items[${index}]`),
+      listingId: boundedString(itemValue.listingId, `items[${index}].listingId`),
+      seller: boundedString(itemValue.seller, `items[${index}].seller`, 128),
+      carrierValueSats: safeInteger(
+        itemValue.carrierValueSats,
+        `items[${index}].carrierValueSats`,
+        { positive: true },
+      )!,
+      priceSats: safeInteger(itemValue.priceSats, `items[${index}].priceSats`, {
+        positive: true,
+      })!,
+      sellerPaymentSats: safeInteger(
+        itemValue.sellerPaymentSats,
+        `items[${index}].sellerPaymentSats`,
+        { positive: true },
+      )!,
+    };
+  });
+  const expectedTxid = boundedString(value.expectedTxid, 'expectedTxid', 64).toLowerCase();
+  if (!/^[0-9a-f]{64}$/.test(expectedTxid)) {
+    throw new Error('expectedTxid must be 32-byte hex');
+  }
+
+  return {
+    standard: MARKETPLACE_INTENT_STANDARD,
+    version: MARKETPLACE_INTENT_VERSION,
+    action: 'buy_listings',
+    operationId: boundedString(value.operationId, 'operationId'),
+    protocolVersion: 'direct_v1',
+    assets: value.assets.map((entry, index) => asset(entry, `assets[${index}]`)),
+    buyer: boundedString(value.buyer, 'buyer', 128),
+    items,
+    subtotalSats: safeInteger(value.subtotalSats, 'subtotalSats', { positive: true })!,
+    networkFeeSats: nonNegativeSafeInteger(value.networkFeeSats, 'networkFeeSats'),
+    platformFeeSats: nonNegativeSafeInteger(value.platformFeeSats, 'platformFeeSats'),
+    totalSats: safeInteger(value.totalSats, 'totalSats', { positive: true })!,
+    expectedTxid,
+    delivery: {
+      mode: 'detached',
+      address: boundedString(value.delivery.address, 'delivery.address', 128),
+    },
+    marketplaceExpiresAt: safeInteger(value.marketplaceExpiresAt, 'marketplaceExpiresAt', {
+      positive: true,
+    })!,
+  };
+};
+
 const sameAddress = (left: string | undefined, right: string) =>
   left !== undefined
   && normalizeAddressForComparison(left) === normalizeAddressForComparison(right);
 
 /** Prove the seller's flexible listing authorization from independent transaction facts. */
-export function analyzeMarketplaceIntent({
-  intent,
+function analyzeCreateListingIntent({
   inputs,
   outputs,
   signedInputs,
@@ -183,7 +287,7 @@ export function analyzeMarketplaceIntent({
   attachedAssets,
   attachedAssetDestination,
   hasCounterpartyPayload,
-}: MarketplaceAnalysisInput): MarketplaceApprovalReview {
+}: MarketplaceAnalysisInput, intent: CreateListingIntentClaim): MarketplaceApprovalReview {
   const blockers: string[] = [];
   const retry: string[] = [];
   const claim = intent.assets[0];
@@ -293,4 +397,271 @@ export function analyzeMarketplaceIntent({
         }],
     blockers: allProblems,
   };
+}
+
+const sameOutpoint = (
+  input: InputLike | undefined,
+  claim: MarketplaceOutpointClaim,
+): boolean => input?.txid.toLowerCase() === claim.txid && input.vout === claim.vout;
+
+const safeSum = (values: number[]): number | null => {
+  const sum = values.reduce((total, value) => total + value, 0);
+  return Number.isSafeInteger(sum) ? sum : null;
+};
+
+/** Prove an atomic buyer checkout whose complete transaction is committed by SIGHASH_ALL. */
+function analyzeBuyListingsIntent(
+  input: MarketplaceAnalysisInput,
+  intent: BuyListingsIntentClaim,
+): MarketplaceApprovalReview {
+  const {
+    inputs,
+    outputs,
+    signedInputs,
+    signerAddresses,
+    attachedAssets,
+    hasCounterpartyPayload,
+    transactionId,
+    localCounterpartyMessage,
+  } = input;
+  const blockers: string[] = [];
+  const retry: string[] = [];
+  const itemCount = intent.items.length;
+  const firstAdditionalBuyerInput = itemCount + 1;
+
+  if (!sameAddress(intent.delivery.address, intent.buyer)) {
+    blockers.push('the claimed detach address differs from the claimed buyer');
+  }
+  if (!transactionId) {
+    retry.push('the wallet could not establish the unsigned transaction id');
+  } else if (transactionId.toLowerCase() !== intent.expectedTxid) {
+    blockers.push('the unsigned transaction id differs from the claim');
+  }
+  if (!hasCounterpartyPayload) {
+    blockers.push('the checkout carries no Counterparty payload');
+  }
+  const detachData = isRecord(localCounterpartyMessage?.data)
+    ? localCounterpartyMessage.data
+    : undefined;
+  if (localCounterpartyMessage?.messageType !== 'detach' || !detachData) {
+    blockers.push('the Counterparty payload is not a locally decoded detach');
+  } else if (
+    typeof detachData.destination !== 'string'
+    || !sameAddress(detachData.destination, intent.delivery.address)
+  ) {
+    blockers.push('the locally decoded detach destination differs from the buyer');
+  }
+
+  if (inputs.length < itemCount + 1) {
+    blockers.push(`expected at least ${itemCount + 1} inputs, got ${inputs.length}`);
+  }
+  const inputOutpoints = inputs.map(transactionInput =>
+    `${transactionInput.txid.toLowerCase()}:${transactionInput.vout}`);
+  if (new Set(inputOutpoints).size !== inputOutpoints.length) {
+    blockers.push('the checkout contains a duplicate input outpoint');
+  }
+  const listingIds = intent.items.map(item => item.listingId);
+  if (new Set(listingIds).size !== listingIds.length) {
+    blockers.push('the checkout contains a duplicate listing id');
+  }
+  if (outputs[0]?.type !== 'op_return' || outputs[0]?.value !== 0) {
+    blockers.push('output 0 is not the zero-value Counterparty detach output');
+  }
+
+  const expectedSignedIndices = [
+    0,
+    ...Array.from(
+      { length: Math.max(0, inputs.length - firstAdditionalBuyerInput) },
+      (_, index) => firstAdditionalBuyerInput + index,
+    ),
+  ];
+  const sortedSignedInputs = [...signedInputs].sort((left, right) => left.index - right.index);
+  if (
+    sortedSignedInputs.length !== expectedSignedIndices.length
+    || sortedSignedInputs.some(
+      (signed, index) => signed.index !== expectedSignedIndices[index] || signed.sighashType !== 0x01,
+    )
+    || new Set(signedInputs.map(signed => signed.index)).size !== signedInputs.length
+  ) {
+    blockers.push('the wallet must sign every buyer funding input, and only those inputs, with ALL (0x01)');
+  }
+  if (signerAddresses.length !== 1 || !sameAddress(signerAddresses[0], intent.buyer)) {
+    blockers.push('the requested signer is not exactly the claimed buyer');
+  }
+  inputs.forEach((transactionInput) => {
+    if (transactionInput.hasSignatures !== false) {
+      blockers.push(`input ${transactionInput.index} must be proven unsigned before buyer approval`);
+    }
+  });
+
+  const balances = new Map(attachedAssets.map(entry => [entry.inputIndex, entry]));
+  for (const buyerInputIndex of expectedSignedIndices) {
+    const buyerInput = inputs[buyerInputIndex];
+    if (!buyerInput) continue;
+    if (!sameAddress(buyerInput.address, intent.buyer)) {
+      blockers.push(`buyer funding input ${buyerInputIndex} is not controlled by the claimed buyer`);
+    }
+    if (buyerInput.value === undefined) {
+      retry.push(`buyer funding input ${buyerInputIndex} has no authenticated value`);
+    }
+    const balance = balances.get(buyerInputIndex);
+    if (balance?.lookupFailed) {
+      retry.push(`the attached-asset lookup for buyer input ${buyerInputIndex} failed`);
+    } else if (balance && balance.assets.length > 0) {
+      blockers.push(`buyer funding input ${buyerInputIndex} carries attached Counterparty assets`);
+    }
+  }
+
+  for (let itemIndex = 0; itemIndex < itemCount; itemIndex += 1) {
+    const item = intent.items[itemIndex]!;
+    const claim = intent.assets[itemIndex]!;
+    const sellerInputIndex = itemIndex + 1;
+    const sellerInput = inputs[sellerInputIndex];
+    const sellerOutput = outputs[sellerInputIndex];
+
+    if (
+      item.asset !== claim.asset
+      || item.quantityRaw !== claim.quantityRaw
+      || item.sourceOutpoint.txid !== claim.sourceOutpoint.txid
+      || item.sourceOutpoint.vout !== claim.sourceOutpoint.vout
+    ) {
+      blockers.push(`item ${itemIndex + 1} does not align with its top-level asset claim`);
+    }
+    if (item.sellerPaymentSats !== item.carrierValueSats + item.priceSats) {
+      blockers.push(`item ${itemIndex + 1} seller payment is not carrier plus price`);
+    }
+    if (!sellerInput) {
+      blockers.push(`seller input ${sellerInputIndex} is missing`);
+    } else {
+      if (!sameOutpoint(sellerInput, item.sourceOutpoint)) {
+        blockers.push(`seller input ${sellerInputIndex} is not the claimed attached outpoint`);
+      }
+      if (!sameAddress(sellerInput.address, item.seller)) {
+        blockers.push(`seller input ${sellerInputIndex} is not controlled by the claimed seller`);
+      }
+      if (sellerInput.value === undefined) {
+        retry.push(`seller input ${sellerInputIndex} has no authenticated carrier value`);
+      } else if (sellerInput.value !== item.carrierValueSats) {
+        blockers.push(`seller input ${sellerInputIndex} carrier value differs from the claim`);
+      }
+    }
+    if (!sellerOutput) {
+      blockers.push(`seller payment output ${sellerInputIndex} is missing`);
+    } else {
+      if (!sameAddress(sellerOutput.address, item.seller)) {
+        blockers.push(`output ${sellerInputIndex} does not pay the claimed seller`);
+      }
+      if (sellerOutput.value !== item.sellerPaymentSats) {
+        blockers.push(`output ${sellerInputIndex} differs from the claimed seller payment`);
+      }
+    }
+
+    const balance = balances.get(sellerInputIndex);
+    if (balance?.lookupFailed) {
+      retry.push(`the attached-asset lookup for seller input ${sellerInputIndex} failed`);
+    } else if (!balance || balance.assets.length !== 1) {
+      blockers.push(`seller input ${sellerInputIndex} does not resolve to exactly one attached asset`);
+    } else {
+      const actual = balance.assets[0]!;
+      if (actual.asset !== item.asset) {
+        blockers.push(`seller input ${sellerInputIndex} attached asset differs from the claim`);
+      }
+      if (actual.quantity === undefined) {
+        retry.push(`seller input ${sellerInputIndex} has no exact raw attached quantity`);
+      } else if (actual.quantity !== item.quantityRaw) {
+        blockers.push(`seller input ${sellerInputIndex} raw attached quantity differs from the claim`);
+      }
+    }
+  }
+
+  const subtotal = safeSum(intent.items.map(item => item.priceSats));
+  if (subtotal === null || subtotal !== intent.subtotalSats) {
+    blockers.push('the claimed subtotal does not equal the item prices');
+  }
+  const claimedTotal = safeSum([
+    intent.subtotalSats,
+    intent.networkFeeSats,
+    intent.platformFeeSats,
+  ]);
+  if (claimedTotal === null || claimedTotal !== intent.totalSats) {
+    blockers.push('the claimed total does not equal subtotal plus network and platform fees');
+  }
+
+  let trailingIndex = itemCount + 1;
+  if (intent.platformFeeSats > 0) {
+    const platformOutput = outputs[trailingIndex];
+    if (
+      !platformOutput
+      || platformOutput.type === 'op_return'
+      || !platformOutput.address
+      || sameAddress(platformOutput.address, intent.buyer)
+      || platformOutput.value !== intent.platformFeeSats
+    ) {
+      blockers.push(`output ${trailingIndex} is not the claimed external platform fee`);
+    }
+    trailingIndex += 1;
+  }
+  const changeOutput = outputs[trailingIndex];
+  if (changeOutput && (!sameAddress(changeOutput.address, intent.buyer) || changeOutput.value <= 0)) {
+    blockers.push(`output ${trailingIndex} is not valid buyer change`);
+  }
+  if (outputs.length > trailingIndex + Number(Boolean(changeOutput))) {
+    blockers.push('the checkout has unexpected trailing outputs');
+  }
+
+  const allInputValues = inputs.map(transactionInput => transactionInput.value);
+  if (allInputValues.some(value => value === undefined)) {
+    retry.push('the wallet could not authenticate every input value needed to prove the miner fee');
+  } else {
+    const inputTotal = safeSum(allInputValues as number[]);
+    const outputTotal = safeSum(outputs.map(output => output.value));
+    const actualFee = inputTotal === null || outputTotal === null ? null : inputTotal - outputTotal;
+    if (actualFee === null || actualFee < 0 || actualFee !== intent.networkFeeSats) {
+      blockers.push('the actual miner fee differs from the claim');
+    }
+  }
+
+  const buyerInputValues = expectedSignedIndices.map(index => inputs[index]?.value);
+  if (!buyerInputValues.some(value => value === undefined)) {
+    const buyerInputTotal = safeSum(buyerInputValues as number[]);
+    const buyerChange = changeOutput?.value ?? 0;
+    if (buyerInputTotal === null || buyerInputTotal - buyerChange !== intent.totalSats) {
+      blockers.push('the buyer funding minus change differs from the claimed total');
+    }
+  }
+
+  const allProblems = [...retry, ...blockers];
+  const status = blockers.length > 0 ? 'blocked' : retry.length > 0 ? 'retry' : 'proved';
+  const distinctAssets = new Set(intent.items.map(item => item.asset)).size;
+  return {
+    status,
+    family: 'buy_listings',
+    title: `Buy ${itemCount} collectible${itemCount === 1 ? '' : 's'} for ${(intent.totalSats / 100_000_000).toFixed(8)} BTC`,
+    facts: [
+      { label: 'Items', value: `${itemCount} across ${distinctAssets} asset${distinctAssets === 1 ? '' : 's'}` },
+      { label: 'Seller subtotal', value: `${intent.subtotalSats.toLocaleString()} sats` },
+      { label: 'Network fee', value: `${intent.networkFeeSats.toLocaleString()} sats` },
+      { label: 'Platform fee', value: `${intent.platformFeeSats.toLocaleString()} sats` },
+      { label: 'You pay', value: `${intent.totalSats.toLocaleString()} sats` },
+      { label: 'Delivery', value: `Detached to ${intent.delivery.address}` },
+      {
+        label: 'Marketplace expiry',
+        value: new Date(intent.marketplaceExpiresAt * 1000).toLocaleString(),
+      },
+    ],
+    notices: allProblems.length > 0
+      ? []
+      : [{
+          severity: 'info',
+          message:
+            'SIGHASH_ALL fixes every input, seller payment, fee, change output, and the detach destination shown above.',
+        }],
+    blockers: allProblems,
+  };
+}
+
+export function analyzeMarketplaceIntent(input: MarketplaceAnalysisInput): MarketplaceApprovalReview {
+  return input.intent.action === 'buy_listings'
+    ? analyzeBuyListingsIntent(input, input.intent)
+    : analyzeCreateListingIntent(input, input.intent);
 }

--- a/src/core/counterparty/marketplaceIntent.ts
+++ b/src/core/counterparty/marketplaceIntent.ts
@@ -651,6 +651,9 @@ function analyzeCreateListingIntent({
   }
 
   const balance = attachedAssets.find(entry => entry.inputIndex === 1);
+  // The ledger-normalized amount, for display: facts only render on proved/caution, where this
+  // lookup has succeeded — so the screen never has to show raw base units.
+  let provedQuantity: string | null = null;
   if (balance?.lookupFailed) {
     retry.push('the attached-asset lookup for seller input 1 failed');
   } else if (!balance || balance.assets.length !== 1) {
@@ -662,12 +665,18 @@ function analyzeCreateListingIntent({
       retry.push('the indexer did not return an exact raw attached quantity');
     } else if (actual.quantity !== claim.quantityRaw) {
       blockers.push('attached asset raw quantity differs from the claim');
+    } else {
+      provedQuantity = actual.quantity_normalized;
     }
   }
 
+  // Unknowable is not disproven: with the balance lookup failed there is no attached-asset
+  // destination to check, and blocking on its absence would present a ledger outage as a lying
+  // site. The retry above already gates signing.
   if (
-    attachedAssetDestination?.destinationCommitted !== false
-    || attachedAssetDestination?.mode !== 'flexible'
+    !balance?.lookupFailed
+    && (attachedAssetDestination?.destinationCommitted !== false
+      || attachedAssetDestination?.mode !== 'flexible')
   ) {
     blockers.push('listing signature does not prove the expected buyer-selected delivery flexibility');
   }
@@ -680,7 +689,7 @@ function analyzeCreateListingIntent({
     title: `List 1 ${claim.asset} for ${(intent.priceSats / 100_000_000).toFixed(8)} BTC`,
     facts: [
       { label: 'Seller receives', value: `${intent.guaranteedSellerPaymentSats.toLocaleString()} sats` },
-      { label: 'Asset quantity', value: `${claim.quantityRaw} raw units` },
+      { label: 'Quantity', value: `${provedQuantity ?? claim.quantityRaw} ${claim.asset}` },
       { label: 'Delivery', value: 'Detached to the eventual buyer' },
       {
         label: 'Marketplace expiry',
@@ -688,7 +697,7 @@ function analyzeCreateListingIntent({
           ? 'None requested'
           : new Date(intent.marketplaceExpiresAt * 1000).toLocaleString(),
       },
-      { label: 'Bitcoin expiry', value: 'None — spend the asset UTXO to invalidate the signature' },
+      { label: 'Bitcoin expiry', value: 'None — cancel by spending the asset' },
     ],
     notices: allProblems.length > 0
       ? []
@@ -879,33 +888,22 @@ function analyzeAttachForListingIntent(
   return {
     status,
     family: 'attach_for_listing',
-    title: `Attach ${claim.quantityRaw} raw unit${claim.quantityRaw === '1' ? '' : 's'} of ${claim.asset}`,
+    // The standard attach screen already states the asset, amount, network fee, and the created
+    // outpoint — these facts carry only what is marketplace-specific, so the merged details list
+    // says each thing once.
+    title: `Attach ${claim.asset} for listing`,
     facts: [
-      { label: 'Creates', value: `${intent.expectedAttachedOutpoint.txid}:${intent.expectedAttachedOutpoint.vout}` },
       { label: 'Carrier value', value: `${intent.carrierValueSats.toLocaleString()} sats` },
-      { label: 'Network fee', value: `${intent.networkFeeSats.toLocaleString()} sats` },
       {
         label: 'Quoted XCP fee',
-        value: formatXcpRaw(intent.protocolFee.quotedAmountRaw),
-      },
-      {
-        label: 'Quote block',
-        value: intent.protocolFee.observedBlock === null
-          ? 'Not supplied'
-          : intent.protocolFee.observedBlock.toLocaleString(),
+        value: `${formatXcpRaw(intent.protocolFee.quotedAmountRaw)} (finalized at confirmation)`,
       },
       {
         label: 'Operation expiry',
         value: new Date(intent.operationExpiresAt * 1000).toLocaleString(),
       },
     ],
-    notices: allProblems.length > 0
-      ? []
-      : [{
-          severity: 'warning',
-          message:
-            'The XCP attach fee is a protocol quote, not a Bitcoin or marketplace fee. Counterparty recomputes it at the block that confirms this transaction, so the final XCP debit may change.',
-        }],
+    notices: [],
     blockers: allProblems,
   };
 }
@@ -1140,8 +1138,8 @@ function analyzeBuyListingsIntent(
     title: `Buy ${itemCount} collectible${itemCount === 1 ? '' : 's'} for ${(intent.totalSats / 100_000_000).toFixed(8)} BTC`,
     facts: [
       { label: 'Items', value: `${itemCount} across ${distinctAssets} asset${distinctAssets === 1 ? '' : 's'}` },
+      // No network-fee row: the money-movement summary beside these facts already states it.
       { label: 'Seller subtotal', value: `${intent.subtotalSats.toLocaleString()} sats` },
-      { label: 'Network fee', value: `${intent.networkFeeSats.toLocaleString()} sats` },
       { label: 'Platform fee', value: `${intent.platformFeeSats.toLocaleString()} sats` },
       { label: 'You pay', value: `${intent.totalSats.toLocaleString()} sats` },
       { label: 'Delivery', value: `Detached to ${intent.delivery.address}` },
@@ -1290,6 +1288,9 @@ function analyzeExactOfferIntent(
     blockers.push('buyer funding input 0 carries attached Counterparty assets');
   }
   const sellerBalance = balances.get(1);
+  // The ledger-normalized amount, for display: the title only needs it on proved/caution, where
+  // this lookup has succeeded — so the screen never has to show raw base units.
+  let provedQuantity: string | null = null;
   if (sellerBalance?.lookupFailed) {
     retry.push('the attached-asset lookup for seller input 1 failed');
   } else if (!sellerBalance || sellerBalance.assets.length !== 1) {
@@ -1303,6 +1304,8 @@ function analyzeExactOfferIntent(
       retry.push('seller input 1 has no exact raw attached quantity');
     } else if (actual.quantity !== claim.quantityRaw) {
       blockers.push('seller input 1 raw attached quantity differs from the claim');
+    } else {
+      provedQuantity = actual.quantity_normalized;
     }
   }
 
@@ -1350,20 +1353,18 @@ function analyzeExactOfferIntent(
   return {
     status,
     family: intent.action,
-    title: authorizing
-      ? `Authorize ${(intent.priceSats / 100_000_000).toFixed(8)} BTC for ${claim.quantityRaw} raw units of ${claim.asset}`
-      : `Accept ${(intent.priceSats / 100_000_000).toFixed(8)} BTC for ${claim.quantityRaw} raw units of ${claim.asset}`,
+    title: `${authorizing ? 'Authorize' : 'Accept'} ${(intent.priceSats / 100_000_000).toFixed(8)} BTC` +
+      ` for ${provedQuantity ? `${provedQuantity} ` : ''}${claim.asset}`,
     facts: [
       { label: 'Offer price', value: `${intent.priceSats.toLocaleString()} sats` },
       { label: 'Seller receives', value: `${intent.sellerProceedsSats.toLocaleString()} sats` },
-      { label: 'Network fee', value: `${intent.networkFeeSats.toLocaleString()} sats` },
       { label: 'Delivery', value: `Detached to ${intent.delivery.address}` },
       { label: 'Funding slot', value: `${fundingOutpoint.txid}:${fundingOutpoint.vout}` },
       {
         label: 'Marketplace expiry',
         value: new Date(intent.marketplaceExpiresAt * 1000).toLocaleString(),
       },
-      { label: 'Bitcoin expiry', value: 'None — spend the funding outpoint to invalidate it' },
+      { label: 'Bitcoin expiry', value: 'None — cancel by spending the funding UTXO' },
     ],
     notices: allProblems.length > 0
       ? []

--- a/src/core/counterparty/marketplaceIntent.ts
+++ b/src/core/counterparty/marketplaceIntent.ts
@@ -190,6 +190,26 @@ export interface MarketplaceAnalysisInput {
   localCounterpartyMessage?: { messageType: string; data: unknown };
 }
 
+/**
+ * Enforce transaction-header invariants that belong to the marketplace protocol itself.
+ * These values are decoded from the PSBT and are never trusted from the requesting site.
+ * A future zero-fee TRUC offer protocol must declare and validate its v3 parent/child shape
+ * separately; exact_offer_v1 deliberately remains version 2 with locktime 0.
+ */
+export function marketplaceTransactionHeaderProblem(
+  intent: { action: string; protocolVersion?: string },
+  transactionVersion: number,
+  lockTime: number,
+): string | null {
+  if (
+    intent.protocolVersion === 'exact_offer_v1'
+    && (transactionVersion !== 2 || lockTime !== 0)
+  ) {
+    return 'exact_offer_v1 requires Bitcoin transaction version 2 with locktime 0';
+  }
+  return null;
+}
+
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
 

--- a/src/core/counterparty/marketplaceIntent.ts
+++ b/src/core/counterparty/marketplaceIntent.ts
@@ -1,0 +1,296 @@
+/**
+ * Wallet-side proof for versioned Counterparty marketplace intent claims.
+ *
+ * An intent is display context from a website, never authority. The parser only bounds its wire
+ * shape; the analyzer independently matches every security-relevant term to PSBT bytes, requested
+ * signatures, prevouts, and Counterparty UTXO balances.
+ */
+
+import { normalizeAddressForComparison } from '@/core/bitcoin/address';
+import type { AttachedAssetDestination } from '@/core/counterparty/attachedAssetMovement';
+import type { InputAttachedAssets } from '@/core/counterparty/inputAssets';
+
+export const MARKETPLACE_INTENT_STANDARD = 'counterparty-marketplace' as const;
+export const MARKETPLACE_INTENT_VERSION = 1 as const;
+
+export interface MarketplaceOutpointClaim {
+  txid: string;
+  vout: number;
+}
+
+export interface MarketplaceAssetClaim {
+  asset: string;
+  quantityRaw: string;
+  sourceOutpoint: MarketplaceOutpointClaim;
+}
+
+export interface CreateListingIntentClaim {
+  standard: typeof MARKETPLACE_INTENT_STANDARD;
+  version: typeof MARKETPLACE_INTENT_VERSION;
+  action: 'create_listing';
+  operationId: string;
+  protocolVersion: 'counterparty_attach_listing_v1';
+  assets: [MarketplaceAssetClaim];
+  seller: string;
+  priceSats: number;
+  carrierValueSats: number;
+  guaranteedSellerPaymentSats: number;
+  delivery: { mode: 'buyer_selected_detach' };
+  signingRequestExpiresAt: number;
+  marketplaceExpiresAt: number | null;
+  bitcoinExpiresAt: null;
+}
+
+export type MarketplaceIntentClaimV1 = CreateListingIntentClaim;
+
+export interface MarketplaceApprovalReview {
+  status: 'proved' | 'caution' | 'retry' | 'blocked';
+  family: 'create_listing';
+  title: string;
+  facts: Array<{ label: string; value: string }>;
+  notices: Array<{ severity: 'info' | 'warning' | 'danger'; message: string }>;
+  blockers: string[];
+}
+
+interface InputLike {
+  index: number;
+  txid: string;
+  vout: number;
+  address?: string;
+  value?: number;
+  hasSignatures?: boolean;
+}
+
+interface OutputLike {
+  index: number;
+  type: string;
+  address?: string;
+  value: number;
+}
+
+export interface MarketplaceAnalysisInput {
+  intent: MarketplaceIntentClaimV1;
+  inputs: InputLike[];
+  outputs: OutputLike[];
+  signedInputs: Array<{ index: number; sighashType: number }>;
+  signerAddresses: string[];
+  attachedAssets: InputAttachedAssets[];
+  attachedAssetDestination: AttachedAssetDestination | null;
+  hasCounterpartyPayload: boolean;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const boundedString = (value: unknown, label: string, max = 160): string => {
+  if (typeof value !== 'string' || value.length < 1 || value.length > max) {
+    throw new Error(`${label} must be a non-empty string of at most ${max} characters`);
+  }
+  return value;
+};
+
+const safeInteger = (
+  value: unknown,
+  label: string,
+  options: { positive?: boolean; nullable?: boolean } = {},
+): number | null => {
+  if (value === null && options.nullable) return null;
+  if (!Number.isSafeInteger(value) || (options.positive && Number(value) <= 0)) {
+    throw new Error(`${label} must be ${options.positive ? 'a positive ' : 'a '}safe integer`);
+  }
+  return Number(value);
+};
+
+const outpoint = (value: unknown, label: string): MarketplaceOutpointClaim => {
+  if (!isRecord(value)) throw new Error(`${label} must be an object`);
+  const txid = boundedString(value.txid, `${label}.txid`, 64).toLowerCase();
+  if (!/^[0-9a-f]{64}$/.test(txid)) throw new Error(`${label}.txid must be 32-byte hex`);
+  const vout = safeInteger(value.vout, `${label}.vout`);
+  if (vout === null || vout < 0) throw new Error(`${label}.vout must be a non-negative safe integer`);
+  return { txid, vout };
+};
+
+const asset = (value: unknown, label: string): MarketplaceAssetClaim => {
+  if (!isRecord(value)) throw new Error(`${label} must be an object`);
+  const quantityRaw = boundedString(value.quantityRaw, `${label}.quantityRaw`, 24);
+  if (!/^[1-9][0-9]*$/.test(quantityRaw)) {
+    throw new Error(`${label}.quantityRaw must be a positive base-unit integer string`);
+  }
+  return {
+    asset: boundedString(value.asset, `${label}.asset`, 250),
+    quantityRaw,
+    sourceOutpoint: outpoint(value.sourceOutpoint, `${label}.sourceOutpoint`),
+  };
+};
+
+/** Bound and copy the v1 wire claim. The result remains untrusted until analyzed. */
+export function parseMarketplaceIntent(value: unknown): MarketplaceIntentClaimV1 {
+  if (!isRecord(value)) throw new Error('marketplace intent must be an object');
+  if (value.standard !== MARKETPLACE_INTENT_STANDARD || value.version !== 1) {
+    throw new Error(`marketplace intent must use ${MARKETPLACE_INTENT_STANDARD} version 1`);
+  }
+  if (value.action !== 'create_listing') {
+    throw new Error('marketplace intent action is not supported by this wallet version');
+  }
+  if (value.protocolVersion !== 'counterparty_attach_listing_v1') {
+    throw new Error('create_listing intent has the wrong protocolVersion');
+  }
+  if (!Array.isArray(value.assets) || value.assets.length !== 1) {
+    throw new Error('create_listing intent must claim exactly one asset');
+  }
+  if (!isRecord(value.delivery) || value.delivery.mode !== 'buyer_selected_detach') {
+    throw new Error('create_listing delivery must be buyer_selected_detach');
+  }
+  if (value.bitcoinExpiresAt !== null) {
+    throw new Error('create_listing has no Bitcoin-level expiry');
+  }
+
+  return {
+    standard: MARKETPLACE_INTENT_STANDARD,
+    version: MARKETPLACE_INTENT_VERSION,
+    action: 'create_listing',
+    operationId: boundedString(value.operationId, 'operationId'),
+    protocolVersion: 'counterparty_attach_listing_v1',
+    assets: [asset(value.assets[0], 'assets[0]')],
+    seller: boundedString(value.seller, 'seller', 128),
+    priceSats: safeInteger(value.priceSats, 'priceSats', { positive: true })!,
+    carrierValueSats: safeInteger(value.carrierValueSats, 'carrierValueSats', { positive: true })!,
+    guaranteedSellerPaymentSats: safeInteger(
+      value.guaranteedSellerPaymentSats,
+      'guaranteedSellerPaymentSats',
+      { positive: true },
+    )!,
+    delivery: { mode: 'buyer_selected_detach' },
+    signingRequestExpiresAt: safeInteger(value.signingRequestExpiresAt, 'signingRequestExpiresAt')!,
+    marketplaceExpiresAt: safeInteger(value.marketplaceExpiresAt, 'marketplaceExpiresAt', {
+      nullable: true,
+    }),
+    bitcoinExpiresAt: null,
+  };
+}
+
+const sameAddress = (left: string | undefined, right: string) =>
+  left !== undefined
+  && normalizeAddressForComparison(left) === normalizeAddressForComparison(right);
+
+/** Prove the seller's flexible listing authorization from independent transaction facts. */
+export function analyzeMarketplaceIntent({
+  intent,
+  inputs,
+  outputs,
+  signedInputs,
+  signerAddresses,
+  attachedAssets,
+  attachedAssetDestination,
+  hasCounterpartyPayload,
+}: MarketplaceAnalysisInput): MarketplaceApprovalReview {
+  const blockers: string[] = [];
+  const retry: string[] = [];
+  const claim = intent.assets[0];
+  const sellerInput = inputs[1];
+  const sellerOutput = outputs[1];
+
+  if (inputs.length !== 2 || outputs.length !== 2) {
+    blockers.push(`expected exactly 2 inputs and 2 outputs, got ${inputs.length}/${outputs.length}`);
+  }
+  if (inputs[0]?.txid !== '0'.repeat(64) || inputs[0]?.vout !== 0) {
+    blockers.push('input 0 is not the null buyer-funding placeholder');
+  }
+  if (inputs[0]?.hasSignatures !== false) {
+    blockers.push('buyer placeholder input 0 must be proven unsigned');
+  }
+  if (hasCounterpartyPayload) blockers.push('a listing authorization must not carry a Counterparty payload yet');
+
+  if (
+    signedInputs.length !== 1
+    || signedInputs[0]?.index !== 1
+    || signedInputs[0]?.sighashType !== 0x83
+  ) {
+    blockers.push('the wallet must sign only input 1 with SINGLE|ANYONECANPAY (0x83)');
+  }
+  if (signerAddresses.length !== 1 || !sameAddress(signerAddresses[0], intent.seller)) {
+    blockers.push('the requested signer is not exactly the claimed seller');
+  }
+
+  if (!sellerInput) {
+    blockers.push('seller input 1 is missing');
+  } else {
+    if (
+      sellerInput.txid.toLowerCase() !== claim.sourceOutpoint.txid
+      || sellerInput.vout !== claim.sourceOutpoint.vout
+    ) {
+      blockers.push('seller input 1 is not the claimed attached outpoint');
+    }
+    if (!sameAddress(sellerInput.address, intent.seller)) {
+      blockers.push('seller input 1 is not controlled by the claimed seller');
+    }
+    if (sellerInput.value !== intent.carrierValueSats) {
+      blockers.push('seller input carrier value differs from the claim');
+    }
+  }
+
+  if (intent.guaranteedSellerPaymentSats !== intent.carrierValueSats + intent.priceSats) {
+    blockers.push('claimed seller payment does not equal carrier plus price');
+  }
+  if (!sellerOutput) {
+    blockers.push('guaranteed seller output 1 is missing');
+  } else {
+    if (!sameAddress(sellerOutput.address, intent.seller)) {
+      blockers.push('output 1 does not pay the seller');
+    }
+    if (sellerOutput.value !== intent.guaranteedSellerPaymentSats) {
+      blockers.push('output 1 amount differs from the guaranteed seller payment');
+    }
+  }
+
+  const balance = attachedAssets.find(entry => entry.inputIndex === 1);
+  if (balance?.lookupFailed) {
+    retry.push('the attached-asset lookup for seller input 1 failed');
+  } else if (!balance || balance.assets.length !== 1) {
+    blockers.push('seller input 1 does not independently resolve to exactly one attached asset');
+  } else {
+    const actual = balance.assets[0]!;
+    if (actual.asset !== claim.asset) blockers.push('attached asset name differs from the claim');
+    if (actual.quantity === undefined) {
+      retry.push('the indexer did not return an exact raw attached quantity');
+    } else if (actual.quantity !== claim.quantityRaw) {
+      blockers.push('attached asset raw quantity differs from the claim');
+    }
+  }
+
+  if (
+    attachedAssetDestination?.destinationCommitted !== false
+    || attachedAssetDestination?.mode !== 'flexible'
+  ) {
+    blockers.push('listing signature does not prove the expected buyer-selected delivery flexibility');
+  }
+
+  const allProblems = [...retry, ...blockers];
+  const status = blockers.length > 0 ? 'blocked' : retry.length > 0 ? 'retry' : 'caution';
+  return {
+    status,
+    family: 'create_listing',
+    title: `List 1 ${claim.asset} for ${(intent.priceSats / 100_000_000).toFixed(8)} BTC`,
+    facts: [
+      { label: 'Seller receives', value: `${intent.guaranteedSellerPaymentSats.toLocaleString()} sats` },
+      { label: 'Asset quantity', value: `${claim.quantityRaw} raw units` },
+      { label: 'Delivery', value: 'Detached to the eventual buyer' },
+      {
+        label: 'Marketplace expiry',
+        value: intent.marketplaceExpiresAt === null
+          ? 'None requested'
+          : new Date(intent.marketplaceExpiresAt * 1000).toLocaleString(),
+      },
+      { label: 'Bitcoin expiry', value: 'None — spend the asset UTXO to invalidate the signature' },
+    ],
+    notices: allProblems.length > 0
+      ? []
+      : [{
+          severity: 'warning',
+          message:
+            'The buyer may add funding inputs and choose the detach destination. Your signature ' +
+            'remains valid only when output 1 pays you the exact amount shown.',
+        }],
+    blockers: allProblems,
+  };
+}

--- a/src/core/counterparty/marketplaceIntent.ts
+++ b/src/core/counterparty/marketplaceIntent.ts
@@ -131,7 +131,8 @@ export interface MarketplaceApprovalReview {
     | 'create_listing'
     | 'buy_listings'
     | 'authorize_exact_offer'
-    | 'accept_exact_offer';
+    | 'accept_exact_offer'
+    | 'accept_exact_offer_with_cpfp';
   title: string;
   facts: Array<{ label: string; value: string }>;
   notices: Array<{ severity: 'info' | 'warning' | 'danger'; message: string }>;

--- a/src/core/counterparty/marketplaceIntent.ts
+++ b/src/core/counterparty/marketplaceIntent.ts
@@ -24,6 +24,28 @@ export interface MarketplaceAssetClaim {
   sourceOutpoint: MarketplaceOutpointClaim;
 }
 
+export interface AttachForListingIntentClaim {
+  standard: typeof MARKETPLACE_INTENT_STANDARD;
+  version: typeof MARKETPLACE_INTENT_VERSION;
+  action: 'attach_for_listing';
+  operationId: string;
+  protocolVersion: 'counterparty_attach_listing_v1';
+  assets: [{ asset: string; quantityRaw: string }];
+  seller: string;
+  expectedAttachedOutpoint: MarketplaceOutpointClaim;
+  carrierAddress: string;
+  carrierValueSats: number;
+  networkFeeSats: number;
+  protocolFee: {
+    asset: 'XCP';
+    quotedAmountRaw: string;
+    actualAmountRaw: string | null;
+    observedBlock: number | null;
+    variableUntilConfirmed: boolean;
+  };
+  operationExpiresAt: number;
+}
+
 export interface CreateListingIntentClaim {
   standard: typeof MARKETPLACE_INTENT_STANDARD;
   version: typeof MARKETPLACE_INTENT_VERSION;
@@ -65,11 +87,14 @@ export interface BuyListingsIntentClaim {
   marketplaceExpiresAt: number;
 }
 
-export type MarketplaceIntentClaimV1 = CreateListingIntentClaim | BuyListingsIntentClaim;
+export type MarketplaceIntentClaimV1 =
+  | AttachForListingIntentClaim
+  | CreateListingIntentClaim
+  | BuyListingsIntentClaim;
 
 export interface MarketplaceApprovalReview {
   status: 'proved' | 'caution' | 'retry' | 'blocked';
-  family: 'create_listing' | 'buy_listings';
+  family: 'attach_for_listing' | 'create_listing' | 'buy_listings';
   title: string;
   facts: Array<{ label: string; value: string }>;
   notices: Array<{ severity: 'info' | 'warning' | 'danger'; message: string }>;
@@ -157,12 +182,36 @@ const asset = (value: unknown, label: string): MarketplaceAssetClaim => {
   };
 };
 
+const assetWithoutOutpoint = (
+  value: unknown,
+  label: string,
+): { asset: string; quantityRaw: string } => {
+  if (!isRecord(value)) throw new Error(`${label} must be an object`);
+  const quantityRaw = boundedString(value.quantityRaw, `${label}.quantityRaw`, 24);
+  if (!/^[1-9][0-9]*$/.test(quantityRaw)) {
+    throw new Error(`${label}.quantityRaw must be a positive base-unit integer string`);
+  }
+  return {
+    asset: boundedString(value.asset, `${label}.asset`, 250),
+    quantityRaw,
+  };
+};
+
+const nonNegativeRawInteger = (value: unknown, label: string): string => {
+  const raw = boundedString(value, label, 24);
+  if (!/^[0-9]+$/.test(raw)) {
+    throw new Error(`${label} must be a non-negative base-unit integer string`);
+  }
+  return raw;
+};
+
 /** Bound and copy the v1 wire claim. The result remains untrusted until analyzed. */
 export function parseMarketplaceIntent(value: unknown): MarketplaceIntentClaimV1 {
   if (!isRecord(value)) throw new Error('marketplace intent must be an object');
   if (value.standard !== MARKETPLACE_INTENT_STANDARD || value.version !== 1) {
     throw new Error(`marketplace intent must use ${MARKETPLACE_INTENT_STANDARD} version 1`);
   }
+  if (value.action === 'attach_for_listing') return parseAttachForListingIntent(value);
   if (value.action === 'buy_listings') return parseBuyListingsIntent(value);
   if (value.action !== 'create_listing') {
     throw new Error('marketplace intent action is not supported by this wallet version');
@@ -203,6 +252,64 @@ export function parseMarketplaceIntent(value: unknown): MarketplaceIntentClaimV1
     bitcoinExpiresAt: null,
   };
 }
+
+const parseAttachForListingIntent = (
+  value: Record<string, unknown>,
+): AttachForListingIntentClaim => {
+  if (value.protocolVersion !== 'counterparty_attach_listing_v1') {
+    throw new Error('attach_for_listing intent has the wrong protocolVersion');
+  }
+  if (!Array.isArray(value.assets) || value.assets.length !== 1) {
+    throw new Error('attach_for_listing intent must claim exactly one asset');
+  }
+  if (!isRecord(value.protocolFee) || value.protocolFee.asset !== 'XCP') {
+    throw new Error('attach_for_listing protocolFee must be denominated in XCP');
+  }
+  const actualAmountRaw = value.protocolFee.actualAmountRaw === null
+    ? null
+    : nonNegativeRawInteger(value.protocolFee.actualAmountRaw, 'protocolFee.actualAmountRaw');
+  const observedBlock = safeInteger(value.protocolFee.observedBlock, 'protocolFee.observedBlock', {
+    nullable: true,
+  });
+  if (observedBlock !== null && observedBlock < 0) {
+    throw new Error('protocolFee.observedBlock must be a non-negative safe integer or null');
+  }
+  if (typeof value.protocolFee.variableUntilConfirmed !== 'boolean') {
+    throw new Error('protocolFee.variableUntilConfirmed must be boolean');
+  }
+
+  return {
+    standard: MARKETPLACE_INTENT_STANDARD,
+    version: MARKETPLACE_INTENT_VERSION,
+    action: 'attach_for_listing',
+    operationId: boundedString(value.operationId, 'operationId'),
+    protocolVersion: 'counterparty_attach_listing_v1',
+    assets: [assetWithoutOutpoint(value.assets[0], 'assets[0]')],
+    seller: boundedString(value.seller, 'seller', 128),
+    expectedAttachedOutpoint: outpoint(
+      value.expectedAttachedOutpoint,
+      'expectedAttachedOutpoint',
+    ),
+    carrierAddress: boundedString(value.carrierAddress, 'carrierAddress', 128),
+    carrierValueSats: safeInteger(value.carrierValueSats, 'carrierValueSats', {
+      positive: true,
+    })!,
+    networkFeeSats: nonNegativeSafeInteger(value.networkFeeSats, 'networkFeeSats'),
+    protocolFee: {
+      asset: 'XCP',
+      quotedAmountRaw: nonNegativeRawInteger(
+        value.protocolFee.quotedAmountRaw,
+        'protocolFee.quotedAmountRaw',
+      ),
+      actualAmountRaw,
+      observedBlock,
+      variableUntilConfirmed: value.protocolFee.variableUntilConfirmed,
+    },
+    operationExpiresAt: safeInteger(value.operationExpiresAt, 'operationExpiresAt', {
+      positive: true,
+    })!,
+  };
+};
 
 const parseBuyListingsIntent = (value: Record<string, unknown>): BuyListingsIntentClaim => {
   if (value.protocolVersion !== 'direct_v1') {
@@ -291,6 +398,7 @@ function analyzeCreateListingIntent({
   const blockers: string[] = [];
   const retry: string[] = [];
   const claim = intent.assets[0];
+
   const sellerInput = inputs[1];
   const sellerOutput = outputs[1];
 
@@ -408,6 +516,204 @@ const safeSum = (values: number[]): number | null => {
   const sum = values.reduce((total, value) => total + value, 0);
   return Number.isSafeInteger(sum) ? sum : null;
 };
+
+const formatXcpRaw = (raw: string): string => {
+  const amount = BigInt(raw);
+  const whole = amount / 100_000_000n;
+  const fraction = (amount % 100_000_000n).toString().padStart(8, '0').replace(/0+$/, '');
+  return fraction ? `${whole}.${fraction} XCP` : `${whole} XCP`;
+};
+
+/** Prove the full-input ALL-signed attach that creates one listable carrier UTXO. */
+function analyzeAttachForListingIntent(
+  input: MarketplaceAnalysisInput,
+  intent: AttachForListingIntentClaim,
+): MarketplaceApprovalReview {
+  const {
+    inputs,
+    outputs,
+    signedInputs,
+    signerAddresses,
+    attachedAssets,
+    hasCounterpartyPayload,
+    transactionId,
+    localCounterpartyMessage,
+  } = input;
+  const blockers: string[] = [];
+  const retry: string[] = [];
+  const claim = intent.assets[0];
+
+  if (!intent.protocolFee.variableUntilConfirmed) {
+    blockers.push('the attach XCP fee must be labeled variable until confirmation');
+  }
+  if (intent.protocolFee.actualAmountRaw !== null) {
+    blockers.push('an unsigned attach cannot claim an actual confirmed XCP fee');
+  }
+
+  if (!transactionId) {
+    retry.push('the wallet could not establish the unsigned transaction id');
+  } else if (transactionId.toLowerCase() !== intent.expectedAttachedOutpoint.txid) {
+    blockers.push('the unsigned transaction id differs from the expected attached outpoint');
+  }
+  if (!hasCounterpartyPayload) {
+    blockers.push('the attach request carries no Counterparty payload');
+  }
+  const attachData = isRecord(localCounterpartyMessage?.data)
+    ? localCounterpartyMessage.data
+    : undefined;
+  if (localCounterpartyMessage?.messageType !== 'attach' || !attachData) {
+    blockers.push('the Counterparty payload is not a locally decoded attach');
+  } else {
+    if (attachData.asset !== claim.asset) {
+      blockers.push('the locally decoded attach asset differs from the claim');
+    }
+    if (
+      typeof attachData.quantity !== 'bigint'
+      || attachData.quantity.toString() !== claim.quantityRaw
+    ) {
+      blockers.push('the locally decoded attach raw quantity differs from the claim');
+    }
+    const destinationVout = typeof attachData.destinationVout === 'number'
+      ? attachData.destinationVout
+      : outputs.find(output => output.type !== 'op_return')?.index;
+    if (destinationVout !== intent.expectedAttachedOutpoint.vout) {
+      blockers.push('the locally decoded attach destination vout differs from the claim');
+    }
+  }
+
+  if (inputs.length < 1) blockers.push('the attach request has no funding inputs');
+  const inputOutpoints = inputs.map(transactionInput =>
+    `${transactionInput.txid.toLowerCase()}:${transactionInput.vout}`);
+  if (new Set(inputOutpoints).size !== inputOutpoints.length) {
+    blockers.push('the attach request contains a duplicate input outpoint');
+  }
+  const expectedSignedIndices = inputs.map((_, index) => index);
+  const sortedSignedInputs = [...signedInputs].sort((left, right) => left.index - right.index);
+  if (
+    sortedSignedInputs.length !== expectedSignedIndices.length
+    || sortedSignedInputs.some(
+      (signed, index) => signed.index !== expectedSignedIndices[index] || signed.sighashType !== 0x01,
+    )
+    || new Set(signedInputs.map(signed => signed.index)).size !== signedInputs.length
+  ) {
+    blockers.push('the wallet must sign every attach input exactly once with ALL (0x01)');
+  }
+  if (!sameAddress(inputs[0]?.address, intent.seller)) {
+    blockers.push('Counterparty source input 0 is not controlled by the claimed seller');
+  }
+
+  const inputAddresses = inputs.map(transactionInput => transactionInput.address);
+  if (inputAddresses.some(address => !address)) {
+    blockers.push('the wallet could not resolve every attach input owner');
+  } else {
+    const expectedSigners = new Set(
+      (inputAddresses as string[]).map(normalizeAddressForComparison),
+    );
+    const actualSigners = new Set(signerAddresses.map(normalizeAddressForComparison));
+    if (
+      expectedSigners.size !== actualSigners.size
+      || [...expectedSigners].some(address => !actualSigners.has(address))
+    ) {
+      blockers.push('the requested signer set does not exactly match the attach input owners');
+    }
+  }
+
+  const balances = new Map(attachedAssets.map(entry => [entry.inputIndex, entry]));
+  for (const transactionInput of inputs) {
+    if (transactionInput.hasSignatures !== false) {
+      blockers.push(`input ${transactionInput.index} must be proven unsigned before attach approval`);
+    }
+    if (transactionInput.value === undefined) {
+      retry.push(`attach input ${transactionInput.index} has no authenticated value`);
+    }
+    const balance = balances.get(transactionInput.index);
+    if (balance?.lookupFailed) {
+      retry.push(`the attached-asset lookup for attach input ${transactionInput.index} failed`);
+    } else if (balance && balance.assets.length > 0) {
+      blockers.push(`attach funding input ${transactionInput.index} already carries attached assets`);
+    }
+  }
+
+  const target = outputs[intent.expectedAttachedOutpoint.vout];
+  if (!target) {
+    blockers.push('the claimed attached carrier output is missing');
+  } else {
+    if (!sameAddress(target.address, intent.carrierAddress)) {
+      blockers.push('the attached carrier output is not controlled by the claimed carrier address');
+    }
+    if (target.value !== intent.carrierValueSats) {
+      blockers.push('the attached carrier output value differs from the claim');
+    }
+    if (target.type === 'op_return') {
+      blockers.push('the attached carrier destination cannot be an OP_RETURN output');
+    }
+  }
+  const dataOutputs = outputs.filter(output => output.type === 'op_return');
+  if (dataOutputs.length !== 1 || dataOutputs[0]?.value !== 0) {
+    blockers.push('the attach must contain exactly one zero-value OP_RETURN data output');
+  }
+  const signerSet = new Set(signerAddresses.map(normalizeAddressForComparison));
+  if (!signerSet.has(normalizeAddressForComparison(intent.carrierAddress))) {
+    blockers.push('the attached carrier address is not among the approved wallet signers');
+  }
+  for (const output of outputs) {
+    if (output.type === 'op_return') continue;
+    if (!output.address || !signerSet.has(normalizeAddressForComparison(output.address))) {
+      blockers.push(`attach output ${output.index} is not controlled by an approved signer`);
+    }
+  }
+
+  const allInputValues = inputs.map(transactionInput => transactionInput.value);
+  if (allInputValues.some(value => value === undefined)) {
+    retry.push('the wallet could not authenticate every input value needed to prove the miner fee');
+  } else {
+    const inputTotal = safeSum(allInputValues as number[]);
+    const outputTotal = safeSum(outputs.map(output => output.value));
+    const actualFee = inputTotal === null || outputTotal === null ? null : inputTotal - outputTotal;
+    if (actualFee === null || actualFee < 0 || actualFee !== intent.networkFeeSats) {
+      blockers.push('the actual Bitcoin miner fee differs from the claim');
+    }
+  }
+
+  const allProblems = [...retry, ...blockers];
+  const status = blockers.length > 0
+    ? 'blocked'
+    : retry.length > 0
+      ? 'retry'
+      : 'caution';
+  return {
+    status,
+    family: 'attach_for_listing',
+    title: `Attach ${claim.quantityRaw} raw unit${claim.quantityRaw === '1' ? '' : 's'} of ${claim.asset}`,
+    facts: [
+      { label: 'Creates', value: `${intent.expectedAttachedOutpoint.txid}:${intent.expectedAttachedOutpoint.vout}` },
+      { label: 'Carrier value', value: `${intent.carrierValueSats.toLocaleString()} sats` },
+      { label: 'Network fee', value: `${intent.networkFeeSats.toLocaleString()} sats` },
+      {
+        label: 'Quoted XCP fee',
+        value: formatXcpRaw(intent.protocolFee.quotedAmountRaw),
+      },
+      {
+        label: 'Quote block',
+        value: intent.protocolFee.observedBlock === null
+          ? 'Not supplied'
+          : intent.protocolFee.observedBlock.toLocaleString(),
+      },
+      {
+        label: 'Operation expiry',
+        value: new Date(intent.operationExpiresAt * 1000).toLocaleString(),
+      },
+    ],
+    notices: allProblems.length > 0
+      ? []
+      : [{
+          severity: 'warning',
+          message:
+            'The XCP attach fee is a protocol quote, not a Bitcoin or marketplace fee. Counterparty recomputes it at the block that confirms this transaction, so the final XCP debit may change.',
+        }],
+    blockers: allProblems,
+  };
+}
 
 /** Prove an atomic buyer checkout whose complete transaction is committed by SIGHASH_ALL. */
 function analyzeBuyListingsIntent(
@@ -661,7 +967,12 @@ function analyzeBuyListingsIntent(
 }
 
 export function analyzeMarketplaceIntent(input: MarketplaceAnalysisInput): MarketplaceApprovalReview {
-  return input.intent.action === 'buy_listings'
-    ? analyzeBuyListingsIntent(input, input.intent)
-    : analyzeCreateListingIntent(input, input.intent);
+  switch (input.intent.action) {
+    case 'attach_for_listing':
+      return analyzeAttachForListingIntent(input, input.intent);
+    case 'buy_listings':
+      return analyzeBuyListingsIntent(input, input.intent);
+    case 'create_listing':
+      return analyzeCreateListingIntent(input, input.intent);
+  }
 }

--- a/src/core/counterparty/marketplaceIntent.ts
+++ b/src/core/counterparty/marketplaceIntent.ts
@@ -87,14 +87,51 @@ export interface BuyListingsIntentClaim {
   marketplaceExpiresAt: number;
 }
 
+interface ExactOfferIntentBase<Action extends 'authorize_exact_offer' | 'accept_exact_offer'> {
+  standard: typeof MARKETPLACE_INTENT_STANDARD;
+  version: typeof MARKETPLACE_INTENT_VERSION;
+  action: Action;
+  operationId: string;
+  protocolVersion: 'exact_offer_v1';
+  assets: [MarketplaceAssetClaim];
+  authorizationId: string;
+  bidder: string;
+  seller: string;
+  priceSats: number;
+  carrierValueSats: number;
+  sellerProceedsSats: number;
+  networkFeeSats: number;
+  expectedTxid: string;
+  delivery: { mode: 'detached'; address: string };
+  marketplaceExpiresAt: number;
+  bitcoinExpiresAt: null;
+  bitcoinInvalidation: {
+    type: 'spend_funding_outpoint';
+    outpoint: MarketplaceOutpointClaim;
+  };
+}
+
+export interface AuthorizeExactOfferIntentClaim
+  extends ExactOfferIntentBase<'authorize_exact_offer'> {}
+
+export interface AcceptExactOfferIntentClaim
+  extends ExactOfferIntentBase<'accept_exact_offer'> {}
+
 export type MarketplaceIntentClaimV1 =
   | AttachForListingIntentClaim
   | CreateListingIntentClaim
-  | BuyListingsIntentClaim;
+  | BuyListingsIntentClaim
+  | AuthorizeExactOfferIntentClaim
+  | AcceptExactOfferIntentClaim;
 
 export interface MarketplaceApprovalReview {
   status: 'proved' | 'caution' | 'retry' | 'blocked';
-  family: 'attach_for_listing' | 'create_listing' | 'buy_listings';
+  family:
+    | 'attach_for_listing'
+    | 'create_listing'
+    | 'buy_listings'
+    | 'authorize_exact_offer'
+    | 'accept_exact_offer';
   title: string;
   facts: Array<{ label: string; value: string }>;
   notices: Array<{ severity: 'info' | 'warning' | 'danger'; message: string }>;
@@ -213,6 +250,9 @@ export function parseMarketplaceIntent(value: unknown): MarketplaceIntentClaimV1
   }
   if (value.action === 'attach_for_listing') return parseAttachForListingIntent(value);
   if (value.action === 'buy_listings') return parseBuyListingsIntent(value);
+  if (value.action === 'authorize_exact_offer' || value.action === 'accept_exact_offer') {
+    return parseExactOfferIntent(value, value.action);
+  }
   if (value.action !== 'create_listing') {
     throw new Error('marketplace intent action is not supported by this wallet version');
   }
@@ -308,6 +348,72 @@ const parseAttachForListingIntent = (
     operationExpiresAt: safeInteger(value.operationExpiresAt, 'operationExpiresAt', {
       positive: true,
     })!,
+  };
+};
+
+const parseExactOfferIntent = <
+  Action extends 'authorize_exact_offer' | 'accept_exact_offer',
+>(
+  value: Record<string, unknown>,
+  action: Action,
+): ExactOfferIntentBase<Action> => {
+  if (value.protocolVersion !== 'exact_offer_v1') {
+    throw new Error(`${action} intent has the wrong protocolVersion`);
+  }
+  if (!Array.isArray(value.assets) || value.assets.length !== 1) {
+    throw new Error(`${action} intent must claim exactly one asset`);
+  }
+  if (!isRecord(value.delivery) || value.delivery.mode !== 'detached') {
+    throw new Error(`${action} delivery must be detached`);
+  }
+  if (value.bitcoinExpiresAt !== null) {
+    throw new Error(`${action} has no Bitcoin-level expiry`);
+  }
+  if (
+    !isRecord(value.bitcoinInvalidation)
+    || value.bitcoinInvalidation.type !== 'spend_funding_outpoint'
+  ) {
+    throw new Error(`${action} must be invalidated by spending its funding outpoint`);
+  }
+  const expectedTxid = boundedString(value.expectedTxid, 'expectedTxid', 64).toLowerCase();
+  if (!/^[0-9a-f]{64}$/.test(expectedTxid)) {
+    throw new Error('expectedTxid must be 32-byte hex');
+  }
+
+  return {
+    standard: MARKETPLACE_INTENT_STANDARD,
+    version: MARKETPLACE_INTENT_VERSION,
+    action,
+    operationId: boundedString(value.operationId, 'operationId'),
+    protocolVersion: 'exact_offer_v1',
+    assets: [asset(value.assets[0], 'assets[0]')],
+    authorizationId: boundedString(value.authorizationId, 'authorizationId'),
+    bidder: boundedString(value.bidder, 'bidder', 128),
+    seller: boundedString(value.seller, 'seller', 128),
+    priceSats: safeInteger(value.priceSats, 'priceSats', { positive: true })!,
+    carrierValueSats: safeInteger(value.carrierValueSats, 'carrierValueSats', {
+      positive: true,
+    })!,
+    sellerProceedsSats: safeInteger(value.sellerProceedsSats, 'sellerProceedsSats', {
+      positive: true,
+    })!,
+    networkFeeSats: nonNegativeSafeInteger(value.networkFeeSats, 'networkFeeSats'),
+    expectedTxid,
+    delivery: {
+      mode: 'detached',
+      address: boundedString(value.delivery.address, 'delivery.address', 128),
+    },
+    marketplaceExpiresAt: safeInteger(value.marketplaceExpiresAt, 'marketplaceExpiresAt', {
+      positive: true,
+    })!,
+    bitcoinExpiresAt: null,
+    bitcoinInvalidation: {
+      type: 'spend_funding_outpoint',
+      outpoint: outpoint(
+        value.bitcoinInvalidation.outpoint,
+        'bitcoinInvalidation.outpoint',
+      ),
+    },
   };
 };
 
@@ -966,6 +1072,222 @@ function analyzeBuyListingsIntent(
   };
 }
 
+/**
+ * Prove the fixed transaction shared by exact-offer authorization and unilateral acceptance.
+ * The role changes, but the economics never do: buyer input 0 pays the exact price, seller input
+ * 1 contributes the asset carrier, output 0 detaches to the bidder, and output 1 returns carrier
+ * plus price minus the miner fee to the seller. Both signatures bind the whole transaction.
+ */
+function analyzeExactOfferIntent(
+  input: MarketplaceAnalysisInput,
+  intent: AuthorizeExactOfferIntentClaim | AcceptExactOfferIntentClaim,
+): MarketplaceApprovalReview {
+  const {
+    inputs,
+    outputs,
+    signedInputs,
+    signerAddresses,
+    attachedAssets,
+    hasCounterpartyPayload,
+    transactionId,
+    localCounterpartyMessage,
+  } = input;
+  const blockers: string[] = [];
+  const retry: string[] = [];
+  const claim = intent.assets[0];
+  const authorizing = intent.action === 'authorize_exact_offer';
+  const requestedInputIndex = authorizing ? 0 : 1;
+  const requestedSigner = authorizing ? intent.bidder : intent.seller;
+
+  if (!sameAddress(intent.delivery.address, intent.bidder)) {
+    blockers.push('the detach delivery address differs from the bidder');
+  }
+  if (!transactionId) {
+    retry.push('the wallet could not establish the unsigned transaction id');
+  } else if (transactionId.toLowerCase() !== intent.expectedTxid) {
+    blockers.push('the unsigned transaction id differs from the exact authorization');
+  }
+  if (!hasCounterpartyPayload) {
+    blockers.push('the exact offer carries no Counterparty payload');
+  }
+  const detachData = isRecord(localCounterpartyMessage?.data)
+    ? localCounterpartyMessage.data
+    : undefined;
+  if (localCounterpartyMessage?.messageType !== 'detach' || !detachData) {
+    blockers.push('the Counterparty payload is not a locally decoded detach');
+  } else if (
+    typeof detachData.destination !== 'string'
+    || !sameAddress(detachData.destination, intent.delivery.address)
+  ) {
+    blockers.push('the locally decoded detach destination differs from the bidder');
+  }
+
+  if (inputs.length !== 2 || outputs.length !== 2) {
+    blockers.push(`expected exactly 2 inputs and 2 outputs, got ${inputs.length}/${outputs.length}`);
+  }
+  const inputOutpoints = inputs.map(transactionInput =>
+    `${transactionInput.txid.toLowerCase()}:${transactionInput.vout}`);
+  if (new Set(inputOutpoints).size !== inputOutpoints.length) {
+    blockers.push('the exact offer contains a duplicate input outpoint');
+  }
+  if (outputs[0]?.type !== 'op_return' || outputs[0]?.value !== 0) {
+    blockers.push('output 0 is not the zero-value Counterparty detach output');
+  }
+
+  if (
+    signedInputs.length !== 1
+    || signedInputs[0]?.index !== requestedInputIndex
+    || signedInputs[0]?.sighashType !== 0x01
+  ) {
+    blockers.push(
+      `the wallet must sign only input ${requestedInputIndex} with ALL (0x01) for this action`,
+    );
+  }
+  if (signerAddresses.length !== 1 || !sameAddress(signerAddresses[0], requestedSigner)) {
+    blockers.push(`the requested signer is not exactly the claimed ${authorizing ? 'bidder' : 'seller'}`);
+  }
+  if (authorizing) {
+    if (inputs[0]?.hasSignatures !== false || inputs[1]?.hasSignatures !== false) {
+      blockers.push('both exact-offer inputs must be proven unsigned before buyer authorization');
+    }
+  } else {
+    if (inputs[0]?.hasSignatures !== true) {
+      blockers.push('seller acceptance requires the stored buyer authorization on input 0');
+    }
+    if (inputs[1]?.hasSignatures !== false) {
+      blockers.push('seller input 1 must be proven unsigned before acceptance');
+    }
+  }
+
+  const bidderInput = inputs[0];
+  if (!bidderInput) {
+    blockers.push('buyer funding input 0 is missing');
+  } else {
+    if (!sameOutpoint(bidderInput, intent.bitcoinInvalidation.outpoint)) {
+      blockers.push('input 0 is not the funding outpoint that invalidates this authorization');
+    }
+    if (!sameAddress(bidderInput.address, intent.bidder)) {
+      blockers.push('input 0 is not controlled by the claimed bidder');
+    }
+    if (bidderInput.value === undefined) {
+      retry.push('buyer funding input 0 has no authenticated value');
+    } else if (bidderInput.value !== intent.priceSats) {
+      blockers.push('buyer funding input 0 does not equal the exact offer price');
+    }
+  }
+
+  const sellerInput = inputs[1];
+  if (!sellerInput) {
+    blockers.push('seller asset input 1 is missing');
+  } else {
+    if (!sameOutpoint(sellerInput, claim.sourceOutpoint)) {
+      blockers.push('input 1 is not the claimed attached asset outpoint');
+    }
+    if (!sameAddress(sellerInput.address, intent.seller)) {
+      blockers.push('input 1 is not controlled by the claimed seller');
+    }
+    if (sellerInput.value === undefined) {
+      retry.push('seller input 1 has no authenticated carrier value');
+    } else if (sellerInput.value !== intent.carrierValueSats) {
+      blockers.push('seller input 1 carrier value differs from the claim');
+    }
+  }
+
+  const balances = new Map(attachedAssets.map(entry => [entry.inputIndex, entry]));
+  const bidderBalance = balances.get(0);
+  if (bidderBalance?.lookupFailed) {
+    retry.push('the attached-asset lookup for buyer funding input 0 failed');
+  } else if (bidderBalance && bidderBalance.assets.length > 0) {
+    blockers.push('buyer funding input 0 carries attached Counterparty assets');
+  }
+  const sellerBalance = balances.get(1);
+  if (sellerBalance?.lookupFailed) {
+    retry.push('the attached-asset lookup for seller input 1 failed');
+  } else if (!sellerBalance || sellerBalance.assets.length !== 1) {
+    blockers.push('seller input 1 does not independently resolve to exactly one attached asset');
+  } else {
+    const actual = sellerBalance.assets[0]!;
+    if (actual.asset !== claim.asset) {
+      blockers.push('seller input 1 attached asset differs from the claim');
+    }
+    if (actual.quantity === undefined) {
+      retry.push('seller input 1 has no exact raw attached quantity');
+    } else if (actual.quantity !== claim.quantityRaw) {
+      blockers.push('seller input 1 raw attached quantity differs from the claim');
+    }
+  }
+
+  const claimedProceeds = safeSum([
+    intent.priceSats,
+    intent.carrierValueSats,
+    -intent.networkFeeSats,
+  ]);
+  if (claimedProceeds === null || claimedProceeds !== intent.sellerProceedsSats) {
+    blockers.push('claimed seller proceeds do not equal price plus carrier minus miner fee');
+  }
+  const sellerOutput = outputs[1];
+  if (!sellerOutput) {
+    blockers.push('seller proceeds output 1 is missing');
+  } else {
+    if (!sameAddress(sellerOutput.address, intent.seller)) {
+      blockers.push('output 1 does not pay the claimed seller');
+    }
+    if (sellerOutput.value !== intent.sellerProceedsSats) {
+      blockers.push('output 1 differs from the claimed seller proceeds');
+    }
+  }
+
+  const allInputValues = inputs.map(transactionInput => transactionInput.value);
+  if (allInputValues.some(value => value === undefined)) {
+    retry.push('the wallet could not authenticate every input value needed to prove the miner fee');
+  } else {
+    const inputTotal = safeSum(allInputValues as number[]);
+    const outputTotal = safeSum(outputs.map(output => output.value));
+    const actualFee = inputTotal === null || outputTotal === null ? null : inputTotal - outputTotal;
+    if (actualFee === null || actualFee < 0 || actualFee !== intent.networkFeeSats) {
+      blockers.push('the actual miner fee differs from the exact-offer claim');
+    }
+  }
+
+  const allProblems = [...retry, ...blockers];
+  const status = blockers.length > 0
+    ? 'blocked'
+    : retry.length > 0
+      ? 'retry'
+      : authorizing
+        ? 'caution'
+        : 'proved';
+  const fundingOutpoint = intent.bitcoinInvalidation.outpoint;
+  return {
+    status,
+    family: intent.action,
+    title: authorizing
+      ? `Authorize ${(intent.priceSats / 100_000_000).toFixed(8)} BTC for ${claim.quantityRaw} raw units of ${claim.asset}`
+      : `Accept ${(intent.priceSats / 100_000_000).toFixed(8)} BTC for ${claim.quantityRaw} raw units of ${claim.asset}`,
+    facts: [
+      { label: 'Offer price', value: `${intent.priceSats.toLocaleString()} sats` },
+      { label: 'Seller receives', value: `${intent.sellerProceedsSats.toLocaleString()} sats` },
+      { label: 'Network fee', value: `${intent.networkFeeSats.toLocaleString()} sats` },
+      { label: 'Delivery', value: `Detached to ${intent.delivery.address}` },
+      { label: 'Funding slot', value: `${fundingOutpoint.txid}:${fundingOutpoint.vout}` },
+      {
+        label: 'Marketplace expiry',
+        value: new Date(intent.marketplaceExpiresAt * 1000).toLocaleString(),
+      },
+      { label: 'Bitcoin expiry', value: 'None — spend the funding outpoint to invalidate it' },
+    ],
+    notices: allProblems.length > 0
+      ? []
+      : [{
+          severity: authorizing ? 'warning' : 'info',
+          message: authorizing
+            ? 'After signing, this seller can complete this exact trade without another approval. Other exact offers backed by the same funding slot are alternatives: the first confirmed spend wins and invalidates its siblings.'
+            : 'Your signature completes this exact sale without a buyer callback. If the buyer already spent this shared funding slot, broadcast fails and your asset remains yours.',
+        }],
+    blockers: allProblems,
+  };
+}
+
 export function analyzeMarketplaceIntent(input: MarketplaceAnalysisInput): MarketplaceApprovalReview {
   switch (input.intent.action) {
     case 'attach_for_listing':
@@ -974,5 +1296,8 @@ export function analyzeMarketplaceIntent(input: MarketplaceAnalysisInput): Marke
       return analyzeBuyListingsIntent(input, input.intent);
     case 'create_listing':
       return analyzeCreateListingIntent(input, input.intent);
+    case 'authorize_exact_offer':
+    case 'accept_exact_offer':
+      return analyzeExactOfferIntent(input, input.intent);
   }
 }

--- a/src/core/counterparty/messageStructure.ts
+++ b/src/core/counterparty/messageStructure.ts
@@ -12,9 +12,9 @@
  * accounts for every payload byte, and would still pass for a payload that is internally perfect
  * but points at an output that does not exist.
  *
- * Findings are warnings, not blocks. A reference that does not resolve makes the transaction
- * ineffective rather than dangerous — core rejects it — so the honest report is that the screen
- * cannot describe what it claims to do.
+ * Findings block signing. A reference that does not resolve makes the transaction ineffective —
+ * core rejects the message — but the Bitcoin transaction still confirms and still spends real
+ * fees, and no honest composer produces one. There is nothing legitimate to acknowledge through.
  */
 
 import type { AttachData, MoveData } from '@/core/counterparty/unpack/messages/attach';

--- a/src/core/counterparty/protocolContext.ts
+++ b/src/core/counterparty/protocolContext.ts
@@ -23,6 +23,7 @@ import {
   fetchAssetHolderCount,
   fetchOrder,
   fetchOrderMatch,
+  fetchPool,
   fetchUtxoBalances,
 } from '@/core/counterparty/api';
 import type { ProtocolContext } from '@/core/counterparty/describe';
@@ -145,10 +146,16 @@ export async function resolveProtocolContext(
     }
 
     if (messageType === 'fairmint' && typeof fields.asset === 'string' && !context.protocolFeeXcp) {
-      // A fairmint's cost is the fairminter's price, which is not in the message.
+      // A fairmint's cost is the fairminter's price, which is not in the message — and neither is
+      // where the payment goes: burned, seeded into the pool, or paid to the issuer.
       const fairminter = await fetchAssetFairminter(fields.asset);
       if (fairminter?.price_normalized) {
         context.protocolFeeXcp = toDisplayAmount(String(fairminter.price_normalized));
+        context.fairmintPaymentModel = isGreaterThan(String(fairminter.pool_quantity ?? 0), 0)
+          ? 'pool'
+          : fairminter.burn_payment
+            ? 'burned'
+            : 'paid';
       }
     }
 
@@ -172,6 +179,26 @@ export async function resolveProtocolContext(
         }
       }
       if (detaching.length > 0) context.detachingAssets = detaching;
+    }
+
+    if (
+      (messageType === 'pooldeposit' || messageType === 'poolwithdraw') &&
+      typeof fields.assetA === 'string' &&
+      typeof fields.assetB === 'string'
+    ) {
+      // The pool's identity and fee are ledger facts: a deposit's wire names the LP asset but a
+      // withdrawal's does not, and neither carries the fee tier.
+      const pool = await fetchPool(fields.assetA, fields.assetB);
+      if (pool?.lp_asset) context.poolLpAsset = pool.lp_asset;
+      // The fee field is not part of the typed Pool shape across core versions, so read it
+      // defensively: a value below 1 is a fraction, at or above 1 it is basis points.
+      const rawFee = [pool?.fee_bps, pool?.fee_rate, pool?.fee].find(
+        (value) => typeof value === 'number' && Number.isFinite(value) && value > 0
+      ) as number | undefined;
+      if (rawFee !== undefined) {
+        const pct = rawFee < 1 ? rawFee * 100 : rawFee / 100;
+        context.poolFeeRate = `${formatDecimal(toBigNumber(pct))}%`;
+      }
     }
 
     if (messageType === 'dispense' && input.outputs?.length) {

--- a/src/core/counterparty/signRequestAnalysis.ts
+++ b/src/core/counterparty/signRequestAnalysis.ts
@@ -286,6 +286,13 @@ export async function analyzeSignRequest(
         ...safety.warnings,
       ];
       safety.blocked = true;
+    } else if (bitcoinPaymentProof?.proved) {
+      // BitcoinPaymentCard shows the exact, full destinations proved against the versioned
+      // intent. The generic safety analyzer has only a truncated duplicate; keeping both spends
+      // attention without adding a second fact.
+      safety.warnings = safety.warnings.filter(
+        (warning) => warning.code !== 'expected_btc_payment'
+      );
     }
     // The Counterparty-only gate remains the default. Plain Bitcoin signing is reachable only
     // through the separate capability above, never because an origin was allowlisted.

--- a/src/core/counterparty/signRequestAnalysis.ts
+++ b/src/core/counterparty/signRequestAnalysis.ts
@@ -361,12 +361,16 @@ export async function analyzeSignRequest(
       ];
       safety.blocked = true;
     } else if (
-      marketplaceReview.status === 'proved'
-      && marketplaceReview.family === 'buy_listings'
+      (marketplaceReview.status === 'proved' || marketplaceReview.status === 'caution')
+      && (
+        marketplaceReview.family === 'buy_listings'
+        || marketplaceReview.family === 'authorize_exact_offer'
+        || marketplaceReview.family === 'accept_exact_offer'
+      )
     ) {
-      // The semantic card proves the exact detach destination and every asset-bearing seller
-      // input. The generic warning is intentionally alarming because it lacks those facts; once
-      // they are independently established, keeping it trains users to ignore red warnings.
+      // These semantic cards prove the exact detach destination, attached asset, payments, and
+      // signature scope. The generic warnings are intentionally alarming because they lack those
+      // facts; once independently established, keeping them trains users to ignore red warnings.
       safety.warnings = safety.warnings.filter(
         warning => warning.code !== 'detach_all' && warning.code !== 'external_btc_output',
       );

--- a/src/core/counterparty/signRequestAnalysis.ts
+++ b/src/core/counterparty/signRequestAnalysis.ts
@@ -339,6 +339,14 @@ export async function analyzeSignRequest(
       attachedAssets,
       attachedAssetDestination,
       hasCounterpartyPayload: Boolean(counterpartyDataHex),
+      transactionId,
+      localCounterpartyMessage: verification.localUnpack?.success
+        && verification.localUnpack.messageType
+        ? {
+            messageType: verification.localUnpack.messageType,
+            data: verification.localUnpack.data,
+          }
+        : undefined,
     });
     if (marketplaceReview.status === 'blocked' || marketplaceReview.status === 'retry') {
       safety.warnings = [
@@ -352,6 +360,16 @@ export async function analyzeSignRequest(
         ...safety.warnings,
       ];
       safety.blocked = true;
+    } else if (
+      marketplaceReview.status === 'proved'
+      && marketplaceReview.family === 'buy_listings'
+    ) {
+      // The semantic card proves the exact detach destination and every asset-bearing seller
+      // input. The generic warning is intentionally alarming because it lacks those facts; once
+      // they are independently established, keeping it trains users to ignore red warnings.
+      safety.warnings = safety.warnings.filter(
+        warning => warning.code !== 'detach_all' && warning.code !== 'external_btc_output',
+      );
     }
   }
 

--- a/src/core/counterparty/signRequestAnalysis.ts
+++ b/src/core/counterparty/signRequestAnalysis.ts
@@ -121,6 +121,8 @@ export interface SignRequestAnalysis {
   attachedAssetDestination: AttachedAssetDestination | null;
   /** Exact external-output proof for a plain Bitcoin provider request. */
   bitcoinPaymentProof?: BitcoinPaymentProof;
+  /** Every reason a plain Bitcoin request is gated, for the payment card to state directly. */
+  bitcoinPaymentBlockers?: string[];
   marketplaceReview?: MarketplaceApprovalReview;
 }
 
@@ -244,6 +246,7 @@ export async function analyzeSignRequest(
   const attachedAssets = await input.attachedAssets;
 
   let bitcoinPaymentProof: BitcoinPaymentProof | undefined;
+  let bitcoinPaymentBlockers: string[] | undefined;
   if (signingPurpose === 'bitcoin-payment') {
     const signed = new Set(signedInputIndices);
     const signedAssets = attachedAssets.filter(
@@ -273,6 +276,7 @@ export async function analyzeSignRequest(
       blockers.push(...bitcoinPaymentProof.errors);
     }
     if (blockers.length > 0) {
+      bitcoinPaymentBlockers = blockers;
       safety.warnings = [
         {
           // Tagged so the approval screen can let the payment card be the one failure voice
@@ -391,6 +395,7 @@ export async function analyzeSignRequest(
     protocolContext,
     attachedAssetDestination,
     bitcoinPaymentProof,
+    bitcoinPaymentBlockers,
     marketplaceReview,
   };
 }

--- a/src/core/counterparty/signRequestAnalysis.ts
+++ b/src/core/counterparty/signRequestAnalysis.ts
@@ -13,11 +13,21 @@
  */
 
 import {
+  type BitcoinPaymentIntentV1,
+  type BitcoinPaymentProof,
+  proveBitcoinPaymentIntent,
+} from '@/core/bitcoin/providerPayment';
+import {
   type AttachedAssetDestination,
   movesCounterpartyValue,
   resolveAttachedAssetDestination,
 } from '@/core/counterparty/attachedAssetMovement';
 import type { InputAttachedAssets } from '@/core/counterparty/inputAssets';
+import {
+  analyzeMarketplaceIntent,
+  type MarketplaceApprovalReview,
+  type MarketplaceIntentClaimV1,
+} from '@/core/counterparty/marketplaceIntent';
 import { checkMessageStructure, type StructureFinding } from '@/core/counterparty/messageStructure';
 import { type ProtocolContext, resolveProtocolContext } from '@/core/counterparty/protocolContext';
 import {
@@ -40,8 +50,12 @@ import type { MPMAData } from '@/core/counterparty/unpack/messages/mpma';
 
 /** An input being signed, identified by the outpoint it spends. */
 export interface AnalyzedInput {
+  index?: number;
   txid: string;
   vout: number;
+  hasSignatures?: boolean;
+  address?: string;
+  value?: number;
 }
 
 /**
@@ -69,6 +83,8 @@ export interface SignRequestAnalysisInput {
    * belong to someone else's side of the transaction.
    */
   signedInputIndices: number[];
+  /** Effective sighash for every requested input, after request/PSBT/default resolution. */
+  signedInputs: Array<{ index: number; sighashType: number }>;
   /** Transaction id, where the caller could establish one. Only the detail lookups use it. */
   transactionId: string | undefined;
   /**
@@ -83,6 +99,12 @@ export interface SignRequestAnalysisInput {
    * with the specific reason.
    */
   inscriptionContext?: InscriptionCommitContext;
+  /** Provider capability selected before approval; defaults to Counterparty-only. */
+  signingPurpose?: 'counterparty' | 'bitcoin-payment';
+  /** Required and independently proved for the bitcoin-payment capability. */
+  bitcoinPaymentIntent?: BitcoinPaymentIntentV1;
+  /** Optional marketplace assertions; every term is proved below before receiving semantic UI. */
+  marketplaceIntent?: MarketplaceIntentClaimV1;
 }
 
 export interface SignRequestAnalysis {
@@ -97,6 +119,9 @@ export interface SignRequestAnalysis {
   structureFindings: StructureFinding[];
   protocolContext: ProtocolContext;
   attachedAssetDestination: AttachedAssetDestination | null;
+  /** Exact external-output proof for a plain Bitcoin provider request. */
+  bitcoinPaymentProof?: BitcoinPaymentProof;
+  marketplaceReview?: MarketplaceApprovalReview;
 }
 
 /**
@@ -154,7 +179,11 @@ export async function analyzeSignRequest(
   const verification = verifyProviderTransaction(counterpartyDataHex, counterpartyMessage);
 
   const messageType = counterpartyMessage?.messageType ?? verification.localUnpack?.messageType;
-  const safety = analyzeTransactionSafety(messageType, outputs, signerAddresses, { verifiedCommit });
+  const signingPurpose = input.signingPurpose ?? 'counterparty';
+  const safety = analyzeTransactionSafety(messageType, outputs, signerAddresses, {
+    verifiedCommit,
+    plainBitcoinPayment: signingPurpose === 'bitcoin-payment',
+  });
 
   if (commitRefusal) {
     safety.warnings = [
@@ -214,12 +243,53 @@ export async function analyzeSignRequest(
 
   const attachedAssets = await input.attachedAssets;
 
-  // The gate: a transaction this wallet signs on a site's behalf either carries a Counterparty
-  // message or spends an input carrying attached assets. Anything else is a plain Bitcoin
-  // transaction, which a site has no Counterparty reason to ask this wallet for and which the user
-  // can make in the wallet directly. Both halves are required — a message alone would miss an
-  // attached UTXO being spent alongside it, and attached assets alone miss every ordinary send.
-  if (!movesCounterpartyValue(Boolean(counterpartyDataHex), attachedAssets, signedInputIndices)) {
+  let bitcoinPaymentProof: BitcoinPaymentProof | undefined;
+  if (signingPurpose === 'bitcoin-payment') {
+    const signed = new Set(signedInputIndices);
+    const signedAssets = attachedAssets.filter(
+      (entry) => signed.has(entry.inputIndex) && entry.assets.length > 0
+    );
+    const unknownAssetStatus = attachedAssets.filter(
+      (entry) => signed.has(entry.inputIndex) && entry.lookupFailed
+    );
+    const blockers: string[] = [];
+    if (counterpartyDataHex) {
+      blockers.push('the PSBT carries Counterparty data');
+    }
+    if (signedAssets.length > 0) {
+      blockers.push('a requested input carries attached Counterparty assets');
+    }
+    if (unknownAssetStatus.length > 0) {
+      blockers.push('the wallet could not verify that every requested input is free of attached assets');
+    }
+    if (!input.bitcoinPaymentIntent) {
+      blockers.push('the site supplied no versioned Bitcoin payment intent');
+    } else {
+      bitcoinPaymentProof = proveBitcoinPaymentIntent(
+        input.bitcoinPaymentIntent,
+        outputs,
+        signerAddresses,
+      );
+      blockers.push(...bitcoinPaymentProof.errors);
+    }
+    if (blockers.length > 0) {
+      safety.warnings = [
+        {
+          severity: 'block',
+          title: unknownAssetStatus.length > 0
+            ? 'Retry Required: Asset Status Unknown'
+            : 'Blocked: Bitcoin Payment Did Not Verify',
+          message:
+            `This plain Bitcoin signing request cannot be proved: ${blockers.join('; ')}. ` +
+            'No origin or site label can bypass these checks.',
+        },
+        ...safety.warnings,
+      ];
+      safety.blocked = true;
+    }
+    // The Counterparty-only gate remains the default. Plain Bitcoin signing is reachable only
+    // through the separate capability above, never because an origin was allowlisted.
+  } else if (!movesCounterpartyValue(Boolean(counterpartyDataHex), attachedAssets, signedInputIndices)) {
     safety.warnings = [
       {
         severity: 'block',
@@ -238,8 +308,45 @@ export async function analyzeSignRequest(
     outputs,
     attachedAssets,
     signedInputIndices,
-    signerAddresses
+    signerAddresses,
+    input.signedInputs,
+    verification.localUnpack?.success
+      ? {
+          messageType: verification.localUnpack.messageType,
+          data: verification.localUnpack.data,
+        }
+      : undefined
   );
+
+  let marketplaceReview: MarketplaceApprovalReview | undefined;
+  if (input.marketplaceIntent) {
+    marketplaceReview = analyzeMarketplaceIntent({
+      intent: input.marketplaceIntent,
+      inputs: inputs.map((transactionInput, index) => ({
+        ...transactionInput,
+        index: transactionInput.index ?? index,
+      })),
+      outputs,
+      signedInputs: input.signedInputs,
+      signerAddresses,
+      attachedAssets,
+      attachedAssetDestination,
+      hasCounterpartyPayload: Boolean(counterpartyDataHex),
+    });
+    if (marketplaceReview.status === 'blocked' || marketplaceReview.status === 'retry') {
+      safety.warnings = [
+        {
+          severity: 'block',
+          title: marketplaceReview.status === 'retry'
+            ? 'Retry Required: Marketplace Proof Incomplete'
+            : 'Blocked: Marketplace Intent Mismatch',
+          message: marketplaceReview.blockers.join('; '),
+        },
+        ...safety.warnings,
+      ];
+      safety.blocked = true;
+    }
+  }
 
   return {
     verifiedCommit,
@@ -251,5 +358,7 @@ export async function analyzeSignRequest(
     structureFindings,
     protocolContext,
     attachedAssetDestination,
+    bitcoinPaymentProof,
+    marketplaceReview,
   };
 }

--- a/src/core/counterparty/signRequestAnalysis.ts
+++ b/src/core/counterparty/signRequestAnalysis.ts
@@ -275,6 +275,9 @@ export async function analyzeSignRequest(
     if (blockers.length > 0) {
       safety.warnings = [
         {
+          // Tagged so the approval screen can let the payment card be the one failure voice
+          // instead of repeating this in its generic warning stack.
+          code: 'bitcoin_payment_gate',
           severity: 'block',
           title: unknownAssetStatus.length > 0
             ? 'Retry Required: Asset Status Unknown'

--- a/src/core/counterparty/transaction.ts
+++ b/src/core/counterparty/transaction.ts
@@ -267,14 +267,14 @@ function fromApiDecode(messageData: Record<string, unknown>): DescribableMessage
     const divisible = infoFor(field)?.divisible;
     if (divisible === true) return fromSatoshis(String(quantity));
     if (divisible === false) return BigInt(String(quantity)).toLocaleString();
-    return `${BigInt(String(quantity)).toLocaleString()} (decimals unconfirmed)`;
+    return `${BigInt(String(quantity)).toLocaleString()} (base units)`;
   };
 
   /**
    * The display-unit value as a bare number string, for figures that are divided rather than shown.
    *
    * Deliberately not `format`'s output with the separators stripped: that output can carry a
-   * "(decimals unconfirmed)" caveat, and parsing a number back out of it would turn an honest
+   * "(base units)" caveat, and parsing a number back out of it would turn an honest
    * "we do not know the scale" into NaN or, worse, a plausible wrong number.
    */
   const numeric = (quantity: unknown, asset?: string): string | undefined => {
@@ -330,6 +330,14 @@ function fromApiDecode(messageData: Record<string, unknown>): DescribableMessage
     recipientCount: Array.isArray(messageData) ? messageData.length : undefined,
     subassetLongname: messageData.asset_longname as string | undefined,
     dispenserStatus: num('status'),
+    // Issuance switches travel in the message itself, so the describer can scale the issued
+    // quantity by the flag being signed instead of falling back to the base-units caveat.
+    divisible: messageData.divisible as boolean | undefined,
+    lock: messageData.lock as boolean | undefined,
+    reset: messageData.reset as boolean | undefined,
+    minLpQuantity: messageData.min_lp_quantity,
+    minQuantityA: messageData.min_quantity_a,
+    minQuantityB: messageData.min_quantity_b,
     format,
     numeric,
     name,
@@ -452,7 +460,7 @@ export async function resolveMpmaRecipients(
           ? fromSatoshis(send.quantity.toString())
           : divisible === false
             ? send.quantity.toLocaleString()
-            : `${send.quantity.toString()} (decimals unconfirmed)`,
+            : `${send.quantity.toString()} (base units)`,
     };
   });
 }

--- a/src/core/counterparty/transactionSafety.ts
+++ b/src/core/counterparty/transactionSafety.ts
@@ -165,6 +165,8 @@ export function analyzeTransactionSafety(
      * the external-address warning exists to check.
      */
     verifiedCommit?: { address: string; value: number };
+    /** A separate provider capability identified this as an explicit Bitcoin payment request. */
+    plainBitcoinPayment?: boolean;
   } = {}
 ): SafetyAnalysis {
   const warnings: SecurityWarning[] = [];
@@ -304,7 +306,8 @@ export function analyzeTransactionSafety(
     const totalSats = suspiciousOutputs.reduce((sum, o) => sum + o.value, 0);
     const btcAmount = (totalSats / 100_000_000).toFixed(8);
     const addresses = suspiciousOutputs.map(o => o.address);
-    const expected = messageType !== undefined && BTC_PAYING_MESSAGE_TYPES.has(messageType);
+    const expected = options.plainBitcoinPayment
+      || (messageType !== undefined && BTC_PAYING_MESSAGE_TYPES.has(messageType));
 
     warnings.push(
       expected
@@ -312,10 +315,12 @@ export function analyzeTransactionSafety(
             // The payment is the transaction, so this is information rather than a warning.
             // The address and amount still need checking, hence the wording.
             severity: 'info',
-            title: 'BTC Payment',
+            title: options.plainBitcoinPayment ? 'Bitcoin Payment' : 'BTC Payment',
             message:
               `This sends ${btcAmount} BTC to ${addresses.map(a => a.slice(0, 12) + '…').join(', ')}, ` +
-              'which is how this type of transaction pays. Check the address is the one you mean.',
+              (options.plainBitcoinPayment
+                ? 'matching the payment outputs the site declared. Check the address is the one you mean.'
+                : 'which is how this type of transaction pays. Check the address is the one you mean.'),
           }
         : {
             severity: 'danger',

--- a/src/core/counterparty/transactionSafety.ts
+++ b/src/core/counterparty/transactionSafety.ts
@@ -188,21 +188,24 @@ export function analyzeTransactionSafety(
         severity: 'block',
         title: 'Blocked: Sweep Transaction',
         message:
-          'This transaction would send ALL of your Counterparty assets to another address. ' +
-          'Sweep transactions cannot be signed through a website. Use the wallet directly if you need to sweep.',
+          'This would send ALL Counterparty assets at your address. Websites cannot request ' +
+          'sweeps — use the wallet directly if you mean to.',
       });
     } else if (DANGEROUS_MESSAGE_TYPES.has(messageType)) {
       warnings.push({
         severity: 'danger',
-        title: 'Danger: Asset Destruction',
+        title: 'Danger: Supply Destruction',
         message:
-          'This transaction permanently destroys assets. This action is irreversible. ' +
+          'This transaction permanently destroys supply. This action is irreversible. ' +
           'Make sure you understand exactly what is being destroyed.',
       });
     } else if (MOVES_EVERYTHING_MESSAGE_TYPES.has(messageType)) {
       warnings.push({
         code: 'detach_all',
-        severity: 'warning',
+        // Info, not warning: a detach doing exactly what a detach does is routine, and the
+        // details list names each released balance. A detach whose assets leave the wallet
+        // escalates through the attached-asset destination warning instead.
+        severity: 'info',
         title: 'Moves Everything on the UTXO',
         message:
           'Detaching transfers every asset attached to this UTXO, not a stated amount. ' +
@@ -310,7 +313,9 @@ export function analyzeTransactionSafety(
     });
   }
 
-  if (suspiciousOutputs.length > 0) {
+  // A dispense's payment is already the screen's subject: the movement rows name the dispenser
+  // address and the detail list says what comes back, so a note restating the payment is noise.
+  if (suspiciousOutputs.length > 0 && messageType !== 'dispense') {
     const totalSats = suspiciousOutputs.reduce((sum, o) => sum + o.value, 0);
     const btcAmount = (totalSats / 100_000_000).toFixed(8);
     const addresses = suspiciousOutputs.map(o => o.address);

--- a/src/core/counterparty/transactionSafety.ts
+++ b/src/core/counterparty/transactionSafety.ts
@@ -15,6 +15,7 @@ export type WarningSeverity = 'block' | 'danger' | 'warning' | 'info';
 
 /** Stable identifiers for warnings that another presentation layer may describe more precisely. */
 export type SecurityWarningCode =
+  | 'bitcoin_payment_gate'
   | 'detach_all'
   | 'expected_btc_payment'
   | 'external_btc_output';

--- a/src/core/counterparty/transactionSafety.ts
+++ b/src/core/counterparty/transactionSafety.ts
@@ -13,8 +13,12 @@ import { bareMultisigRecoveryPubkey } from '@/core/counterparty/unpack/multisig'
 /** Severity of a security warning */
 export type WarningSeverity = 'block' | 'danger' | 'warning' | 'info';
 
+/** Stable identifiers for warnings that another presentation layer may describe more precisely. */
+export type SecurityWarningCode = 'detach_all' | 'expected_btc_payment';
+
 /** A single security warning */
 export interface SecurityWarning {
+  code?: SecurityWarningCode;
   severity: WarningSeverity;
   title: string;
   message: string;
@@ -194,6 +198,7 @@ export function analyzeTransactionSafety(
       });
     } else if (MOVES_EVERYTHING_MESSAGE_TYPES.has(messageType)) {
       warnings.push({
+        code: 'detach_all',
         severity: 'warning',
         title: 'Moves Everything on the UTXO',
         message:
@@ -312,6 +317,7 @@ export function analyzeTransactionSafety(
     warnings.push(
       expected
         ? {
+            code: 'expected_btc_payment',
             // The payment is the transaction, so this is information rather than a warning.
             // The address and amount still need checking, hence the wording.
             severity: 'info',

--- a/src/core/counterparty/transactionSafety.ts
+++ b/src/core/counterparty/transactionSafety.ts
@@ -14,7 +14,10 @@ import { bareMultisigRecoveryPubkey } from '@/core/counterparty/unpack/multisig'
 export type WarningSeverity = 'block' | 'danger' | 'warning' | 'info';
 
 /** Stable identifiers for warnings that another presentation layer may describe more precisely. */
-export type SecurityWarningCode = 'detach_all' | 'expected_btc_payment';
+export type SecurityWarningCode =
+  | 'detach_all'
+  | 'expected_btc_payment'
+  | 'external_btc_output';
 
 /** A single security warning */
 export interface SecurityWarning {
@@ -329,6 +332,7 @@ export function analyzeTransactionSafety(
                 : 'which is how this type of transaction pays. Check the address is the one you mean.'),
           }
         : {
+            code: 'external_btc_output',
             severity: 'danger',
             title: 'BTC Sent to External Address',
             message:

--- a/src/entrypoints/injected.ts
+++ b/src/entrypoints/injected.ts
@@ -28,6 +28,7 @@ const INTERACTIVE_METHODS = new Set([
   'xcp_requestAccounts',
   'xcp_signTransaction',
   'xcp_signPsbt',
+  'xcp_signBitcoinPsbt',
   'xcp_signMessage',
 ]);
 

--- a/src/entrypoints/injected.ts
+++ b/src/entrypoints/injected.ts
@@ -28,6 +28,7 @@ const INTERACTIVE_METHODS = new Set([
   'xcp_requestAccounts',
   'xcp_signTransaction',
   'xcp_signPsbt',
+  'xcp_signPsbts',
   'xcp_signBitcoinPsbt',
   'xcp_signMessage',
 ]);

--- a/src/entrypoints/popup/app.tsx
+++ b/src/entrypoints/popup/app.tsx
@@ -82,6 +82,7 @@ import PoolPositionPage from '@/pages/pools/[lpAsset]';
 import ApproveConnectionPage from '@/pages/requests/connect/approve';
 import ApproveMessagePage from '@/pages/requests/message/approve';
 import ApprovePsbtPage from '@/pages/requests/psbt/approve';
+import ApprovePsbtsPage from '@/pages/requests/psbts/approve';
 import ApproveTransactionPage from '@/pages/requests/transaction/approve';
 import SettingsPage from '@/pages/settings';
 // Settings
@@ -153,6 +154,7 @@ export default function App() {
           <Route path="/requests/connect/approve" element={<ApproveConnectionPage />} />
           <Route path="/requests/transaction/approve" element={<ApproveTransactionPage />} />
           <Route path="/requests/psbt/approve" element={<ApprovePsbtPage />} />
+          <Route path="/requests/psbts/approve" element={<ApprovePsbtsPage />} />
           <Route path="/requests/message/approve" element={<ApproveMessagePage />} />
         </Route>
 

--- a/src/hooks/usePopupLifecycle.ts
+++ b/src/hooks/usePopupLifecycle.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 
-export type SignRequestKind = 'sign-transaction' | 'sign-psbt' | 'sign-message';
+export type SignRequestKind = 'sign-transaction' | 'sign-psbt' | 'sign-psbts' | 'sign-message';
 
 /**
  * Connects the 'popup-lifecycle' port so the background can promptly cancel this

--- a/src/hooks/useSignPsbtRequest.ts
+++ b/src/hooks/useSignPsbtRequest.ts
@@ -12,8 +12,14 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router';
-import { extractPsbtDetails, type PsbtDetails } from '@/core/bitcoin/psbt';
+import type { BitcoinPaymentIntentV1 } from '@/core/bitcoin/providerPayment';
+import {
+  extractPsbtDetails,
+  type PsbtDetails,
+  resolvePsbtSighashType,
+} from '@/core/bitcoin/psbt';
 import { fetchInputsAttachedAssets } from '@/core/counterparty/inputAssets';
+import type { MarketplaceIntentClaimV1 } from '@/core/counterparty/marketplaceIntent';
 import {
   type InscriptionCommitContext,
   resolveRevealMessage,
@@ -51,7 +57,11 @@ export function useSignPsbtRequest(signerAddress?: string) {
     psbtHex: string,
     signerAddresses?: string[],
     signedInputIndices?: number[],
-    inscriptionContext?: InscriptionCommitContext
+    requestedSighashTypes?: number[],
+    inscriptionContext?: InscriptionCommitContext,
+    signingPurpose: 'counterparty' | 'bitcoin-payment' = 'counterparty',
+    bitcoinPaymentIntent?: BitcoinPaymentIntentV1,
+    marketplaceIntent?: MarketplaceIntentClaimV1,
   ): Promise<DecodedPsbtInfo> => {
     // First, extract pure Bitcoin details (no API calls)
     const psbtDetails = extractPsbtDetails(psbtHex);
@@ -114,9 +124,19 @@ export function useSignPsbtRequest(signerAddress?: string) {
       outputs: psbtDetails.outputs,
       signerAddresses: signerAddresses ?? [],
       signedInputIndices: signedInputIndices ?? [],
+      signedInputs: (signedInputIndices ?? []).map(index => ({
+        index,
+        sighashType: resolvePsbtSighashType(
+          requestedSighashTypes?.[index],
+          psbtDetails.inputs[index]?.sighashType,
+        ),
+      })),
       transactionId: txid,
       attachedAssets: attachedAssetsPromise,
       inscriptionContext,
+      signingPurpose,
+      bitcoinPaymentIntent,
+      marketplaceIntent,
     });
 
     return {
@@ -154,7 +174,11 @@ export function useSignPsbtRequest(signerAddress?: string) {
           req.psbtHex,
           requestedSigners.length > 0 ? requestedSigners : signerAddress ? [signerAddress] : [],
           Object.values(req.signInputs ?? {}).flat(),
-          req.inscription
+          req.sighashTypes,
+          req.inscription,
+          req.signingPurpose,
+          req.bitcoinPaymentIntent,
+          req.marketplaceIntent,
         );
         setDecodedInfo(decoded);
       } catch (err) {
@@ -182,7 +206,11 @@ export function useSignPsbtRequest(signerAddress?: string) {
               req.psbtHex,
               requestedSigners.length > 0 ? requestedSigners : signerAddress ? [signerAddress] : [],
               Object.values(req.signInputs ?? {}).flat(),
-              req.inscription
+              req.sighashTypes,
+              req.inscription,
+              req.signingPurpose,
+              req.bitcoinPaymentIntent,
+              req.marketplaceIntent,
             );
             setDecodedInfo(decoded);
           }

--- a/src/hooks/useSignPsbtRequest.ts
+++ b/src/hooks/useSignPsbtRequest.ts
@@ -39,7 +39,7 @@ import { getSignFlow, recordSignOutcome, type SignPsbtRequest } from '@/platform
  */
 export interface DecodedPsbtInfo extends SignRequestAnalysis {
   psbtDetails: PsbtDetails;
-  /** Decoded transaction ID (if available from API) */
+  /** Unsigned transaction ID computed locally from the PSBT. */
   txid?: string;
 }
 
@@ -70,7 +70,10 @@ export function useSignPsbtRequest(signerAddress?: string) {
     // OP_RETURN/txid API decodes below rather than adding a serial round-trip.
     const attachedAssetsPromise = fetchInputsAttachedAssets(psbtDetails.inputs, signedInputIndices);
 
-    let txid: string | undefined;
+    // The unsigned transaction id is a local PSBT fact. The remote decoder may enrich scripts we
+    // could not render, but an outage or a dishonest response must not decide whether an exact
+    // marketplace transaction matches its intent.
+    let txid: string | undefined = psbtDetails.transactionId;
     let counterpartyDataHex: string | undefined;
 
     // Resolve any Counterparty payload the outputs carry — plaintext or ARC4 OP_RETURN, or
@@ -99,7 +102,7 @@ export function useSignPsbtRequest(signerAddress?: string) {
     if (psbtDetails.rawTxHex) {
       try {
         const decoded = await decodeRawTransaction(psbtDetails.rawTxHex, true);
-        txid = decoded.txid;
+        txid ??= decoded.txid;
 
         // Fill in addresses the local decode couldn't derive — never replace one
         // it did. The signature commits to the output scripts, so an address the

--- a/src/hooks/useSignPsbtRequest.ts
+++ b/src/hooks/useSignPsbtRequest.ts
@@ -12,36 +12,12 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router';
-import type { BitcoinPaymentIntentV1 } from '@/core/bitcoin/providerPayment';
 import {
-  extractPsbtDetails,
-  type PsbtDetails,
-  resolvePsbtSighashType,
-} from '@/core/bitcoin/psbt';
-import { fetchInputsAttachedAssets } from '@/core/counterparty/inputAssets';
-import type { MarketplaceIntentClaimV1 } from '@/core/counterparty/marketplaceIntent';
-import {
-  type InscriptionCommitContext,
-  resolveRevealMessage,
-} from '@/core/counterparty/providerInscriptions';
-import {
-  analyzeSignRequest,
-  type SignRequestAnalysis,
-} from '@/core/counterparty/signRequestAnalysis';
-import { decodeRawTransaction } from '@/core/counterparty/transaction';
-import { extractPayloadFromOutputs } from '@/core/counterparty/unpack/opReturn';
+  type DecodedPsbtInfo,
+  decodePsbtForApproval,
+} from '@/core/bitcoin/psbtApprovalDecoder';
 import { emitToBackground } from '@/platform/provider/emitToBackground';
 import { getSignFlow, recordSignOutcome, type SignPsbtRequest } from '@/platform/provider/signFlow';
-
-/**
- * PSBT details with address enrichment, plus the safety analysis every signing request gets
- * (`signRequestAnalysis.ts`, shared with the raw-transaction screen).
- */
-export interface DecodedPsbtInfo extends SignRequestAnalysis {
-  psbtDetails: PsbtDetails;
-  /** Unsigned transaction ID computed locally from the PSBT. */
-  txid?: string;
-}
 
 export function useSignPsbtRequest(signerAddress?: string) {
   const [searchParams] = useSearchParams();
@@ -52,102 +28,7 @@ export function useSignPsbtRequest(signerAddress?: string) {
 
   const requestId = searchParams.get('requestId');
 
-  // Decode PSBT and enrich with API data
-  const decodePsbt = useCallback(async (
-    psbtHex: string,
-    signerAddresses?: string[],
-    signedInputIndices?: number[],
-    requestedSighashTypes?: number[],
-    inscriptionContext?: InscriptionCommitContext,
-    signingPurpose: 'counterparty' | 'bitcoin-payment' = 'counterparty',
-    bitcoinPaymentIntent?: BitcoinPaymentIntentV1,
-    marketplaceIntent?: MarketplaceIntentClaimV1,
-  ): Promise<DecodedPsbtInfo> => {
-    // First, extract pure Bitcoin details (no API calls)
-    const psbtDetails = extractPsbtDetails(psbtHex);
-
-    // Kick off per-input attached-asset lookups now so they overlap with the
-    // OP_RETURN/txid API decodes below rather than adding a serial round-trip.
-    const attachedAssetsPromise = fetchInputsAttachedAssets(psbtDetails.inputs, signedInputIndices);
-
-    // The unsigned transaction id is a local PSBT fact. The remote decoder may enrich scripts we
-    // could not render, but an outage or a dishonest response must not decide whether an exact
-    // marketplace transaction matches its intent.
-    let txid: string | undefined = psbtDetails.transactionId;
-    let counterpartyDataHex: string | undefined;
-
-    // Resolve any Counterparty payload the outputs carry — plaintext or ARC4 OP_RETURN, or
-    // bare-multisig data outputs, which produce no OP_RETURN at all. Classifying every encoding
-    // here is what lets the sweep block apply regardless of how the message is carried.
-    const firstInputTxid = psbtDetails.inputs[0]?.txid;
-    if (firstInputTxid) {
-      counterpartyDataHex = extractPayloadFromOutputs(
-        psbtDetails.outputs.map((output) => output.script ?? ''),
-        firstInputTxid
-      ) ?? undefined;
-    }
-
-    // An inscription reveal carries its message in input 0's tapleaf instead of any output — the
-    // outputs hold only the bare CNTRPRTY marker. Recognized under core's own conditions
-    // (`providerInscriptions.ts`), the envelope's message takes the payload's place and the
-    // ordinary gate and display apply to it. Raw-transaction requests have no equivalent: an
-    // unsigned raw transaction cannot carry the leaf it will reveal, so that path stays blocked.
-    if (!counterpartyDataHex) {
-      const reveal = resolveRevealMessage(psbtDetails.inputs, psbtDetails.outputs);
-      if (reveal) counterpartyDataHex = reveal.messageHex;
-    }
-
-    // Enrich the outputs before analysing them, so the safety checks see every address that could
-    // be resolved. Try to get txid and enrich outputs with addresses from API.
-    if (psbtDetails.rawTxHex) {
-      try {
-        const decoded = await decodeRawTransaction(psbtDetails.rawTxHex, true);
-        txid ??= decoded.txid;
-
-        // Fill in addresses the local decode couldn't derive — never replace one
-        // it did. The signature commits to the output scripts, so an address the
-        // API supplies for a script we already read would let it relabel someone
-        // else's output as your own change: `analyzeTransactionSafety` and
-        // `computeMoneyMovement` both classify on this same array, so the
-        // "BTC Sent to External Address" warning would not fire (ADR-019).
-        for (const vout of decoded.vout) {
-          const output = psbtDetails.outputs.find(o => o.index === vout.n);
-          if (output && !output.address && vout.scriptPubKey.address) {
-            output.address = vout.scriptPubKey.address;
-          }
-        }
-      } catch (err) {
-        console.warn('Failed to decode transaction via API:', err);
-      }
-    }
-
-    const analysis = await analyzeSignRequest({
-      counterpartyDataHex,
-      inputs: psbtDetails.inputs,
-      outputs: psbtDetails.outputs,
-      signerAddresses: signerAddresses ?? [],
-      signedInputIndices: signedInputIndices ?? [],
-      signedInputs: (signedInputIndices ?? []).map(index => ({
-        index,
-        sighashType: resolvePsbtSighashType(
-          requestedSighashTypes?.[index],
-          psbtDetails.inputs[index]?.sighashType,
-        ),
-      })),
-      transactionId: txid,
-      attachedAssets: attachedAssetsPromise,
-      inscriptionContext,
-      signingPurpose,
-      bitcoinPaymentIntent,
-      marketplaceIntent,
-    });
-
-    return {
-      psbtDetails,
-      txid,
-      ...analysis,
-    };
-  }, []);
+  const decodePsbt = useCallback(decodePsbtForApproval, []);
 
   // Load PSBT request data if we have a request ID
   useEffect(() => {

--- a/src/hooks/useSignPsbtsRequest.ts
+++ b/src/hooks/useSignPsbtsRequest.ts
@@ -1,4 +1,4 @@
-/** Provider hook for the atomic exact-acceptance plus CPFP approval flow. */
+/** Provider hook for atomic marketplace multi-PSBT approval phases. */
 
 import { useCallback, useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router';
@@ -7,6 +7,10 @@ import {
   type DecodedPsbtInfo,
   decodePsbtForApproval,
 } from '@/core/bitcoin/psbtApprovalDecoder';
+import {
+  analyzeMarketplaceBatch,
+  parseMarketplaceBatchIntents,
+} from '@/core/counterparty/marketplaceBatch';
 import {
   analyzeAcceptanceCpfpBundle,
   type BumpAcceptanceFeeIntentClaim,
@@ -23,11 +27,25 @@ import {
   type SignPsbtsRequest,
 } from '@/platform/provider/signFlow';
 
+export interface DecodedPsbtBundleItem {
+  psbtDetails: ReturnType<typeof extractPsbtDetails>;
+  txid?: string;
+  marketplaceReview?: MarketplaceApprovalReview;
+}
+
 export interface DecodedPsbtBundleInfo {
-  parent: DecodedPsbtInfo;
-  child: ReturnType<typeof extractPsbtDetails>;
+  items: DecodedPsbtBundleItem[];
   review: MarketplaceApprovalReview;
 }
+
+const missingReview = (family: MarketplaceApprovalReview['family'], message: string) => ({
+  status: 'blocked' as const,
+  family,
+  title: 'Marketplace transaction did not verify',
+  facts: [],
+  notices: [],
+  blockers: [message],
+});
 
 export function useSignPsbtsRequest() {
   const [searchParams] = useSearchParams();
@@ -49,63 +67,95 @@ export function useSignPsbtsRequest() {
       setError(null);
       try {
         const stored = await getSignFlow(requestId) as SignPsbtsRequest | null;
-        if (!stored || stored.kind !== 'sign-psbts') {
+        if (!stored || stored.kind !== 'sign-psbts' || stored.items.length < 1) {
           throw new Error('PSBT bundle signing request not found or expired');
         }
-        const [parentItem, childItem] = stored.items;
-        if (parentItem.marketplaceIntent.action !== 'accept_exact_offer') {
-          throw new Error('Bundle parent is not an exact-offer acceptance');
-        }
-        if (childItem.marketplaceIntent.action !== 'bump_acceptance_fee') {
-          throw new Error('Bundle child is not an acceptance fee bump');
-        }
-        const parentIntent = parentItem.marketplaceIntent as AcceptExactOfferIntentClaim;
-        const childIntent = childItem.marketplaceIntent as BumpAcceptanceFeeIntentClaim;
-        const parent = await decodePsbtForApproval(
-          parentItem.psbtHex,
-          Object.keys(parentItem.signInputs),
-          Object.values(parentItem.signInputs).flat(),
-          parentItem.sighashTypes,
-          undefined,
-          'counterparty',
-          undefined,
-          parentIntent,
-        );
-        const child = extractPsbtDetails(childItem.psbtHex);
-        const firstChildInputTxid = child.inputs[0]?.txid;
-        const childPayload = firstChildInputTxid
-          ? extractPayloadFromOutputs(
-              child.outputs.map(output => output.script ?? ''),
-              firstChildInputTxid,
-            )
-          : null;
-        const childIndices = Object.values(childItem.signInputs).flat();
-        const review = analyzeAcceptanceCpfpBundle({
-          parentIntent,
-          parentReview: parent.marketplaceReview ?? {
-            status: 'blocked',
-            family: 'accept_exact_offer',
-            title: 'Exact offer parent did not verify',
-            facts: [],
-            notices: [],
-            blockers: ['the parent exact-offer semantic proof is missing'],
-          },
-          childIntent,
-          childInputs: child.inputs,
-          childOutputs: child.outputs,
-          childSignedInputs: childIndices.map(index => ({
-            index,
-            sighashType: resolvePsbtSighashType(
-              childItem.sighashTypes[index],
-              child.inputs[index]?.sighashType,
+
+        if (stored.bundleKind === 'acceptance-cpfp') {
+          if (stored.items.length !== 2) {
+            throw new Error('Exact acceptance fee-bump bundle must contain two transactions');
+          }
+          const [parentItem, childItem] = stored.items;
+          if (parentItem!.marketplaceIntent.action !== 'accept_exact_offer') {
+            throw new Error('Bundle parent is not an exact-offer acceptance');
+          }
+          if (childItem!.marketplaceIntent.action !== 'bump_acceptance_fee') {
+            throw new Error('Bundle child is not an acceptance fee bump');
+          }
+          const parentIntent = parentItem!.marketplaceIntent as AcceptExactOfferIntentClaim;
+          const childIntent = childItem!.marketplaceIntent as BumpAcceptanceFeeIntentClaim;
+          const parent = await decodePsbtForApproval(
+            parentItem!.psbtHex,
+            Object.keys(parentItem!.signInputs),
+            Object.values(parentItem!.signInputs).flat(),
+            parentItem!.sighashTypes,
+            undefined,
+            'counterparty',
+            undefined,
+            parentIntent,
+          );
+          const child = extractPsbtDetails(childItem!.psbtHex);
+          const firstChildInputTxid = child.inputs[0]?.txid;
+          const childPayload = firstChildInputTxid
+            ? extractPayloadFromOutputs(
+                child.outputs.map(output => output.script ?? ''),
+                firstChildInputTxid,
+              )
+            : null;
+          const childIndices = Object.values(childItem!.signInputs).flat();
+          const review = analyzeAcceptanceCpfpBundle({
+            parentIntent,
+            parentReview: parent.marketplaceReview ?? missingReview(
+              'accept_exact_offer',
+              'the parent exact-offer semantic proof is missing',
             ),
-          })),
-          childSignerAddresses: Object.keys(childItem.signInputs),
-          childTransactionId: child.transactionId,
-          childHasCounterpartyPayload: childPayload !== null,
-        });
+            childIntent,
+            childInputs: child.inputs,
+            childOutputs: child.outputs,
+            childSignedInputs: childIndices.map(index => ({
+              index,
+              sighashType: resolvePsbtSighashType(
+                childItem!.sighashTypes[index],
+                child.inputs[index]?.sighashType,
+              ),
+            })),
+            childSignerAddresses: Object.keys(childItem!.signInputs),
+            childTransactionId: child.transactionId,
+            childHasCounterpartyPayload: childPayload !== null,
+          });
+          setRequest(stored);
+          setDecodedInfo({
+            items: [parent, { psbtDetails: child, txid: child.transactionId }],
+            review,
+          });
+          return;
+        }
+
+        const parsed = parseMarketplaceBatchIntents(
+          stored.items.map(item => item.marketplaceIntent),
+        );
+        if (parsed.kind !== stored.bundleKind) {
+          throw new Error('Stored marketplace batch kind differs from its intents');
+        }
+        const decoded: DecodedPsbtInfo[] = await Promise.all(stored.items.map((item, index) =>
+          decodePsbtForApproval(
+            item.psbtHex,
+            Object.keys(item.signInputs),
+            Object.values(item.signInputs).flat(),
+            item.sighashTypes,
+            undefined,
+            'counterparty',
+            undefined,
+            parsed.intents[index],
+          )));
+        const itemReviews = decoded.map((item, index) =>
+          item.marketplaceReview ?? missingReview(
+            parsed.intents[index]!.action,
+            `marketplace semantic proof ${index + 1} is missing`,
+          ));
+        const review = analyzeMarketplaceBatch(parsed.kind, parsed.intents, itemReviews);
         setRequest(stored);
-        setDecodedInfo({ parent, child, review });
+        setDecodedInfo({ items: decoded, review });
       } catch (loadError) {
         setError(loadError instanceof Error ? loadError.message : 'Failed to load PSBT bundle');
       } finally {
@@ -116,7 +166,7 @@ export function useSignPsbtsRequest() {
     void load();
   }, [requestId]);
 
-  const handleSuccess = useCallback(async (signedPsbtHexes: [string, string]) => {
+  const handleSuccess = useCallback(async (signedPsbtHexes: string[]) => {
     if (!requestId) return;
     await recordSignOutcome(requestId, 'completed', { signedPsbtHexes });
     emitToBackground(`sign-psbts-complete-${requestId}`, { signedPsbtHexes });

--- a/src/hooks/useSignPsbtsRequest.ts
+++ b/src/hooks/useSignPsbtsRequest.ts
@@ -1,0 +1,132 @@
+/** Provider hook for the atomic exact-acceptance plus CPFP approval flow. */
+
+import { useCallback, useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router';
+import { extractPsbtDetails, resolvePsbtSighashType } from '@/core/bitcoin/psbt';
+import {
+  type DecodedPsbtInfo,
+  decodePsbtForApproval,
+} from '@/core/bitcoin/psbtApprovalDecoder';
+import {
+  analyzeAcceptanceCpfpBundle,
+  type BumpAcceptanceFeeIntentClaim,
+} from '@/core/counterparty/marketplaceBundle';
+import type {
+  AcceptExactOfferIntentClaim,
+  MarketplaceApprovalReview,
+} from '@/core/counterparty/marketplaceIntent';
+import { extractPayloadFromOutputs } from '@/core/counterparty/unpack/opReturn';
+import { emitToBackground } from '@/platform/provider/emitToBackground';
+import {
+  getSignFlow,
+  recordSignOutcome,
+  type SignPsbtsRequest,
+} from '@/platform/provider/signFlow';
+
+export interface DecodedPsbtBundleInfo {
+  parent: DecodedPsbtInfo;
+  child: ReturnType<typeof extractPsbtDetails>;
+  review: MarketplaceApprovalReview;
+}
+
+export function useSignPsbtsRequest() {
+  const [searchParams] = useSearchParams();
+  const [request, setRequest] = useState<SignPsbtsRequest | null>(null);
+  const [decodedInfo, setDecodedInfo] = useState<DecodedPsbtBundleInfo | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const requestId = searchParams.get('requestId');
+
+  useEffect(() => {
+    if (!requestId) {
+      setError('No PSBT bundle request ID provided');
+      setIsLoading(false);
+      return;
+    }
+
+    const load = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const stored = await getSignFlow(requestId) as SignPsbtsRequest | null;
+        if (!stored || stored.kind !== 'sign-psbts') {
+          throw new Error('PSBT bundle signing request not found or expired');
+        }
+        const [parentItem, childItem] = stored.items;
+        if (parentItem.marketplaceIntent.action !== 'accept_exact_offer') {
+          throw new Error('Bundle parent is not an exact-offer acceptance');
+        }
+        if (childItem.marketplaceIntent.action !== 'bump_acceptance_fee') {
+          throw new Error('Bundle child is not an acceptance fee bump');
+        }
+        const parentIntent = parentItem.marketplaceIntent as AcceptExactOfferIntentClaim;
+        const childIntent = childItem.marketplaceIntent as BumpAcceptanceFeeIntentClaim;
+        const parent = await decodePsbtForApproval(
+          parentItem.psbtHex,
+          Object.keys(parentItem.signInputs),
+          Object.values(parentItem.signInputs).flat(),
+          parentItem.sighashTypes,
+          undefined,
+          'counterparty',
+          undefined,
+          parentIntent,
+        );
+        const child = extractPsbtDetails(childItem.psbtHex);
+        const firstChildInputTxid = child.inputs[0]?.txid;
+        const childPayload = firstChildInputTxid
+          ? extractPayloadFromOutputs(
+              child.outputs.map(output => output.script ?? ''),
+              firstChildInputTxid,
+            )
+          : null;
+        const childIndices = Object.values(childItem.signInputs).flat();
+        const review = analyzeAcceptanceCpfpBundle({
+          parentIntent,
+          parentReview: parent.marketplaceReview ?? {
+            status: 'blocked',
+            family: 'accept_exact_offer',
+            title: 'Exact offer parent did not verify',
+            facts: [],
+            notices: [],
+            blockers: ['the parent exact-offer semantic proof is missing'],
+          },
+          childIntent,
+          childInputs: child.inputs,
+          childOutputs: child.outputs,
+          childSignedInputs: childIndices.map(index => ({
+            index,
+            sighashType: resolvePsbtSighashType(
+              childItem.sighashTypes[index],
+              child.inputs[index]?.sighashType,
+            ),
+          })),
+          childSignerAddresses: Object.keys(childItem.signInputs),
+          childTransactionId: child.transactionId,
+          childHasCounterpartyPayload: childPayload !== null,
+        });
+        setRequest(stored);
+        setDecodedInfo({ parent, child, review });
+      } catch (loadError) {
+        setError(loadError instanceof Error ? loadError.message : 'Failed to load PSBT bundle');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    void load();
+  }, [requestId]);
+
+  const handleSuccess = useCallback(async (signedPsbtHexes: [string, string]) => {
+    if (!requestId) return;
+    await recordSignOutcome(requestId, 'completed', { signedPsbtHexes });
+    emitToBackground(`sign-psbts-complete-${requestId}`, { signedPsbtHexes });
+  }, [requestId]);
+
+  const handleCancel = useCallback(async () => {
+    if (!requestId) return;
+    await recordSignOutcome(requestId, 'cancelled');
+    emitToBackground(`sign-psbts-cancel-${requestId}`, { reason: 'User cancelled' });
+  }, [requestId]);
+
+  return { request, decodedInfo, isLoading, error, handleSuccess, handleCancel };
+}

--- a/src/hooks/useSignTransactionRequest.ts
+++ b/src/hooks/useSignTransactionRequest.ts
@@ -137,6 +137,7 @@ export function useSignTransactionRequest(signerAddress?: string) {
       outputs,
       signerAddresses: signerAddress ? [signerAddress] : [],
       signedInputIndices: inputs.map((_, index) => index),
+      signedInputs: inputs.map((_, index) => ({ index, sighashType: 0x01 })),
       transactionId: parsed.txid,
       attachedAssets: attachedAssetsPromise,
     });

--- a/src/pages/requests/psbt/approve.tsx
+++ b/src/pages/requests/psbt/approve.tsx
@@ -1,4 +1,11 @@
 import { useEffect, useState } from 'react';
+import {
+  ApprovalAttentionScreen,
+  ApprovalNotes,
+  highFeeAttentionItem,
+  partitionApprovalItems,
+  verificationAttentionItem,
+} from '@/components/domain/approval/approval-attention';
 import {ApprovalExpired, ApprovalFooter,
   ApprovalLoading, ApprovalNoWallet,ApprovalSiteBar, 
   ApprovalWalletHeader, 
@@ -14,8 +21,8 @@ import { buildOrderAction } from '@/components/domain/approval/order-card';
 import { describePsbtFlexibility } from '@/components/domain/approval/psbt-flexibility';
 import { getTxActionInfo } from '@/components/domain/tx/tx-action-info';
 import { VerificationStatus } from '@/components/domain/tx/verification-status';
+import { Collapsible } from '@/components/ui/collapsible';
 import { ErrorAlert } from '@/components/ui/error-alert';
-import { CheckboxInput } from '@/components/ui/inputs/checkbox-input';
 import { type WarningItem, WarningStack } from '@/components/ui/warning-stack';
 import { useHeader } from '@/contexts/header-context';
 import { useSettings } from '@/contexts/settings-context';
@@ -27,6 +34,7 @@ import { classifySignedInputAssets } from '@/core/counterparty/inputAssets';
 import { shouldBlockSigning } from '@/core/counterparty/unpack/providerVerify';
 import { formatAddress, formatAmount } from '@/core/format';
 import { fromSatoshis, toFiniteNumber } from "@/core/numeric";
+import { useFeeRates } from '@/hooks/useFeeRates';
 import { usePopupLifecycle } from '@/hooks/usePopupLifecycle';
 import { useSignPsbtRequest } from '@/hooks/useSignPsbtRequest';
 import { getIdentityMismatchError, getPsbtPermissionError } from '@/platform/provider/requestIdentity';
@@ -54,11 +62,12 @@ export default function ApprovePsbtPage() {
     handleSuccess,
     handleCancel,
   } = useSignPsbtRequest(activeAddress?.address);
+  const { feeRates } = useFeeRates();
   usePopupLifecycle(request?.id, 'sign-psbt');
 
   const [isSigning, setIsSigning] = useState(false);
   const [error, setError] = useState<string>('');
-  const [acceptedAtRisk, setAcceptedAtRisk] = useState(false);
+  const [showAttention, setShowAttention] = useState(false);
 
   // Configure header
   useEffect(() => {
@@ -78,6 +87,8 @@ export default function ApprovePsbtPage() {
                   : 'Sign Transaction',
     });
   }, [request?.marketplaceIntent?.action, request?.signingPurpose, setHeaderProps]);
+
+  useEffect(() => setShowAttention(false), [request?.id]);
 
   const handleSign = async () => {
     if (!request || !decodedInfo) return;
@@ -148,7 +159,7 @@ export default function ApprovePsbtPage() {
     ? psbtDetails.rawTxHex.length / 2 + psbtDetails.inputs.length * 110
     : undefined;
   const feeRateAbsurd = !psbtDetails.unfunded
-    && exceedsSaneFeeRate(psbtDetails.fee, estimatedVsize);
+    && exceedsSaneFeeRate(psbtDetails.fee, estimatedVsize, feeRates?.fastestFee);
   const hasHighFee = psbtDetails.fee > 10000000 || feeRateAbsurd; // > 0.1 BTC, or an absurd rate
 
   // Distinguish seller vs buyer in atomic swap PSBTs:
@@ -160,10 +171,13 @@ export default function ApprovePsbtPage() {
   const verificationPassed = verification?.passed;
   const verificationWarning = verification?.warning;
   const isStrictMode = settings?.strictTransactionVerification !== false;
+  const deferredVerificationFailure = verificationPassed === false
+    && verification?.repackProved !== true
+    && !isStrictMode;
   const safetyBlocked = safety?.blocked ?? false;
   const safetyWarnings = safety?.warnings ?? [];
   // Shared with the raw-transaction approval screen so the two cannot drift.
-  const blockSigning = shouldBlockSigning({
+  const verificationBlocked = shouldBlockSigning({
     safetyBlocked,
     verificationPassed,
     repackProved: verification?.repackProved ?? false,
@@ -202,18 +216,6 @@ export default function ApprovePsbtPage() {
     ({ address }) => normalizeAddressForComparison(address)
       !== normalizeAddressForComparison(activeAddress.address)
   );
-  const requestedSignerSet = new Set(
-    requestedAddressSpends.map(({ address }) => normalizeAddressForComparison(address))
-  );
-  const spendableOutputs = psbtDetails.outputs.filter(output => output.type !== 'op_return');
-  const externalOutputValue = spendableOutputs.every(output => Boolean(output.address))
-    ? spendableOutputs.reduce(
-        (sum, output) => requestedSignerSet.has(normalizeAddressForComparison(output.address!))
-          ? sum
-          : sum + output.value,
-        0
-      )
-    : null;
 
   // Net effect of this transaction on your wallet — the money-movement summary,
   // computed structurally (replaces the old swap-detection heuristic; works for
@@ -264,6 +266,69 @@ export default function ApprovePsbtPage() {
       ),
     });
   }
+
+  const marketplaceReview = decodedInfo.marketplaceReview;
+  const marketplaceBlocked = marketplaceReview?.status === 'blocked'
+    || marketplaceReview?.status === 'retry';
+  // A missing balance answer is uncertainty, not permission to assume an input is clean.
+  const assetStatusBlocked = signedInputsUnknownStatus.length > 0;
+  const blockSigning = verificationBlocked || marketplaceBlocked || assetStatusBlocked;
+  const { informational, attention } = partitionApprovalItems(warningItems);
+  const genericAttention = movement.atRisk > 0
+    ? attention.filter(item => item.key !== 'anyonecanpay')
+    : attention;
+  // Attach quotes are intrinsically block-dependent and already disclosed in the action card. A
+  // second click on every attach would turn that routine protocol fact into warning wallpaper.
+  const marketplaceRequiresAttention = marketplaceReview?.status === 'caution'
+    && marketplaceReview.family !== 'attach_for_listing';
+  const marketplaceAttention: WarningItem[] = marketplaceRequiresAttention
+    ? marketplaceReview.notices.map((notice, index) => ({
+        key: `marketplace-${index}`,
+        severity: notice.severity,
+        title: marketplaceReview.family === 'authorize_exact_offer'
+          ? 'The seller can accept without another approval'
+          : 'This authorization remains usable after signing',
+        description: notice.message,
+      }))
+    : [];
+  const approvalAttentionItems: WarningItem[] = [
+    ...marketplaceAttention,
+    ...genericAttention,
+    ...(deferredVerificationFailure ? [verificationAttentionItem(verificationWarning)] : []),
+    ...(movement.atRisk > 0 ? [{
+      key: 'btc-at-risk',
+      severity: 'danger' as const,
+      title: `${formatAmount({
+        value: fromSatoshis(movement.atRisk, true),
+        minimumFractionDigits: 8,
+        maximumFractionDigits: 8,
+      })} BTC is not guaranteed back`,
+      description:
+        'The requested signature does not commit every output returning this amount. Whoever completes the transaction may redirect it.',
+    }] : []),
+    ...(hasHighFee ? [highFeeAttentionItem(psbtDetails.fee, estimatedVsize)] : []),
+  ];
+  const requiresAttention = !blockSigning && approvalAttentionItems.length > 0;
+  const attentionTitle = marketplaceRequiresAttention
+    ? 'Review authorization'
+    : approvalAttentionItems.some(item => item.severity === 'danger')
+      ? 'Review transaction risk'
+      : 'Review before signing';
+  const confirmLabel = marketplaceReview?.family === 'create_listing'
+    ? 'Authorize listing'
+    : marketplaceReview?.family === 'authorize_exact_offer'
+      ? 'Authorize offer'
+      : counterpartyMessage?.messageType === 'destroy'
+        ? 'Destroy assets'
+        : 'Confirm and sign';
+  const handleApprovalAction = () => {
+    if (requiresAttention) {
+      setShowAttention(true);
+      return;
+    }
+    void handleSign();
+  };
+
   return (
     <div className="flex flex-col h-full bg-gray-50">
       {/* Content */}
@@ -272,31 +337,22 @@ export default function ApprovePsbtPage() {
           <ApprovalWalletHeader walletName={activeWallet.name} address={activeAddress.address} />
 
           {usesPairedAddress && (
-            <div className="rounded-lg border border-blue-200 bg-blue-50 p-4">
-              <p className="text-sm font-medium text-blue-900">Uses a paired wallet address</p>
-              <p className="mt-1 text-xs text-blue-800">
-                This request signs explicitly selected inputs from your paired Legacy and SegWit addresses.
+            <Collapsible variant="card" title={`Signing addresses (${requestedAddressSpends.length})`}>
+              <p className="text-xs text-gray-500">
+                The request explicitly selects inputs from paired Legacy and SegWit addresses in this wallet.
               </p>
-              <div className="mt-3 space-y-2">
+              <div className="space-y-2">
                 {requestedAddressSpends.map(({ address, indices, value }) => (
                   <div key={address} className="flex items-start justify-between gap-3 text-xs">
                     <div>
-                      <p className="font-mono text-blue-900">{formatAddress(address, true)}</p>
-                      <p className="text-blue-700">Inputs {indices.map(index => `#${index}`).join(', ')}</p>
+                      <p className="font-mono text-gray-700">{formatAddress(address, true)}</p>
+                      <p className="text-gray-500">Inputs {indices.map(index => `#${index}`).join(', ')}</p>
                     </div>
-                    <p className="font-medium text-blue-900">{value.toLocaleString()} sats</p>
+                    <p className="font-medium text-gray-700">{value.toLocaleString()} sats</p>
                   </div>
                 ))}
               </div>
-              <div className="mt-3 flex justify-between text-xs font-medium text-blue-900">
-                <span>Network fee: {psbtDetails.fee.toLocaleString()} sats</span>
-                <span>
-                  External BTC: {externalOutputValue === null
-                    ? 'unknown'
-                    : `${externalOutputValue.toLocaleString()} sats`}
-                </span>
-              </div>
-            </div>
+            </Collapsible>
           )}
 
           <ApprovalSiteBar origin={request.origin} />
@@ -312,6 +368,10 @@ export default function ApprovePsbtPage() {
             <MarketplaceReviewCard review={decodedInfo.marketplaceReview} />
           )}
 
+          {marketplaceBlocked && marketplaceReview.blockers.length > 0 && (
+            <ErrorAlert message={marketplaceReview.blockers.join('; ')} />
+          )}
+
           {error && <ErrorAlert message={error} />}
 
           {/* Transaction action & fee */}
@@ -322,6 +382,7 @@ export default function ApprovePsbtPage() {
             movement={movement}
             flexibility={semanticMarketplaceReview ? undefined : flexibilityReview?.kind}
             hasHighFee={hasHighFee}
+            deferCautions={requiresAttention}
             protocolFeeXcp={counterpartyMessage?.messageData?.fee != null
               ? toFiniteNumber(counterpartyMessage.messageData.fee) ?? null
               : null}
@@ -339,42 +400,46 @@ export default function ApprovePsbtPage() {
             verification={verification}
           />
 
-          {/* Warnings, rendered in a fixed severity order (danger → success) */}
-          <WarningStack items={warningItems} />
+          <ApprovalNotes items={informational} />
+
+          {/* A blocked request explains itself immediately. Signable cautions wait behind Review. */}
+          {blockSigning && <WarningStack items={attention} />}
 
           {/* Verification Status (compact badge when passed) */}
           {!isBitcoinPayment && !decodedInfo.marketplaceReview && (
             <VerificationStatus
-              passed={verification?.repackProved ? true : verificationPassed}
+              passed={deferredVerificationFailure
+                ? undefined
+                : verification?.repackProved ? true : verificationPassed}
               warning={verificationWarning}
               isStrict={isStrictMode}
             />
           )}
 
-          {movement.atRisk > 0 && (
-            <div className="rounded-lg border border-danger-200 bg-danger-50 p-3">
-              <CheckboxInput
-                name="acceptAtRisk"
-                label={`I understand ${formatAmount({
-                  value: fromSatoshis(movement.atRisk, true),
-                  minimumFractionDigits: 8,
-                  maximumFractionDigits: 8,
-                })} BTC may not come back to me`}
-                checked={acceptedAtRisk}
-                onChange={setAcceptedAtRisk}
-              />
-            </div>
-          )}
         </div>
       </div>
 
       <ApprovalFooter
         onCancel={handleReject}
-        onSign={handleSign}
+        onSign={handleApprovalAction}
         busy={isSigning}
-        blocked={blockSigning || (movement.atRisk > 0 && !acceptedAtRisk)}
+        blocked={blockSigning}
         isHardware={activeWallet.type === 'hardware'}
+        signLabel={requiresAttention ? 'Review' : 'Sign'}
       />
+
+      {showAttention && requiresAttention && (
+        <ApprovalAttentionScreen
+          title={attentionTitle}
+          description="Confirm the exceptional authorization below before the wallet adds your signature."
+          items={approvalAttentionItems}
+          confirmLabel={confirmLabel}
+          busy={isSigning}
+          isHardware={activeWallet.type === 'hardware'}
+          onBack={() => setShowAttention(false)}
+          onConfirm={() => void handleSign()}
+        />
+      )}
     </div>
   );
 }

--- a/src/pages/requests/psbt/approve.tsx
+++ b/src/pages/requests/psbt/approve.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
 import {
   ApprovalAttentionScreen,
-  ApprovalNotes,
   highFeeAttentionItem,
   partitionApprovalItems,
   verificationAttentionItem,
@@ -19,7 +18,7 @@ import { MarketplaceReviewCard } from '@/components/domain/approval/marketplace-
 import { computeMoneyMovement } from '@/components/domain/approval/money-movement';
 import { buildOrderAction } from '@/components/domain/approval/order-card';
 import { describePsbtFlexibility } from '@/components/domain/approval/psbt-flexibility';
-import { getTxActionInfo } from '@/components/domain/tx/tx-action-info';
+import { attachDestinationVout, getTxActionInfo } from '@/components/domain/tx/tx-action-info';
 import { VerificationStatus } from '@/components/domain/tx/verification-status';
 import { Collapsible } from '@/components/ui/collapsible';
 import { ErrorAlert } from '@/components/ui/error-alert';
@@ -272,8 +271,11 @@ export default function ApprovePsbtPage() {
     || marketplaceReview?.status === 'retry';
   // A missing balance answer is uncertainty, not permission to assume an input is clean.
   const assetStatusBlocked = signedInputsUnknownStatus.length > 0;
-  const blockSigning = verificationBlocked || marketplaceBlocked || assetStatusBlocked;
-  const { informational, attention } = partitionApprovalItems(warningItems);
+  // A structure finding blocks: the message provably cannot do what it claims, so signing only
+  // spends fees on a broken transaction no honest composer produces.
+  const structureBlocked = (decodedInfo.structureFindings ?? []).length > 0;
+  const blockSigning = verificationBlocked || marketplaceBlocked || assetStatusBlocked || structureBlocked;
+  const { attention } = partitionApprovalItems(warningItems);
   const genericAttention = movement.atRisk > 0
     ? attention.filter(item => item.key !== 'anyonecanpay')
     : attention;
@@ -281,21 +283,45 @@ export default function ApprovePsbtPage() {
   // second click on every attach would turn that routine protocol fact into warning wallpaper.
   const marketplaceRequiresAttention = marketplaceReview?.status === 'caution'
     && marketplaceReview.family !== 'attach_for_listing';
-  const marketplaceAttention: WarningItem[] = marketplaceRequiresAttention
-    ? marketplaceReview.notices.map((notice, index) => ({
-        key: `marketplace-${index}`,
-        severity: notice.severity,
-        title: marketplaceReview.family === 'authorize_exact_offer'
-          ? 'The seller can accept without another approval'
-          : 'This authorization remains usable after signing',
-        description: notice.message,
-      }))
-    : [];
+  // Plain-language consequences per family: what signing does, and how to undo it. The analyzer's
+  // notices state the same facts in protocol terms; this screen is where a person decides.
+  const marketplaceAttention: WarningItem[] = !marketplaceRequiresAttention
+    ? []
+    : marketplaceReview.family === 'create_listing'
+      ? [{
+          key: 'marketplace-listing',
+          severity: 'warning' as const,
+          title: 'This listing stays open until filled or cancelled',
+          description:
+            'Signing puts this up for sale. Anyone who pays you exactly ' +
+            `${request.marketplaceIntent?.action === 'create_listing'
+              ? request.marketplaceIntent.guaranteedSellerPaymentSats.toLocaleString()
+              : 'the shown'} sats can complete the purchase without asking you again. ` +
+            'To cancel the listing later, spend the asset UTXO.',
+        }]
+      : marketplaceReview.family === 'authorize_exact_offer'
+        ? [{
+            key: 'marketplace-offer',
+            severity: 'warning' as const,
+            title: 'The seller can complete this sale at any time',
+            description:
+              'Signing lets the seller finish this exact trade without asking you again — the ' +
+              'first confirmed spend of your funding wins. To withdraw the offer, spend your ' +
+              'funding UTXO.',
+          }]
+        : marketplaceReview.notices.map((notice, index) => ({
+            key: `marketplace-${index}`,
+            severity: notice.severity,
+            title: 'This authorization remains usable after signing',
+            description: notice.message,
+          }));
   const approvalAttentionItems: WarningItem[] = [
     ...marketplaceAttention,
     ...genericAttention,
     ...(deferredVerificationFailure ? [verificationAttentionItem(verificationWarning)] : []),
-    ...(movement.atRisk > 0 ? [{
+    // A proved marketplace review has already named the flexible amount and its rules, so the
+    // generic redirection alarm would restate it in scarier words.
+    ...(movement.atRisk > 0 && !semanticMarketplaceReview ? [{
       key: 'btc-at-risk',
       severity: 'danger' as const,
       title: `${formatAmount({
@@ -310,7 +336,11 @@ export default function ApprovePsbtPage() {
   ];
   const requiresAttention = !blockSigning && approvalAttentionItems.length > 0;
   const attentionTitle = marketplaceRequiresAttention
-    ? 'Review authorization'
+    ? marketplaceReview.family === 'create_listing'
+      ? 'Before you list'
+      : marketplaceReview.family === 'authorize_exact_offer'
+        ? 'Before you authorize'
+        : 'Review before signing'
     : approvalAttentionItems.some(item => item.severity === 'danger')
       ? 'Review transaction risk'
       : 'Review before signing';
@@ -319,8 +349,36 @@ export default function ApprovePsbtPage() {
     : marketplaceReview?.family === 'authorize_exact_offer'
       ? 'Authorize offer'
       : counterpartyMessage?.messageType === 'destroy'
-        ? 'Destroy assets'
+        ? 'Destroy supply'
         : 'Confirm and sign';
+  // The payment card is the one voice for a failed plain-Bitcoin payment, exactly as the
+  // marketplace card is for its gate: the generic stack stays silent and the card carries the
+  // analyzer's reason.
+  const bitcoinPaymentGate = isBitcoinPayment
+    ? safetyWarnings.find(warning => warning.code === 'bitcoin_payment_gate')
+    : undefined;
+
+  // The marketplace review is the screen's one voice: proved/caution states take over the
+  // headline and merge their facts into the Counterparty details instead of stacking a second
+  // presentation on top of the generic one. attach_for_listing keeps the standard attach
+  // headline — the semantic title adds nothing over "Attach 1 RAREPEPE".
+  const marketplaceHeadline = semanticMarketplaceReview
+    && marketplaceReview!.family !== 'attach_for_listing'
+    ? { label: '', description: marketplaceReview!.title }
+    : null;
+  const marketplaceFacts = semanticMarketplaceReview ? marketplaceReview!.facts : [];
+  const protocolFields = txAction && 'protocol' in txAction ? txAction.protocol : [];
+  const detailFields = [
+    ...marketplaceFacts,
+    // The quoted marketplace XCP fee supersedes the generic XCP-fee row on an attach.
+    ...protocolFields.filter(field =>
+      !(field.label === 'XCP fee' && marketplaceFacts.some(fact => fact.label === 'Quoted XCP fee'))),
+  ];
+  // An unfunded marketplace authorization moves nothing yet; the facts (or the gating card)
+  // state exactly where things stand, so the movement block would only resolve to an alarming
+  // "Couldn't be determined" beside them.
+  const hideMovement = Boolean(marketplaceReview && psbtDetails.unfunded);
+
   const handleApprovalAction = () => {
     if (requiresAttention) {
       setShowAttention(true);
@@ -361,49 +419,55 @@ export default function ApprovePsbtPage() {
             <BitcoinPaymentCard
               intent={request.bitcoinPaymentIntent}
               proof={decodedInfo.bitcoinPaymentProof}
+              failure={bitcoinPaymentGate?.message}
             />
           )}
 
-          {decodedInfo.marketplaceReview && (
-            <MarketplaceReviewCard review={decodedInfo.marketplaceReview} />
-          )}
-
-          {marketplaceBlocked && marketplaceReview.blockers.length > 0 && (
-            <ErrorAlert message={marketplaceReview.blockers.join('; ')} />
+          {/* A gating failure gets exactly one voice: the review card alone carries the
+              blockers, and the generic warning stack below stays silent for it. Proved and
+              caution reviews render through the standard headline and details instead. */}
+          {marketplaceBlocked && marketplaceReview && (
+            <MarketplaceReviewCard review={marketplaceReview} />
           )}
 
           {error && <ErrorAlert message={error} />}
 
-          {/* Transaction action & fee */}
+          {/* Transaction action & fee. Skipped when there is nothing to put in it — a gated
+              unfunded authorization with no decodable action would render an empty card. */}
+          {(order || marketplaceHeadline || txAction || !hideMovement) && (
           <ApprovalSummaryCard
             unfunded={psbtDetails.unfunded}
-            txAction={txAction}
+            txAction={marketplaceHeadline ?? txAction}
             order={order}
             movement={movement}
             flexibility={semanticMarketplaceReview ? undefined : flexibilityReview?.kind}
             hasHighFee={hasHighFee}
             deferCautions={requiresAttention}
+            hideMovement={hideMovement}
             protocolFeeXcp={counterpartyMessage?.messageData?.fee != null
               ? toFiniteNumber(counterpartyMessage.messageData.fee) ?? null
               : null}
           />
-
-          {txAction && 'protocol' in txAction && (
-            <CounterpartyDetailsCard fields={txAction.protocol} />
           )}
+
+          <CounterpartyDetailsCard
+            fields={detailFields}
+            recipients={decodedInfo.mpmaRecipients}
+          />
           <ApprovalTransactionDetails
             txid={txid}
             inputs={psbtDetails.inputs}
             outputs={psbtDetails.outputs}
-            recipients={decodedInfo.mpmaRecipients}
             attachedAssets={attachedAssets}
             verification={verification}
+            attachVout={attachDestinationVout(decodedInfo)}
           />
 
-          <ApprovalNotes items={informational} />
-
-          {/* A blocked request explains itself immediately. Signable cautions wait behind Review. */}
-          {blockSigning && <WarningStack items={attention} />}
+          {/* A blocked request explains itself. The marketplace and payment gates speak through
+              their own cards above, so their echo warnings stay out of the stack. */}
+          {blockSigning && !marketplaceBlocked && !bitcoinPaymentGate && (
+            <WarningStack items={attention} />
+          )}
 
           {/* Verification Status (compact badge when passed) */}
           {!isBitcoinPayment && !decodedInfo.marketplaceReview && (

--- a/src/pages/requests/psbt/approve.tsx
+++ b/src/pages/requests/psbt/approve.tsx
@@ -5,7 +5,9 @@ import {ApprovalExpired, ApprovalFooter,
 } from '@/components/domain/approval/approval-chrome';
 import { ApprovalSummaryCard } from '@/components/domain/approval/approval-summary-card';
 import { buildApprovalWarnings } from '@/components/domain/approval/approval-warnings';
+import { BitcoinPaymentCard } from '@/components/domain/approval/bitcoin-payment-card';
 import { CounterpartyDetailsCard } from '@/components/domain/approval/counterparty-details-card';
+import { MarketplaceReviewCard } from '@/components/domain/approval/marketplace-review-card';
 import { computeMoneyMovement } from '@/components/domain/approval/money-movement';
 import { buildOrderAction } from '@/components/domain/approval/order-card';
 import { getTxActionInfo } from '@/components/domain/tx/tx-action-info';
@@ -60,9 +62,13 @@ export default function ApprovePsbtPage() {
   // Configure header
   useEffect(() => {
     setHeaderProps({
-      title: "Sign Transaction",
+      title: request?.signingPurpose === 'bitcoin-payment'
+        ? 'Send Bitcoin'
+        : request?.marketplaceIntent?.action === 'create_listing'
+          ? 'Create Listing'
+          : 'Sign Transaction',
     });
-  }, [setHeaderProps]);
+  }, [request?.marketplaceIntent?.action, request?.signingPurpose, setHeaderProps]);
 
   const handleSign = async () => {
     if (!request || !decodedInfo) return;
@@ -116,6 +122,9 @@ export default function ApprovePsbtPage() {
   if (!activeAddress || !activeWallet) return <ApprovalNoWallet />;
 
   const { psbtDetails, counterpartyMessage, txid, verification, safety, attachedAssets } = decodedInfo;
+  const isBitcoinPayment = request.signingPurpose === 'bitcoin-payment';
+  const semanticMarketplaceReview = decodedInfo.marketplaceReview?.status === 'proved'
+    || decodedInfo.marketplaceReview?.status === 'caution';
   // The same card the raw-transaction screen shows, so an order looks identical whichever signing
   // method the site called.
   const order = buildOrderAction(decodedInfo);
@@ -218,14 +227,16 @@ export default function ApprovePsbtPage() {
 
   const warningItems: WarningItem[] = buildApprovalWarnings({
     safetyWarnings,
-    attachedAssetDestination: decodedInfo.attachedAssetDestination,
+    attachedAssetDestination: semanticMarketplaceReview
+      ? null
+      : decodedInfo.attachedAssetDestination,
     structureFindings: decodedInfo.structureFindings ?? [],
-    signedInputsWithAssets,
+    signedInputsWithAssets: semanticMarketplaceReview ? [] : signedInputsWithAssets,
     signedInputsUnknownStatus,
   });
 
   // PSBT-only: a raw transaction is signed SIGHASH_ALL throughout and cannot change after signing.
-  if (userSignsWithAnyoneCanPay) {
+  if (userSignsWithAnyoneCanPay && !semanticMarketplaceReview) {
     // Money the signature leaves redirectable is a different order of risk from a transaction that
     // can merely gain inputs, so it reads as danger rather than caution.
     const redirectable = movement.atRisk > 0;
@@ -281,6 +292,17 @@ export default function ApprovePsbtPage() {
           )}
 
           <ApprovalSiteBar origin={request.origin} />
+
+          {isBitcoinPayment && request.bitcoinPaymentIntent && (
+            <BitcoinPaymentCard
+              intent={request.bitcoinPaymentIntent}
+              proof={decodedInfo.bitcoinPaymentProof}
+            />
+          )}
+
+          {decodedInfo.marketplaceReview && (
+            <MarketplaceReviewCard review={decodedInfo.marketplaceReview} />
+          )}
 
           {error && <ErrorAlert message={error} />}
 
@@ -409,11 +431,13 @@ export default function ApprovePsbtPage() {
           <WarningStack items={warningItems} />
 
           {/* Verification Status (compact badge when passed) */}
-          <VerificationStatus
-            passed={verification?.repackProved ? true : verificationPassed}
-            warning={verificationWarning}
-            isStrict={isStrictMode}
-          />
+          {!isBitcoinPayment && !decodedInfo.marketplaceReview && (
+            <VerificationStatus
+              passed={verification?.repackProved ? true : verificationPassed}
+              warning={verificationWarning}
+              isStrict={isStrictMode}
+            />
+          )}
 
           {movement.atRisk > 0 && (
             <div className="rounded-lg border border-danger-200 bg-danger-50 p-3">

--- a/src/pages/requests/psbt/approve.tsx
+++ b/src/pages/requests/psbt/approve.tsx
@@ -71,7 +71,11 @@ export default function ApprovePsbtPage() {
             ? 'Create Listing'
             : request?.marketplaceIntent?.action === 'buy_listings'
               ? 'Buy Collectibles'
-              : 'Sign Transaction',
+              : request?.marketplaceIntent?.action === 'authorize_exact_offer'
+                ? 'Authorize Offer'
+                : request?.marketplaceIntent?.action === 'accept_exact_offer'
+                  ? 'Accept Offer'
+                  : 'Sign Transaction',
     });
   }, [request?.marketplaceIntent?.action, request?.signingPurpose, setHeaderProps]);
 

--- a/src/pages/requests/psbt/approve.tsx
+++ b/src/pages/requests/psbt/approve.tsx
@@ -67,6 +67,8 @@ export default function ApprovePsbtPage() {
         ? 'Send Bitcoin'
         : request?.marketplaceIntent?.action === 'create_listing'
           ? 'Create Listing'
+          : request?.marketplaceIntent?.action === 'buy_listings'
+            ? 'Buy Collectibles'
           : 'Sign Transaction',
     });
   }, [request?.marketplaceIntent?.action, request?.signingPurpose, setHeaderProps]);

--- a/src/pages/requests/psbt/approve.tsx
+++ b/src/pages/requests/psbt/approve.tsx
@@ -419,7 +419,7 @@ export default function ApprovePsbtPage() {
             <BitcoinPaymentCard
               intent={request.bitcoinPaymentIntent}
               proof={decodedInfo.bitcoinPaymentProof}
-              failure={bitcoinPaymentGate?.message}
+              failure={decodedInfo.bitcoinPaymentBlockers}
             />
           )}
 

--- a/src/pages/requests/psbt/approve.tsx
+++ b/src/pages/requests/psbt/approve.tsx
@@ -11,6 +11,7 @@ import { MarketplaceReviewCard } from '@/components/domain/approval/marketplace-
 import { computeMoneyMovement } from '@/components/domain/approval/money-movement';
 import { buildOrderAction } from '@/components/domain/approval/order-card';
 import { describePsbtFlexibility } from '@/components/domain/approval/psbt-flexibility';
+import { VerificationDetails } from '@/components/domain/approval/verification-details';
 import { getTxActionInfo } from '@/components/domain/tx/tx-action-info';
 import { VerificationStatus } from '@/components/domain/tx/verification-status';
 import { Collapsible } from '@/components/ui/collapsible';
@@ -433,6 +434,8 @@ export default function ApprovePsbtPage() {
                     </div>
                   </div>
                 )}
+
+                <VerificationDetails verification={verification} />
 
           </Collapsible>
 

--- a/src/pages/requests/psbt/approve.tsx
+++ b/src/pages/requests/psbt/approve.tsx
@@ -4,6 +4,7 @@ import {ApprovalExpired, ApprovalFooter,
   ApprovalWalletHeader, 
 } from '@/components/domain/approval/approval-chrome';
 import { ApprovalSummaryCard } from '@/components/domain/approval/approval-summary-card';
+import { ApprovalTransactionDetails } from '@/components/domain/approval/approval-transaction-details';
 import { buildApprovalWarnings } from '@/components/domain/approval/approval-warnings';
 import { BitcoinPaymentCard } from '@/components/domain/approval/bitcoin-payment-card';
 import { CounterpartyDetailsCard } from '@/components/domain/approval/counterparty-details-card';
@@ -11,10 +12,8 @@ import { MarketplaceReviewCard } from '@/components/domain/approval/marketplace-
 import { computeMoneyMovement } from '@/components/domain/approval/money-movement';
 import { buildOrderAction } from '@/components/domain/approval/order-card';
 import { describePsbtFlexibility } from '@/components/domain/approval/psbt-flexibility';
-import { VerificationDetails } from '@/components/domain/approval/verification-details';
 import { getTxActionInfo } from '@/components/domain/tx/tx-action-info';
 import { VerificationStatus } from '@/components/domain/tx/verification-status';
-import { Collapsible } from '@/components/ui/collapsible';
 import { ErrorAlert } from '@/components/ui/error-alert';
 import { CheckboxInput } from '@/components/ui/inputs/checkbox-input';
 import { type WarningItem, WarningStack } from '@/components/ui/warning-stack';
@@ -139,7 +138,6 @@ export default function ApprovePsbtPage() {
   // method the site called.
   const order = buildOrderAction(decodedInfo);
   const txAction = order ? null : getTxActionInfo(decodedInfo, decodedInfo.protocolContext);
-  const attachedByInput = new Map(attachedAssets.map((entry) => [entry.inputIndex, entry]));
   // Warn on the fee *rate* as well as its absolute size: a fee under the absolute ceiling can still
   // be absurd on a small transaction, and that case previously drew no warning at all. It warns
   // rather than blocks — an expensive transaction can be legitimate here, the transaction was built
@@ -329,115 +327,17 @@ export default function ApprovePsbtPage() {
               : null}
           />
 
-          {/* Transaction Details (expandable) */}
-
           {txAction && 'protocol' in txAction && (
             <CounterpartyDetailsCard fields={txAction.protocol} />
           )}
-          <Collapsible variant="card" title="Transaction Details">
-                {/* TX Hash */}
-                {txid && (
-                  <div>
-                    <h4 className="text-xs font-medium text-gray-500 uppercase mb-2">TX Hash</h4>
-                    <div className="bg-gray-50 p-2 rounded text-xs text-gray-600 break-all">
-                      {txid}
-                    </div>
-                  </div>
-                )}
-
-                {/* Inputs List */}
-                <div>
-                  <h4 className="text-xs font-medium text-gray-500 uppercase mb-2">Inputs ({psbtDetails.inputs.length})</h4>
-                  <div className="space-y-2">
-                    {psbtDetails.inputs.map((input) => {
-                      const inputAssets = attachedByInput.get(input.index);
-                      return (
-                      <div key={input.index} className="bg-gray-50 p-2 rounded text-xs">
-                        <div className="flex justify-between">
-                          <span className="text-gray-600">#{input.index}</span>
-                          {input.value !== undefined && (
-                            <span className="text-gray-900 font-medium">{formatAmount({ value: fromSatoshis(input.value, true), minimumFractionDigits: 8, maximumFractionDigits: 8 })} BTC</span>
-                          )}
-                        </div>
-                        {input.address && (
-                          <div className="text-gray-500 truncate" title={input.address}>
-                            {formatAddress(input.address, true)}
-                          </div>
-                        )}
-                        <div className="text-gray-400 truncate" title={input.txid}>
-                          {input.txid.slice(0, 8)}...:{input.vout}
-                        </div>
-                        {inputAssets?.assets.map((asset) => (
-                          <div key={asset.asset} className="mt-1 flex justify-between text-purple-700">
-                            <span className="truncate" title={asset.asset_longname ?? asset.asset}>
-                              {asset.asset_longname ?? asset.asset}
-                            </span>
-                            <span className="font-medium flex-shrink-0 ml-2">{asset.quantity_normalized}</span>
-                          </div>
-                        ))}
-                        {inputAssets?.lookupFailed && (
-                          <div className="mt-1 text-amber-600">Asset status unavailable</div>
-                        )}
-                      </div>
-                      );
-                    })}
-                  </div>
-                </div>
-
-                {/* Outputs List */}
-                <div>
-                  <h4 className="text-xs font-medium text-gray-500 uppercase mb-2">Outputs ({psbtDetails.outputs.length})</h4>
-                  <div className="space-y-2">
-                    {psbtDetails.outputs.map((output, idx) => (
-                      <div key={idx} className="bg-gray-50 p-2 rounded text-xs">
-                        <div className="flex justify-between">
-                          <span className={`${output.type === 'op_return' ? 'text-purple-600' : 'text-gray-600'}`}>
-                            {output.type === 'op_return' ? 'OP_RETURN' : output.type.toUpperCase()}
-                          </span>
-                          <span className="text-gray-900 font-medium">{formatAmount({ value: fromSatoshis(output.value, true), minimumFractionDigits: 8, maximumFractionDigits: 8 })} BTC</span>
-                        </div>
-                        {/* Shown in full and allowed to wrap - see the matching note in the
-                            transaction approval screen. Outputs are where a site's transaction
-                            sends money, so the whole address has to be comparable. */}
-                        {output.address && (
-                          <div className="text-gray-500 break-all font-mono" title={output.address}>
-                            {formatAddress(output.address, false)}
-                          </div>
-                        )}
-                      </div>
-                    ))}
-                  </div>
-                </div>
-
-                {/* Recipients of a multi-destination send. Carried in the payload rather than as
-                    outputs, so the list above cannot show them and this is the only place they
-                    appear — the same reason the transaction screen lists them. */}
-                {decodedInfo.mpmaRecipients.length > 0 && (
-                  <div>
-                    <h4 className="text-xs font-medium text-gray-500 uppercase mb-2">
-                      Recipients ({decodedInfo.mpmaRecipients.length})
-                    </h4>
-                    <div className="space-y-2">
-                      {decodedInfo.mpmaRecipients.map((recipient, idx) => (
-                        <div key={idx} className="bg-gray-50 p-2 rounded text-xs">
-                          <div className="flex justify-between gap-2">
-                            <span className="text-gray-600 truncate">{recipient.asset}</span>
-                            <span className="text-gray-900 font-medium flex-shrink-0">
-                              {recipient.quantity}
-                            </span>
-                          </div>
-                          <div className="text-gray-500 break-all font-mono" title={recipient.address}>
-                            {recipient.address}
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                )}
-
-                <VerificationDetails verification={verification} />
-
-          </Collapsible>
+          <ApprovalTransactionDetails
+            txid={txid}
+            inputs={psbtDetails.inputs}
+            outputs={psbtDetails.outputs}
+            recipients={decodedInfo.mpmaRecipients}
+            attachedAssets={attachedAssets}
+            verification={verification}
+          />
 
           {/* Warnings, rendered in a fixed severity order (danger → success) */}
           <WarningStack items={warningItems} />

--- a/src/pages/requests/psbt/approve.tsx
+++ b/src/pages/requests/psbt/approve.tsx
@@ -65,11 +65,13 @@ export default function ApprovePsbtPage() {
     setHeaderProps({
       title: request?.signingPurpose === 'bitcoin-payment'
         ? 'Send Bitcoin'
-        : request?.marketplaceIntent?.action === 'create_listing'
-          ? 'Create Listing'
-          : request?.marketplaceIntent?.action === 'buy_listings'
-            ? 'Buy Collectibles'
-          : 'Sign Transaction',
+        : request?.marketplaceIntent?.action === 'attach_for_listing'
+          ? 'Attach for Listing'
+          : request?.marketplaceIntent?.action === 'create_listing'
+            ? 'Create Listing'
+            : request?.marketplaceIntent?.action === 'buy_listings'
+              ? 'Buy Collectibles'
+              : 'Sign Transaction',
     });
   }, [request?.marketplaceIntent?.action, request?.signingPurpose, setHeaderProps]);
 

--- a/src/pages/requests/psbt/approve.tsx
+++ b/src/pages/requests/psbt/approve.tsx
@@ -10,6 +10,7 @@ import { CounterpartyDetailsCard } from '@/components/domain/approval/counterpar
 import { MarketplaceReviewCard } from '@/components/domain/approval/marketplace-review-card';
 import { computeMoneyMovement } from '@/components/domain/approval/money-movement';
 import { buildOrderAction } from '@/components/domain/approval/order-card';
+import { describePsbtFlexibility } from '@/components/domain/approval/psbt-flexibility';
 import { getTxActionInfo } from '@/components/domain/tx/tx-action-info';
 import { VerificationStatus } from '@/components/domain/tx/verification-status';
 import { Collapsible } from '@/components/ui/collapsible';
@@ -190,7 +191,6 @@ export default function ApprovePsbtPage() {
     ),
   }));
   const anyoneCanPaySighashes = effectiveSighashes.filter(({ type }) => (type & 0x80) !== 0);
-  const userSignsWithAnyoneCanPay = anyoneCanPaySighashes.length > 0;
   const usesPairedAddress = requestedAddressSpends.some(
     ({ address }) => normalizeAddressForComparison(address)
       !== normalizeAddressForComparison(activeAddress.address)
@@ -224,6 +224,10 @@ export default function ApprovePsbtPage() {
     fee: psbtDetails.fee,
     committedOutputs,
   });
+  const flexibilityReview = describePsbtFlexibility(
+    effectiveSighashes.map(({ index, type }) => ({ index, sighashType: type })),
+    movement.atRisk
+  );
 
   const warningItems: WarningItem[] = buildApprovalWarnings({
     safetyWarnings,
@@ -236,17 +240,14 @@ export default function ApprovePsbtPage() {
   });
 
   // PSBT-only: a raw transaction is signed SIGHASH_ALL throughout and cannot change after signing.
-  if (userSignsWithAnyoneCanPay && !semanticMarketplaceReview) {
-    // Money the signature leaves redirectable is a different order of risk from a transaction that
-    // can merely gain inputs, so it reads as danger rather than caution.
-    const redirectable = movement.atRisk > 0;
+  if (flexibilityReview && !semanticMarketplaceReview) {
+    // ALL|ANYONECANPAY commits every present output; SINGLE|ANYONECANPAY does not. Keep that
+    // distinction visible so normal collaborative funding does not look like output redirection.
     warningItems.push({
       key: 'anyonecanpay',
-      severity: redirectable ? 'danger' : 'warning',
-      title: redirectable ? 'Some of your funds can be redirected' : 'This transaction can still change',
-      description: redirectable
-        ? 'Part of the amount shown returning to your wallet can be sent somewhere else after you sign.'
-        : 'Inputs or outputs can be added after you sign. Check the amounts above before approving.',
+      severity: flexibilityReview.severity,
+      title: flexibilityReview.title,
+      description: flexibilityReview.description,
       children: (
         <ul className="mt-2 space-y-1 text-xs font-medium">
           {anyoneCanPaySighashes.map(({ index, type }) => (
@@ -312,7 +313,7 @@ export default function ApprovePsbtPage() {
             txAction={txAction}
             order={order}
             movement={movement}
-            flexible={userSignsWithAnyoneCanPay}
+            flexibility={semanticMarketplaceReview ? undefined : flexibilityReview?.kind}
             hasHighFee={hasHighFee}
             protocolFeeXcp={counterpartyMessage?.messageData?.fee != null
               ? toFiniteNumber(counterpartyMessage.messageData.fee) ?? null

--- a/src/pages/requests/psbts/approve.tsx
+++ b/src/pages/requests/psbts/approve.tsx
@@ -134,7 +134,8 @@ export default function ApprovePsbtsPage() {
               {decodedInfo.items.map((item, index) => (
                 <div key={`${item.txid ?? 'transaction'}-${index}`} className={index > 0 ? 'border-t border-gray-200 pt-3' : ''}>
                   <p className="font-semibold text-gray-900">
-                    {index + 1}. {request.items[index]?.marketplaceIntent.action.replaceAll('_', ' ')}
+                    {index + 1}. {item.marketplaceReview?.title
+                      ?? request.items[index]?.marketplaceIntent.action.replaceAll('_', ' ')}
                   </p>
                   <p className="mt-1 break-all text-gray-500">{item.txid}</p>
                   <p className="mt-1 text-gray-700">

--- a/src/pages/requests/psbts/approve.tsx
+++ b/src/pages/requests/psbts/approve.tsx
@@ -35,8 +35,10 @@ export default function ApprovePsbtsPage() {
   const [showAttention, setShowAttention] = useState(false);
 
   useEffect(() => {
+    // "Accept Offer", not "Accept Offer + Fee Bump": the longer form truncates at popup width,
+    // and the fee bump is a line item of the acceptance rather than a second act.
     const title = request?.bundleKind === 'acceptance-cpfp'
-      ? 'Accept Offer + Fee Bump'
+      ? 'Accept Offer'
       : request?.bundleKind === 'bulk-fanout'
         ? 'Prepare Listing Funds'
         : request?.bundleKind === 'bulk-attach'
@@ -145,18 +147,18 @@ export default function ApprovePsbtsPage() {
         <div className="max-w-md mx-auto space-y-4">
           <ApprovalWalletHeader walletName={activeWallet.name} address={activeAddress.address} />
           <ApprovalSiteBar origin={request.origin} />
+          {/* One voice for failures: the review card itself carries the blockers. */}
           <MarketplaceReviewCard review={decodedInfo.review} />
           {error && <ErrorAlert message={error} />}
-          {blocked && decodedInfo.review.blockers.length > 0 && (
-            <ErrorAlert message={decodedInfo.review.blockers.join('; ')} />
-          )}
           <Collapsible variant="card" title="Linked Transaction Details">
             <div className="space-y-3 text-xs">
               {decodedInfo.items.map((item, index) => (
                 <div key={`${item.txid ?? 'transaction'}-${index}`} className={index > 0 ? 'border-t border-gray-200 pt-3' : ''}>
                   <p className="font-semibold text-gray-900">
                     {index + 1}. {item.marketplaceReview?.title
-                      ?? request.items[index]?.marketplaceIntent.action.replaceAll('_', ' ')}
+                      ?? request.items[index]?.marketplaceIntent.action
+                        .replaceAll('_', ' ')
+                        .replace(/\b\w/g, (c) => c.toUpperCase())}
                   </p>
                   <p className="mt-1 break-all text-gray-500">{item.txid}</p>
                   <p className="mt-1 text-gray-700">

--- a/src/pages/requests/psbts/approve.tsx
+++ b/src/pages/requests/psbts/approve.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { ApprovalAttentionScreen } from '@/components/domain/approval/approval-attention';
 import {
   ApprovalExpired,
   ApprovalFooter,
@@ -10,6 +11,7 @@ import {
 import { MarketplaceReviewCard } from '@/components/domain/approval/marketplace-review-card';
 import { Collapsible } from '@/components/ui/collapsible';
 import { ErrorAlert } from '@/components/ui/error-alert';
+import type { WarningItem } from '@/components/ui/warning-stack';
 import { useHeader } from '@/contexts/header-context';
 import { useWallet } from '@/contexts/wallet-context';
 import { usePopupLifecycle } from '@/hooks/usePopupLifecycle';
@@ -30,6 +32,7 @@ export default function ApprovePsbtsPage() {
   usePopupLifecycle(request?.id, 'sign-psbts');
   const [isSigning, setIsSigning] = useState(false);
   const [error, setError] = useState('');
+  const [showAttention, setShowAttention] = useState(false);
 
   useEffect(() => {
     const title = request?.bundleKind === 'acceptance-cpfp'
@@ -43,6 +46,8 @@ export default function ApprovePsbtsPage() {
             : 'Review Transaction Batch';
     setHeaderProps({ title });
   }, [request?.bundleKind, setHeaderProps]);
+
+  useEffect(() => setShowAttention(false), [request?.id]);
 
   const handleSign = async () => {
     if (!request || !decodedInfo || !activeAddress || !activeWallet) return;
@@ -114,6 +119,26 @@ export default function ApprovePsbtsPage() {
   if (!activeAddress || !activeWallet) return <ApprovalNoWallet />;
 
   const blocked = decodedInfo.review.status === 'blocked' || decodedInfo.review.status === 'retry';
+  // Bulk attach quotes are inherently block-dependent and already visible in the summary. The
+  // durable listing signatures are the exceptional phase that deserves a second decision.
+  const requiresAttention = !blocked
+    && decodedInfo.review.status === 'caution'
+    && request.bundleKind === 'bulk-listing';
+  const attentionItems: WarningItem[] = requiresAttention
+    ? decodedInfo.review.notices.map((notice, index) => ({
+        key: `marketplace-${index}`,
+        severity: notice.severity,
+        title: 'Each listing remains valid after signing',
+        description: notice.message,
+      }))
+    : [];
+  const handleApprovalAction = () => {
+    if (requiresAttention) {
+      setShowAttention(true);
+      return;
+    }
+    void handleSign();
+  };
   return (
     <div className="flex flex-col h-full bg-gray-50">
       <div className="flex-1 overflow-y-auto p-4">
@@ -125,10 +150,6 @@ export default function ApprovePsbtsPage() {
           {blocked && decodedInfo.review.blockers.length > 0 && (
             <ErrorAlert message={decodedInfo.review.blockers.join('; ')} />
           )}
-          <div className="rounded-lg border border-blue-200 bg-blue-50 p-3 text-xs text-blue-900">
-            Every transaction in this phase was reviewed before signing begins. The wallet returns
-            no signatures unless every signing operation finishes successfully.
-          </div>
           <Collapsible variant="card" title="Linked Transaction Details">
             <div className="space-y-3 text-xs">
               {decodedInfo.items.map((item, index) => (
@@ -143,17 +164,33 @@ export default function ApprovePsbtsPage() {
                   </p>
                 </div>
               ))}
+              <p className="border-t border-gray-100 pt-3 text-gray-500">
+                The wallet returns this batch only after every requested signature succeeds.
+              </p>
             </div>
           </Collapsible>
         </div>
       </div>
       <ApprovalFooter
         onCancel={handleReject}
-        onSign={handleSign}
+        onSign={handleApprovalAction}
         busy={isSigning}
         blocked={blocked}
         isHardware={activeWallet.type === 'hardware'}
+        signLabel={requiresAttention ? 'Review' : 'Sign'}
       />
+      {showAttention && requiresAttention && (
+        <ApprovalAttentionScreen
+          title="Review listing authorizations"
+          description="These signatures can be completed later without another seller approval."
+          items={attentionItems}
+          confirmLabel={`Authorize ${request.items.length} listings`}
+          busy={isSigning}
+          isHardware={activeWallet.type === 'hardware'}
+          onBack={() => setShowAttention(false)}
+          onConfirm={() => void handleSign()}
+        />
+      )}
     </div>
   );
 }

--- a/src/pages/requests/psbts/approve.tsx
+++ b/src/pages/requests/psbts/approve.tsx
@@ -18,6 +18,7 @@ import {
   getIdentityMismatchError,
   getPsbtPermissionError,
 } from '@/platform/provider/requestIdentity';
+import { signPsbtPhaseForDelivery } from '@/platform/provider/signPsbtPhase';
 import { getConnectionService } from '@/services/connectionService';
 import { getWalletService } from '@/services/walletService';
 
@@ -31,8 +32,17 @@ export default function ApprovePsbtsPage() {
   const [error, setError] = useState('');
 
   useEffect(() => {
-    setHeaderProps({ title: 'Accept Offer + Fee Bump' });
-  }, [setHeaderProps]);
+    const title = request?.bundleKind === 'acceptance-cpfp'
+      ? 'Accept Offer + Fee Bump'
+      : request?.bundleKind === 'bulk-fanout'
+        ? 'Prepare Listing Funds'
+        : request?.bundleKind === 'bulk-attach'
+          ? 'Attach Collectibles'
+          : request?.bundleKind === 'bulk-listing'
+            ? 'Authorize Listings'
+            : 'Review Transaction Batch';
+    setHeaderProps({ title });
+  }, [request?.bundleKind, setHeaderProps]);
 
   const handleSign = async () => {
     if (!request || !decodedInfo || !activeAddress || !activeWallet) return;
@@ -63,8 +73,8 @@ export default function ApprovePsbtsPage() {
       setError(permissionError);
       return;
     }
-    if (decodedInfo.review.status !== 'proved') {
-      setError('Both linked transactions must prove before signing begins.');
+    if (decodedInfo.review.status === 'blocked' || decodedInfo.review.status === 'retry') {
+      setError('Every transaction in this phase must verify before signing begins.');
       return;
     }
 
@@ -72,19 +82,15 @@ export default function ApprovePsbtsPage() {
     setError('');
     try {
       const walletService = getWalletService();
-      // Nothing is returned to the site until both signers succeed. A rejection or hardware
-      // cancellation on the child discards the in-memory parent result.
-      const parent = await walletService.signPsbt(
-        request.items[0].psbtHex,
-        request.items[0].signInputs,
-        request.items[0].sighashTypes,
-      );
-      const child = await walletService.signPsbt(
-        request.items[1].psbtHex,
-        request.items[1].signInputs,
-        request.items[1].sighashTypes,
-      );
-      await handleSuccess([parent, child]);
+      // Nothing is returned to the site until every signer succeeds. A rejection or hardware
+      // cancellation on a later item discards every earlier in-memory result.
+      const results = await signPsbtPhaseForDelivery(request.items, item =>
+        walletService.signPsbt(
+          item.psbtHex,
+          item.signInputs,
+          item.sighashTypes,
+        ));
+      await handleSuccess(results);
       window.close();
     } catch (signError) {
       console.error('Failed to sign PSBT bundle:', signError);
@@ -107,7 +113,7 @@ export default function ApprovePsbtsPage() {
   if (loadError || !request || !decodedInfo) return <ApprovalExpired message={loadError} />;
   if (!activeAddress || !activeWallet) return <ApprovalNoWallet />;
 
-  const blocked = decodedInfo.review.status !== 'proved';
+  const blocked = decodedInfo.review.status === 'blocked' || decodedInfo.review.status === 'retry';
   return (
     <div className="flex flex-col h-full bg-gray-50">
       <div className="flex-1 overflow-y-auto p-4">
@@ -120,25 +126,22 @@ export default function ApprovePsbtsPage() {
             <ErrorAlert message={decodedInfo.review.blockers.join('; ')} />
           )}
           <div className="rounded-lg border border-blue-200 bg-blue-50 p-3 text-xs text-blue-900">
-            Both transactions were reviewed together. The wallet returns neither signature unless
-            both signing operations finish successfully.
+            Every transaction in this phase was reviewed before signing begins. The wallet returns
+            no signatures unless every signing operation finishes successfully.
           </div>
           <Collapsible variant="card" title="Linked Transaction Details">
             <div className="space-y-3 text-xs">
-              <div>
-                <p className="font-semibold text-gray-900">1. Exact sale parent</p>
-                <p className="mt-1 break-all text-gray-500">{decodedInfo.parent.txid}</p>
-                <p className="mt-1 text-gray-700">
-                  Fee: {decodedInfo.parent.psbtDetails.fee.toLocaleString()} sats
-                </p>
-              </div>
-              <div className="border-t border-gray-200 pt-3">
-                <p className="font-semibold text-gray-900">2. Seller CPFP child</p>
-                <p className="mt-1 break-all text-gray-500">{decodedInfo.child.transactionId}</p>
-                <p className="mt-1 text-gray-700">
-                  Fee: {decodedInfo.child.fee.toLocaleString()} sats
-                </p>
-              </div>
+              {decodedInfo.items.map((item, index) => (
+                <div key={`${item.txid ?? 'transaction'}-${index}`} className={index > 0 ? 'border-t border-gray-200 pt-3' : ''}>
+                  <p className="font-semibold text-gray-900">
+                    {index + 1}. {request.items[index]?.marketplaceIntent.action.replaceAll('_', ' ')}
+                  </p>
+                  <p className="mt-1 break-all text-gray-500">{item.txid}</p>
+                  <p className="mt-1 text-gray-700">
+                    Fee: {item.psbtDetails.fee.toLocaleString()} sats
+                  </p>
+                </div>
+              ))}
             </div>
           </Collapsible>
         </div>

--- a/src/pages/requests/psbts/approve.tsx
+++ b/src/pages/requests/psbts/approve.tsx
@@ -1,0 +1,155 @@
+import { useEffect, useState } from 'react';
+import {
+  ApprovalExpired,
+  ApprovalFooter,
+  ApprovalLoading,
+  ApprovalNoWallet,
+  ApprovalSiteBar,
+  ApprovalWalletHeader,
+} from '@/components/domain/approval/approval-chrome';
+import { MarketplaceReviewCard } from '@/components/domain/approval/marketplace-review-card';
+import { Collapsible } from '@/components/ui/collapsible';
+import { ErrorAlert } from '@/components/ui/error-alert';
+import { useHeader } from '@/contexts/header-context';
+import { useWallet } from '@/contexts/wallet-context';
+import { usePopupLifecycle } from '@/hooks/usePopupLifecycle';
+import { useSignPsbtsRequest } from '@/hooks/useSignPsbtsRequest';
+import {
+  getIdentityMismatchError,
+  getPsbtPermissionError,
+} from '@/platform/provider/requestIdentity';
+import { getConnectionService } from '@/services/connectionService';
+import { getWalletService } from '@/services/walletService';
+
+export default function ApprovePsbtsPage() {
+  const { activeAddress, activeWallet } = useWallet();
+  const { setHeaderProps } = useHeader();
+  const { request, decodedInfo, isLoading, error: loadError, handleSuccess, handleCancel } =
+    useSignPsbtsRequest();
+  usePopupLifecycle(request?.id, 'sign-psbts');
+  const [isSigning, setIsSigning] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    setHeaderProps({ title: 'Accept Offer + Fee Bump' });
+  }, [setHeaderProps]);
+
+  const handleSign = async () => {
+    if (!request || !decodedInfo || !activeAddress || !activeWallet) return;
+    const identityError = getIdentityMismatchError(
+      request,
+      activeAddress.address,
+      activeWallet.id,
+    );
+    if (identityError) {
+      setError(identityError);
+      return;
+    }
+    const combinedSignInputs = request.items.reduce<Record<string, number[]>>(
+      (combined, item) => {
+        for (const [address, indices] of Object.entries(item.signInputs)) {
+          combined[address] = [...new Set([...(combined[address] ?? []), ...indices])];
+        }
+        return combined;
+      },
+      {},
+    );
+    const permissionError = await getPsbtPermissionError(
+      { ...request, signInputs: combinedSignInputs },
+      activeAddress.address,
+      getConnectionService(),
+    );
+    if (permissionError) {
+      setError(permissionError);
+      return;
+    }
+    if (decodedInfo.review.status !== 'proved') {
+      setError('Both linked transactions must prove before signing begins.');
+      return;
+    }
+
+    setIsSigning(true);
+    setError('');
+    try {
+      const walletService = getWalletService();
+      // Nothing is returned to the site until both signers succeed. A rejection or hardware
+      // cancellation on the child discards the in-memory parent result.
+      const parent = await walletService.signPsbt(
+        request.items[0].psbtHex,
+        request.items[0].signInputs,
+        request.items[0].sighashTypes,
+      );
+      const child = await walletService.signPsbt(
+        request.items[1].psbtHex,
+        request.items[1].signInputs,
+        request.items[1].sighashTypes,
+      );
+      await handleSuccess([parent, child]);
+      window.close();
+    } catch (signError) {
+      console.error('Failed to sign PSBT bundle:', signError);
+      setError(signError instanceof Error ? signError.message : 'Failed to sign PSBT bundle');
+      setIsSigning(false);
+    }
+  };
+
+  const handleReject = async () => {
+    setIsSigning(true);
+    try {
+      await handleCancel();
+      window.close();
+    } catch {
+      setIsSigning(false);
+    }
+  };
+
+  if (isLoading) return <ApprovalLoading />;
+  if (loadError || !request || !decodedInfo) return <ApprovalExpired message={loadError} />;
+  if (!activeAddress || !activeWallet) return <ApprovalNoWallet />;
+
+  const blocked = decodedInfo.review.status !== 'proved';
+  return (
+    <div className="flex flex-col h-full bg-gray-50">
+      <div className="flex-1 overflow-y-auto p-4">
+        <div className="max-w-md mx-auto space-y-4">
+          <ApprovalWalletHeader walletName={activeWallet.name} address={activeAddress.address} />
+          <ApprovalSiteBar origin={request.origin} />
+          <MarketplaceReviewCard review={decodedInfo.review} />
+          {error && <ErrorAlert message={error} />}
+          {blocked && decodedInfo.review.blockers.length > 0 && (
+            <ErrorAlert message={decodedInfo.review.blockers.join('; ')} />
+          )}
+          <div className="rounded-lg border border-blue-200 bg-blue-50 p-3 text-xs text-blue-900">
+            Both transactions were reviewed together. The wallet returns neither signature unless
+            both signing operations finish successfully.
+          </div>
+          <Collapsible variant="card" title="Linked Transaction Details">
+            <div className="space-y-3 text-xs">
+              <div>
+                <p className="font-semibold text-gray-900">1. Exact sale parent</p>
+                <p className="mt-1 break-all text-gray-500">{decodedInfo.parent.txid}</p>
+                <p className="mt-1 text-gray-700">
+                  Fee: {decodedInfo.parent.psbtDetails.fee.toLocaleString()} sats
+                </p>
+              </div>
+              <div className="border-t border-gray-200 pt-3">
+                <p className="font-semibold text-gray-900">2. Seller CPFP child</p>
+                <p className="mt-1 break-all text-gray-500">{decodedInfo.child.transactionId}</p>
+                <p className="mt-1 text-gray-700">
+                  Fee: {decodedInfo.child.fee.toLocaleString()} sats
+                </p>
+              </div>
+            </div>
+          </Collapsible>
+        </div>
+      </div>
+      <ApprovalFooter
+        onCancel={handleReject}
+        onSign={handleSign}
+        busy={isSigning}
+        blocked={blocked}
+        isHardware={activeWallet.type === 'hardware'}
+      />
+    </div>
+  );
+}

--- a/src/pages/requests/transaction/approve.tsx
+++ b/src/pages/requests/transaction/approve.tsx
@@ -1,4 +1,11 @@
 import { useEffect, useState } from 'react';
+import {
+  ApprovalAttentionScreen,
+  ApprovalNotes,
+  highFeeAttentionItem,
+  partitionApprovalItems,
+  verificationAttentionItem,
+} from '@/components/domain/approval/approval-attention';
 import {ApprovalExpired, ApprovalFooter,
   ApprovalLoading, ApprovalNoWallet,ApprovalSiteBar, 
   ApprovalWalletHeader, 
@@ -24,6 +31,7 @@ import { classifySignedInputAssets } from '@/core/counterparty/inputAssets';
 import { shouldBlockSigning } from '@/core/counterparty/unpack/providerVerify';
 import { formatAmount } from '@/core/format';
 import { fromSatoshis, isGreaterThan } from "@/core/numeric";
+import { useFeeRates } from '@/hooks/useFeeRates';
 import { usePopupLifecycle } from '@/hooks/usePopupLifecycle';
 import type { DecodedTransactionInfo } from '@/hooks/useSignTransactionRequest';
 import { useSignTransactionRequest } from '@/hooks/useSignTransactionRequest';
@@ -65,10 +73,12 @@ export default function ApproveTransactionPage() {
     handleSuccess,
     handleCancel,
   } = useSignTransactionRequest(activeAddress?.address);
+  const { feeRates } = useFeeRates();
   usePopupLifecycle(request?.id, 'sign-transaction');
 
   const [isSigning, setIsSigning] = useState(false);
   const [error, setError] = useState<string>('');
+  const [showAttention, setShowAttention] = useState(false);
 
   // Configure header
   useEffect(() => {
@@ -76,6 +86,8 @@ export default function ApproveTransactionPage() {
       title: "Sign Transaction",
     });
   }, [setHeaderProps]);
+
+  useEffect(() => setShowAttention(false), [request?.id]);
 
   const handleSign = async () => {
     if (!request || !decodedInfo || !activeAddress) return;
@@ -135,16 +147,23 @@ export default function ApproveTransactionPage() {
   // transaction was built elsewhere, so an expensive one can be legitimate and the wallet cannot
   // know the intent. The compose path blocks the same condition because it built the transaction
   // itself, and there an absurd fee means the response misbehaved.
-  const feeRateAbsurd = exceedsSaneFeeRate(decodedInfo.fee, decodedInfo.vsize);
+  const feeRateAbsurd = exceedsSaneFeeRate(
+    decodedInfo.fee,
+    decodedInfo.vsize,
+    feeRates?.fastestFee,
+  );
   const hasHighFee = decodedInfo.fee > 10000000 || feeRateAbsurd; // > 0.1 BTC, or an absurd rate
   const verificationPassed = decodedInfo.verification?.passed;
   const verificationRepackProved = decodedInfo.verification?.repackProved ?? false;
   const verificationWarning = decodedInfo.verification?.warning;
   const isStrictMode = settings?.strictTransactionVerification !== false;
+  const deferredVerificationFailure = verificationPassed === false
+    && !verificationRepackProved
+    && !isStrictMode;
   const safetyBlocked = decodedInfo.safety?.blocked ?? false;
   const safetyWarnings = decodedInfo.safety?.warnings ?? [];
   // Shared with the PSBT approval screen so the two cannot drift.
-  const blockSigning = shouldBlockSigning({
+  const verificationBlocked = shouldBlockSigning({
     safetyBlocked,
     verificationPassed,
     repackProved: verificationRepackProved,
@@ -178,6 +197,30 @@ export default function ApproveTransactionPage() {
     signedInputsWithAssets,
     signedInputsUnknownStatus,
   });
+
+  // An unavailable asset lookup is a retry state. It cannot be acknowledged away because the
+  // wallet does not know whether signing moves an attached asset.
+  const blockSigning = verificationBlocked || signedInputsUnknownStatus.length > 0;
+  const { informational, attention } = partitionApprovalItems(warningItems);
+  const approvalAttentionItems: WarningItem[] = [
+    ...attention,
+    ...(deferredVerificationFailure ? [verificationAttentionItem(verificationWarning)] : []),
+    ...(hasHighFee ? [highFeeAttentionItem(decodedInfo.fee, decodedInfo.vsize)] : []),
+  ];
+  const requiresAttention = !blockSigning && approvalAttentionItems.length > 0;
+  const attentionTitle = approvalAttentionItems.some(item => item.severity === 'danger')
+    ? 'Review transaction risk'
+    : 'Review before signing';
+  const confirmLabel = decodedInfo.counterpartyMessage?.messageType === 'destroy'
+    ? 'Destroy assets'
+    : 'Confirm and sign';
+  const handleApprovalAction = () => {
+    if (requiresAttention) {
+      setShowAttention(true);
+      return;
+    }
+    void handleSign();
+  };
 
   return (
     <div className="flex flex-col h-full bg-gray-50">
@@ -223,7 +266,12 @@ export default function ApproveTransactionPage() {
                 })()}
               </div>
             ) : null}
-            <MoneyMovementView movement={movement} hasHighFee={hasHighFee} showHeadline={!txAction} />
+            <MoneyMovementView
+              movement={movement}
+              hasHighFee={hasHighFee}
+              deferCautions={requiresAttention}
+              showHeadline={!txAction}
+            />
             {decodedInfo.counterpartyMessage?.messageData?.fee != null &&
               isGreaterThan(decodedInfo.counterpartyMessage.messageData.fee as string | number, 0) && (
               <div className="mt-1.5 flex items-center justify-center gap-2 text-xs">
@@ -251,12 +299,16 @@ export default function ApproveTransactionPage() {
             verification={decodedInfo.verification}
           />
 
-          {/* Warnings, rendered in a fixed severity order (danger → success) */}
-          <WarningStack items={warningItems} />
+          <ApprovalNotes items={informational} />
+
+          {/* A blocked request explains itself immediately. Signable cautions wait behind Review. */}
+          {blockSigning && <WarningStack items={attention} />}
 
           {/* Verification Status (compact badge when passed) */}
           <VerificationStatus
-            passed={verificationRepackProved ? true : verificationPassed}
+            passed={deferredVerificationFailure
+              ? undefined
+              : verificationRepackProved ? true : verificationPassed}
             warning={verificationWarning}
             isStrict={isStrictMode}
           />
@@ -266,11 +318,25 @@ export default function ApproveTransactionPage() {
 
       <ApprovalFooter
         onCancel={handleReject}
-        onSign={handleSign}
+        onSign={handleApprovalAction}
         busy={isSigning}
         blocked={blockSigning}
         isHardware={activeWallet.type === 'hardware'}
+        signLabel={requiresAttention ? 'Review' : 'Sign'}
       />
+
+      {showAttention && requiresAttention && (
+        <ApprovalAttentionScreen
+          title={attentionTitle}
+          description="Confirm the exceptional transaction behavior below before the wallet adds your signature."
+          items={approvalAttentionItems}
+          confirmLabel={confirmLabel}
+          busy={isSigning}
+          isHardware={activeWallet.type === 'hardware'}
+          onBack={() => setShowAttention(false)}
+          onConfirm={() => void handleSign()}
+        />
+      )}
     </div>
   );
 }

--- a/src/pages/requests/transaction/approve.tsx
+++ b/src/pages/requests/transaction/approve.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
 import {
   ApprovalAttentionScreen,
-  ApprovalNotes,
   highFeeAttentionItem,
   partitionApprovalItems,
   verificationAttentionItem,
@@ -17,7 +16,7 @@ import { CounterpartyDetailsCard } from '@/components/domain/approval/counterpar
 import { computeMoneyMovement } from '@/components/domain/approval/money-movement';
 import { MoneyMovementView } from '@/components/domain/approval/money-movement-view';
 import { buildOrderAction, type OrderAction, OrderCard } from '@/components/domain/approval/order-card';
-import { getTxActionInfo } from '@/components/domain/tx/tx-action-info';
+import { attachDestinationVout, getTxActionInfo } from '@/components/domain/tx/tx-action-info';
 import { VerificationStatus } from '@/components/domain/tx/verification-status';
 import { ErrorAlert } from '@/components/ui/error-alert';
 import { type WarningItem, WarningStack } from '@/components/ui/warning-stack';
@@ -199,9 +198,13 @@ export default function ApproveTransactionPage() {
   });
 
   // An unavailable asset lookup is a retry state. It cannot be acknowledged away because the
-  // wallet does not know whether signing moves an attached asset.
-  const blockSigning = verificationBlocked || signedInputsUnknownStatus.length > 0;
-  const { informational, attention } = partitionApprovalItems(warningItems);
+  // wallet does not know whether signing moves an attached asset. A structure finding blocks too:
+  // the message provably cannot do what it claims, so signing only spends fees on a broken
+  // transaction no honest composer produces.
+  const blockSigning = verificationBlocked
+    || signedInputsUnknownStatus.length > 0
+    || (decodedInfo.structureFindings ?? []).length > 0;
+  const { attention } = partitionApprovalItems(warningItems);
   const approvalAttentionItems: WarningItem[] = [
     ...attention,
     ...(deferredVerificationFailure ? [verificationAttentionItem(verificationWarning)] : []),
@@ -212,7 +215,7 @@ export default function ApproveTransactionPage() {
     ? 'Review transaction risk'
     : 'Review before signing';
   const confirmLabel = decodedInfo.counterpartyMessage?.messageType === 'destroy'
-    ? 'Destroy assets'
+    ? 'Destroy supply'
     : 'Confirm and sign';
   const handleApprovalAction = () => {
     if (requiresAttention) {
@@ -252,10 +255,13 @@ export default function ApproveTransactionPage() {
                   // the lookalike-grinding problem the outputs list deliberately avoids, and for
                   // an enhanced send the destination lives in the payload, so this headline is
                   // the only place it appears at all.
-                  const { sentence, address } = splitTrailingAddress(txAction.description);
+                  const { sentence, address, subline } = splitTrailingAddress(txAction.description);
                   return (
                     <>
                       <p className="text-lg font-bold text-gray-900 break-words">{sentence}</p>
+                      {subline && (
+                        <p className="mt-1 text-sm text-gray-700 break-words">{subline}</p>
+                      )}
                       {address && (
                         <p className="mt-1 text-sm font-medium font-mono text-gray-700 break-all">
                           {address}
@@ -287,19 +293,18 @@ export default function ApproveTransactionPage() {
             )}
           </div>
 
-          {txAction && 'protocol' in txAction && (
-            <CounterpartyDetailsCard fields={txAction.protocol} />
-          )}
+          <CounterpartyDetailsCard
+            fields={txAction && 'protocol' in txAction ? txAction.protocol : []}
+            recipients={decodedInfo.mpmaRecipients}
+          />
           <ApprovalTransactionDetails
             txid={decodedInfo.txid}
             inputs={decodedInfo.inputs.map((input, index) => ({ ...input, index }))}
             outputs={decodedInfo.outputs}
-            recipients={decodedInfo.mpmaRecipients}
             attachedAssets={decodedInfo.attachedAssets}
             verification={decodedInfo.verification}
+            attachVout={attachDestinationVout(decodedInfo)}
           />
-
-          <ApprovalNotes items={informational} />
 
           {/* A blocked request explains itself immediately. Signable cautions wait behind Review. */}
           {blockSigning && <WarningStack items={attention} />}

--- a/src/pages/requests/transaction/approve.tsx
+++ b/src/pages/requests/transaction/approve.tsx
@@ -4,15 +4,14 @@ import {ApprovalExpired, ApprovalFooter,
   ApprovalWalletHeader, 
 } from '@/components/domain/approval/approval-chrome';
 import { splitTrailingAddress } from '@/components/domain/approval/approval-summary-card';
+import { ApprovalTransactionDetails } from '@/components/domain/approval/approval-transaction-details';
 import { buildApprovalWarnings } from '@/components/domain/approval/approval-warnings';
 import { CounterpartyDetailsCard } from '@/components/domain/approval/counterparty-details-card';
 import { computeMoneyMovement } from '@/components/domain/approval/money-movement';
 import { MoneyMovementView } from '@/components/domain/approval/money-movement-view';
 import { buildOrderAction, type OrderAction, OrderCard } from '@/components/domain/approval/order-card';
-import { VerificationDetails } from '@/components/domain/approval/verification-details';
 import { getTxActionInfo } from '@/components/domain/tx/tx-action-info';
 import { VerificationStatus } from '@/components/domain/tx/verification-status';
-import { Collapsible } from '@/components/ui/collapsible';
 import { ErrorAlert } from '@/components/ui/error-alert';
 import { type WarningItem, WarningStack } from '@/components/ui/warning-stack';
 import { useHeader } from '@/contexts/header-context';
@@ -23,7 +22,7 @@ import { exceedsSaneFeeRate } from '@/core/bitcoin/feeVerification';
 import type { ProtocolField } from '@/core/counterparty/describe';
 import { classifySignedInputAssets } from '@/core/counterparty/inputAssets';
 import { shouldBlockSigning } from '@/core/counterparty/unpack/providerVerify';
-import { formatAddress, formatAmount } from '@/core/format';
+import { formatAmount } from '@/core/format';
 import { fromSatoshis, isGreaterThan } from "@/core/numeric";
 import { usePopupLifecycle } from '@/hooks/usePopupLifecycle';
 import type { DecodedTransactionInfo } from '@/hooks/useSignTransactionRequest';
@@ -153,7 +152,6 @@ export default function ApproveTransactionPage() {
   });
 
   // Attached-asset status per input. Inputs are dense, so array position is the index.
-  const attachedByInput = new Map(decodedInfo.attachedAssets.map(entry => [entry.inputIndex, entry]));
   // The wallet signs inputs it controls, i.e. those belonging to the active address.
   const signerInputIndices = decodedInfo.inputs
     .map((input, index) => ({ input, index }))
@@ -244,109 +242,14 @@ export default function ApproveTransactionPage() {
           {txAction && 'protocol' in txAction && (
             <CounterpartyDetailsCard fields={txAction.protocol} />
           )}
-          {/* Transaction Details (expandable) */}
-          <Collapsible variant="card" title="Transaction Details">
-                  {/* TX Hash */}
-                  {decodedInfo.txid && (
-                    <div>
-                      <h4 className="text-xs font-medium text-gray-500 uppercase mb-2">TX Hash</h4>
-                      <div className="bg-gray-50 p-2 rounded text-xs text-gray-600 break-all">
-                        {decodedInfo.txid}
-                      </div>
-                    </div>
-                  )}
-
-                  {/* Inputs List */}
-                  <div>
-                    <h4 className="text-xs font-medium text-gray-500 uppercase mb-2">Inputs ({decodedInfo.inputs.length})</h4>
-                    <div className="space-y-2">
-                      {decodedInfo.inputs.map((input, idx) => {
-                        const inputAssets = attachedByInput.get(idx);
-                        return (
-                        <div key={idx} className="bg-gray-50 p-2 rounded text-xs">
-                          <span className="text-gray-600">#{idx}</span>
-                          {input.address && (
-                            <div className="text-gray-500 truncate" title={input.address}>
-                              {formatAddress(input.address, true)}
-                            </div>
-                          )}
-                          <div className="text-gray-400 truncate" title={input.txid}>
-                            {input.txid.slice(0, 8)}...:{input.vout}
-                          </div>
-                          {inputAssets?.assets.map((asset) => (
-                            <div key={asset.asset} className="mt-1 flex justify-between text-purple-700">
-                              <span className="truncate" title={asset.asset_longname ?? asset.asset}>
-                                {asset.asset_longname ?? asset.asset}
-                              </span>
-                              <span className="font-medium flex-shrink-0 ml-2">{asset.quantity_normalized}</span>
-                            </div>
-                          ))}
-                          {inputAssets?.lookupFailed && (
-                            <div className="mt-1 text-amber-600">Asset status unavailable</div>
-                          )}
-                        </div>
-                        );
-                      })}
-                    </div>
-                  </div>
-
-                  {/* Outputs List */}
-                  <div>
-                    <h4 className="text-xs font-medium text-gray-500 uppercase mb-2">Outputs ({decodedInfo.outputs.length})</h4>
-                    <div className="space-y-2">
-                      {decodedInfo.outputs.map((output, idx) => (
-                        <div key={idx} className="bg-gray-50 p-2 rounded text-xs">
-                          <div className="flex justify-between">
-                            <span className={`${output.type === 'op_return' ? 'text-purple-600' : 'text-gray-600'}`}>
-                              {output.type === 'op_return' ? 'OP_RETURN' : output.type.toUpperCase()}
-                            </span>
-                            <span className="text-gray-900 font-medium">{formatAmount({ value: fromSatoshis(output.value, true), minimumFractionDigits: 8, maximumFractionDigits: 8 })} BTC</span>
-                          </div>
-                          {/* Shown in full and allowed to wrap. This is where the user checks
-                              where a site's transaction sends money, and 6 leading + 6 trailing
-                              characters is grindable for a lookalike - the prefix of a bech32
-                              address is fixed, so only a handful of characters are actually
-                              being compared. */}
-                          {output.address && (
-                            <div className="text-gray-500 break-all font-mono" title={output.address}>
-                              {formatAddress(output.address, false)}
-                            </div>
-                          )}
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-
-                  {/* Recipients of a multi-destination send. These live in the Counterparty
-                      payload rather than in BTC outputs, so the outputs list above cannot show
-                      them and this is the only place they appear. Addresses are shown in full for
-                      the same reason as the outputs above. */}
-                  {decodedInfo.mpmaRecipients.length > 0 && (
-                    <div>
-                      <h4 className="text-xs font-medium text-gray-500 uppercase mb-2">
-                        Recipients ({decodedInfo.mpmaRecipients.length})
-                      </h4>
-                      <div className="space-y-2">
-                        {decodedInfo.mpmaRecipients.map((recipient, idx) => (
-                          <div key={idx} className="bg-gray-50 p-2 rounded text-xs">
-                            <div className="flex justify-between gap-2">
-                              <span className="text-gray-600 truncate">{recipient.asset}</span>
-                              <span className="text-gray-900 font-medium flex-shrink-0">
-                                {recipient.quantity}
-                              </span>
-                            </div>
-                            <div className="text-gray-500 break-all font-mono" title={recipient.address}>
-                              {recipient.address}
-                            </div>
-                          </div>
-                        ))}
-                      </div>
-                    </div>
-                  )}
-
-                  <VerificationDetails verification={decodedInfo.verification} />
-
-          </Collapsible>
+          <ApprovalTransactionDetails
+            txid={decodedInfo.txid}
+            inputs={decodedInfo.inputs.map((input, index) => ({ ...input, index }))}
+            outputs={decodedInfo.outputs}
+            recipients={decodedInfo.mpmaRecipients}
+            attachedAssets={decodedInfo.attachedAssets}
+            verification={decodedInfo.verification}
+          />
 
           {/* Warnings, rendered in a fixed severity order (danger → success) */}
           <WarningStack items={warningItems} />

--- a/src/pages/requests/transaction/approve.tsx
+++ b/src/pages/requests/transaction/approve.tsx
@@ -9,6 +9,7 @@ import { CounterpartyDetailsCard } from '@/components/domain/approval/counterpar
 import { computeMoneyMovement } from '@/components/domain/approval/money-movement';
 import { MoneyMovementView } from '@/components/domain/approval/money-movement-view';
 import { buildOrderAction, type OrderAction, OrderCard } from '@/components/domain/approval/order-card';
+import { VerificationDetails } from '@/components/domain/approval/verification-details';
 import { getTxActionInfo } from '@/components/domain/tx/tx-action-info';
 import { VerificationStatus } from '@/components/domain/tx/verification-status';
 import { Collapsible } from '@/components/ui/collapsible';
@@ -342,6 +343,8 @@ export default function ApproveTransactionPage() {
                       </div>
                     </div>
                   )}
+
+                  <VerificationDetails verification={decodedInfo.verification} />
 
           </Collapsible>
 

--- a/src/platform/provider/__tests__/signPsbtPhase.test.ts
+++ b/src/platform/provider/__tests__/signPsbtPhase.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest';
+import { signPsbtPhaseForDelivery } from '@/platform/provider/signPsbtPhase';
+
+describe('signPsbtPhaseForDelivery', () => {
+  it('signs sequentially and returns the complete ordered phase', async () => {
+    const active: number[] = [];
+    const sign = vi.fn(async (item: string, index: number) => {
+      active.push(index);
+      expect(active).toEqual([index]);
+      active.pop();
+      return `signed-${item}`;
+    });
+
+    await expect(signPsbtPhaseForDelivery(['a', 'b', 'c'], sign)).resolves.toEqual([
+      'signed-a',
+      'signed-b',
+      'signed-c',
+    ]);
+    expect(sign.mock.calls.map(call => call[1])).toEqual([0, 1, 2]);
+  });
+
+  it('rejects the whole delivery when a later signer fails', async () => {
+    let delivered: string[] | undefined;
+    const sign = vi.fn(async (item: string) => {
+      if (item === 'b') throw new Error('hardware signer cancelled');
+      return `signed-${item}`;
+    });
+
+    await expect(
+      signPsbtPhaseForDelivery(['a', 'b', 'c'], sign).then(result => {
+        delivered = result;
+      }),
+    ).rejects.toThrow('hardware signer cancelled');
+    expect(delivered).toBeUndefined();
+    expect(sign).toHaveBeenCalledTimes(2);
+  });
+
+  it('refuses an empty or oversized phase', async () => {
+    const sign = vi.fn(async () => 'signed');
+    await expect(signPsbtPhaseForDelivery([], sign)).rejects.toThrow('1..8');
+    await expect(signPsbtPhaseForDelivery(Array.from({ length: 9 }, () => 'x'), sign))
+      .rejects.toThrow('1..8');
+    expect(sign).not.toHaveBeenCalled();
+  });
+});

--- a/src/platform/provider/signFlow.ts
+++ b/src/platform/provider/signFlow.ts
@@ -11,6 +11,7 @@
  */
 
 import type { BitcoinPaymentIntentV1 } from '@/core/bitcoin/providerPayment';
+import type { MarketplaceBatchKind } from '@/core/counterparty/marketplaceBatch';
 import type { BumpAcceptanceFeeIntentClaim } from '@/core/counterparty/marketplaceBundle';
 import type { MarketplaceIntentClaimV1 } from '@/core/counterparty/marketplaceIntent';
 import { type AuthorizedRequest, RequestStorage } from '@/platform/storage/requestStorage';
@@ -61,9 +62,10 @@ export interface SignPsbtBundleItem {
   marketplaceIntent: MarketplaceIntentClaimV1 | BumpAcceptanceFeeIntentClaim;
 }
 
-/** Atomic provider bundle: every item is proved before any signer is invoked. */
+/** Fail-closed provider bundle: every item is proved before any signer is invoked. */
 export type SignPsbtsRequest = SignFlowEntry<{
-  items: [SignPsbtBundleItem, SignPsbtBundleItem];
+  bundleKind: 'acceptance-cpfp' | MarketplaceBatchKind;
+  items: SignPsbtBundleItem[];
 }>;
 
 /**

--- a/src/platform/provider/signFlow.ts
+++ b/src/platform/provider/signFlow.ts
@@ -10,6 +10,8 @@
  * writes and two removes that had to be kept in step by hand.
  */
 
+import type { BitcoinPaymentIntentV1 } from '@/core/bitcoin/providerPayment';
+import type { MarketplaceIntentClaimV1 } from '@/core/counterparty/marketplaceIntent';
 import { type AuthorizedRequest, RequestStorage } from '@/platform/storage/requestStorage';
 
 export type SignFlowStatus = 'pending' | 'completed' | 'cancelled';
@@ -38,6 +40,10 @@ export type SignPsbtRequest = SignFlowEntry<{
   psbtHex: string;
   signInputs?: Record<string, number[]>;
   sighashTypes?: number[];
+  /** Defaults to counterparty for requests stored by older wallet versions. */
+  signingPurpose?: 'counterparty' | 'bitcoin-payment';
+  bitcoinPaymentIntent?: BitcoinPaymentIntentV1;
+  marketplaceIntent?: MarketplaceIntentClaimV1;
   /**
    * A site's claim about the inscription commit this PSBT funds: the reveal's tapleaf script and
    * the taproot internal key, both hex. Never trusted — the approval screen recomputes the commit

--- a/src/platform/provider/signFlow.ts
+++ b/src/platform/provider/signFlow.ts
@@ -11,13 +11,14 @@
  */
 
 import type { BitcoinPaymentIntentV1 } from '@/core/bitcoin/providerPayment';
+import type { BumpAcceptanceFeeIntentClaim } from '@/core/counterparty/marketplaceBundle';
 import type { MarketplaceIntentClaimV1 } from '@/core/counterparty/marketplaceIntent';
 import { type AuthorizedRequest, RequestStorage } from '@/platform/storage/requestStorage';
 
 export type SignFlowStatus = 'pending' | 'completed' | 'cancelled';
 
 /** Which screen the flow belongs to, and the prefix of the events it emits. */
-export type SignFlowKind = 'sign-message' | 'sign-psbt' | 'sign-transaction';
+export type SignFlowKind = 'sign-message' | 'sign-psbt' | 'sign-psbts' | 'sign-transaction';
 
 /**
  * A signing request in flight.
@@ -51,6 +52,18 @@ export type SignPsbtRequest = SignFlowEntry<{
    * (`core/counterparty/providerInscriptions.ts`).
    */
   inscription?: { revealScript: string; tapInternalKey: string };
+}>;
+
+export interface SignPsbtBundleItem {
+  psbtHex: string;
+  signInputs: Record<string, number[]>;
+  sighashTypes: number[];
+  marketplaceIntent: MarketplaceIntentClaimV1 | BumpAcceptanceFeeIntentClaim;
+}
+
+/** Atomic provider bundle: every item is proved before any signer is invoked. */
+export type SignPsbtsRequest = SignFlowEntry<{
+  items: [SignPsbtBundleItem, SignPsbtBundleItem];
 }>;
 
 /**

--- a/src/platform/provider/signPsbtPhase.ts
+++ b/src/platform/provider/signPsbtPhase.ts
@@ -1,0 +1,18 @@
+/**
+ * Sign one already-proved phase in order, but disclose results only as a complete set.
+ * Earlier signatures may exist in local memory if a later signer fails; callers cannot
+ * observe them because the result array is returned only after every call completes.
+ */
+export async function signPsbtPhaseForDelivery<T>(
+  items: T[],
+  sign: (item: T, index: number) => Promise<string>,
+): Promise<string[]> {
+  if (items.length < 1 || items.length > 8) {
+    throw new Error('PSBT signing phase must contain 1..8 transactions');
+  }
+  const results: string[] = [];
+  for (const [index, item] of items.entries()) {
+    results.push(await sign(item, index));
+  }
+  return results;
+}

--- a/src/platform/proxy.ts
+++ b/src/platform/proxy.ts
@@ -44,6 +44,7 @@ const NON_REPLAYABLE_PROVIDER_METHODS = new Set([
   'xcp_signMessage',
   'xcp_signTransaction',
   'xcp_signPsbt',
+  'xcp_signPsbts',
   'xcp_signBitcoinPsbt',
 ]);
 

--- a/src/platform/proxy.ts
+++ b/src/platform/proxy.ts
@@ -44,6 +44,7 @@ const NON_REPLAYABLE_PROVIDER_METHODS = new Set([
   'xcp_signMessage',
   'xcp_signTransaction',
   'xcp_signPsbt',
+  'xcp_signBitcoinPsbt',
 ]);
 
 /** A call is replay-safe unless it is a provider request for a non-idempotent method. */

--- a/src/services/__tests__/providerService.test.ts
+++ b/src/services/__tests__/providerService.test.ts
@@ -70,6 +70,27 @@ const MARKETPLACE_LISTING_INTENT = {
   marketplaceExpiresAt: null,
   bitcoinExpiresAt: null,
 } as const;
+const MARKETPLACE_ATTACH_INTENT = {
+  standard: 'counterparty-marketplace',
+  version: 1,
+  action: 'attach_for_listing',
+  operationId: 'attach-1',
+  protocolVersion: 'counterparty_attach_listing_v1',
+  assets: [{ asset: 'RAREPEPE', quantityRaw: '1' }],
+  seller: '1FvyAqqELFiQyaEWdhFbWF8MZapKPZS8J7',
+  expectedAttachedOutpoint: { txid: 'ac'.repeat(32), vout: 0 },
+  carrierAddress: 'bc1qtest123',
+  carrierValueSats: 546,
+  networkFeeSats: 1_000,
+  protocolFee: {
+    asset: 'XCP',
+    quotedAmountRaw: '25000000',
+    actualAmountRaw: null,
+    observedBlock: 900_000,
+    variableUntilConfirmed: true,
+  },
+  operationExpiresAt: 2_000_000_000,
+} as const;
 const MARKETPLACE_BUY_INTENT = {
   standard: 'counterparty-marketplace',
   version: 1,
@@ -899,6 +920,33 @@ describe('ProviderService', () => {
             origin: 'https://digirare.com',
             signingPurpose: 'counterparty',
             marketplaceIntent: MARKETPLACE_LISTING_INTENT,
+          })
+        );
+      });
+
+      it('stores a bounded attach claim without treating its XCP fee quote as authority', async () => {
+        const connection = vi.mocked(connectionService.getConnectionService)();
+        connection.hasPermission = vi.fn().mockResolvedValue(true);
+        connection.hasPairedAddressPermission = vi.fn().mockResolvedValue(true);
+
+        providerService.handleRequest(
+          'https://digirare.com',
+          'xcp_signPsbt',
+          [{
+            hex: VALID_PSBT_HEX,
+            signInputs: { '1FvyAqqELFiQyaEWdhFbWF8MZapKPZS8J7': [0] },
+            sighashTypes: [0x01],
+            intent: MARKETPLACE_ATTACH_INTENT,
+          }]
+        ).catch(() => {});
+
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        expect(signFlow.beginSignFlow).toHaveBeenCalledWith(
+          expect.objectContaining({
+            origin: 'https://digirare.com',
+            signingPurpose: 'counterparty',
+            marketplaceIntent: MARKETPLACE_ATTACH_INTENT,
           })
         );
       });

--- a/src/services/__tests__/providerService.test.ts
+++ b/src/services/__tests__/providerService.test.ts
@@ -39,6 +39,37 @@ import { createProviderService } from '../providerService';
 import * as walletService from '../walletService';
 
 const VALID_PSBT_HEX = '70736274ff01009a0200000002dcdd8cd287d40de3d260ccfc5fa3008f14ff8f13fc840164715cbb2b925874190000000000ffffffff98f9e476f918cc143cf8a6bd09042d1f2ee7c46bfd29c906166613b2d9c516c90000000000ffffffff022202000000000000160014670caa79e51d78ed0c583b89ff39d9c49b7199e75c12000000000000160014670caa79e51d78ed0c583b89ff39d9c49b7199e70000000000010055020000000101010101010101010101010101010101010101010101010101010101010101010000000000ffffffff0122020000000000001976a914a3c6b1ee4a49d9f2af3b3802974744fba924164a88ac000000000001011f8813000000000000160014670caa79e51d78ed0c583b89ff39d9c49b7199e7000000';
+const BITCOIN_PAYMENT_INTENT = {
+  standard: 'xcp-wallet/bitcoin-payment',
+  version: 1,
+  action: 'pay',
+  outputs: [{
+    address: 'bc1qglv8hh3l23y0qu5uw4zu7e8q4td0gcjsa8f3tq',
+    amountSats: 21_600,
+  }],
+  description: 'Fund Emblem Vault',
+  reference: 'vault-63',
+} as const;
+const MARKETPLACE_LISTING_INTENT = {
+  standard: 'counterparty-marketplace',
+  version: 1,
+  action: 'create_listing',
+  operationId: 'preflight-1',
+  protocolVersion: 'counterparty_attach_listing_v1',
+  assets: [{
+    asset: 'RAREPEPE',
+    quantityRaw: '1',
+    sourceOutpoint: { txid: 'ab'.repeat(32), vout: 4 },
+  }],
+  seller: '1FvyAqqELFiQyaEWdhFbWF8MZapKPZS8J7',
+  priceSats: 250_000,
+  carrierValueSats: 546,
+  guaranteedSellerPaymentSats: 250_546,
+  delivery: { mode: 'buyer_selected_detach' },
+  signingRequestExpiresAt: 2_000_000_000,
+  marketplaceExpiresAt: null,
+  bitcoinExpiresAt: null,
+} as const;
 
 // Mock the imports
 vi.mock('../walletService');
@@ -813,6 +844,122 @@ describe('ProviderService', () => {
             psbtHex
           })
         );
+      });
+
+      it('stores a bounded marketplace claim for independent approval proof', async () => {
+        const connection = vi.mocked(connectionService.getConnectionService)();
+        connection.hasPermission = vi.fn().mockResolvedValue(true);
+        connection.hasPairedAddressPermission = vi.fn().mockResolvedValue(true);
+
+        providerService.handleRequest(
+          'https://digirare.com',
+          'xcp_signPsbt',
+          [{
+            hex: VALID_PSBT_HEX,
+            signInputs: { '1FvyAqqELFiQyaEWdhFbWF8MZapKPZS8J7': [0] },
+            sighashTypes: [0x83],
+            intent: MARKETPLACE_LISTING_INTENT,
+          }]
+        ).catch(() => {});
+
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        expect(signFlow.beginSignFlow).toHaveBeenCalledWith(
+          expect.objectContaining({
+            origin: 'https://digirare.com',
+            signingPurpose: 'counterparty',
+            marketplaceIntent: MARKETPLACE_LISTING_INTENT,
+          })
+        );
+      });
+
+      describe('xcp_signBitcoinPsbt', () => {
+        const paymentParams = {
+          hex: VALID_PSBT_HEX,
+          signInputs: { '1FvyAqqELFiQyaEWdhFbWF8MZapKPZS8J7': [0] },
+          sighashTypes: [0x01],
+          intent: BITCOIN_PAYMENT_INTENT,
+        };
+
+        it('requires a versioned payment intent before approval', async () => {
+          const connection = vi.mocked(connectionService.getConnectionService)();
+          connection.hasPermission = vi.fn().mockResolvedValue(true);
+
+          await expect(providerService.handleRequest(
+            'https://emblem.finance',
+            'xcp_signBitcoinPsbt',
+            [{ ...paymentParams, intent: undefined }]
+          )).rejects.toThrow('intent must be an object');
+
+          expect(signFlow.beginSignFlow).not.toHaveBeenCalled();
+        });
+
+        it('requires an explicit owned-input map', async () => {
+          const connection = vi.mocked(connectionService.getConnectionService)();
+          connection.hasPermission = vi.fn().mockResolvedValue(true);
+
+          await expect(providerService.handleRequest(
+            'https://emblem.finance',
+            'xcp_signBitcoinPsbt',
+            [{ ...paymentParams, signInputs: undefined }]
+          )).rejects.toThrow('require explicit signInputs');
+
+          expect(signFlow.beginSignFlow).not.toHaveBeenCalled();
+        });
+
+        it.each([undefined, [0x81], [0x83]])(
+          'requires explicit SIGHASH_ALL entries (%j)',
+          async (sighashTypes) => {
+            const connection = vi.mocked(connectionService.getConnectionService)();
+            connection.hasPermission = vi.fn().mockResolvedValue(true);
+
+            await expect(providerService.handleRequest(
+              'https://emblem.finance',
+              'xcp_signBitcoinPsbt',
+              [{ ...paymentParams, sighashTypes }]
+            )).rejects.toThrow(/SIGHASH_ALL/);
+
+            expect(signFlow.beginSignFlow).not.toHaveBeenCalled();
+          }
+        );
+
+        it('still requires normal site connection permission', async () => {
+          const connection = vi.mocked(connectionService.getConnectionService)();
+          connection.hasPermission = vi.fn().mockResolvedValue(false);
+
+          await expect(providerService.handleRequest(
+            'https://emblem.finance',
+            'xcp_signBitcoinPsbt',
+            [paymentParams]
+          )).rejects.toThrow('Unauthorized - not connected to wallet');
+
+          expect(signFlow.beginSignFlow).not.toHaveBeenCalled();
+        });
+
+        it('stores the proved-capability context without trusting the origin', async () => {
+          const connection = vi.mocked(connectionService.getConnectionService)();
+          connection.hasPermission = vi.fn().mockResolvedValue(true);
+          connection.hasPairedAddressPermission = vi.fn().mockResolvedValue(true);
+
+          providerService.handleRequest(
+            'https://emblem.finance',
+            'xcp_signBitcoinPsbt',
+            [paymentParams]
+          ).catch(() => {});
+
+          await new Promise(resolve => setTimeout(resolve, 10));
+
+          expect(signFlow.beginSignFlow).toHaveBeenCalledWith(
+            expect.objectContaining({
+              origin: 'https://emblem.finance',
+              psbtHex: VALID_PSBT_HEX,
+              signInputs: paymentParams.signInputs,
+              sighashTypes: [0x01],
+              signingPurpose: 'bitcoin-payment',
+              bitcoinPaymentIntent: BITCOIN_PAYMENT_INTENT,
+            })
+          );
+        });
       });
     });
 

--- a/src/services/__tests__/providerService.test.ts
+++ b/src/services/__tests__/providerService.test.ts
@@ -70,6 +70,36 @@ const MARKETPLACE_LISTING_INTENT = {
   marketplaceExpiresAt: null,
   bitcoinExpiresAt: null,
 } as const;
+const MARKETPLACE_BUY_INTENT = {
+  standard: 'counterparty-marketplace',
+  version: 1,
+  action: 'buy_listings',
+  operationId: 'checkout-1',
+  protocolVersion: 'direct_v1',
+  assets: [{
+    asset: 'RAREPEPE',
+    quantityRaw: '1',
+    sourceOutpoint: { txid: 'ab'.repeat(32), vout: 4 },
+  }],
+  buyer: '1FvyAqqELFiQyaEWdhFbWF8MZapKPZS8J7',
+  items: [{
+    asset: 'RAREPEPE',
+    quantityRaw: '1',
+    sourceOutpoint: { txid: 'ab'.repeat(32), vout: 4 },
+    listingId: 'listing-1',
+    seller: 'bc1qtest123',
+    carrierValueSats: 546,
+    priceSats: 250_000,
+    sellerPaymentSats: 250_546,
+  }],
+  subtotalSats: 250_000,
+  networkFeeSats: 2_000,
+  platformFeeSats: 0,
+  totalSats: 252_000,
+  expectedTxid: 'cd'.repeat(32),
+  delivery: { mode: 'detached', address: '1FvyAqqELFiQyaEWdhFbWF8MZapKPZS8J7' },
+  marketplaceExpiresAt: 2_000_003_600,
+} as const;
 
 // Mock the imports
 vi.mock('../walletService');
@@ -869,6 +899,33 @@ describe('ProviderService', () => {
             origin: 'https://digirare.com',
             signingPurpose: 'counterparty',
             marketplaceIntent: MARKETPLACE_LISTING_INTENT,
+          })
+        );
+      });
+
+      it('stores a bounded buy-listings claim without granting it origin-based trust', async () => {
+        const connection = vi.mocked(connectionService.getConnectionService)();
+        connection.hasPermission = vi.fn().mockResolvedValue(true);
+        connection.hasPairedAddressPermission = vi.fn().mockResolvedValue(true);
+
+        providerService.handleRequest(
+          'https://digirare.com',
+          'xcp_signPsbt',
+          [{
+            hex: VALID_PSBT_HEX,
+            signInputs: { '1FvyAqqELFiQyaEWdhFbWF8MZapKPZS8J7': [0] },
+            sighashTypes: [0x01],
+            intent: MARKETPLACE_BUY_INTENT,
+          }]
+        ).catch(() => {});
+
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        expect(signFlow.beginSignFlow).toHaveBeenCalledWith(
+          expect.objectContaining({
+            origin: 'https://digirare.com',
+            signingPurpose: 'counterparty',
+            marketplaceIntent: MARKETPLACE_BUY_INTENT,
           })
         );
       });

--- a/src/services/__tests__/providerService.test.ts
+++ b/src/services/__tests__/providerService.test.ts
@@ -148,6 +148,25 @@ const MARKETPLACE_EXACT_INTENT = {
     outpoint: { txid: 'ef'.repeat(32), vout: 1 },
   },
 } as const;
+const MARKETPLACE_CPFP_INTENT = {
+  standard: 'counterparty-marketplace',
+  version: 1,
+  action: 'bump_acceptance_fee',
+  operationId: 'authorization-1',
+  protocolVersion: 'exact_offer_v1',
+  assets: MARKETPLACE_EXACT_INTENT.assets,
+  authorizationId: 'authorization-1',
+  seller: '1FvyAqqELFiQyaEWdhFbWF8MZapKPZS8J7',
+  parentExpectedTxid: MARKETPLACE_EXACT_INTENT.expectedTxid,
+  childExpectedTxid: 'ee'.repeat(32),
+  parentSellerProceedsVout: 1,
+  parentSellerProceedsSats: 250_046,
+  parentNetworkFeeSats: 500,
+  childNetworkFeeSats: 1_000,
+  packageFeeSats: 1_500,
+  packageFeeRate: 5,
+  finalSellerProceedsSats: 249_046,
+} as const;
 
 // Mock the imports
 vi.mock('../walletService');
@@ -580,6 +599,39 @@ describe('ProviderService', () => {
             'https://notconnected.com',
             'xcp_signPsbt',
             [{ hex: VALID_PSBT_HEX }]
+          )
+        ).rejects.toThrow('Unauthorized - not connected to wallet');
+      });
+
+      it('should throw error for an unauthorized atomic PSBT bundle', async () => {
+        const mockConnectionService = vi.mocked(connectionService.getConnectionService)();
+        mockConnectionService.hasPermission = vi.fn().mockResolvedValue(false);
+        const seller = MARKETPLACE_CPFP_INTENT.seller;
+
+        await expect(
+          providerService.handleRequest(
+            'https://notconnected.com',
+            'xcp_signPsbts',
+            [{
+              requests: [
+                {
+                  hex: VALID_PSBT_HEX,
+                  signInputs: { [seller]: [0] },
+                  sighashTypes: [0x01],
+                  intent: {
+                    ...MARKETPLACE_EXACT_INTENT,
+                    action: 'accept_exact_offer',
+                    seller,
+                  },
+                },
+                {
+                  hex: VALID_PSBT_HEX,
+                  signInputs: { [seller]: [0] },
+                  sighashTypes: [0x01],
+                  intent: MARKETPLACE_CPFP_INTENT,
+                },
+              ],
+            }],
           )
         ).rejects.toThrow('Unauthorized - not connected to wallet');
       });
@@ -1028,6 +1080,52 @@ describe('ProviderService', () => {
             origin: 'https://digirare.com',
             signingPurpose: 'counterparty',
             marketplaceIntent: MARKETPLACE_EXACT_INTENT,
+          })
+        );
+      });
+
+      it('stores one atomic exact-acceptance plus CPFP signing flow', async () => {
+        const connection = vi.mocked(connectionService.getConnectionService)();
+        connection.hasPermission = vi.fn().mockResolvedValue(true);
+        connection.hasPairedAddressPermission = vi.fn().mockResolvedValue(true);
+        const seller = '1FvyAqqELFiQyaEWdhFbWF8MZapKPZS8J7';
+        const acceptIntent = {
+          ...MARKETPLACE_EXACT_INTENT,
+          action: 'accept_exact_offer' as const,
+          seller,
+        };
+
+        providerService.handleRequest(
+          'https://digirare.com',
+          'xcp_signPsbts',
+          [{
+            requests: [
+              {
+                hex: VALID_PSBT_HEX,
+                signInputs: { [seller]: [0] },
+                sighashTypes: [0x01],
+                intent: acceptIntent,
+              },
+              {
+                hex: VALID_PSBT_HEX,
+                signInputs: { [seller]: [0] },
+                sighashTypes: [0x01],
+                intent: MARKETPLACE_CPFP_INTENT,
+              },
+            ],
+          }]
+        ).catch(() => {});
+
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        expect(signFlow.beginSignFlow).toHaveBeenCalledWith(
+          expect.objectContaining({
+            origin: 'https://digirare.com',
+            kind: 'sign-psbts',
+            items: [
+              expect.objectContaining({ marketplaceIntent: acceptIntent }),
+              expect.objectContaining({ marketplaceIntent: MARKETPLACE_CPFP_INTENT }),
+            ],
           })
         );
       });

--- a/src/services/__tests__/providerService.test.ts
+++ b/src/services/__tests__/providerService.test.ts
@@ -121,6 +121,33 @@ const MARKETPLACE_BUY_INTENT = {
   delivery: { mode: 'detached', address: '1FvyAqqELFiQyaEWdhFbWF8MZapKPZS8J7' },
   marketplaceExpiresAt: 2_000_003_600,
 } as const;
+const MARKETPLACE_EXACT_INTENT = {
+  standard: 'counterparty-marketplace',
+  version: 1,
+  action: 'authorize_exact_offer',
+  operationId: 'authorization-1',
+  protocolVersion: 'exact_offer_v1',
+  assets: [{
+    asset: 'RAREPEPE',
+    quantityRaw: '1',
+    sourceOutpoint: { txid: 'ab'.repeat(32), vout: 4 },
+  }],
+  authorizationId: 'authorization-1',
+  bidder: '1FvyAqqELFiQyaEWdhFbWF8MZapKPZS8J7',
+  seller: 'bc1qtest123',
+  priceSats: 250_000,
+  carrierValueSats: 546,
+  sellerProceedsSats: 250_046,
+  networkFeeSats: 500,
+  expectedTxid: 'cd'.repeat(32),
+  delivery: { mode: 'detached', address: '1FvyAqqELFiQyaEWdhFbWF8MZapKPZS8J7' },
+  marketplaceExpiresAt: 2_000_003_600,
+  bitcoinExpiresAt: null,
+  bitcoinInvalidation: {
+    type: 'spend_funding_outpoint',
+    outpoint: { txid: 'ef'.repeat(32), vout: 1 },
+  },
+} as const;
 
 // Mock the imports
 vi.mock('../walletService');
@@ -974,6 +1001,33 @@ describe('ProviderService', () => {
             origin: 'https://digirare.com',
             signingPurpose: 'counterparty',
             marketplaceIntent: MARKETPLACE_BUY_INTENT,
+          })
+        );
+      });
+
+      it('stores a bounded exact-offer claim without granting it origin-based trust', async () => {
+        const connection = vi.mocked(connectionService.getConnectionService)();
+        connection.hasPermission = vi.fn().mockResolvedValue(true);
+        connection.hasPairedAddressPermission = vi.fn().mockResolvedValue(true);
+
+        providerService.handleRequest(
+          'https://digirare.com',
+          'xcp_signPsbt',
+          [{
+            hex: VALID_PSBT_HEX,
+            signInputs: { '1FvyAqqELFiQyaEWdhFbWF8MZapKPZS8J7': [0] },
+            sighashTypes: [0x01],
+            intent: MARKETPLACE_EXACT_INTENT,
+          }]
+        ).catch(() => {});
+
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        expect(signFlow.beginSignFlow).toHaveBeenCalledWith(
+          expect.objectContaining({
+            origin: 'https://digirare.com',
+            signingPurpose: 'counterparty',
+            marketplaceIntent: MARKETPLACE_EXACT_INTENT,
           })
         );
       });

--- a/src/services/__tests__/providerService.test.ts
+++ b/src/services/__tests__/providerService.test.ts
@@ -1,3 +1,5 @@
+import { hex } from '@scure/base';
+import { Transaction } from '@scure/btc-signer';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fakeBrowser } from 'wxt/testing/fake-browser';
 
@@ -39,6 +41,18 @@ import { createProviderService } from '../providerService';
 import * as walletService from '../walletService';
 
 const VALID_PSBT_HEX = '70736274ff01009a0200000002dcdd8cd287d40de3d260ccfc5fa3008f14ff8f13fc840164715cbb2b925874190000000000ffffffff98f9e476f918cc143cf8a6bd09042d1f2ee7c46bfd29c906166613b2d9c516c90000000000ffffffff022202000000000000160014670caa79e51d78ed0c583b89ff39d9c49b7199e75c12000000000000160014670caa79e51d78ed0c583b89ff39d9c49b7199e70000000000010055020000000101010101010101010101010101010101010101010101010101010101010101010000000000ffffffff0122020000000000001976a914a3c6b1ee4a49d9f2af3b3802974744fba924164a88ac000000000001011f8813000000000000160014670caa79e51d78ed0c583b89ff39d9c49b7199e7000000';
+const listingPsbtHex = (): string => {
+  const source = Transaction.fromPSBT(hex.decode(VALID_PSBT_HEX), {
+    allowUnknownInputs: true,
+    allowUnknownOutputs: true,
+  });
+  const listing = new Transaction({ allowUnknownInputs: true, allowUnknownOutputs: true });
+  listing.addInput({ txid: new Uint8Array(32), index: 0 });
+  listing.addInput(source.getInput(0));
+  listing.addOutput(source.getOutput(0));
+  listing.addOutput(source.getOutput(1));
+  return hex.encode(listing.toPSBT());
+};
 const BITCOIN_PAYMENT_INTENT = {
   standard: 'xcp-wallet/bitcoin-payment',
   version: 1,
@@ -166,6 +180,24 @@ const MARKETPLACE_CPFP_INTENT = {
   packageFeeSats: 1_500,
   packageFeeRate: 5,
   finalSellerProceedsSats: 249_046,
+} as const;
+const MARKETPLACE_FANOUT_INTENT = {
+  standard: 'counterparty-marketplace',
+  version: 1,
+  action: 'prepare_bulk_fanout',
+  operationId: 'bulk-1',
+  protocolVersion: 'counterparty_bulk_attach_v1',
+  assets: [],
+  batchIndex: 0,
+  seller: '1FvyAqqELFiQyaEWdhFbWF8MZapKPZS8J7',
+  fundingOutpoint: { txid: '11'.repeat(32), vout: 0 },
+  fundingValueSats: 5_000,
+  slotCount: 1,
+  slotValueSats: 546,
+  networkFeeSats: 100,
+  changeSats: 4_354,
+  expectedTxid: '22'.repeat(32),
+  operationExpiresAt: 2_000_000_000,
 } as const;
 
 // Mock the imports
@@ -1122,10 +1154,73 @@ describe('ProviderService', () => {
           expect.objectContaining({
             origin: 'https://digirare.com',
             kind: 'sign-psbts',
+            bundleKind: 'acceptance-cpfp',
             items: [
               expect.objectContaining({ marketplaceIntent: acceptIntent }),
               expect.objectContaining({ marketplaceIntent: MARKETPLACE_CPFP_INTENT }),
             ],
+          })
+        );
+      });
+
+      it('stores a bounded homogeneous bulk fan-out phase', async () => {
+        const connection = vi.mocked(connectionService.getConnectionService)();
+        connection.hasPermission = vi.fn().mockResolvedValue(true);
+        connection.hasPairedAddressPermission = vi.fn().mockResolvedValue(true);
+        const seller = MARKETPLACE_FANOUT_INTENT.seller;
+
+        providerService.handleRequest(
+          'https://digirare.com',
+          'xcp_signPsbts',
+          [{
+            requests: [{
+              hex: VALID_PSBT_HEX,
+              signInputs: { [seller]: [0] },
+              sighashTypes: [0x01],
+              intent: MARKETPLACE_FANOUT_INTENT,
+            }],
+          }]
+        ).catch(() => {});
+
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        expect(signFlow.beginSignFlow).toHaveBeenCalledWith(
+          expect.objectContaining({
+            origin: 'https://digirare.com',
+            kind: 'sign-psbts',
+            bundleKind: 'bulk-fanout',
+            items: [expect.objectContaining({ marketplaceIntent: MARKETPLACE_FANOUT_INTENT })],
+          })
+        );
+      });
+
+      it('permits only the intentional null buyer placeholder in a listing batch', async () => {
+        const connection = vi.mocked(connectionService.getConnectionService)();
+        connection.hasPermission = vi.fn().mockResolvedValue(true);
+        connection.hasPairedAddressPermission = vi.fn().mockResolvedValue(true);
+        const seller = '1FvyAqqELFiQyaEWdhFbWF8MZapKPZS8J7';
+
+        providerService.handleRequest(
+          'https://digirare.com',
+          'xcp_signPsbts',
+          [{
+            requests: [{
+              hex: listingPsbtHex(),
+              signInputs: { [seller]: [1] },
+              sighashTypes: [0x01, 0x83],
+              intent: { ...MARKETPLACE_LISTING_INTENT, seller },
+            }],
+          }]
+        ).catch(() => {});
+
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        expect(signFlow.beginSignFlow).toHaveBeenCalledWith(
+          expect.objectContaining({
+            bundleKind: 'bulk-listing',
+            items: [expect.objectContaining({
+              sighashTypes: [0x01, 0x83],
+            })],
           })
         );
       });

--- a/src/services/__tests__/providerService.test.ts
+++ b/src/services/__tests__/providerService.test.ts
@@ -41,6 +41,7 @@ import { createProviderService } from '../providerService';
 import * as walletService from '../walletService';
 
 const VALID_PSBT_HEX = '70736274ff01009a0200000002dcdd8cd287d40de3d260ccfc5fa3008f14ff8f13fc840164715cbb2b925874190000000000ffffffff98f9e476f918cc143cf8a6bd09042d1f2ee7c46bfd29c906166613b2d9c516c90000000000ffffffff022202000000000000160014670caa79e51d78ed0c583b89ff39d9c49b7199e75c12000000000000160014670caa79e51d78ed0c583b89ff39d9c49b7199e70000000000010055020000000101010101010101010101010101010101010101010101010101010101010101010000000000ffffffff0122020000000000001976a914a3c6b1ee4a49d9f2af3b3802974744fba924164a88ac000000000001011f8813000000000000160014670caa79e51d78ed0c583b89ff39d9c49b7199e7000000';
+const V3_PSBT_HEX = VALID_PSBT_HEX.replace('ff01009a02000000', 'ff01009a03000000');
 const listingPsbtHex = (): string => {
   const source = Transaction.fromPSBT(hex.decode(VALID_PSBT_HEX), {
     allowUnknownInputs: true,
@@ -1114,6 +1115,26 @@ describe('ProviderService', () => {
             marketplaceIntent: MARKETPLACE_EXACT_INTENT,
           })
         );
+      });
+
+      it('rejects an exact-offer PSBT with an incompatible transaction header', async () => {
+        const connection = vi.mocked(connectionService.getConnectionService)();
+        connection.hasPermission = vi.fn().mockResolvedValue(true);
+        connection.hasPairedAddressPermission = vi.fn().mockResolvedValue(true);
+
+        await expect(providerService.handleRequest(
+          'https://digirare.com',
+          'xcp_signPsbt',
+          [{
+            hex: V3_PSBT_HEX,
+            signInputs: { '1FvyAqqELFiQyaEWdhFbWF8MZapKPZS8J7': [0] },
+            sighashTypes: [0x01],
+            intent: MARKETPLACE_EXACT_INTENT,
+          }],
+        )).rejects.toThrow(
+          'exact_offer_v1 requires Bitcoin transaction version 2 with locktime 0',
+        );
+        expect(signFlow.beginSignFlow).not.toHaveBeenCalled();
       });
 
       it('stores one atomic exact-acceptance plus CPFP signing flow', async () => {

--- a/src/services/__tests__/providerService.test.ts
+++ b/src/services/__tests__/providerService.test.ts
@@ -960,6 +960,82 @@ describe('ProviderService', () => {
             })
           );
         });
+
+        it('preserves permissioned mixed Legacy and SegWit signers in the payment profile', async () => {
+          const connection = vi.mocked(connectionService.getConnectionService)();
+          connection.hasPermission = vi.fn().mockResolvedValue(true);
+          connection.hasPairedAddressPermission = vi.fn().mockResolvedValue(true);
+
+          const segwitAddress = 'bc1qvux25709r4uw6rzc8wyl7wwecjdhrx085hm5ty';
+          const legacyAddress = '1FvyAqqELFiQyaEWdhFbWF8MZapKPZS8J7';
+          const wallet = vi.mocked(walletService.getWalletService)();
+          wallet.getActiveAddress = vi.fn().mockResolvedValue({
+            id: 'addr1',
+            address: segwitAddress,
+            label: 'SegWit',
+            walletId: 'wallet1',
+            walletName: 'Test Wallet',
+            index: 0,
+            pubKey: '02aa',
+          });
+          wallet.getActiveWallet = vi.fn().mockResolvedValue({
+            id: 'wallet1',
+            name: 'Test Wallet',
+            type: 'mnemonic',
+            addressFormat: 'p2wpkh',
+            addresses: [{
+              address: segwitAddress,
+              path: "m/84'/0'/0'/0/0",
+              pubKey: '02aa',
+              name: 'SegWit',
+            }],
+          });
+          wallet.getPairedAddresses = vi.fn().mockResolvedValue({
+            legacy: {
+              address: legacyAddress,
+              pubKey: '02bb',
+              path: "m/44'/0'/0'/0/0",
+              name: 'Legacy',
+              format: 'p2pkh',
+              type: 'p2pkh',
+            },
+            segwit: {
+              address: segwitAddress,
+              pubKey: '02aa',
+              path: "m/84'/0'/0'/0/0",
+              name: 'SegWit',
+              format: 'p2wpkh',
+              type: 'p2wpkh',
+            },
+          });
+
+          const signInputs = {
+            [legacyAddress]: [0],
+            [segwitAddress]: [1],
+          };
+          providerService.handleRequest(
+            'https://rare-btc-assets.com',
+            'xcp_signBitcoinPsbt',
+            [{ ...paymentParams, signInputs, sighashTypes: [0x01, 0x01] }]
+          ).catch(() => {});
+
+          await new Promise(resolve => setTimeout(resolve, 10));
+
+          expect(connection.hasPairedAddressPermission).toHaveBeenCalledWith(
+            'https://rare-btc-assets.com',
+            'wallet1',
+            segwitAddress
+          );
+          expect(signFlow.beginSignFlow).toHaveBeenCalledWith(
+            expect.objectContaining({
+              origin: 'https://rare-btc-assets.com',
+              psbtHex: VALID_PSBT_HEX,
+              signInputs,
+              sighashTypes: [0x01, 0x01],
+              signingPurpose: 'bitcoin-payment',
+            })
+          );
+        });
       });
     });
 

--- a/src/services/__tests__/providerSurface.test.ts
+++ b/src/services/__tests__/providerSurface.test.ts
@@ -63,6 +63,7 @@ const CONTRACTS: Record<string, Contract> = {
   xcp_signMessage: 'needs-grant',
   xcp_signTransaction: 'needs-grant',
   xcp_signPsbt: 'needs-grant',
+  xcp_signBitcoinPsbt: 'needs-grant',
   xcp_broadcastTransaction: 'needs-grant',
   xcp_chainId: 'public-constant',
   xcp_getNetwork: 'public-constant',
@@ -77,6 +78,17 @@ const PLAUSIBLE_PARAMS: Record<string, unknown[]> = {
   xcp_signMessage: ['hello'],
   xcp_signTransaction: ['0200000001' + '00'.repeat(40)],
   xcp_signPsbt: ['70736274ff' + '00'.repeat(20)],
+  xcp_signBitcoinPsbt: [{
+    hex: '70736274ff' + '00'.repeat(20),
+    signInputs: { bc1qexample: [0] },
+    sighashTypes: [0x01],
+    intent: {
+      standard: 'xcp-wallet/bitcoin-payment',
+      version: 1,
+      action: 'pay',
+      outputs: [{ address: 'bc1qdestination', amountSats: 1_000 }],
+    },
+  }],
   xcp_broadcastTransaction: ['0200000001' + '00'.repeat(40)],
 };
 

--- a/src/services/__tests__/providerSurface.test.ts
+++ b/src/services/__tests__/providerSurface.test.ts
@@ -63,6 +63,7 @@ const CONTRACTS: Record<string, Contract> = {
   xcp_signMessage: 'needs-grant',
   xcp_signTransaction: 'needs-grant',
   xcp_signPsbt: 'needs-grant',
+  xcp_signPsbts: 'needs-grant',
   xcp_signBitcoinPsbt: 'needs-grant',
   xcp_broadcastTransaction: 'needs-grant',
   xcp_chainId: 'public-constant',
@@ -78,6 +79,7 @@ const PLAUSIBLE_PARAMS: Record<string, unknown[]> = {
   xcp_signMessage: ['hello'],
   xcp_signTransaction: ['0200000001' + '00'.repeat(40)],
   xcp_signPsbt: ['70736274ff' + '00'.repeat(20)],
+  xcp_signPsbts: [{ requests: [] }],
   xcp_signBitcoinPsbt: [{
     hex: '70736274ff' + '00'.repeat(20),
     signInputs: { bc1qexample: [0] },

--- a/src/services/popupMonitorService.ts
+++ b/src/services/popupMonitorService.ts
@@ -20,6 +20,7 @@ type SignRequestKind = SignFlowKind;
 const REQUEST_KINDS = {
   'sign-message': { eventPrefix: 'sign-message' },
   'sign-psbt': { eventPrefix: 'sign-psbt' },
+  'sign-psbts': { eventPrefix: 'sign-psbts' },
   'sign-transaction': { eventPrefix: 'sign-tx' },
 } as const;
 
@@ -141,8 +142,8 @@ class PopupMonitorService {
             eventEmitterService.emit(`sign-message-cancel-${requestId}`, {
               reason: 'Request timeout - popup inactive'
             });
-          } else if (info.type === 'sign-psbt') {
-            eventEmitterService.emit(`sign-psbt-cancel-${requestId}`, {
+          } else if (info.type === 'sign-psbt' || info.type === 'sign-psbts') {
+            eventEmitterService.emit(`${REQUEST_KINDS[info.type].eventPrefix}-cancel-${requestId}`, {
               reason: 'Request timeout - popup inactive'
             });
           }

--- a/src/services/providerService.ts
+++ b/src/services/providerService.ts
@@ -15,7 +15,10 @@ import { extractPsbtDetails, tapLeafOwnerAddress, validateSignInputs } from '@/c
 import { fetchTokenBalances } from '@/core/counterparty/api';
 import { parseMarketplaceBatchIntents } from '@/core/counterparty/marketplaceBatch';
 import { parseAcceptanceCpfpBundleIntents } from '@/core/counterparty/marketplaceBundle';
-import { parseMarketplaceIntent } from '@/core/counterparty/marketplaceIntent';
+import {
+  marketplaceTransactionHeaderProblem,
+  parseMarketplaceIntent,
+} from '@/core/counterparty/marketplaceIntent';
 import { generateRequestId } from '@/core/id';
 import { checkReplayAttempt, markTransactionBroadcasted, recordTransaction } from '@/core/replayPrevention';
 import { PROVIDER_ERROR_CODES, ProviderError } from '@/core/rpcErrors';
@@ -760,6 +763,14 @@ export function createProviderService(): ProviderService {
           for (const [requestIndex, request] of parsedRequests.entries()) {
             const details = extractPsbtDetails(request.psbtHex);
             const marketplaceIntent = parsedBundle.intents[requestIndex]!;
+            const headerProblem = marketplaceTransactionHeaderProblem(
+              marketplaceIntent,
+              details.transactionVersion,
+              details.lockTime,
+            );
+            if (headerProblem) {
+              throw new Error(`PSBT bundle request ${requestIndex}: ${headerProblem}`);
+            }
             const permitsNullBuyerPlaceholder = marketplaceIntent.action === 'create_listing';
             const missingAuthenticatedPrevout = details.inputs.some((input, inputIndex) =>
               input.value === undefined && !(permitsNullBuyerPlaceholder && inputIndex === 0));
@@ -931,6 +942,14 @@ export function createProviderService(): ProviderService {
           }
 
           const psbtDetails = extractPsbtDetails(psbtHex);
+          if (marketplaceIntent) {
+            const headerProblem = marketplaceTransactionHeaderProblem(
+              marketplaceIntent,
+              psbtDetails.transactionVersion,
+              psbtDetails.lockTime,
+            );
+            if (headerProblem) throw new Error(headerProblem);
+          }
           if (isBitcoinPayment && (
             psbtDetails.unfunded
             || psbtDetails.inputs.some(input => input.value === undefined)

--- a/src/services/providerService.ts
+++ b/src/services/providerService.ts
@@ -10,8 +10,10 @@
 import { normalizeAddressForComparison } from '@/core/bitcoin/address';
 import { fetchBTCBalance } from '@/core/bitcoin/balance';
 import { signMessage as signMessageDirect } from '@/core/bitcoin/messageSigner';
+import { parseBitcoinPaymentIntent } from '@/core/bitcoin/providerPayment';
 import { extractPsbtDetails, tapLeafOwnerAddress, validateSignInputs } from '@/core/bitcoin/psbt';
 import { fetchTokenBalances } from '@/core/counterparty/api';
+import { parseMarketplaceIntent } from '@/core/counterparty/marketplaceIntent';
 import { generateRequestId } from '@/core/id';
 import { checkReplayAttempt, markTransactionBroadcasted, recordTransaction } from '@/core/replayPrevention';
 import { PROVIDER_ERROR_CODES, ProviderError } from '@/core/rpcErrors';
@@ -661,7 +663,9 @@ export function createProviderService(): ProviderService {
           });
         }
 
-        case 'xcp_signPsbt': {
+        case 'xcp_signPsbt':
+        case 'xcp_signBitcoinPsbt': {
+          const isBitcoinPayment = method === 'xcp_signBitcoinPsbt';
           const psbtParams = params?.[0];
 
           // Validate params structure
@@ -669,11 +673,12 @@ export function createProviderService(): ProviderService {
             throw new Error('PSBT parameters must be an object with hex property');
           }
 
-          const { hex: psbtHex, signInputs, sighashTypes, inscription } = psbtParams as {
+          const { hex: psbtHex, signInputs, sighashTypes, inscription, intent } = psbtParams as {
             hex?: string;
             signInputs?: Record<string, number[]>;
             sighashTypes?: number[];
             inscription?: { revealScript?: string; tapInternalKey?: string };
+            intent?: unknown;
           };
 
           if (!psbtHex) {
@@ -681,6 +686,15 @@ export function createProviderService(): ProviderService {
           }
           if (typeof psbtHex !== 'string') {
             throw new Error('PSBT hex must be a string');
+          }
+          const bitcoinPaymentIntent = isBitcoinPayment
+            ? parseBitcoinPaymentIntent(intent)
+            : undefined;
+          const marketplaceIntent = !isBitcoinPayment && intent !== undefined
+            ? parseMarketplaceIntent(intent)
+            : undefined;
+          if (isBitcoinPayment && inscription !== undefined) {
+            throw new Error('Plain Bitcoin payment requests cannot carry inscription context');
           }
           // Shape-checked here, verified on the approval screen: the context is a claim the site
           // makes about what the commit funds, and every field of it gets recomputed there.
@@ -698,12 +712,20 @@ export function createProviderService(): ProviderService {
           )) {
             throw new Error('signInputs must be an address-to-input-indices object');
           }
+          if (isBitcoinPayment && (!signInputs || Object.keys(signInputs).length === 0)) {
+            throw new Error('Plain Bitcoin payment requests require explicit signInputs');
+          }
           if (sighashTypes !== undefined) {
             if (!Array.isArray(sighashTypes) || sighashTypes.some(
-              value => ![0x01, 0x81, 0x83].includes(value)
+              value => !(isBitcoinPayment ? [0x01] : [0x01, 0x81, 0x83]).includes(value)
             )) {
-              throw new Error('Only SIGHASH_ALL, ALL|ANYONECANPAY, and SINGLE|ANYONECANPAY are supported');
+              throw new Error(isBitcoinPayment
+                ? 'Plain Bitcoin payment requests support only SIGHASH_ALL'
+                : 'Only SIGHASH_ALL, ALL|ANYONECANPAY, and SINGLE|ANYONECANPAY are supported');
             }
+          }
+          if (isBitcoinPayment && sighashTypes === undefined) {
+            throw new Error('Plain Bitcoin payment requests require explicit SIGHASH_ALL entries');
           }
 
           // Check if connected
@@ -719,6 +741,14 @@ export function createProviderService(): ProviderService {
           }
 
           const psbtDetails = extractPsbtDetails(psbtHex);
+          if (isBitcoinPayment && (
+            psbtDetails.unfunded
+            || psbtDetails.inputs.some(input => input.value === undefined)
+          )) {
+            throw new Error(
+              'Plain Bitcoin payment requests must be fully funded with authenticated prevout amounts before review'
+            );
+          }
           if (sighashTypes && sighashTypes.length > psbtDetails.inputs.length) {
             throw new Error('sighashTypes contains more entries than the PSBT has inputs');
           }
@@ -805,6 +835,9 @@ export function createProviderService(): ProviderService {
                 psbtHex,
                 signInputs,
                 sighashTypes,
+                signingPurpose: isBitcoinPayment ? 'bitcoin-payment' : 'counterparty',
+                ...(bitcoinPaymentIntent ? { bitcoinPaymentIntent } : {}),
+                ...(marketplaceIntent ? { marketplaceIntent } : {}),
                 ...(inscription ? {
                   inscription: {
                     revealScript: inscription.revealScript!,

--- a/src/services/providerService.ts
+++ b/src/services/providerService.ts
@@ -13,6 +13,7 @@ import { signMessage as signMessageDirect } from '@/core/bitcoin/messageSigner';
 import { parseBitcoinPaymentIntent } from '@/core/bitcoin/providerPayment';
 import { extractPsbtDetails, tapLeafOwnerAddress, validateSignInputs } from '@/core/bitcoin/psbt';
 import { fetchTokenBalances } from '@/core/counterparty/api';
+import { parseMarketplaceBatchIntents } from '@/core/counterparty/marketplaceBatch';
 import { parseAcceptanceCpfpBundleIntents } from '@/core/counterparty/marketplaceBundle';
 import { parseMarketplaceIntent } from '@/core/counterparty/marketplaceIntent';
 import { generateRequestId } from '@/core/id';
@@ -670,8 +671,8 @@ export function createProviderService(): ProviderService {
             throw new Error('PSBT bundle parameters must be an object with requests');
           }
           const requests = (bundleParams as { requests?: unknown }).requests;
-          if (!Array.isArray(requests) || requests.length !== 2) {
-            throw new Error('This wallet version supports exactly 2 linked PSBT requests');
+          if (!Array.isArray(requests) || requests.length < 1 || requests.length > 8) {
+            throw new Error('This wallet version supports 1..8 linked PSBT requests');
           }
           const parsedRequests = requests.map((request, requestIndex) => {
             if (!request || typeof request !== 'object' || Array.isArray(request)) {
@@ -696,9 +697,11 @@ export function createProviderService(): ProviderService {
             }
             if (
               !Array.isArray(candidate.sighashTypes)
-              || candidate.sighashTypes.some(value => value !== 0x01)
+              || candidate.sighashTypes.some(value => ![0x01, 0x83].includes(value as number))
             ) {
-              throw new Error(`PSBT bundle request ${requestIndex} supports only SIGHASH_ALL`);
+              throw new Error(
+                `PSBT bundle request ${requestIndex} supports only ALL or SINGLE|ANYONECANPAY`,
+              );
             }
             return {
               psbtHex: candidate.hex,
@@ -707,10 +710,24 @@ export function createProviderService(): ProviderService {
               intent: candidate.intent,
             };
           });
-          const bundleIntents = parseAcceptanceCpfpBundleIntents(
-            parsedRequests[0]!.intent,
-            parsedRequests[1]!.intent,
-          );
+          const firstIntent = parsedRequests[0]!.intent;
+          const exactCpfp = requests.length === 2
+            && firstIntent !== null
+            && typeof firstIntent === 'object'
+            && !Array.isArray(firstIntent)
+            && (firstIntent as { action?: unknown }).action === 'accept_exact_offer';
+          const parsedBundle = exactCpfp
+            ? (() => {
+                const pair = parseAcceptanceCpfpBundleIntents(
+                  parsedRequests[0]!.intent,
+                  parsedRequests[1]!.intent,
+                );
+                return {
+                  kind: 'acceptance-cpfp' as const,
+                  intents: [pair.parent, pair.child],
+                };
+              })()
+            : parseMarketplaceBatchIntents(parsedRequests.map(request => request.intent));
 
           if (!await connectionService.hasPermission(origin)) {
             throw new ProviderError(
@@ -742,13 +759,24 @@ export function createProviderService(): ProviderService {
 
           for (const [requestIndex, request] of parsedRequests.entries()) {
             const details = extractPsbtDetails(request.psbtHex);
-            if (details.unfunded || details.inputs.some(input => input.value === undefined)) {
+            const marketplaceIntent = parsedBundle.intents[requestIndex]!;
+            const permitsNullBuyerPlaceholder = marketplaceIntent.action === 'create_listing';
+            const missingAuthenticatedPrevout = details.inputs.some((input, inputIndex) =>
+              input.value === undefined && !(permitsNullBuyerPlaceholder && inputIndex === 0));
+            if ((!permitsNullBuyerPlaceholder && details.unfunded) || missingAuthenticatedPrevout) {
               throw new Error(
                 `PSBT bundle request ${requestIndex} must be fully funded with authenticated prevouts`,
               );
             }
             if (request.sighashTypes.length > details.inputs.length) {
               throw new Error(`PSBT bundle request ${requestIndex} has too many sighash entries`);
+            }
+            if (request.sighashTypes.some(
+              (value, index) => value === 0x83 && index >= details.outputs.length,
+            )) {
+              throw new Error(
+                `PSBT bundle request ${requestIndex} uses SINGLE without a paired output`,
+              );
             }
             const validation = validateSignInputs(
               request.signInputs,
@@ -805,20 +833,13 @@ export function createProviderService(): ProviderService {
                 origin,
                 requestKey,
                 kind: 'sign-psbts',
-                items: [
-                  {
-                    psbtHex: parsedRequests[0]!.psbtHex,
-                    signInputs: parsedRequests[0]!.signInputs,
-                    sighashTypes: parsedRequests[0]!.sighashTypes,
-                    marketplaceIntent: bundleIntents.parent,
-                  },
-                  {
-                    psbtHex: parsedRequests[1]!.psbtHex,
-                    signInputs: parsedRequests[1]!.signInputs,
-                    sighashTypes: parsedRequests[1]!.sighashTypes,
-                    marketplaceIntent: bundleIntents.child,
-                  },
-                ],
+                bundleKind: parsedBundle.kind,
+                items: parsedRequests.map((request, index) => ({
+                  psbtHex: request.psbtHex,
+                  signInputs: request.signInputs,
+                  sighashTypes: request.sighashTypes,
+                  marketplaceIntent: parsedBundle.intents[index]!,
+                })),
                 address: activeAddress.address,
                 walletId: activeWallet.id,
                 timestamp: Date.now(),

--- a/src/services/providerService.ts
+++ b/src/services/providerService.ts
@@ -13,6 +13,7 @@ import { signMessage as signMessageDirect } from '@/core/bitcoin/messageSigner';
 import { parseBitcoinPaymentIntent } from '@/core/bitcoin/providerPayment';
 import { extractPsbtDetails, tapLeafOwnerAddress, validateSignInputs } from '@/core/bitcoin/psbt';
 import { fetchTokenBalances } from '@/core/counterparty/api';
+import { parseAcceptanceCpfpBundleIntents } from '@/core/counterparty/marketplaceBundle';
 import { parseMarketplaceIntent } from '@/core/counterparty/marketplaceIntent';
 import { generateRequestId } from '@/core/id';
 import { checkReplayAttempt, markTransactionBroadcasted, recordTransaction } from '@/core/replayPrevention';
@@ -659,6 +660,174 @@ export function createProviderService(): ProviderService {
                 signTxRequestId: requestId,
               }).catch(() => { /* Popup might not be open yet */ });
               await openExtensionPopup(`#/requests/transaction/approve?requestId=${requestId}`);
+            },
+          });
+        }
+
+        case 'xcp_signPsbts': {
+          const bundleParams = params?.[0];
+          if (!bundleParams || typeof bundleParams !== 'object' || Array.isArray(bundleParams)) {
+            throw new Error('PSBT bundle parameters must be an object with requests');
+          }
+          const requests = (bundleParams as { requests?: unknown }).requests;
+          if (!Array.isArray(requests) || requests.length !== 2) {
+            throw new Error('This wallet version supports exactly 2 linked PSBT requests');
+          }
+          const parsedRequests = requests.map((request, requestIndex) => {
+            if (!request || typeof request !== 'object' || Array.isArray(request)) {
+              throw new Error(`PSBT bundle request ${requestIndex} must be an object`);
+            }
+            const candidate = request as {
+              hex?: unknown;
+              signInputs?: unknown;
+              sighashTypes?: unknown;
+              intent?: unknown;
+            };
+            if (typeof candidate.hex !== 'string' || candidate.hex.length === 0) {
+              throw new Error(`PSBT bundle request ${requestIndex} requires hex`);
+            }
+            if (
+              !candidate.signInputs
+              || typeof candidate.signInputs !== 'object'
+              || Array.isArray(candidate.signInputs)
+              || Object.keys(candidate.signInputs).length === 0
+            ) {
+              throw new Error(`PSBT bundle request ${requestIndex} requires explicit signInputs`);
+            }
+            if (
+              !Array.isArray(candidate.sighashTypes)
+              || candidate.sighashTypes.some(value => value !== 0x01)
+            ) {
+              throw new Error(`PSBT bundle request ${requestIndex} supports only SIGHASH_ALL`);
+            }
+            return {
+              psbtHex: candidate.hex,
+              signInputs: candidate.signInputs as Record<string, number[]>,
+              sighashTypes: candidate.sighashTypes as number[],
+              intent: candidate.intent,
+            };
+          });
+          const bundleIntents = parseAcceptanceCpfpBundleIntents(
+            parsedRequests[0]!.intent,
+            parsedRequests[1]!.intent,
+          );
+
+          if (!await connectionService.hasPermission(origin)) {
+            throw new ProviderError(
+              PROVIDER_ERROR_CODES.UNAUTHORIZED,
+              'Unauthorized - not connected to wallet',
+            );
+          }
+          const activeAddress = await walletService.getActiveAddress();
+          const activeWallet = await walletService.getActiveWallet();
+          if (!activeAddress || !activeWallet) throw new Error('No active address');
+
+          const supportsPairedAddresses = Boolean(
+            getPairedAddressFormats(activeWallet.addressFormat),
+          );
+          const paired = activeWallet.type === 'mnemonic' && supportsPairedAddresses
+            ? await walletService.getPairedAddresses()
+            : null;
+          const allowedAddresses = [
+            activeAddress.address,
+            ...(paired ? [paired.legacy.address, paired.segwit.address] : []),
+          ];
+          const pairedAddressSet = new Set(
+            paired
+              ? [paired.legacy.address, paired.segwit.address].map(normalizeAddressForComparison)
+              : [],
+          );
+          const normalizedActiveAddress = normalizeAddressForComparison(activeAddress.address);
+          let usesPairedAddress = false;
+
+          for (const [requestIndex, request] of parsedRequests.entries()) {
+            const details = extractPsbtDetails(request.psbtHex);
+            if (details.unfunded || details.inputs.some(input => input.value === undefined)) {
+              throw new Error(
+                `PSBT bundle request ${requestIndex} must be fully funded with authenticated prevouts`,
+              );
+            }
+            if (request.sighashTypes.length > details.inputs.length) {
+              throw new Error(`PSBT bundle request ${requestIndex} has too many sighash entries`);
+            }
+            const validation = validateSignInputs(
+              request.signInputs,
+              allowedAddresses,
+              details.inputs.length,
+              details.inputs.map(input => tapLeafOwnerAddress(input) ?? input.address),
+            );
+            if (!validation.valid) {
+              throw new Error(`PSBT bundle request ${requestIndex}: ${validation.error}`);
+            }
+            const requestedInputIndices = Object.values(request.signInputs).flat();
+            const missing = requestedInputIndices.filter(
+              inputIndex => request.sighashTypes[inputIndex] === undefined,
+            );
+            if (missing.length > 0) {
+              throw new Error(
+                `PSBT bundle request ${requestIndex} is missing absolute sighash entries for inputs: ${missing.join(', ')}`,
+              );
+            }
+            usesPairedAddress ||= Object.keys(request.signInputs).some(address => {
+              const normalizedAddress = normalizeAddressForComparison(address);
+              return normalizedAddress !== normalizedActiveAddress
+                && pairedAddressSet.has(normalizedAddress);
+            });
+          }
+          if (
+            usesPairedAddress
+            && !await connectionService.hasPairedAddressPermission(
+              origin,
+              activeWallet.id,
+              activeAddress.address,
+            )
+          ) {
+            throw new ProviderError(
+              PROVIDER_ERROR_CODES.UNAUTHORIZED,
+              'Paired Legacy/SegWit address access has not been granted',
+            );
+          }
+
+          return runSignFlow({
+            origin,
+            method,
+            params,
+            approval: {
+              eventPrefix: 'sign-psbts',
+              analyticsEvent: 'psbt_bundle_signed',
+              cancelMessage: 'User cancelled PSBT bundle signing request',
+              timeoutMessage: 'PSBT bundle signing request timeout',
+              mapResult: result => ({ hexes: result.signedPsbtHexes }),
+            },
+            createAndOpen: async (requestId, requestKey) => {
+              await beginSignFlow({
+                id: requestId,
+                origin,
+                requestKey,
+                kind: 'sign-psbts',
+                items: [
+                  {
+                    psbtHex: parsedRequests[0]!.psbtHex,
+                    signInputs: parsedRequests[0]!.signInputs,
+                    sighashTypes: parsedRequests[0]!.sighashTypes,
+                    marketplaceIntent: bundleIntents.parent,
+                  },
+                  {
+                    psbtHex: parsedRequests[1]!.psbtHex,
+                    signInputs: parsedRequests[1]!.signInputs,
+                    sighashTypes: parsedRequests[1]!.sighashTypes,
+                    marketplaceIntent: bundleIntents.child,
+                  },
+                ],
+                address: activeAddress.address,
+                walletId: activeWallet.id,
+                timestamp: Date.now(),
+              });
+              chrome.runtime.sendMessage({
+                type: 'NAVIGATE_TO_APPROVE_PSBTS',
+                signPsbtsRequestId: requestId,
+              }).catch(() => {});
+              await openExtensionPopup(`#/requests/psbts/approve?requestId=${requestId}`);
             },
           });
         }


### PR DESCRIPTION
## Summary

- add a dedicated `xcp_signBitcoinPsbt` capability for exact, fully funded plain-Bitcoin provider payments without weakening the Counterparty-only `xcp_signPsbt` gate
- make attached-asset movement sighash-aware and detach-aware, including honest `SINGLE|ANYONECANPAY` delivery flexibility
- add the v1 `counterparty-marketplace` intent contract and independent semantic proof for `create_listing`
- show purpose-specific approval cards while retaining hard blocks for mismatches, unknown asset status, and unsafe transaction shapes
- add regtest address normalization and document both provider contracts

No origin is allowlisted or allowed to bypass transaction validation. Site-supplied intent is display context until every security-relevant term is independently matched to the PSBT, requested signatures, prevouts, and Counterparty UTXO balances.

## Verification

- `tsc --noEmit`
- `biome check src`
- `oxlint src` (17 pre-existing React hook warnings; no errors)
- `vitest run src`: 273 files passed, 3 skipped; 4,659 tests passed, 60 skipped
- `wxt build`: Chrome MV3 production build succeeded

## Deliberate follow-ups

This PR proves the foundational provider profiles and `create_listing`. The same versioned analyzer boundary should be extended in follow-up PRs for cart checkout, exact-offer authorization/acceptance (including cryptographic verification of the buyer signature), and parent/child CPFP bundles. Unsupported marketplace actions are rejected rather than receiving semantic trust.