### PR TITLE
Fail closed when provider balance APIs are unavailable

### DIFF
--- a/PROVIDER.md
+++ b/PROVIDER.md
@@ -404,11 +404,17 @@ const result = await xcpwallet.request({
 
 #### `xcp_getBalances`
 
-Get BTC and token balances for the connected address.
+Get the BTC and address-level XCP balances for the connected address. This is
+not a portfolio endpoint: applications should query the Counterparty API for a
+specific asset when they need another token's balance.
 
 ```js
 const result = await xcpwallet.request({ method: 'xcp_getBalances' });
-// { address: 'bc1q...', btc: { ... }, xcp: { ... }, tokens: [...] }
+// {
+//   address: 'bc1q...',
+//   btc: { confirmed: 12345, unconfirmed: 0, total: 12345 },
+//   xcp: '10.5'
+// }
 ```
 
 #### `xcp_getAddresses`

--- a/src/services/__tests__/providerService.security.test.ts
+++ b/src/services/__tests__/providerService.security.test.ts
@@ -245,7 +245,18 @@ describe('ProviderService Security Tests', () => {
       
       // Mock the API responses
       const apiModule = await import('@/core/counterparty/api');
-      vi.spyOn(apiModule, 'fetchTokenBalances').mockResolvedValue([]);
+      vi.spyOn(apiModule, 'fetchTokenBalance').mockResolvedValue({
+        asset: 'XCP',
+        quantity: '0' as any,
+        quantity_normalized: '0' as any,
+        asset_info: {
+          asset_longname: null,
+          description: '',
+          issuer: '',
+          divisible: true,
+          locked: false
+        }
+      });
       
       const balanceModule = await import('@/core/bitcoin/balance');
       vi.spyOn(balanceModule, 'fetchBTCBalance').mockResolvedValue(0);
@@ -279,6 +290,55 @@ describe('ProviderService Security Tests', () => {
 
       const balanceModule = await import('@/core/bitcoin/balance');
       vi.spyOn(balanceModule, 'fetchBTCBalance').mockRejectedValue(new Error('upstream unavailable'));
+
+      await expect(
+        providerService.handleRequest(origin, 'xcp_getBalances', [])
+      ).rejects.toThrow('Unable to fetch wallet balances');
+    });
+
+    it('should fetch XCP directly instead of paging every asset balance', async () => {
+      const origin = 'https://connected.com';
+      vi.mocked(walletManager.getSettings).mockReturnValue({
+        ...DEFAULT_SETTINGS,
+        connectedWebsites: [origin]
+      });
+
+      const balanceModule = await import('@/core/bitcoin/balance');
+      vi.spyOn(balanceModule, 'fetchBTCBalance').mockResolvedValue(1250);
+      const apiModule = await import('@/core/counterparty/api');
+      const fetchXcp = vi.spyOn(apiModule, 'fetchTokenBalance').mockResolvedValue({
+        asset: 'XCP',
+        quantity: '1050000000' as any,
+        quantity_normalized: '10.5' as any,
+        asset_info: {
+          asset_longname: null,
+          description: '',
+          issuer: '',
+          divisible: true,
+          locked: false
+        }
+      });
+
+      await expect(
+        providerService.handleRequest(origin, 'xcp_getBalances', [])
+      ).resolves.toMatchObject({ address: expect.any(String), xcp: '10.5' });
+      expect(fetchXcp).toHaveBeenCalledWith(expect.any(String), 'XCP', {
+        verbose: true,
+        type: 'address'
+      });
+    });
+
+    it('should fail closed when the XCP balance API is unavailable', async () => {
+      const origin = 'https://connected.com';
+      vi.mocked(walletManager.getSettings).mockReturnValue({
+        ...DEFAULT_SETTINGS,
+        connectedWebsites: [origin]
+      });
+
+      const balanceModule = await import('@/core/bitcoin/balance');
+      vi.spyOn(balanceModule, 'fetchBTCBalance').mockResolvedValue(1250);
+      const apiModule = await import('@/core/counterparty/api');
+      vi.spyOn(apiModule, 'fetchTokenBalance').mockRejectedValue(new Error('upstream unavailable'));
 
       await expect(
         providerService.handleRequest(origin, 'xcp_getBalances', [])

--- a/src/services/__tests__/providerService.security.test.ts
+++ b/src/services/__tests__/providerService.security.test.ts
@@ -245,16 +245,10 @@ describe('ProviderService Security Tests', () => {
       
       // Mock the API responses
       const apiModule = await import('@/core/counterparty/api');
-      vi.spyOn(apiModule, 'fetchTokenBalances').mockResolvedValue({ 
-        result: [],
-        result_count: 0
-      } as any);
+      vi.spyOn(apiModule, 'fetchTokenBalances').mockResolvedValue([]);
       
       const balanceModule = await import('@/core/bitcoin/balance');
-      vi.spyOn(balanceModule, 'fetchBTCBalance').mockResolvedValue({ 
-        confirmed: 0, 
-        unconfirmed: 0 
-      } as any);
+      vi.spyOn(balanceModule, 'fetchBTCBalance').mockResolvedValue(0);
       
       // Setup API rate limiter to allow 10 requests then reject
       let callCount = 0;
@@ -274,6 +268,21 @@ describe('ProviderService Security Tests', () => {
       await expect(
         providerService.handleRequest(origin, 'xcp_getBalances', [])
       ).rejects.toThrow(/API rate limit exceeded/);
+    });
+
+    it('should surface balance API failures instead of returning zero balances', async () => {
+      const origin = 'https://connected.com';
+      vi.mocked(walletManager.getSettings).mockReturnValue({
+        ...DEFAULT_SETTINGS,
+        connectedWebsites: [origin]
+      });
+
+      const balanceModule = await import('@/core/bitcoin/balance');
+      vi.spyOn(balanceModule, 'fetchBTCBalance').mockRejectedValue(new Error('upstream unavailable'));
+
+      await expect(
+        providerService.handleRequest(origin, 'xcp_getBalances', [])
+      ).rejects.toThrow('Unable to fetch wallet balances');
     });
     
     it('should have separate rate limits per origin', async () => {

--- a/src/services/providerService.ts
+++ b/src/services/providerService.ts
@@ -12,7 +12,7 @@ import { fetchBTCBalance } from '@/core/bitcoin/balance';
 import { signMessage as signMessageDirect } from '@/core/bitcoin/messageSigner';
 import { parseBitcoinPaymentIntent } from '@/core/bitcoin/providerPayment';
 import { extractPsbtDetails, tapLeafOwnerAddress, validateSignInputs } from '@/core/bitcoin/psbt';
-import { fetchTokenBalances } from '@/core/counterparty/api';
+import { fetchTokenBalance } from '@/core/counterparty/api';
 import { parseMarketplaceBatchIntents } from '@/core/counterparty/marketplaceBatch';
 import { parseAcceptanceCpfpBundleIntents } from '@/core/counterparty/marketplaceBundle';
 import {
@@ -1072,15 +1072,15 @@ export function createProviderService(): ProviderService {
             // Fetch BTC balance
             const btcBalance = await fetchBTCBalance(activeAddress.address);
 
-            // Fetch token balances
-            const tokenBalances = await fetchTokenBalances(activeAddress.address, {
+            // Ask for XCP directly. Enumerating an address's balances is both
+            // wasteful for collectors and wrong once XCP falls outside the
+            // first page of assets.
+            const xcpBalance = await fetchTokenBalance(activeAddress.address, 'XCP', {
               verbose: true,
               // UTXO-attached XCP is not spendable as the address's ordinary
               // balance and must not make a dApp think it can fund an action.
               type: 'address'
             });
-
-            const xcpBalance = tokenBalances?.find((b: any) => b.asset === 'XCP');
 
             return {
               address: activeAddress.address,
@@ -1089,7 +1089,7 @@ export function createProviderService(): ProviderService {
                 unconfirmed: 0,
                 total: btcBalance || 0
               },
-              xcp: xcpBalance?.quantity_normalized || 0
+              xcp: xcpBalance.quantity_normalized ?? '0'
             };
           } catch (error) {
             console.error('[ProviderService] Error fetching balances:', error);

--- a/src/services/providerService.ts
+++ b/src/services/providerService.ts
@@ -1074,7 +1074,10 @@ export function createProviderService(): ProviderService {
 
             // Fetch token balances
             const tokenBalances = await fetchTokenBalances(activeAddress.address, {
-              verbose: true
+              verbose: true,
+              // UTXO-attached XCP is not spendable as the address's ordinary
+              // balance and must not make a dApp think it can fund an action.
+              type: 'address'
             });
 
             const xcpBalance = tokenBalances?.find((b: any) => b.asset === 'XCP');
@@ -1090,12 +1093,10 @@ export function createProviderService(): ProviderService {
             };
           } catch (error) {
             console.error('[ProviderService] Error fetching balances:', error);
-            // Return zeros if API fails
-            return {
-              address: activeAddress.address,
-              btc: { confirmed: 0, unconfirmed: 0, total: 0 },
-              xcp: 0
-            };
+            // An unavailable API is not evidence that the wallet is empty.
+            // Returning zeros made connected dApps reject valid transactions
+            // as "insufficient balance" until a refresh happened to succeed.
+            throw new Error('Unable to fetch wallet balances — please try again');
           }
         }
         


### PR DESCRIPTION
## Summary
- return a provider error when BTC or Counterparty balance reads fail instead of fabricating zero balances
- request address-level XCP balances so UTXO-attached balances are not presented as spendable
- correct the provider rate-limit fixture and add a regression test for upstream balance failures

## Verification
- TypeScript compile
- Biome on changed files
- focused provider suites: 73 tests passed