### PR TITLE
Fail closed while fee rates are unavailable

### DIFF
--- a/e2e/inputs/amount-with-max-input.spec.ts
+++ b/e2e/inputs/amount-with-max-input.spec.ts
@@ -179,7 +179,9 @@ walletTest.describe('AmountWithMaxInput Component', () => {
 
       // Click Max - should show error (either "No available balance." if API succeeded
       // with empty array, or "Failed to fetch UTXOs." if network request failed,
-      // or generic "Failed to calculate maximum amount" if other error occurred)
+      // or generic "Failed to calculate maximum amount" if other error occurred,
+      // or "Fee rates are still loading" while no valid fee rate is available —
+      // the component fails closed instead of assuming a rate)
       await maxButton.click();
 
       // Wait for the error to appear
@@ -192,7 +194,8 @@ walletTest.describe('AmountWithMaxInput Component', () => {
       const hasExpectedError =
         errorText?.includes('No available balance') ||
         errorText?.includes('Failed to fetch UTXOs') ||
-        errorText?.includes('Failed to calculate maximum amount');
+        errorText?.includes('Failed to calculate maximum amount') ||
+        errorText?.includes('Fee rates are still loading');
       // Log the actual error for debugging if it fails
       if (!hasExpectedError) {
         console.log('Unexpected error text:', errorText);

--- a/e2e/inputs/fee-rate-input.spec.ts
+++ b/e2e/inputs/fee-rate-input.spec.ts
@@ -205,10 +205,11 @@ walletTest.describe('FeeRateInput Component', () => {
 
   walletTest.describe('Form Integration', () => {
     walletTest('fee rate is included in form submission', async ({ page }) => {
-      // Fee rate should have a hidden input or visible input with name
-      const hiddenInput = page.locator('input[name="sat_per_vbyte"]');
-      const hasInput = await hiddenInput.count();
-      expect(hasInput).toBeGreaterThan(0);
+      // Fail closed: the sat_per_vbyte input only exists once fee rates resolve
+      // (hidden input for presets, visible custom input if the fetch errored),
+      // so wait for it to attach rather than counting immediately.
+      const feeInput = page.locator('input[name="sat_per_vbyte"]');
+      await expect(feeInput.first()).toBeAttached({ timeout: 15000 });
     });
 
     walletTest('selected fee rate value is positive', async ({ page }) => {

--- a/src/components/composer/composer-form.tsx
+++ b/src/components/composer/composer-form.tsx
@@ -59,6 +59,8 @@ export function ComposerForm({
 
   // Determine if form is submitting
   const isSubmitting = isLocalSubmitting || state.isComposing;
+  const feeRateMissing = showFeeRate &&
+    (feeRate === null || !Number.isFinite(feeRate) || feeRate < 0.1);
   
   return (
     <div className={className}>
@@ -79,7 +81,7 @@ export function ComposerForm({
             e.preventDefault();
             e.stopPropagation();
 
-            if (isLocalSubmitting) return;
+            if (isLocalSubmitting || feeRateMissing) return;
 
             setIsLocalSubmitting(true);
             try {
@@ -107,7 +109,7 @@ export function ComposerForm({
             type="submit"
             color="blue"
             fullWidth
-            disabled={isSubmitting || submitDisabled}
+            disabled={isSubmitting || submitDisabled || feeRateMissing}
           >
             {isSubmitting ? "Submitting…" : submitText}
           </Button>

--- a/src/components/domain/balance/amount-with-max-input.test.tsx
+++ b/src/components/domain/balance/amount-with-max-input.test.tsx
@@ -300,7 +300,7 @@ describe('AmountWithMaxInput', () => {
     });
   });
 
-  it('should fallback to 0.1 feeRate when feeRate is null', async () => {
+  it('should not calculate a BTC maximum before the fee rate loads', async () => {
     const { selectUtxosForTransaction } = await import('@/core/counterparty/utxoSelection');
     (selectUtxosForTransaction as ReturnType<typeof vi.fn>).mockResolvedValue({
       utxos: [createMockUtxo('tx1', 0, 1000000)],
@@ -310,25 +310,22 @@ describe('AmountWithMaxInput', () => {
     });
 
     const onChange = vi.fn();
+    const setError = vi.fn();
     render(<AmountWithMaxInput
       {...defaultProps}
       asset="BTC"
       availableBalance="0.01000000"
       onChange={onChange}
+      setError={setError}
       feeRate={null}
     />);
 
     const maxButton = screen.getByLabelText('Use maximum available amount');
     fireEvent.click(maxButton);
 
-    await waitFor(() => {
-      expect(onChange).toHaveBeenCalled();
-      // vsize = 10.5 + (1 * 68) + (2 * 31) = 140.5 -> 141 (1 destination + 1 change = 2 outputs)
-      // + OP_RETURN overhead (30 vbytes) = 171 vbytes
-      // fee = 171 * 0.1 = 17.1 -> 18 sats (ceil)
-      // max = 1,000,000 - 18 = 999,982 sats = 0.00999982 BTC
-      expect(onChange).toHaveBeenCalledWith('0.00999982');
-    });
+    expect(onChange).not.toHaveBeenCalled();
+    expect(selectUtxosForTransaction).not.toHaveBeenCalled();
+    expect(setError).toHaveBeenCalledWith('Fee rates are still loading. Please wait.');
   });
 
   it('should show error when no spendable UTXOs available', async () => {

--- a/src/components/domain/balance/amount-with-max-input.tsx
+++ b/src/components/domain/balance/amount-with-max-input.tsx
@@ -59,7 +59,7 @@ export function AmountWithMaxInput({
   availableBalance,
   value,
   onChange,
-  feeRate = 0.1,
+  feeRate,
   setError,
   showHelpText = false,
   sourceAddress,
@@ -116,6 +116,11 @@ export function AmountWithMaxInput({
       return;
     }
 
+    if (feeRate === null || feeRate === undefined) {
+      setError("Fee rates are still loading. Please wait.");
+      return;
+    }
+
     setIsLoading(true);
     try {
       setError(null);
@@ -146,8 +151,7 @@ export function AmountWithMaxInput({
       const OP_RETURN_OVERHEAD = 30;
       const totalVbytes = estimatedVbytes + OP_RETURN_OVERHEAD;
 
-      const effectiveFeeRate = feeRate ?? 0.1;
-      const estimatedFee = toNumber(roundUp(multiply(totalVbytes, effectiveFeeRate)));
+      const estimatedFee = toNumber(roundUp(multiply(totalVbytes, feeRate)));
 
       const candidate = totalValue - estimatedFee;
 

--- a/src/components/ui/inputs/fee-rate-input.test.tsx
+++ b/src/components/ui/inputs/fee-rate-input.test.tsx
@@ -44,9 +44,23 @@ describe('FeeRateInput', () => {
         uniquePresetOptions: []
       });
 
-      render(<FeeRateInput />);
+      const { container } = render(<FeeRateInput />);
       
       expect(screen.getByText('Loading fee rates…')).toBeInTheDocument();
+      expect(container.querySelector('input[name="sat_per_vbyte"]')).not.toBeInTheDocument();
+    });
+
+    it('should not preserve an invalid initial fee while loading', () => {
+      mockUseFeeRates.mockReturnValue({
+        feeRates: null,
+        isLoading: true,
+        error: null,
+        uniquePresetOptions: []
+      });
+
+      const { container } = render(<FeeRateInput initialValue={0.01} />);
+
+      expect(container.querySelector('input[name="sat_per_vbyte"]')).not.toBeInTheDocument();
     });
   });
 
@@ -64,6 +78,7 @@ describe('FeeRateInput', () => {
       const input = screen.getByRole('textbox');
       expect(input).toBeInTheDocument();
       expect(input).toHaveAttribute('name', 'sat_per_vbyte');
+      expect(input).toHaveValue('');
     });
   });
 
@@ -375,7 +390,7 @@ describe('FeeRateInput', () => {
       expect(onFeeRateChange).toHaveBeenCalledWith(5);
     });
 
-    it('should not call onFeeRateChange for invalid input', async () => {
+    it('should clear the selected fee rate for empty input', async () => {
       const onFeeRateChange = vi.fn();
 
       render(<FeeRateInput onFeeRateChange={onFeeRateChange} initialValue={15} />);
@@ -386,8 +401,22 @@ describe('FeeRateInput', () => {
       // User types empty string
       fireEvent.change(input, { target: { value: '' } });
 
-      // Callback should NOT be called for empty input
-      expect(onFeeRateChange).not.toHaveBeenCalled();
+      // An empty custom value must make the parent fail closed.
+      expect(onFeeRateChange).toHaveBeenCalledWith(null);
+    });
+
+    it('should not replace an invalid custom fee with 0.1 on blur', () => {
+      const onFeeRateChange = vi.fn();
+      render(<FeeRateInput onFeeRateChange={onFeeRateChange} initialValue={15} />);
+
+      const input = screen.getByRole('textbox');
+      onFeeRateChange.mockClear();
+      fireEvent.change(input, { target: { value: '0.01' } });
+      fireEvent.blur(input);
+
+      expect(input).toHaveValue('0.01');
+      expect(onFeeRateChange).toHaveBeenLastCalledWith(null);
+      expect(screen.getByRole('alert')).toBeInTheDocument();
     });
   });
 });

--- a/src/components/ui/inputs/fee-rate-input.tsx
+++ b/src/components/ui/inputs/fee-rate-input.tsx
@@ -18,11 +18,19 @@ import { type FeeRateOption, useFeeRates } from "@/hooks/useFeeRates";
 interface FeeRateInputProps {
   showHelpText?: boolean;
   disabled?: boolean;
-  onFeeRateChange?: (satPerVbyte: number) => void;
+  onFeeRateChange?: (satPerVbyte: number | null) => void;
   initialValue?: number | null;
 }
 
 type LocalFeeRateOption = FeeRateOption | "custom";
+
+function getValidInitialFeeRate(value: number | null | undefined): number | null {
+  if (value === null || value === undefined) return null;
+  const validation = validateFeeRate(value, { minRate: 0.1, maxRate: 5000, warnHighFee: false });
+  return validation.isValid && validation.satsPerVByte !== undefined
+    ? validation.satsPerVByte
+    : null;
+}
 
 /**
  * FeeRateInput provides fee rate selection with presets and custom input option.
@@ -37,8 +45,11 @@ export function FeeRateInput({
   initialValue,
 }: FeeRateInputProps): ReactElement {
   const { feeRates, isLoading, error: fetchError, uniquePresetOptions } = useFeeRates(true);
+  const validInitialValue = getValidInitialFeeRate(initialValue);
   const [selectedOption, setSelectedOption] = useState<LocalFeeRateOption>("fast");
-  const [customInput, setCustomInput] = useState<string>("0.1");
+  const [customInput, setCustomInput] = useState<string>(() =>
+    validInitialValue !== null ? validInitialValue.toString() : ""
+  );
   const [internalError, setInternalError] = useState<string | null>(null);
   const isInitial = useRef(true);
   const hasRunPresetEffect = useRef(false);
@@ -51,27 +62,28 @@ export function FeeRateInput({
   const disabledProps = disabled === true ? { disabled: true } : {};
 
   // Calculate the current fee rate value based on selection
-  const currentFeeRate = selectedOption === "custom" 
-    ? parseFloat(customInput) || 0.1 
-    : feeRates && uniquePresetOptions.find(opt => opt.id === selectedOption)?.value || 0.1;
+  const parsedCustomInput = Number.parseFloat(customInput);
+  const currentFeeRate = selectedOption === "custom"
+    ? (Number.isFinite(parsedCustomInput) ? parsedCustomInput : null)
+    : uniquePresetOptions.find((opt) => opt.id === selectedOption)?.value ?? null;
 
   useEffect(() => {
     if (feeRates && isInitial.current) {
       isInitial.current = false;
 
       // Check if user explicitly set a fee rate (null = use network default)
-      if (initialValue !== undefined && initialValue !== null) {
+      if (validInitialValue !== null) {
         // Check if it matches a preset
-        const matchingPreset = uniquePresetOptions.find(opt => opt.value === initialValue);
+        const matchingPreset = uniquePresetOptions.find(opt => opt.value === validInitialValue);
         if (matchingPreset) {
           setSelectedOption(matchingPreset.id);
-          setCustomInput(initialValue.toString());
+          setCustomInput(validInitialValue.toString());
         } else {
           // Use custom mode for non-preset values
           setSelectedOption("custom");
-          setCustomInput(initialValue.toString());
+          setCustomInput(validInitialValue.toString());
         }
-        onFeeRateChangeRef.current?.(initialValue);
+        onFeeRateChangeRef.current?.(validInitialValue);
       } else {
         // Default to fast preset (fresh load or default value)
         const defaultValue = toNumber(maximum(feeRates.fastestFee, 0.1));
@@ -80,7 +92,7 @@ export function FeeRateInput({
         onFeeRateChangeRef.current?.(defaultValue);
       }
     }
-  }, [feeRates, initialValue, uniquePresetOptions]);
+  }, [feeRates, validInitialValue, uniquePresetOptions]);
 
   useEffect(() => {
     // Skip the first run - initialization is handled by the initialization effect above.
@@ -100,8 +112,8 @@ export function FeeRateInput({
   }, [selectedOption, feeRates, uniquePresetOptions]);
 
   const feeOptions: { id: LocalFeeRateOption; name: string; value: number; }[] = feeRates
-    ? [...uniquePresetOptions, { id: "custom", name: "Custom", value: parseFloat(customInput) || 0.1 }]
-    : [{ id: "custom", name: "Custom", value: parseFloat(customInput) || 0.1 }];
+    ? [...uniquePresetOptions, { id: "custom", name: "Custom", value: currentFeeRate ?? 0 }]
+    : [{ id: "custom", name: "Custom", value: currentFeeRate ?? 0 }];
 
   const handleCustomInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const trimmed = e.target.value.trim();
@@ -110,6 +122,7 @@ export function FeeRateInput({
     // Allow empty input temporarily while typing
     if (trimmed === "") {
       setCustomInput("");
+      onFeeRateChangeRef.current?.(null);
       return;
     }
     
@@ -130,10 +143,16 @@ export function FeeRateInput({
       const formattedValue = formatAmount({
         value: num,
         maximumFractionDigits: 2,
-        minimumFractionDigits: 0
+        minimumFractionDigits: 0,
+        useGrouping: false,
       });
       setCustomInput(formattedValue);
-      onFeeRateChangeRef.current?.(toNumber(formattedValue));
+      const validation = validateFeeRate(formattedValue, { minRate: 0.1, warnHighFee: false });
+      onFeeRateChangeRef.current?.(
+        validation.isValid && validation.satsPerVByte !== undefined
+          ? validation.satsPerVByte
+          : null
+      );
       return;
     }
     
@@ -142,8 +161,10 @@ export function FeeRateInput({
     
     // Use validation utility to check if value is valid before notifying parent
     const validation = validateFeeRate(num, { minRate: 0.1, warnHighFee: false });
-    if (validation.isValid && validation.satsPerVByte) {
+    if (validation.isValid && validation.satsPerVByte !== undefined) {
       onFeeRateChangeRef.current?.(validation.satsPerVByte);
+    } else {
+      onFeeRateChangeRef.current?.(null);
     }
   };
 
@@ -152,9 +173,8 @@ export function FeeRateInput({
     
     // Handle empty input
     if (trimmed === "") {
-      setCustomInput("0.1");
       setInternalError("Fee rate is required");
-      onFeeRateChangeRef.current?.(0.1);
+      onFeeRateChangeRef.current?.(null);
       return;
     }
     
@@ -164,21 +184,26 @@ export function FeeRateInput({
     if (!validation.isValid) {
       // Use the error message from validation or default
       setInternalError(validation.error || "Invalid fee rate");
-      setCustomInput("0.1");
-      onFeeRateChangeRef.current?.(0.1);
+      onFeeRateChangeRef.current?.(null);
       return;
     }
     
-    const num = validation.satsPerVByte || 0.1;
+    const num = validation.satsPerVByte;
+    if (num === undefined) {
+      setInternalError("Invalid fee rate");
+      onFeeRateChangeRef.current?.(null);
+      return;
+    }
     
     // Format the final value and notify parent
     const formattedValue = formatAmount({
       value: num,
       maximumFractionDigits: 2,
-      minimumFractionDigits: 0
+      minimumFractionDigits: 0,
+      useGrouping: false,
     });
     setCustomInput(formattedValue);
-    onFeeRateChange?.(toNumber(formattedValue));
+    onFeeRateChangeRef.current?.(toNumber(formattedValue));
   };
 
   const handleOptionSelect = (option: { id: LocalFeeRateOption; name: string; value: number } | null) => {
@@ -211,8 +236,9 @@ export function FeeRateInput({
         <div className="mt-1">
           <p>Loading fee rates…</p>
         </div>
-        {/* Always include the hidden input even when loading */}
-        <input type="hidden" name="sat_per_vbyte" value="0.1" />
+        {validInitialValue !== null && (
+          <input type="hidden" name="sat_per_vbyte" value={validInitialValue.toString()} />
+        )}
       </Field>
     );
   }
@@ -286,7 +312,9 @@ export function FeeRateInput({
         ) : (
           <>
             {/* Hidden input that will be included in form submission when using dropdown */}
-            <input type="hidden" name="sat_per_vbyte" value={currentFeeRate.toString()} />
+            {currentFeeRate !== null && (
+              <input type="hidden" name="sat_per_vbyte" value={currentFeeRate.toString()} />
+            )}
             
             {feeRates && feeOptions.length > 0 && (
               <div className="relative">

--- a/src/contexts/composer-context-object.ts
+++ b/src/contexts/composer-context-object.ts
@@ -25,7 +25,7 @@ export interface ComposerState<T> {
   isComposing: boolean;
   isSigning: boolean;
   composedAt: number | null;
-  /** sat/vB; null means use the network default. */
+  /** sat/vB; null means a valid fee rate has not been selected yet. */
   feeRate: number | null;
 }
 
@@ -42,7 +42,7 @@ export interface ComposerContextType<T> {
   showHelpText: boolean;
   toggleHelpText: () => void;
   feeRate: number | null;
-  setFeeRate: (rate: number) => void;
+  setFeeRate: (rate: number | null) => void;
 
   activeAddress: ReturnType<typeof useWallet>["activeAddress"];
   activeWallet: ReturnType<typeof useWallet>["activeWallet"];

--- a/src/contexts/composer-context.tsx
+++ b/src/contexts/composer-context.tsx
@@ -193,7 +193,7 @@ export function ComposerProvider<T>({
     setLocalShowHelpText(prev => prev === null ? !settings?.showHelpText : !prev);
   }, [settings?.showHelpText]);
 
-  const setFeeRate = useCallback((rate: number) => {
+  const setFeeRate = useCallback((rate: number | null) => {
     setState(prev => ({ ...prev, feeRate: rate }));
   }, []);
   

--- a/src/pages/actions/consolidate/form.tsx
+++ b/src/pages/actions/consolidate/form.tsx
@@ -20,7 +20,7 @@ export interface ConsolidationFormData {
 }
 
 const DEFAULT_FORM_DATA: ConsolidationFormData = {
-  feeRateSatPerVByte: 1,
+  feeRateSatPerVByte: 0,
   destinationAddress: "",
   consolidationData: null,
   allBatches: [],
@@ -114,8 +114,8 @@ export function ConsolidationForm({ onSubmit, showHelpText }: ConsolidationFormP
     fetchData();
   }, [activeAddress, formData.includeProtectedStamps, isInitialLoad]);
 
-  const handleFeeRateChange = (value: number) => {
-    setFormData((prev) => ({ ...prev, feeRateSatPerVByte: value }));
+  const handleFeeRateChange = (value: number | null) => {
+    setFormData((prev) => ({ ...prev, feeRateSatPerVByte: value ?? 0 }));
   };
 
   const handleDestinationChange = (value: string) => {
@@ -136,6 +136,10 @@ export function ConsolidationForm({ onSubmit, showHelpText }: ConsolidationFormP
 
   const handleSubmitInternal = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    if (formData.feeRateSatPerVByte <= 0) {
+      setError("Enter a valid fee rate before continuing.");
+      return;
+    }
     if (
       !formData.consolidationData ||
       formData.consolidationData.stamp_protection.included !==

--- a/src/pages/compose/dispenser/dispense/form.tsx
+++ b/src/pages/compose/dispenser/dispense/form.tsx
@@ -188,12 +188,12 @@ export function DispenseForm({
   const maxDispenses = (() => {
     if (!selectedDispenser || !activeAddress?.address || spendableBtc.isLoading) return 0;
     if (spendableBtc.utxoCount === 0) return 0;
+    if (feeRate === null) return 0;
 
     // Calculate fee based on actual UTXO count and address type
-    const effectiveFeeRate = feeRate ?? 0.1;
     // Dispense transaction has 1 output to dispenser
     const estimatedVbytes = estimateVsize(spendableBtc.utxoCount, 1, activeAddress.address);
-    const estimatedFee = toNumber(roundUp(multiply(estimatedVbytes, effectiveFeeRate)));
+    const estimatedFee = toNumber(roundUp(multiply(estimatedVbytes, feeRate)));
 
     const affordableDispenses = calculateMaximumDispenses(
       selectedDispenser.satoshirate,
@@ -286,6 +286,11 @@ export function DispenseForm({
       return;
     }
 
+    if (feeRate === null) {
+      setValidationError("Fee rates are still loading. Please wait.");
+      return;
+    }
+
     if (maxDispenses === 0) {
       const remainingDispenses = calculateRemainingDispenses(
         selectedDispenser.dispenser
@@ -301,9 +306,8 @@ export function DispenseForm({
         setValidationError(message);
       } else {
         // Calculate fee for error message
-        const effectiveFeeRate = feeRate ?? 0.1;
         const estimatedVbytes = estimateVsize(spendableBtc.utxoCount || 1, 1, activeAddress?.address || "");
-        const estimatedFee = toNumber(roundUp(multiply(estimatedVbytes, effectiveFeeRate)));
+        const estimatedFee = toNumber(roundUp(multiply(estimatedVbytes, feeRate)));
         const requiredSatoshis = selectedDispenser.satoshirate + estimatedFee;
         const requiredBTC = requiredSatoshis / SATOSHIS_PER_BTC;
         setValidationError(`Insufficient BTC balance. You need at least ${formatAmount({

--- a/src/pages/compose/swap/form.tsx
+++ b/src/pages/compose/swap/form.tsx
@@ -270,7 +270,9 @@ export function SwapForm({
         )
       }
       submitText="Review Swap"
-      submitDisabled={pending || submitDisabled}
+      submitDisabled={
+        pending || submitDisabled || feeRate === null || !Number.isFinite(feeRate) || feeRate < 0.1
+      }
       showFeeRate={false}
       containerClassName=""
     >


### PR DESCRIPTION
## Summary

- Remove the silent 0.1 sat/vB fallback while fee quotes are loading or unavailable.
- Default to the live Fast preset when fee APIs succeed; show an empty custom field when they fail.
- Block shared composer, swap, consolidation, dispenser, and BTC Max flows until a valid fee rate exists.
- Preserve valid fee selections when returning to a form.

## Verification

- TypeScript compile
- Biome and oxlint on changed files
- 104 focused Vitest tests
- Chrome MV3 production build