### PR TITLE
Prefer the canonical XCP ticker instead of racing it

### DIFF
--- a/src/core/counterparty/price.test.ts
+++ b/src/core/counterparty/price.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { fetchFromXCPIO } from "./price";
+import { fetchFromXCPIO, getXCPPrice } from "./price";
 
 describe("canonical XCP price", () => {
   afterEach(() => vi.unstubAllGlobals());
@@ -24,5 +24,83 @@ describe("canonical XCP price", () => {
       vi.fn().mockResolvedValue(Response.json({ result: { xcp: { usd: 0 } } })),
     );
     await expect(fetchFromXCPIO()).rejects.toThrow("Invalid XCP price value");
+  });
+});
+
+describe("XCP price source preference", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  /** xcp.io answers slowly; Dex-Trade answers at once. The old Promise.any race
+   *  returned whichever landed first, so this ordering is what is under test. */
+  const stub = ({
+    ticker,
+    dexTrade,
+    tickerDelayMs = 0,
+  }: {
+    ticker: () => Response;
+    dexTrade: () => Response;
+    tickerDelayMs?: number;
+  }) =>
+    vi.fn(async (url: string) => {
+      if (url.startsWith("https://api.xcp.io")) {
+        await new Promise((resolve) => setTimeout(resolve, tickerDelayMs));
+        return ticker();
+      }
+      if (url.startsWith("https://api.dex-trade.com")) return dexTrade();
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+
+  const CHAIN = Response.json({ result: { xcp: { usd: 2.87, change_pct: -1.9 } } });
+  // 0.000023 BTC x $79,000 = $1.817 — the exchange print, a third below the chain.
+  const EXCHANGE = { status: true, data: { pair: "XCPBTC", last: "0.000023" } };
+
+  it("prefers the canonical ticker even when the exchange answers first", async () => {
+    const fetch = stub({
+      ticker: () => CHAIN,
+      dexTrade: () => Response.json(EXCHANGE),
+      tickerDelayMs: 25,
+    });
+    vi.stubGlobal("fetch", fetch);
+
+    await expect(getXCPPrice(79_000)).resolves.toBe(2.87);
+    // And the loser is never even asked for, so a slow exchange cannot delay us.
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith("https://api.xcp.io/v2/price/ticker");
+  });
+
+  it("falls back to the exchange only once the canonical ticker fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      stub({
+        ticker: () => new Response("", { status: 503 }),
+        dexTrade: () => Response.json(EXCHANGE),
+      }),
+    );
+    await expect(getXCPPrice(79_000)).resolves.toBeCloseTo(1.817, 3);
+  });
+
+  it("skips the exchange without a BTC rate to convert through", async () => {
+    const fetch = stub({
+      ticker: () => new Response("", { status: 503 }),
+      dexTrade: () => Response.json(EXCHANGE),
+    });
+    vi.stubGlobal("fetch", fetch);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(getXCPPrice(null)).resolves.toBeNull();
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns null rather than a zero when every source is unusable", async () => {
+    vi.stubGlobal(
+      "fetch",
+      stub({
+        ticker: () => Response.json({ result: { xcp: { usd: 0 } } }),
+        dexTrade: () => Response.json({ status: true, data: { pair: "XCPBTC", last: "0" } }),
+      }),
+    );
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(getXCPPrice(79_000)).resolves.toBeNull();
   });
 });

--- a/src/core/counterparty/price.test.ts
+++ b/src/core/counterparty/price.test.ts
@@ -42,11 +42,15 @@ describe("XCP price source preference", () => {
     tickerDelayMs?: number;
   }) =>
     vi.fn(async (url: string) => {
-      if (url.startsWith("https://api.xcp.io")) {
+      // Dispatch on the exact host. A startsWith on the origin would also match
+      // api.xcp.io.example.com, which is both wrong and what CodeQL's
+      // incomplete-url-substring-sanitization rule exists to catch.
+      const { host } = new URL(url);
+      if (host === "api.xcp.io") {
         await new Promise((resolve) => setTimeout(resolve, tickerDelayMs));
         return ticker();
       }
-      if (url.startsWith("https://api.dex-trade.com")) return dexTrade();
+      if (host === "api.dex-trade.com") return dexTrade();
       throw new Error(`unexpected fetch: ${url}`);
     });
 

--- a/src/core/counterparty/price.ts
+++ b/src/core/counterparty/price.ts
@@ -218,53 +218,54 @@ export async function getXcpPriceHistory(): Promise<XcpPriceHistoryData> {
   };
 }
 
