### PR TITLE
Keep popup footer inside the extension viewport

### DIFF
--- a/e2e/pages/index.spec.ts
+++ b/e2e/pages/index.spec.ts
@@ -10,8 +10,8 @@
  * - History
  */
 
-import { walletTest, expect, navigateTo } from '../fixtures';
-import { index, viewAddress, header } from '../selectors';
+import { expect, navigateTo, walletTest } from '../fixtures';
+import { header, index, viewAddress } from '../selectors';
 
 walletTest.describe('Index Page', () => {
   walletTest.describe('Navigation', () => {
@@ -71,6 +71,28 @@ walletTest.describe('Index Page', () => {
         await navigateTo(page, 'wallet');
         await expect(page).toHaveURL(/index/);
       }
+    });
+
+    walletTest('keeps the app shell and footer inside the popup viewport', async ({ page }) => {
+      const metrics = await page.evaluate(() => {
+        const root = document.querySelector<HTMLElement>('#root');
+        const footer = document.querySelector<HTMLElement>('footer[aria-label="Primary"]');
+
+        if (!root || !footer) throw new Error('Popup shell did not render');
+
+        return {
+          viewportHeight: window.innerHeight,
+          rootClientHeight: root.clientHeight,
+          rootScrollHeight: root.scrollHeight,
+          rootOverflow: getComputedStyle(root).overflow,
+          footerBottom: footer.getBoundingClientRect().bottom,
+        };
+      });
+
+      expect(metrics.rootOverflow).toBe('hidden');
+      expect(metrics.rootClientHeight).toBe(metrics.viewportHeight);
+      expect(metrics.rootScrollHeight).toBe(metrics.rootClientHeight);
+      expect(Math.abs(metrics.footerBottom - metrics.viewportHeight)).toBeLessThanOrEqual(1);
     });
 
     walletTest('wallet selector in header is visible and clickable', async ({ page }) => {

--- a/src/components/layout/api-status-banner.tsx
+++ b/src/components/layout/api-status-banner.tsx
@@ -23,7 +23,7 @@ export function ApiStatusBanner(): ReactElement | null {
 
   return (
     <div
-      className={`${bgColor} ${textColor} px-4 py-1.5 text-xs font-medium flex items-center justify-between`}
+      className={`${bgColor} ${textColor} flex shrink-0 items-center justify-between px-4 py-1.5 text-xs font-medium`}
       role="alert"
     >
       <span>{displayMessage}</span>

--- a/src/components/layout/footer.test.tsx
+++ b/src/components/layout/footer.test.tsx
@@ -191,9 +191,12 @@ describe('Footer', () => {
     
     const footerContainer = container.firstChild as HTMLElement;
     expect(footerContainer).toHaveClass('p-2');
+    expect(footerContainer).toHaveClass('shrink-0');
     expect(footerContainer).toHaveClass('bg-white');
     expect(footerContainer).toHaveClass('border-t');
     expect(footerContainer).toHaveClass('border-gray-300');
+    expect(footerContainer.tagName).toBe('FOOTER');
+    expect(footerContainer).toHaveAttribute('aria-label', 'Primary');
   });
 
   it('should use grid layout for buttons', () => {

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -31,7 +31,7 @@ export const Footer = (): ReactElement => {
   };
 
   return (
-    <div className="p-2 bg-white border-t border-gray-300">
+    <footer className="shrink-0 border-t border-gray-300 bg-white p-2" aria-label="Primary">
       <div className="grid grid-cols-4 gap-2">
         <Button
           variant="transparent"
@@ -82,6 +82,6 @@ export const Footer = (): ReactElement => {
           </div>
         </Button>
       </div>
-    </div>
+    </footer>
   );
 };

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -52,7 +52,7 @@ export function Header({
   }, []);
 
   return (
-    <header className="grid grid-cols-4 items-center p-4 h-16 bg-white shadow-md">
+    <header className="grid h-16 shrink-0 grid-cols-4 items-center bg-white p-4 shadow-md">
       {/* Left Section */}
       <div className="col-span-1 flex justify-start">
         {onBack ? (

--- a/src/components/layout/layout.test.tsx
+++ b/src/components/layout/layout.test.tsx
@@ -93,7 +93,9 @@ describe('Layout', () => {
     const layoutDiv = container.firstChild as HTMLElement;
     expect(layoutDiv).toHaveClass('flex');
     expect(layoutDiv).toHaveClass('flex-col');
-    expect(layoutDiv).toHaveClass('h-dvh');
+    expect(layoutDiv).toHaveClass('h-full');
+    expect(layoutDiv).toHaveClass('min-h-0');
+    expect(layoutDiv).toHaveClass('overflow-hidden');
     expect(layoutDiv).toHaveClass('bg-gray-100');
   });
 
@@ -101,6 +103,7 @@ describe('Layout', () => {
     render(<Layout />);
     
     const main = screen.getByRole('main');
+    expect(main).toHaveClass('min-h-0');
     expect(main).toHaveClass('flex-1');
     expect(main).toHaveClass('overflow-y-auto');
     expect(main).toHaveClass('no-scrollbar');
@@ -186,10 +189,11 @@ describe('Layout', () => {
     expect(screen.queryByTestId('footer')).not.toBeInTheDocument();
   });
 
-  it('should take full screen height', () => {
+  it('should take the height of its extension container', () => {
     const { container } = render(<Layout />);
     
     const layoutDiv = container.firstChild as HTMLElement;
-    expect(layoutDiv).toHaveClass('h-dvh');
+    expect(layoutDiv).toHaveClass('h-full');
+    expect(layoutDiv).not.toHaveClass('h-dvh');
   });
 });

--- a/src/components/layout/layout.tsx
+++ b/src/components/layout/layout.tsx
@@ -19,10 +19,10 @@ export function Layout({ showFooter = false }: LayoutProps): ReactElement {
   const { headerProps } = useHeader();
 
   return (
-    <div className="flex flex-col h-dvh bg-gray-100">
+    <div className="flex h-full min-h-0 flex-col overflow-hidden bg-gray-100">
       <Header {...headerProps} />
       <ApiStatusBanner />
-      <main className="flex-1 overflow-y-auto no-scrollbar relative">
+      <main className="relative min-h-0 flex-1 overflow-y-auto no-scrollbar">
         <Outlet />
       </main>
       {showFooter && <Footer />}

--- a/src/entrypoints/popup/index.html
+++ b/src/entrypoints/popup/index.html
@@ -7,10 +7,8 @@
     <meta name="manifest.type" content="browser_action" />
     <style>
       html, body {
-        min-width: 350px;
-        min-height: 600px;
-        width: 100%;
-        height: 100%;
+        width: 350px;
+        height: 600px;
         margin: 0;
         padding: 0;
         overflow: hidden;
@@ -18,7 +16,7 @@
       #root {
         height: 100%;
         width: 100%;
-        overflow-y: auto;
+        overflow: hidden;
       }
     </style>
   </head>


### PR DESCRIPTION
## Summary
- give the action popup an explicit 350 x 600 canvas and prevent the root from becoming a second scroll owner
- size the shell from its extension container and allow the main flex item to shrink
- keep the header, status banner, and footer at their natural heights
- add a Chromium regression test for root overflow and footer placement

## Why
A Chrome popup report showed the entire shell scrolling, which moved the footer upward and exposed a large blank area. Dynamic viewport units are supported in current desktop browsers; the fragile part was mixing a viewport-height shell with percentage-height roots and nested scroll containers.

## Testing
- 59 focused Vitest assertions
- TypeScript compile
- production WXT build
- focused Playwright popup-geometry test
- Biome and oxlint