### PR TITLE
Charge a fairmint at what core bills for it

### DIFF
--- a/src/core/counterparty/__tests__/protocolContext.test.ts
+++ b/src/core/counterparty/__tests__/protocolContext.test.ts
@@ -19,8 +19,11 @@ vi.mock('@/core/bitcoin/blockHeight', () => ({
 import { fetchAssetDetails, fetchAssetFairminter, fetchAssetHolderCount } from '@/core/counterparty/api';
 import { resolveProtocolContext } from '../protocolContext';
 
-/** A fairmint of `asset`, the shape the approval screen resolves context from. */
-const fairmintOf = (asset: string) => ({ messageType: 'fairmint', data: { asset } });
+/** A fairmint of `quantity` base units of `asset`, the shape the approval screen resolves context from. */
+const fairmintOf = (asset: string, quantity: number = 1) => ({
+  messageType: 'fairmint',
+  data: { asset, quantity },
+});
 
 describe('resolveProtocolContext', () => {
   beforeEach(() => {
@@ -28,33 +31,53 @@ describe('resolveProtocolContext', () => {
   });
 
   describe('XCP figures', () => {
-    it('trims a fairminter price to its significant digits', async () => {
-      // What core actually sends: the normalized figure at full working precision.
+    it('charges the whole mint, not one unit of it', async () => {
+      // 10 XCP buys a lot of 1,000,000 (divisible) units. price_normalized is per unit — 0.00001 —
+      // and that is what a 10 XCP mint was being shown as costing.
       vi.mocked(fetchAssetFairminter).mockResolvedValue({
+        price: 1000000000,
         price_normalized: '0.00001000000000000',
+        quantity_by_price: 100000000000000,
+        quantity_by_price_normalized: '1000000.00000000',
+        pool_quantity: 500000000000,
+      } as any);
+
+      const { context } = await resolveProtocolContext(fairmintOf('FAFOMFERS', 100000000000000));
+      expect(context.protocolFeeXcp).toBe('10');
+      expect(context.fairmintPaymentModel).toBe('pool');
+    });
+
+    it('charges by the lot for several lots', async () => {
+      vi.mocked(fetchAssetFairminter).mockResolvedValue({
+        price: 150000000,
+        quantity_by_price: 1000,
+        burn_payment: true,
+      } as any);
+
+      const { context } = await resolveProtocolContext(fairmintOf('MYASSET', 3000));
+      expect(context.protocolFeeXcp).toBe('4.5');
+      expect(context.fairmintPaymentModel).toBe('burned');
+    });
+
+    it('trims a fairminter price to its significant digits', async () => {
+      vi.mocked(fetchAssetFairminter).mockResolvedValue({
+        price: 1000,
+        quantity_by_price: 1,
       } as any);
 
       const { context } = await resolveProtocolContext(fairmintOf('MYASSET'));
       expect(context.protocolFeeXcp).toBe('0.00001');
+      expect(context.fairmintPaymentModel).toBe('paid');
     });
 
     it('keeps every one of the eight places XCP is divisible to', async () => {
       vi.mocked(fetchAssetFairminter).mockResolvedValue({
-        price_normalized: '1.23456789000000000',
+        price: 123456789,
+        quantity_by_price: 1,
       } as any);
 
       const { context } = await resolveProtocolContext(fairmintOf('MYASSET'));
       expect(context.protocolFeeXcp).toBe('1.23456789');
-    });
-
-    it('states a price too small to show as a bound rather than as zero', async () => {
-      vi.mocked(fetchAssetFairminter).mockResolvedValue({
-        price_normalized: '0.000000001',
-      } as any);
-
-      const { context } = await resolveProtocolContext(fairmintOf('MYASSET'));
-      // "0 XCP" on a price row would read as a free mint.
-      expect(context.protocolFeeXcp).toBe('<0.00000001');
     });
 
     it('trims the protocol fee carried by the message itself', async () => {
@@ -67,8 +90,16 @@ describe('resolveProtocolContext', () => {
       expect(context.protocolFeeXcp).toBe('0.5');
     });
 
-    it('leaves a fairminter with no price unpriced', async () => {
-      vi.mocked(fetchAssetFairminter).mockResolvedValue({ price_normalized: null } as any);
+    it('leaves a free fairminter unpriced and unrouted', async () => {
+      vi.mocked(fetchAssetFairminter).mockResolvedValue({ price: 0, quantity_by_price: 1 } as any);
+
+      const { context } = await resolveProtocolContext(fairmintOf('MYASSET'));
+      expect(context.protocolFeeXcp).toBeUndefined();
+      expect(context.fairmintPaymentModel).toBeUndefined();
+    });
+
+    it('leaves a fairminter whose lot size is unknown unpriced', async () => {
+      vi.mocked(fetchAssetFairminter).mockResolvedValue({ price: 1000 } as any);
 
       const { context } = await resolveProtocolContext(fairmintOf('MYASSET'));
       expect(context.protocolFeeXcp).toBeUndefined();

--- a/src/core/counterparty/protocolContext.ts
+++ b/src/core/counterparty/protocolContext.ts
@@ -29,12 +29,12 @@ import {
 import type { ProtocolContext } from '@/core/counterparty/describe';
 import { describePayout, resolveDispensersAt } from '@/core/counterparty/dispenseOutcome';
 import { DIVIDEND_FEE_XCP_PER_HOLDER } from '@/core/counterparty/dividendModel';
+import { readFairminterPaymentModel } from '@/core/counterparty/fairminterModel';
 import {
   oracleDispenserWarning,
   oracleDispenseWarning,
 } from '@/core/counterparty/oraclePolicy';
 import type { SecurityWarning } from '@/core/counterparty/transactionSafety';
-import { readFairminterPaymentModel } from '@/core/counterparty/fairminterModel';
 import { type BigNumber, formatDecimal, fromSatoshis, isGreaterThan, roundUp, toBigNumber } from '@/core/numeric';
 
 export type { ProtocolContext };

--- a/src/core/counterparty/protocolContext.ts
+++ b/src/core/counterparty/protocolContext.ts
@@ -34,7 +34,8 @@ import {
   oracleDispenseWarning,
 } from '@/core/counterparty/oraclePolicy';
 import type { SecurityWarning } from '@/core/counterparty/transactionSafety';
-import { type BigNumber, formatDecimal, fromSatoshis, isGreaterThan, toBigNumber } from '@/core/numeric';
+import { readFairminterPaymentModel } from '@/core/counterparty/fairminterModel';
+import { type BigNumber, formatDecimal, fromSatoshis, isGreaterThan, roundUp, toBigNumber } from '@/core/numeric';
 
 export type { ProtocolContext };
 
@@ -146,16 +147,29 @@ export async function resolveProtocolContext(
     }
 
     if (messageType === 'fairmint' && typeof fields.asset === 'string' && !context.protocolFeeXcp) {
-      // A fairmint's cost is the fairminter's price, which is not in the message — and neither is
-      // where the payment goes: burned, seeded into the pool, or paid to the issuer.
+      // A fairmint's cost is not in the message — and neither is where the payment goes: burned,
+      // seeded into the pool, or paid to the issuer. Core charges `quantity / quantity_by_price *
+      // price` (messages/fairmint.py), every term in base units, so the figure is derived the same
+      // way from the same fields. The fairminter's `price_normalized` alone is the price of one
+      // whole unit, which is what a mint of 1,000,000 units was being shown as costing.
       const fairminter = await fetchAssetFairminter(fields.asset);
-      if (fairminter?.price_normalized) {
-        context.protocolFeeXcp = toDisplayAmount(String(fairminter.price_normalized));
-        context.fairmintPaymentModel = isGreaterThan(String(fairminter.pool_quantity ?? 0), 0)
-          ? 'pool'
-          : fairminter.burn_payment
-            ? 'burned'
-            : 'paid';
+      const quantity = fields.quantity;
+      if (
+        fairminter
+        && (typeof quantity === 'number' || typeof quantity === 'string' || typeof quantity === 'bigint')
+        && isGreaterThan(String(quantity), 0)
+        && isGreaterThan(String(fairminter.quantity_by_price ?? 0), 0)
+      ) {
+        const cost = toBigNumber(String(quantity))
+          .div(String(fairminter.quantity_by_price))
+          .times(String(fairminter.price ?? 0));
+        if (cost.isGreaterThan(0)) {
+          context.protocolFeeXcp = toDisplayAmount(fromSatoshis(roundUp(cost).toString()));
+        }
+        const model = readFairminterPaymentModel(fairminter);
+        if (model !== 'free') {
+          context.fairmintPaymentModel = model === 'issuer' ? 'paid' : model;
+        }
       }
     }
 

--- a/src/pages/transactions/_messages/fairminter.tsx
+++ b/src/pages/transactions/_messages/fairminter.tsx
@@ -57,10 +57,10 @@ export function fairminter(tx: Transaction): Array<{ label: string; value: strin
   }
 
   if (isPaidFairminter(paymentModel)) {
-    // Price per mint (normalized)
+    // Core derives price_normalized as price / quantity_by_price: it is per unit, not per lot.
     if (params.price_normalized !== undefined) {
       fields.push({
-        label: "Price per Mint",
+        label: "Price per Unit",
         value: `${formatAmount({
           value: params.price_normalized,
           minimumFractionDigits: 8,


### PR DESCRIPTION
## Problem

The sign screen for a fairmint showed `price_normalized` as the XCP cost. Core defines that as XCP **per whole unit** (`price / quantity_by_price`), not the cost of the mint, and the message's quantity was never read. Minting one 1,000,000-unit lot of FAFOMFERS at 10 XCP rendered "XCP to pool 0.00001 XCP".

## Fix

- `protocolContext.ts`: cost is `quantity / quantity_by_price * price`, all base units, rounded up — the same arithmetic as `messages/fairmint.py`. Payment routing goes through `readFairminterPaymentModel`; free fairminters get no row; an unknown lot size yields no figure rather than a wrong one.
- Tests: the exact FAFOMFERS case (expects 10 XCP, `pool`), a multi-lot case, free and unknown-lot-size cases.
- History view: `Price per Mint` → `Price per Unit`, which is what `price_normalized` is.

Other fairmint screens (compose form, review, mint history) already used `getFairmintCost` / core's `paid_quantity` and were correct.