-// Future: Add more XCP price sources here if needed
-const xcpPriceFetchers = [
-  fetchFromXCPIO,
-  // fetchFromDexTrade requires BTC price, so it's handled separately in getXCPPrice
-];
+// Future: Add more XCP price sources here if needed. Order is preference order.
+const xcpPriceFetchers = [fetchFromXCPIO];
 
 /**
- * Fetches XCP price from available APIs, returning the first successful result.
- * Includes fallback to dex-trade.com using BTC price conversion.
- * @param {number | null} btcPriceUsd - Optional BTC price for dex-trade fallback.
- * @returns {Promise<number | null>} XCP price in USD or null if all fail.
+ * XCP price in USD, from the first source that answers with a usable quote.
+ *
+ * Tried IN ORDER, and that ordering is the point. This used to race every
+ * source with Promise.any, which resolves with the first to FULFIL rather than
+ * the first in the list — so the Dex-Trade leg, described here as a fallback,
+ * won whenever it answered before xcp.io. Non-deterministic by construction,
+ * and it silently swapped the source of a price the user is shown.
+ *
+ * The two do not agree, so which one wins matters. xcp.io's ticker prices XCP
+ * from executions on its own chain — dispenser fills and DEX order matches,
+ * the venues where XCP actually changes hands. Dex-Trade is a single exchange
+ * whose XCP/BTC pair has cleared no meaningful volume in months, and it has
+ * been printing on the order of a third below the chain. Racing them meant the
+ * extension showed one number or the other depending on which host was quicker
+ * to respond, which reads to a user as the price flickering.
+ *
+ * Dex-Trade stays as a genuine last resort, reached only if every canonical
+ * source has failed, because a stale cross-rate beats no price at all. It
+ * needs BTC/USD to convert its XCP/BTC quote, so it is skipped without one.
  */
 export async function getXCPPrice(
   btcPriceUsd?: number | null,
 ): Promise<number | null> {
-  // First try direct USD fetchers
-  const directFetcherPromises = xcpPriceFetchers.map(async (fetcher) => {
-    const data = await fetcher();
-    const price = data.xcp?.usd;
-    if (typeof price !== "number" || Number.isNaN(price)) {
-      throw new DataFetchError(
-        `${fetcher.name} returned invalid XCP price`,
-        "xcp-price",
-      );
+  const usable = (price: unknown): price is number =>
+    typeof price === "number" && Number.isFinite(price) && price > 0;
+
+  for (const fetcher of xcpPriceFetchers) {
+    try {
+      const { xcp } = await fetcher();
+      if (usable(xcp?.usd)) return xcp.usd;
+    } catch {
+      // Fall through to the next source; a failure here is not the answer.
     }
-    return price;
-  });
-
-  // If BTC price is available, add dex-trade as fallback
-  if (btcPriceUsd && typeof btcPriceUsd === "number") {
-    const dexTradePromise = (async () => {
-      const data = await fetchFromDexTrade(btcPriceUsd);
-      const price = data.xcp?.usd;
-      if (typeof price !== "number" || Number.isNaN(price)) {
-        throw new DataFetchError(
-          "fetchFromDexTrade returned invalid XCP price",
-          "dex-trade.com",
-        );
-      }
-      return price;
-    })();
-
-    directFetcherPromises.push(dexTradePromise);
   }
 
-  return Promise.any(directFetcherPromises).catch(() => {
-    console.error("All XCP price fetchers failed");
-    return null;
-  });
+  if (usable(btcPriceUsd)) {
+    try {
+      const { xcp } = await fetchFromDexTrade(btcPriceUsd);
+      if (usable(xcp?.usd)) return xcp.usd;
+    } catch {
+      // Nothing left to try.
+    }
+  }
+
+  console.error("All XCP price fetchers failed");
+  return null;
 }


### PR DESCRIPTION
`getXCPPrice` described Dex-Trade as a fallback and implemented it as a race.

```ts
const directFetcherPromises = xcpPriceFetchers.map(...)   // [ fetchFromXCPIO ]
if (btcPriceUsd && typeof btcPriceUsd === "number") {
  directFetcherPromises.push(dexTradePromise)             // hits dex-trade.com
}
return Promise.any(directFetcherPromises)
```

`Promise.any` resolves with the first promise to **fulfil**, not the first in the list. So the Dex-Trade leg won whenever `api.dex-trade.com` answered before `api.xcp.io` — which host was quicker decided which source priced XCP for the user, request by request.

### Why it matters

The two don't agree. The xcp.io ticker prices XCP from executions on its own chain — dispenser fills and DEX order matches, the venues where XCP actually changes hands. Dex-Trade is a single exchange whose XCP/BTC pair has cleared no meaningful volume in months, and it has been printing about a third below the chain: **$1.82 against $2.87** as this was written.

Racing them showed one number or the other at random, which reads to a user as the price flickering rather than as a bug.

### What changed

- Sources are tried **in order**; Dex-Trade is reached only after every canonical source has failed — which is what the old comment already claimed.
- No second request on the happy path, so a slow exchange can no longer delay a price that never needed it.
- A non-positive quote is treated as a failure and the next source is tried. The old guard only rejected `NaN`, so `getXCPPrice` could return `0` as a real price.
- A missing BTC rate skips the Dex-Trade leg explicitly rather than relying on it being absent from the array.

`getXcpStats`, `fetchFromXCPIO` and `getXcpPriceHistory` are untouched — they already read xcp.io directly.

### Tests

Four new cases in `src/core/counterparty/price.test.ts`. They are not vacuous — run against the previous implementation, two fail:

```
× prefers the canonical ticker even when the exchange answers first
  AssertionError: expected 1.817 to be 2.87
× returns null rather than a zero when every source is unusable
  AssertionError: expected +0 to be null
```

`npx vitest run src/core/counterparty/price.test.ts src/core/bitcoin/__tests__/price.test.ts` → 49 passed. `npm run compile` and `npm run lint` clean (lint warnings present are pre-existing `exhaustive-deps` elsewhere).

### Context

Upstream, `api.xcp.io` had a related defect: its chain-derived price was rebuilt once a day while the Dex-Trade spot beside it was rebuilt every block, so an exchange print took each new UTC day at midnight and held it for hours. That is fixed in XCP/explorer@347d72e. This PR is the client-side half — without it the extension could still bypass the corrected ticker at random.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EeUgdYtFLuB5jgiNQRpeUX
