### PR TITLE
Make the nightly E2E step run, and report without jq

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -77,25 +77,43 @@ jobs:
           NODE_OPTIONS: --max-old-space-size=6144
         run: npx vitest run src --config vitest.fuzz.config.ts
       
+      # continue-on-error so the report and artifact steps below still run; the report step
+      # re-raises the failure, so a red E2E run still fails the job and files the issue.
       - name: Run all E2E tests
+        id: e2e
         timeout-minutes: 60
         run: npx playwright test --retries=3 --workers=1
         continue-on-error: true
       
+      # The Playwright image does not ship jq, so the stats are read with node. A missing
+      # test-results.json means Playwright never got as far as running anything — a config or
+      # load error — and is treated as a failure rather than an empty report.
       - name: Generate test report
         if: always()
         run: |
-          echo "# Nightly Test Report" >> $GITHUB_STEP_SUMMARY
-          echo "Date: $(date)" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          
-          if [ -f "test-results.json" ]; then
-            echo "## Test Results" >> $GITHUB_STEP_SUMMARY
-            echo '```json' >> $GITHUB_STEP_SUMMARY
-            cat test-results.json | jq '.stats' >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
+          {
+            echo "# Nightly Test Report"
+            echo "Date: $(date)"
+            echo ""
+            if [ -f "test-results.json" ]; then
+              echo "## E2E Results"
+              echo '```json'
+              node -e 'console.log(JSON.stringify(require("./test-results.json").stats, null, 2))'
+              echo '```'
+            else
+              echo "## E2E Results"
+              echo "No test-results.json was written: Playwright did not run."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ ! -f "test-results.json" ]; then
+            echo "::error::Playwright produced no test-results.json"
+            exit 1
           fi
-      
+          if [ "${{ steps.e2e.outcome }}" != "success" ]; then
+            echo "::error::E2E tests failed"
+            exit 1
+          fi
+
       - name: Upload test artifacts
         if: always()
         uses: actions/upload-artifact@v6

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,6 +4,11 @@ const isCI = !!process.env.CI;
 
 export default defineConfig({
   testDir: './e2e',
+  // Only Playwright specs. The directory also holds a vitest file
+  // (hardware/trezor-node-integration.test.ts, run by the trezor-emulator workflow), and
+  // Playwright's default match picks up *.test.ts too — loading it crashes the runner before a
+  // single spec runs, which `continue-on-error` in the nightly job then hid for months.
+  testMatch: '**/*.spec.ts',
   fullyParallel: false,
 
   // Single worker for extension tests to avoid state conflicts


### PR DESCRIPTION
Fixes #338.

## What CI reported

`jq: not found` in **Generate test report** (exit 127), every night since #317 moved the job into the Playwright image, which does not ship `jq`.

## What was underneath

Playwright itself has not been running any E2E tests. `e2e/hardware/trezor-node-integration.test.ts` is a vitest file (run by the trezor-emulator workflow) sitting inside Playwright's `testDir`, and Playwright's default `testMatch` includes `*.test.ts`. Loading it throws `TypeError: Cannot read properties of undefined (reading 'config')` at collection — `Total: 0 tests in 0 files`. The E2E step is `continue-on-error`, so nightlies were green with zero E2E coverage until `jq` went missing and made the job red for an unrelated reason.

## Fix

- `playwright.config.ts`: `testMatch: '**/*.spec.ts'` — now collects 1,263 tests in 124 files.
- `nightly-tests.yml`: read the stats with `node`; fail the job if `test-results.json` is missing or the E2E step's outcome is not success, so the suite cannot silently stop running again. `continue-on-error` stays so artifacts still upload.

## Verified

- Old config reproduces the crash locally (`0 tests in 0 files`); new config collects everything.
- Ran `e2e/pages/assets` under `CI=1`: 41 passed, 2 flaky (passed on retry), 0 failed.