### PR TITLE
Unify wallet activation and preserve address count

### DIFF
--- a/src/components/domain/wallet/wallet-menu.test.tsx
+++ b/src/components/domain/wallet/wallet-menu.test.tsx
@@ -15,13 +15,11 @@ vi.mock('react-router', async () => {
 });
 
 // Mock wallet context to avoid webext-bridge import side effects
-const mockSetActiveWallet = vi.fn();
 const mockRemoveWallet = vi.fn();
 vi.mock('@/contexts/wallet-context', () => ({
   useWallet: () => ({
     wallets: [],
     activeWallet: null,
-    setActiveWallet: mockSetActiveWallet,
     removeWallet: mockRemoveWallet
   })
 }));
@@ -47,7 +45,6 @@ describe('WalletMenu', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockSetActiveWallet.mockClear();
     mockRemoveWallet.mockClear();
   });
 

--- a/src/contexts/__tests__/wallet-context.test.tsx
+++ b/src/contexts/__tests__/wallet-context.test.tsx
@@ -265,6 +265,33 @@ describe('WalletContext', () => {
       expect(mockWalletService.createMnemonicWallet).toHaveBeenCalled();
     });
 
+    it('should resolve the default address format before crossing the service boundary', async () => {
+      const newWallet = {
+        id: 'wallet3',
+        name: 'New Wallet',
+        type: 'mnemonic' as const,
+        addressFormat: AddressFormat.P2TR,
+        addressCount: 1,
+        addresses: []
+      };
+      mockWalletService.createMnemonicWallet.mockResolvedValue(newWallet);
+
+      const { result } = renderHook(() => useWallet(), {
+        wrapper: WalletProvider
+      });
+
+      await act(async () => {
+        await result.current.createMnemonicWallet('test mnemonic', 'password123');
+      });
+
+      expect(mockWalletService.createMnemonicWallet).toHaveBeenCalledWith(
+        'test mnemonic',
+        'password123',
+        undefined,
+        AddressFormat.P2TR
+      );
+    });
+
     it('should handle wallet creation failure', async () => {
       mockWalletService.createMnemonicWallet.mockRejectedValue(new Error('Creation failed'));
 

--- a/src/contexts/__tests__/wallet-context.test.tsx
+++ b/src/contexts/__tests__/wallet-context.test.tsx
@@ -6,6 +6,7 @@ import { AddressFormat } from '@/core/bitcoin/address';
 import * as sessionManager from '@/platform/auth/sessionManager';
 import { saveKeychainRecord } from '@/platform/storage/walletStorage';
 import { walletManager } from '@/platform/walletManager';
+import type { Wallet } from '@/types/wallet';
 import { useWallet, WalletProvider } from '../wallet-context';
 
 // Mock webext-bridge first with comprehensive mocking
@@ -83,9 +84,10 @@ const mockWalletService = {
   refreshWallets: vi.fn().mockResolvedValue(undefined),
   getWallets: vi.fn().mockResolvedValue([]),
   getActiveWallet: vi.fn().mockResolvedValue(null),
+  getActiveAddress: vi.fn().mockResolvedValue(undefined),
   getLastActiveAddress: vi.fn().mockResolvedValue(null),
   getSettings: vi.fn().mockResolvedValue({ connectedWebsites: [] }),
-  setActiveWallet: vi.fn().mockResolvedValue(undefined),
+  selectWallet: vi.fn().mockResolvedValue(undefined),
   setLastActiveAddress: vi.fn().mockResolvedValue(undefined),
   emitProviderEvent: vi.fn().mockResolvedValue(undefined),
   isKeychainUnlocked: vi.fn().mockResolvedValue(false),
@@ -162,10 +164,11 @@ describe('WalletContext', () => {
     mockWalletService.refreshWallets.mockResolvedValue(undefined);
     mockWalletService.getWallets.mockResolvedValue(mockWallets);
     mockWalletService.getActiveWallet.mockResolvedValue(mockWallets[0]);
+    mockWalletService.getActiveAddress.mockResolvedValue(undefined);
     mockWalletService.getLastActiveAddress.mockResolvedValue(null);
     mockWalletService.getSettings.mockResolvedValue({ connectedWebsites: [] });
     mockWalletService.isKeychainUnlocked.mockResolvedValue(false);
-    mockWalletService.setActiveWallet.mockResolvedValue(undefined);
+    mockWalletService.selectWallet.mockResolvedValue(undefined);
     mockWalletService.setLastActiveAddress.mockResolvedValue(undefined);
     mockWalletService.emitProviderEvent.mockResolvedValue(undefined);
 
@@ -447,13 +450,35 @@ describe('WalletContext', () => {
   });
 
   describe('Active Wallet/Address Management', () => {
-    it('should set active wallet', async () => {
-      // Set up mock to return the new active wallet after setActiveWallet is called
-      mockWalletService.setActiveWallet.mockImplementation(async (walletId: string) => {
-        const wallet = mockWallets.find(w => w.id === walletId);
-        if (wallet) {
-          mockWalletService.getActiveWallet.mockResolvedValue(wallet);
-        }
+    it('selects and loads the active wallet through one public operation', async () => {
+      const firstWallet: Wallet = {
+        ...mockWallets[0]!,
+        addressFormat: AddressFormat.P2WPKH,
+        addresses: [{
+          address: 'bc1qfirst',
+          path: "m/84'/0'/0'/0/0",
+          name: 'Address 1',
+          pubKey: '02first',
+        }],
+      };
+      const secondWallet: Wallet = {
+        ...mockWallets[1]!,
+        addressFormat: AddressFormat.P2PKH,
+        addresses: [{
+          address: '1second',
+          path: "m/44'/0'/0'/0/0",
+          name: 'Address 1',
+          pubKey: '02second',
+        }],
+      };
+      let selectedWallet = firstWallet;
+      mockWalletService.isKeychainUnlocked.mockResolvedValue(true);
+      mockWalletService.getWallets.mockResolvedValue([firstWallet, secondWallet]);
+      mockWalletService.getActiveWallet.mockImplementation(async () => selectedWallet);
+      mockWalletService.getActiveAddress.mockImplementation(async () => selectedWallet.addresses[0]);
+      mockWalletService.getLastActiveAddress.mockResolvedValue('bc1qfirst');
+      mockWalletService.selectWallet.mockImplementation(async (walletId: string) => {
+        selectedWallet = walletId === secondWallet.id ? secondWallet : firstWallet;
       });
 
       const { result } = renderHook(() => useWallet(), {
@@ -461,46 +486,51 @@ describe('WalletContext', () => {
       });
 
       await waitFor(() => {
-        expect(result.current.wallets.length).toBeGreaterThan(0);
+        expect(result.current.activeWallet?.id).toBe(firstWallet.id);
       });
 
       await act(async () => {
-        await result.current.setActiveWallet(mockWallets[1] as any);
+        await result.current.selectWallet(secondWallet.id);
       });
 
-      // Wait for state to update
       await waitFor(() => {
-        expect(result.current.activeWallet?.id).toBe(mockWallets[1]!.id);
+        expect(result.current.activeWallet?.id).toBe(secondWallet.id);
       });
+      expect(mockWalletService.selectWallet).toHaveBeenCalledWith(secondWallet.id);
     });
 
     it('emits accountsChanged to each connected site when a wallet switch changes the address', async () => {
-      const firstWallet = {
-        ...mockWallets[0],
+      const firstWallet: Wallet = {
+        ...mockWallets[0]!,
+        addressFormat: AddressFormat.P2WPKH,
         addresses: [{
           address: 'bc1qfirst',
           path: "m/84'/0'/0'/0/0",
-          addressFormat: 'P2WPKH' as const,
           name: 'Address 1',
           pubKey: '02first',
         }],
       };
-      const secondWallet = {
-        ...mockWallets[1],
+      const secondWallet: Wallet = {
+        ...mockWallets[1]!,
+        addressFormat: AddressFormat.P2PKH,
         addresses: [{
           address: '1second',
           path: "m/44'/0'/0'/0/0",
-          addressFormat: 'P2PKH' as const,
           name: 'Address 1',
           pubKey: '02second',
         }],
       };
       mockWalletService.getWallets.mockResolvedValue([firstWallet, secondWallet]);
       mockWalletService.getActiveWallet.mockResolvedValue(firstWallet);
+      mockWalletService.getActiveAddress.mockResolvedValue(firstWallet.addresses[0]);
       mockWalletService.getLastActiveAddress.mockResolvedValue('bc1qfirst');
       mockWalletService.isKeychainUnlocked.mockResolvedValue(true);
       mockWalletService.getSettings.mockResolvedValue({
         connectedWebsites: ['https://one.example', 'https://two.example'],
+      });
+      mockWalletService.selectWallet.mockImplementation(async () => {
+        mockWalletService.getActiveWallet.mockResolvedValue(secondWallet);
+        mockWalletService.getActiveAddress.mockResolvedValue(secondWallet.addresses[0]);
       });
 
       const { result } = renderHook(() => useWallet(), { wrapper: WalletProvider });
@@ -509,7 +539,7 @@ describe('WalletContext', () => {
       });
 
       await act(async () => {
-        await result.current.setActiveWallet(secondWallet as any);
+        await result.current.selectWallet(secondWallet.id);
       });
 
       expect(mockWalletService.emitProviderEvent).toHaveBeenNthCalledWith(
@@ -523,6 +553,70 @@ describe('WalletContext', () => {
         'https://two.example',
         'accountsChanged',
         ['1second']
+      );
+    });
+
+    it('preserves the selected index and emits accountsChanged after an address format change', async () => {
+      const legacyWallet: Wallet = {
+        ...mockWallets[0]!,
+        addressFormat: AddressFormat.P2PKH,
+        addressCount: 2,
+        addresses: [0, 1].map(index => ({
+          address: `legacy-${index}`,
+          path: `m/44'/0'/0'/0/${index}`,
+          name: `Address ${index + 1}`,
+          pubKey: `02legacy${index}`,
+        })),
+      };
+      const taprootWallet: Wallet = {
+        ...legacyWallet,
+        addressFormat: AddressFormat.P2TR,
+        addresses: [0, 1].map(index => ({
+          address: `taproot-${index}`,
+          path: `m/86'/0'/0'/0/${index}`,
+          name: `Address ${index + 1}`,
+          pubKey: `02taproot${index}`,
+        })),
+      };
+      let activeWallet: Wallet = legacyWallet;
+      let activeAddress = legacyWallet.addresses[1]!;
+      let lastActiveAddress = activeAddress.address;
+
+      mockWalletService.getWallets.mockImplementation(async () => [activeWallet]);
+      mockWalletService.getActiveWallet.mockImplementation(async () => activeWallet);
+      mockWalletService.getActiveAddress.mockImplementation(async () => activeAddress);
+      mockWalletService.getLastActiveAddress.mockImplementation(async () => lastActiveAddress);
+      mockWalletService.setLastActiveAddress.mockImplementation(async address => {
+        lastActiveAddress = address;
+      });
+      mockWalletService.isKeychainUnlocked.mockResolvedValue(true);
+      mockWalletService.getSettings.mockResolvedValue({
+        connectedWebsites: ['https://market.example'],
+      });
+      mockWalletService.updateWalletAddressFormat.mockImplementation(async () => {
+        activeWallet = taprootWallet;
+        activeAddress = taprootWallet.addresses[1]!;
+        lastActiveAddress = activeAddress.address;
+      });
+
+      const { result } = renderHook(() => useWallet(), { wrapper: WalletProvider });
+      await waitFor(() => {
+        expect(result.current.activeAddress?.address).toBe('legacy-1');
+      });
+
+      await act(async () => {
+        await result.current.updateWalletAddressFormat(
+          legacyWallet.id,
+          AddressFormat.P2TR
+        );
+      });
+
+      expect(result.current.activeWallet?.addressCount).toBe(2);
+      expect(result.current.activeAddress?.address).toBe('taproot-1');
+      expect(mockWalletService.emitProviderEvent).toHaveBeenCalledWith(
+        'https://market.example',
+        'accountsChanged',
+        ['taproot-1']
       );
     });
 

--- a/src/contexts/wallet-context.tsx
+++ b/src/contexts/wallet-context.tsx
@@ -45,7 +45,7 @@ import {
   useState
 } from "react";
 import { onMessage } from 'webext-bridge/popup'; // Import for popup context
-import type { AddressFormat } from '@/core/bitcoin/address';
+import { AddressFormat } from '@/core/bitcoin/address';
 import { recordSpentInputsFromRawTx } from '@/core/bitcoin/spentUtxoCache';
 import { recordOwnChangeFromRawTx } from '@/core/counterparty/pendingChange';
 import { setSourcePubkeyProvider } from '@/core/counterparty/sourcePubkey';
@@ -585,7 +585,12 @@ export function WalletProvider({ children }: { children: ReactNode }): ReactElem
     createMnemonicWallet: async (mnemonic, password, name, addressFormat) => {
       const wallet = await withIdentityRefresh(
         'wallet-create-mnemonic',
-        () => walletService.createMnemonicWallet(mnemonic, password, name, addressFormat)
+        () => walletService.createMnemonicWallet(
+          mnemonic,
+          password,
+          name,
+          addressFormat ?? AddressFormat.P2TR
+        )
       );
       setWalletState((prev) => ({ ...prev, authState: AuthState.Unlocked }));
       return wallet;
@@ -593,7 +598,12 @@ export function WalletProvider({ children }: { children: ReactNode }): ReactElem
     createPrivateKeyWallet: async (privateKey, password, name, addressFormat) => {
       const wallet = await withIdentityRefresh(
         'wallet-create-private-key',
-        () => walletService.createPrivateKeyWallet(privateKey, password, name, addressFormat)
+        () => walletService.createPrivateKeyWallet(
+          privateKey,
+          password,
+          name,
+          addressFormat ?? AddressFormat.P2TR
+        )
       );
       setWalletState((prev) => ({ ...prev, authState: AuthState.Unlocked }));
       return wallet;

--- a/src/contexts/wallet-context.tsx
+++ b/src/contexts/wallet-context.tsx
@@ -143,7 +143,7 @@ interface WalletContextType {
   // ─── Authentication ────────────────────────────────────────────────────────
   /** Unlock the keychain with password */
   unlockKeychain: (password: string) => Promise<void>;
-  /** Load a specific wallet after keychain is unlocked */
+  /** Decrypt, derive, and make a specific wallet active */
   selectWallet: (walletId: string) => Promise<void>;
   /** Lock the keychain and clear sensitive data from memory */
   lockKeychain: () => Promise<void>;
@@ -153,8 +153,6 @@ interface WalletContextType {
   updatePassword: (currentPassword: string, newPassword: string) => Promise<void>;
 
   // ─── Wallet Selection ──────────────────────────────────────────────────────
-  /** Set the active wallet. If useLastActive, restores last used address */
-  setActiveWallet: (wallet: Wallet | null, useLastActive?: boolean) => Promise<void>;
   /** Set the active address within the current wallet */
   setActiveAddress: (address: Address | null) => Promise<void>;
   /** Update last activity timestamp (for auto-lock) */
@@ -496,43 +494,29 @@ export function WalletProvider({ children }: { children: ReactNode }): ReactElem
     }
   }, [walletService]);
 
-  const setActiveWallet = useCallback(
-    async (wallet: Wallet | null, useLastActive?: boolean) => {
-      return withStateLock('wallet-set-active', async () => {
-        const oldAddress = walletStateRef.current.activeAddress?.address;
+  const withIdentityRefresh = useCallback(
+    async <T,>(lockKey: string, operation: () => Promise<T>): Promise<T> => {
+      return withStateLock(lockKey, async () => {
+        const previousAddress = walletStateRef.current.activeAddress?.address;
+        const result = await operation();
 
-        if (wallet) {
-          await walletService.setActiveWallet(wallet.id);
-          const lastActiveAddress = useLastActive
-            ? await walletService.getLastActiveAddress()
-            : undefined;
-          const newActiveAddress =
-            lastActiveAddress && wallet.addresses.some((addr) => addr.address === lastActiveAddress)
-              ? wallet.addresses.find((addr) => addr.address === lastActiveAddress) ?? wallet.addresses[0]
-              : wallet.addresses[0];
-
-          // When switching wallets, maintain unlocked state if keychain is unlocked
-          const isUnlocked = await walletService.isKeychainUnlocked();
-
-          setWalletState((prev) => ({
-            ...prev,
-            activeWallet: wallet,
-            activeAddress: newActiveAddress ?? null,
-            authState: isUnlocked ? AuthState.Unlocked : prev.authState,
-            keychainLocked: !isUnlocked,
-          }));
-          if (newActiveAddress) await walletService.setLastActiveAddress(newActiveAddress.address);
-          if (oldAddress !== newActiveAddress?.address) {
-            await emitAccountsChanged(newActiveAddress?.address);
-          }
-        } else {
-          await walletService.setActiveWallet("");
-          setWalletState((prev) => ({ ...prev, activeWallet: null, activeAddress: null }));
-          if (oldAddress) await emitAccountsChanged();
+        await refreshWalletState();
+        const activeAddress = await walletService.getActiveAddress();
+        const nextAddress = activeAddress?.address;
+        if (
+          nextAddress &&
+          nextAddress !== await walletService.getLastActiveAddress()
+        ) {
+          await walletService.setLastActiveAddress(nextAddress);
         }
+        if (previousAddress !== nextAddress) {
+          await emitAccountsChanged(nextAddress);
+        }
+
+        return result;
       });
     },
-    [emitAccountsChanged, walletService]
+    [emitAccountsChanged, refreshWalletState, walletService]
   );
 
   const setActiveAddress = useCallback(
@@ -576,7 +560,10 @@ export function WalletProvider({ children }: { children: ReactNode }): ReactElem
       await refreshWalletState();
       setWalletState((prev) => ({ ...prev, authState: AuthState.Unlocked }));
     }, 'wallet-unlock-keychain'),
-    selectWallet: withRefresh(walletService.selectWallet, refreshWalletState, 'wallet-load'),
+    selectWallet: (walletId) => withIdentityRefresh(
+      'wallet-load',
+      () => walletService.selectWallet(walletId)
+    ),
     lockKeychain: async () => {
       return withStateLock('wallet-lock', async () => {
         // Immediately set state to locked to trigger navigation
@@ -592,23 +579,37 @@ export function WalletProvider({ children }: { children: ReactNode }): ReactElem
         await walletService.lockKeychain();
       });
     },
-    setActiveWallet,
     setActiveAddress,
     addAddress: withRefresh(walletService.addAddress, refreshWalletState),
     updatePassword: withRefresh(walletService.updatePassword, refreshWalletState),
-    createMnemonicWallet: withRefresh(walletService.createMnemonicWallet, async () => {
-      await refreshWalletState();
+    createMnemonicWallet: async (mnemonic, password, name, addressFormat) => {
+      const wallet = await withIdentityRefresh(
+        'wallet-create-mnemonic',
+        () => walletService.createMnemonicWallet(mnemonic, password, name, addressFormat)
+      );
       setWalletState((prev) => ({ ...prev, authState: AuthState.Unlocked }));
-    }),
-    createPrivateKeyWallet: withRefresh(walletService.createPrivateKeyWallet, async () => {
-      await refreshWalletState();
+      return wallet;
+    },
+    createPrivateKeyWallet: async (privateKey, password, name, addressFormat) => {
+      const wallet = await withIdentityRefresh(
+        'wallet-create-private-key',
+        () => walletService.createPrivateKeyWallet(privateKey, password, name, addressFormat)
+      );
       setWalletState((prev) => ({ ...prev, authState: AuthState.Unlocked }));
-    }),
-    importTestAddress: withRefresh(walletService.importTestAddress, async () => {
-      await refreshWalletState();
+      return wallet;
+    },
+    importTestAddress: async (address, name) => {
+      const wallet = await withIdentityRefresh(
+        'wallet-import-test-address',
+        () => walletService.importTestAddress(address, name)
+      );
       setWalletState((prev) => ({ ...prev, authState: AuthState.Unlocked }));
-    }),
-    createHardwareWalletWithDiscovery: withRefresh(walletService.createHardwareWalletWithDiscovery, refreshWalletState),
+      return wallet;
+    },
+    createHardwareWalletWithDiscovery: (deviceType, name, usePassphrase) => withIdentityRefresh(
+      'wallet-create-hardware',
+      () => walletService.createHardwareWalletWithDiscovery(deviceType, name, usePassphrase)
+    ),
     resetKeychain: async (password) => {
       await walletService.resetKeychain(password);
       setWalletState({
@@ -626,10 +627,16 @@ export function WalletProvider({ children }: { children: ReactNode }): ReactElem
     getPrivateKey: walletService.getPrivateKey,
     setLastActiveTime,
     verifyPassword: walletService.verifyPassword,
-    updateWalletAddressFormat: withRefresh(walletService.updateWalletAddressFormat, refreshWalletState),
+    updateWalletAddressFormat: (walletId, newType) => withIdentityRefresh(
+      'wallet-update-address-format',
+      () => walletService.updateWalletAddressFormat(walletId, newType)
+    ),
     getPreviewAddressForFormat: walletService.getPreviewAddressForFormat,
     isAddressInAnyWallet: walletService.isAddressInAnyWallet,
-    removeWallet: withRefresh(walletService.removeWallet, refreshWalletState),
+    removeWallet: (walletId) => withIdentityRefresh(
+      'wallet-remove',
+      () => walletService.removeWallet(walletId)
+    ),
     signTransaction: walletService.signTransaction,
     // Wrapped rather than passed through: the spent-UTXO cache is per-context, and compose runs
     // HERE, in the popup. Recording only in the background (where the broadcast executes) left
@@ -651,8 +658,8 @@ export function WalletProvider({ children }: { children: ReactNode }): ReactElem
     walletState,
     walletService,
     refreshWalletState,
-    setActiveWallet,
     setActiveAddress,
+    withIdentityRefresh,
     setLastActiveTime,
     setHardwareOperationInProgress,
     isKeychainLocked,

--- a/src/pages/keychain/setup/create-mnemonic.tsx
+++ b/src/pages/keychain/setup/create-mnemonic.tsx
@@ -54,7 +54,7 @@ function CreateMnemonicPage() {
       try {
         await createMnemonicWallet(mnemonic, password);
         analytics.track('wallet_created');
-        navigate(PATHS.SUCCESS);
+        window.location.hash = PATHS.SUCCESS;
         return { error: null };
       } catch {
         return { error: "Failed to create wallet. Please try again." };

--- a/src/pages/keychain/setup/import-mnemonic.tsx
+++ b/src/pages/keychain/setup/import-mnemonic.tsx
@@ -85,7 +85,7 @@ function ImportMnemonicPage() {
 
         await createMnemonicWallet(mnemonic, password, undefined, addressFormat);
         analytics.track('wallet_imported');
-        navigate(PATHS.SUCCESS);
+        window.location.hash = PATHS.SUCCESS;
         return { error: null };
       } catch (error: unknown) {
         console.error("Detailed error importing wallet:", error);

--- a/src/pages/keychain/wallets/remove.tsx
+++ b/src/pages/keychain/wallets/remove.tsx
@@ -18,7 +18,7 @@ function RemoveWalletPage() {
   const { walletId } = useParams<{ walletId: string }>();
   const navigate = useNavigate();
   const { setHeaderProps } = useHeader();
-  const { wallets, setActiveWallet, activeWallet, removeWallet, verifyPassword } = useWallet();
+  const { wallets, removeWallet, verifyPassword } = useWallet();
   const { pending } = useFormStatus();
 
   const [walletName, setWalletName] = useState("");
@@ -72,10 +72,6 @@ function RemoveWalletPage() {
     }
 
     try {
-      const remainingWallets = wallets.filter((w) => w.id !== walletId);
-      if (activeWallet?.id === walletId) {
-        await setActiveWallet(remainingWallets.length > 0 ? remainingWallets[0]! : null);
-      }
       await removeWallet(walletId);
       navigate(PATHS.SUCCESS, { replace: true });
     } catch (err) {

--- a/src/platform/__tests__/walletManager.test.ts
+++ b/src/platform/__tests__/walletManager.test.ts
@@ -46,7 +46,7 @@ vi.mock('@scure/bip39');
 import { bytesToHex } from '@noble/hashes/utils.js';
 import { HDKey } from '@scure/bip32';
 import { mnemonicToSeedSync } from '@scure/bip39';
-import { getAddressFromMnemonic, getDerivationPathForAddressFormat } from '@/core/bitcoin/address';
+import { encodeAddress, getAddressFromMnemonic, getDerivationPathForAddressFormat } from '@/core/bitcoin/address';
 import { getAddressFromPrivateKey } from '@/core/bitcoin/privateKey';
 import { signPSBT } from '@/core/bitcoin/psbt';
 import { base64ToBuffer } from '@/core/encryption/buffer';
@@ -201,18 +201,71 @@ describe('WalletManager', () => {
       expect(found).toBeUndefined();
     });
 
-    it('should set active wallet', async () => {
-      const wallet = createTestWallet();
+    it('selects a wallet by decrypting its secret and deriving its addresses', async () => {
+      const wallet = createTestWallet({ addressCount: 1 });
       const keychain = createTestKeychain([wallet]);
       walletManager['wallets'] = [wallet];
       walletManager['keychain'] = keychain;
+      mocks.sessionManager.getKeychainMasterKey.mockResolvedValue({} as CryptoKey);
+      mocks.keyBased.decryptWithKey.mockResolvedValue('test mnemonic');
+      vi.mocked(HDKey.fromMasterSeed).mockReturnValue({
+        derive: vi.fn().mockReturnValue({ publicKey: new Uint8Array([2, 3, 4]) }),
+      } as any);
+      vi.mocked(encodeAddress).mockReturnValue('bc1qselected');
 
-      // Mock storage record for persistKeychain
-      mocks.walletStorage.getKeychainRecord.mockResolvedValue(createTestKeychainRecord());
-
-      await walletManager.setActiveWallet(wallet.id);
+      await walletManager.selectWallet(wallet.id);
 
       expect(walletManager.getActiveWallet()).toEqual(wallet);
+      expect(wallet.addresses).toHaveLength(1);
+      expect(mocks.sessionManager.storeUnlockedSecret).toHaveBeenCalledWith(
+        wallet.id,
+        'test mnemonic'
+      );
+    });
+  });
+
+  describe('Address Format Changes', () => {
+    it('preserves the wallet address count and selected derivation index', async () => {
+      const wallet = createTestWallet({
+        addressFormat: AddressFormat.P2PKH,
+        addressCount: 3,
+        addresses: [0, 1, 2].map(index => ({
+          name: `Address ${index + 1}`,
+          address: `legacy-${index}`,
+          path: `m/44'/0'/0'/0/${index}`,
+          pubKey: `02legacy${index}`,
+        })),
+      });
+      const keychain = createTestKeychain([wallet]);
+      keychain.settings.lastActiveAddress = 'legacy-2';
+      walletManager['wallets'] = [wallet];
+      walletManager['keychain'] = keychain;
+      walletManager['activeWalletId'] = wallet.id;
+      mocks.sessionManager.getUnlockedSecret.mockResolvedValue('test mnemonic');
+      mocks.sessionManager.getKeychainMasterKey.mockResolvedValue({} as CryptoKey);
+      mocks.walletStorage.getKeychainRecord.mockResolvedValue(createTestKeychainRecord());
+      mocks.bitcoin.getDerivationPathForAddressFormat.mockReturnValue("m/86'/0'/0'/0");
+      vi.mocked(HDKey.fromMasterSeed).mockReturnValue({
+        derive: vi.fn((path: string) => ({
+          publicKey: new Uint8Array([2, Number(path.split('/').at(-1))]),
+        })),
+      } as any);
+      vi.mocked(encodeAddress).mockImplementation(
+        publicKey => `taproot-${publicKey[1]}`
+      );
+
+      await walletManager.updateWalletAddressFormat(wallet.id, AddressFormat.P2TR);
+
+      expect(wallet.addressFormat).toBe(AddressFormat.P2TR);
+      expect(wallet.addressCount).toBe(3);
+      expect(wallet.addresses.map(address => address.address)).toEqual([
+        'taproot-0',
+        'taproot-1',
+        'taproot-2',
+      ]);
+      expect(keychain.wallets[0]!.addressCount).toBe(3);
+      expect(keychain.wallets[0]!.addressFormat).toBe(AddressFormat.P2TR);
+      expect(keychain.settings.lastActiveAddress).toBe('taproot-2');
     });
   });
 

--- a/src/platform/walletManager.ts
+++ b/src/platform/walletManager.ts
@@ -21,6 +21,7 @@ import { type AppSettings, DEFAULT_SETTINGS, getAutoLockTimeoutMs, setSettingsPr
 import {
   deriveAddressesFromSecret,
   deriveMnemonicAddress,
+  deriveMnemonicAddresses,
   generateWalletId,
   generateWalletIdFromPrivateKey,
   getPairedAddressFormats,
@@ -223,11 +224,6 @@ export class WalletManager {
   public getActiveWallet(): Wallet | undefined {
     if (!this.activeWalletId) return undefined;
     return this.getWalletById(this.activeWalletId);
-  }
-
-  public async setActiveWallet(walletId: string): Promise<void> {
-    this.activeWalletId = walletId;
-    await this.updateSettings({ lastActiveWalletId: walletId });
   }
 
   public getWalletById(id: string): Wallet | undefined {
@@ -1139,12 +1135,25 @@ export class WalletManager {
       throw new Error('Wallet is locked. Please unlock first.');
     }
 
+    // Address count belongs to the mnemonic wallet. A format switch changes the
+    // derivation branch, not how many derivation indices the user has exposed.
+    const activeAddress = wallet.addresses.find(
+      address => address.address === this.getSettings().lastActiveAddress
+    ) ?? wallet.addresses[0];
+    const activeIndex = activeAddress
+      ? Number(activeAddress.path.split('/').at(-1))
+      : 0;
+    const selectedIndex = Number.isSafeInteger(activeIndex) && activeIndex >= 0
+      ? Math.min(activeIndex, Math.max(wallet.addressCount - 1, 0))
+      : 0;
+
     wallet.addressFormat = newType;
-    wallet.addressCount = 1;
-    wallet.addresses = [deriveMnemonicAddress(mnemonic, newType, 0)];
-    // Update preview address to match new format
-    const derivationPath = `${getDerivationPathForAddressFormat(newType)}/0`;
-    wallet.previewAddress = getAddressFromMnemonic(mnemonic, derivationPath, newType);
+    wallet.addresses = deriveMnemonicAddresses(
+      mnemonic,
+      newType,
+      Math.max(wallet.addressCount, 1)
+    );
+    wallet.previewAddress = wallet.addresses[0]!.address;
 
     // Update keychain record
     if (!this.keychain) throw new Error('Keychain not loaded');
@@ -1152,14 +1161,13 @@ export class WalletManager {
     if (!keychainRecord) throw new Error('Missing keychain record.');
 
     keychainRecord.addressFormat = newType;
-    keychainRecord.addressCount = 1;
     keychainRecord.previewAddress = wallet.previewAddress;
 
-    await this.persistKeychain();
-
     if (this.activeWalletId === walletId) {
-      await this.setActiveWallet(walletId);
+      this.keychain.settings.lastActiveAddress = wallet.addresses[selectedIndex]!.address;
     }
+
+    await this.persistKeychain();
   }
 
   /**

--- a/src/services/__tests__/providerService.test.ts
+++ b/src/services/__tests__/providerService.test.ts
@@ -343,7 +343,6 @@ describe('ProviderService', () => {
         addressFormat: 'p2wpkh',
         addresses: [{ address: 'bc1qtest123', path: "m/84'/0'/0'/0/0", pubKey: '02aa', name: 'Address 1' }]
       }),
-      setActiveWallet: vi.fn().mockResolvedValue(undefined),
       unlockKeychain: vi.fn().mockResolvedValue(undefined),
       lockKeychain: vi.fn().mockResolvedValue(undefined),
       createMnemonicWallet: vi.fn(),

--- a/src/services/walletService.ts
+++ b/src/services/walletService.ts
@@ -31,7 +31,6 @@ interface WalletService {
   getWallets: () => Promise<Wallet[]>;
   getActiveWallet: () => Promise<Wallet | undefined>;
   getActiveAddress: () => Promise<Address | undefined>;
-  setActiveWallet: (walletId: string) => Promise<void>;
   unlockKeychain: (password: string) => Promise<void>;
   selectWallet: (walletId: string) => Promise<void>;
   isKeychainUnlocked: () => Promise<boolean>;
@@ -146,10 +145,6 @@ function createWalletService(): WalletService {
       // Find the address in the active wallet
       const address = activeWallet.addresses.find(addr => addr.address === lastActiveAddress);
       return address || activeWallet.addresses[0];
-    },
-    setActiveWallet: async (walletId) => {
-      await walletManager.setActiveWallet(walletId);
-      // Don't emit here - address switching is handled in wallet-context
     },
     unlockKeychain: async (password) => {
       await walletManager.unlockKeychain(password);

--- a/src/types/wallet.ts
+++ b/src/types/wallet.ts
@@ -46,7 +46,7 @@ export interface Wallet {
   type: 'mnemonic' | 'privateKey' | 'hardware';
   /** Bitcoin address format for derivation */
   addressFormat: AddressFormat;
-  /** Number of derived addresses */
+  /** Number of derivation indices exposed in every compatible address format */
   addressCount: number;
   /** Array of derived addresses */
   addresses: Address[];
@@ -73,7 +73,7 @@ export interface WalletRecord {
   type: 'mnemonic' | 'privateKey' | 'hardware';
   /** Bitcoin address format for derivation */
   addressFormat: AddressFormat;
-  /** Number of derived addresses */
+  /** Number of derivation indices exposed in every compatible address format */
   addressCount: number;
   /** First address for display (m/.../0/0) */
   previewAddress: string;


### PR DESCRIPTION
## What changed

- remove the old pointer-only setActiveWallet path and keep selectWallet as the single activation operation
- preserve the one-secret-in-memory security boundary when switching wallets
- refresh active identity and emit accountsChanged consistently after wallet, address-format, creation, and removal changes
- preserve each mnemonic wallet's address count and selected derivation index when changing address format
- remove the removal-page workaround that selected an undecrypted wallet before deletion

## Why

The original setActiveWallet predates the keychain redesign. The redesign added selectWallet because selection must decrypt the chosen wallet, clear the previous secret, and derive the selected wallet's addresses. The UI migrated to it, but the old context and service path remained and later accumulated provider-event behavior. This finishes that migration instead of retaining two operations with different security semantics.

Address count belongs to the mnemonic wallet, not its currently displayed address format. Changing Legacy, SegWit, or Taproot should therefore derive the same number of indices and keep the corresponding selected index.

## Verification

- npm run compile
- npm run lint
- focused wallet, context, provider, and menu tests: 124 passed
- CI=1 npm run test:unit: production build plus 285 test files, 4,823 passed, 60 skipped