### PR TITLE
Align XCP price view with live ask

### DIFF
--- a/e2e/pages/market/xcp-price.spec.ts
+++ b/e2e/pages/market/xcp-price.spec.ts
@@ -9,8 +9,8 @@
  */
 
 import type { Page } from '@playwright/test';
-import { walletTest, expect } from '../../fixtures';
-import { market, common } from '../../selectors';
+import { expect, walletTest } from '../../fixtures';
+import { common, market } from '../../selectors';
 
 const TICKER = {
   result: {
@@ -37,7 +37,7 @@ const PRICE_HISTORY = {
 /** Serve the endpoints the page reads. Registered most-specific-last so it wins. */
 async function stubPriceApi(
   page: Page,
-  overrides: { tickerStatus?: number; dispensers?: object[] } = {},
+  overrides: { tickerStatus?: number; ticker?: object } = {},
 ) {
   await page.route('**/v2/price', (route) =>
     route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(PRICE_HISTORY) }),
@@ -46,17 +46,7 @@ async function stubPriceApi(
     route.fulfill({
       status: overrides.tickerStatus ?? 200,
       contentType: 'application/json',
-      body: JSON.stringify(overrides.tickerStatus ? { error: 'unavailable' } : TICKER),
-    }),
-  );
-  // Open XCP dispensers feed the floor-price row; with none open the page
-  // falls back to the explorer's DEX rate.
-  const dispensers = overrides.dispensers ?? [];
-  await page.route('**/v2/assets/XCP/dispensers*', (route) =>
-    route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ result: dispensers, result_count: dispensers.length }),
+      body: JSON.stringify(overrides.tickerStatus ? { error: 'unavailable' } : (overrides.ticker ?? TICKER)),
     }),
   );
 }
@@ -76,7 +66,7 @@ walletTest.describe('XCP Price Page (/market/xcp)', () => {
     await expect(page.getByText(/Counterparty \(USD\)/i)).toBeVisible();
   });
 
-  walletTest('falls back to the DEX rate when no dispensers are open', async ({ page }) => {
+  walletTest('falls back to the historical DEX rate when the ticker has no sats quote', async ({ page }) => {
     await stubPriceApi(page);
     await gotoXcpPrice(page);
 
@@ -87,12 +77,15 @@ walletTest.describe('XCP Price Page (/market/xcp)', () => {
     await expect(page.getByText(/\$88\.93/)).toBeVisible();
   });
 
-  walletTest('reports the floor price from the cheapest open dispenser', async ({ page }) => {
+  walletTest('reports the live mempool-adjusted floor from the ticker', async ({ page }) => {
     await stubPriceApi(page, {
-      dispensers: [
-        { source: 'bc1qcheapest', satoshirate: 2400, give_quantity_normalized: '1' },
-        { source: 'bc1qpricier', satoshirate: 5000, give_quantity_normalized: '1' },
-      ],
+      ticker: {
+        ...TICKER,
+        result: {
+          ...TICKER.result,
+          xcp: { ...TICKER.result.xcp, sats: 2400, quote: 'confirmed_unit_dispenser_ask' },
+        },
+      },
     });
     await gotoXcpPrice(page);
 

--- a/src/core/counterparty/price.test.ts
+++ b/src/core/counterparty/price.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { fetchFromXCPIO, getXcpStats } from "./price";
+import { fetchFromXCPIO, getXCPPrice, getXcpStats } from "./price";
 
 describe("canonical XCP price", () => {
   afterEach(() => vi.unstubAllGlobals());
@@ -48,5 +48,87 @@ describe("canonical XCP price", () => {
       change24h: null,
       satsPerXcp: 5700,
     });
+  });
+});
+
+describe("XCP price source preference", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  /** xcp.io answers slowly; Dex-Trade answers at once. The old Promise.any race
+   *  returned whichever landed first, so this ordering is what is under test. */
+  const stub = ({
+    ticker,
+    dexTrade,
+    tickerDelayMs = 0,
+  }: {
+    ticker: () => Response;
+    dexTrade: () => Response;
+    tickerDelayMs?: number;
+  }) =>
+    vi.fn(async (url: string) => {
+      // Dispatch on the exact host. A startsWith on the origin would also match
+      // api.xcp.io.example.com, which is both wrong and what CodeQL's
+      // incomplete-url-substring-sanitization rule exists to catch.
+      const { host } = new URL(url);
+      if (host === "api.xcp.io") {
+        await new Promise((resolve) => setTimeout(resolve, tickerDelayMs));
+        return ticker();
+      }
+      if (host === "api.dex-trade.com") return dexTrade();
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+
+  const CHAIN = Response.json({ result: { xcp: { usd: 2.87, change_pct: -1.9 } } });
+  // 0.000023 BTC x $79,000 = $1.817 — the exchange print, a third below the chain.
+  const EXCHANGE = { status: true, data: { pair: "XCPBTC", last: "0.000023" } };
+
+  it("prefers the canonical ticker even when the exchange answers first", async () => {
+    const fetch = stub({
+      ticker: () => CHAIN,
+      dexTrade: () => Response.json(EXCHANGE),
+      tickerDelayMs: 25,
+    });
+    vi.stubGlobal("fetch", fetch);
+
+    await expect(getXCPPrice(79_000)).resolves.toBe(2.87);
+    // And the loser is never even asked for, so a slow exchange cannot delay us.
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith("https://api.xcp.io/v2/price/ticker");
+  });
+
+  it("falls back to the exchange only once the canonical ticker fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      stub({
+        ticker: () => new Response("", { status: 503 }),
+        dexTrade: () => Response.json(EXCHANGE),
+      }),
+    );
+    await expect(getXCPPrice(79_000)).resolves.toBeCloseTo(1.817, 3);
+  });
+
+  it("skips the exchange without a BTC rate to convert through", async () => {
+    const fetch = stub({
+      ticker: () => new Response("", { status: 503 }),
+      dexTrade: () => Response.json(EXCHANGE),
+    });
+    vi.stubGlobal("fetch", fetch);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(getXCPPrice(null)).resolves.toBeNull();
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns null rather than a zero when every source is unusable", async () => {
+    vi.stubGlobal(
+      "fetch",
+      stub({
+        ticker: () => Response.json({ result: { xcp: { usd: 0 } } }),
+        dexTrade: () => Response.json({ status: true, data: { pair: "XCPBTC", last: "0" } }),
+      }),
+    );
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(getXCPPrice(79_000)).resolves.toBeNull();
   });
 });

--- a/src/core/counterparty/price.test.ts
+++ b/src/core/counterparty/price.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { fetchFromXCPIO } from "./price";
+import { fetchFromXCPIO, getXCPPrice } from "./price";
 
 describe("canonical XCP price", () => {
   afterEach(() => vi.unstubAllGlobals());
@@ -24,5 +24,83 @@ describe("canonical XCP price", () => {
       vi.fn().mockResolvedValue(Response.json({ result: { xcp: { usd: 0 } } })),
     );
     await expect(fetchFromXCPIO()).rejects.toThrow("Invalid XCP price value");
+  });
+});
+
+describe("XCP price source preference", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  /** xcp.io answers slowly; Dex-Trade answers at once. The old Promise.any race
+   *  returned whichever landed first, so this ordering is what is under test. */
+  const stub = ({
+    ticker,
+    dexTrade,
+    tickerDelayMs = 0,
+  }: {
+    ticker: () => Response;
+    dexTrade: () => Response;
+    tickerDelayMs?: number;
+  }) =>
+    vi.fn(async (url: string) => {
+      if (url.startsWith("https://api.xcp.io")) {
+        await new Promise((resolve) => setTimeout(resolve, tickerDelayMs));
+        return ticker();
+      }
+      if (url.startsWith("https://api.dex-trade.com")) return dexTrade();
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+
+  const CHAIN = Response.json({ result: { xcp: { usd: 2.87, change_pct: -1.9 } } });
+  // 0.000023 BTC x $79,000 = $1.817 — the exchange print, a third below the chain.
+  const EXCHANGE = { status: true, data: { pair: "XCPBTC", last: "0.000023" } };
+
+  it("prefers the canonical ticker even when the exchange answers first", async () => {
+    const fetch = stub({
+      ticker: () => CHAIN,
+      dexTrade: () => Response.json(EXCHANGE),
+      tickerDelayMs: 25,
+    });
+    vi.stubGlobal("fetch", fetch);
+
+    await expect(getXCPPrice(79_000)).resolves.toBe(2.87);
+    // And the loser is never even asked for, so a slow exchange cannot delay us.
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith("https://api.xcp.io/v2/price/ticker");
+  });
+
+  it("falls back to the exchange only once the canonical ticker fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      stub({
+        ticker: () => new Response("", { status: 503 }),
+        dexTrade: () => Response.json(EXCHANGE),
+      }),
+    );
+    await expect(getXCPPrice(79_000)).resolves.toBeCloseTo(1.817, 3);
+  });
+
+  it("skips the exchange without a BTC rate to convert through", async () => {
+    const fetch = stub({
+      ticker: () => new Response("", { status: 503 }),
+      dexTrade: () => Response.json(EXCHANGE),
+    });
+    vi.stubGlobal("fetch", fetch);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(getXCPPrice(null)).resolves.toBeNull();
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns null rather than a zero when every source is unusable", async () => {
+    vi.stubGlobal(
+      "fetch",
+      stub({
+        ticker: () => Response.json({ result: { xcp: { usd: 0 } } }),
+        dexTrade: () => Response.json({ status: true, data: { pair: "XCPBTC", last: "0" } }),
+      }),
+    );
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(getXCPPrice(79_000)).resolves.toBeNull();
   });
 });

--- a/src/core/counterparty/price.test.ts
+++ b/src/core/counterparty/price.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { fetchFromXCPIO } from "./price";
+import { fetchFromXCPIO, getXcpStats } from "./price";
 
 describe("canonical XCP price", () => {
   afterEach(() => vi.unstubAllGlobals());
@@ -24,5 +24,29 @@ describe("canonical XCP price", () => {
       vi.fn().mockResolvedValue(Response.json({ result: { xcp: { usd: 0 } } })),
     );
     await expect(fetchFromXCPIO()).rejects.toThrow("Invalid XCP price value");
+  });
+
+  it("reads the live dispenser ask from the ticker", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        Response.json({
+          result: {
+            xcp: {
+              usd: 4.56,
+              change_pct: null,
+              sats: 5700,
+              quote: "confirmed_unit_dispenser_ask",
+            },
+          },
+        }),
+      ),
+    );
+
+    await expect(getXcpStats()).resolves.toEqual({
+      price: 4.56,
+      change24h: null,
+      satsPerXcp: 5700,
+    });
   });
 });

--- a/src/core/counterparty/price.test.ts
+++ b/src/core/counterparty/price.test.ts
@@ -42,11 +42,15 @@ describe("XCP price source preference", () => {
     tickerDelayMs?: number;
   }) =>
     vi.fn(async (url: string) => {
-      if (url.startsWith("https://api.xcp.io")) {
+      // Dispatch on the exact host. A startsWith on the origin would also match
+      // api.xcp.io.example.com, which is both wrong and what CodeQL's
+      // incomplete-url-substring-sanitization rule exists to catch.
+      const { host } = new URL(url);
+      if (host === "api.xcp.io") {
         await new Promise((resolve) => setTimeout(resolve, tickerDelayMs));
         return ticker();
       }
-      if (url.startsWith("https://api.dex-trade.com")) return dexTrade();
+      if (host === "api.dex-trade.com") return dexTrade();
       throw new Error(`unexpected fetch: ${url}`);
     });
 

--- a/src/core/counterparty/price.ts
+++ b/src/core/counterparty/price.ts
@@ -218,53 +218,54 @@ export async function getXcpPriceHistory(): Promise<XcpPriceHistoryData> {
   };
 }
 
-// Future: Add more XCP price sources here if needed
-const xcpPriceFetchers = [
-  fetchFromXCPIO,
-  // fetchFromDexTrade requires BTC price, so it's handled separately in getXCPPrice
-];
+// Future: Add more XCP price sources here if needed. Order is preference order.
+const xcpPriceFetchers = [fetchFromXCPIO];
 
 /**
- * Fetches XCP price from available APIs, returning the first successful result.
- * Includes fallback to dex-trade.com using BTC price conversion.
- * @param {number | null} btcPriceUsd - Optional BTC price for dex-trade fallback.
- * @returns {Promise<number | null>} XCP price in USD or null if all fail.
+ * XCP price in USD, from the first source that answers with a usable quote.
+ *
+ * Tried IN ORDER, and that ordering is the point. This used to race every
+ * source with Promise.any, which resolves with the first to FULFIL rather than
+ * the first in the list — so the Dex-Trade leg, described here as a fallback,
+ * won whenever it answered before xcp.io. Non-deterministic by construction,
+ * and it silently swapped the source of a price the user is shown.
+ *
+ * The two do not agree, so which one wins matters. xcp.io's ticker prices XCP
+ * from executions on its own chain — dispenser fills and DEX order matches,
+ * the venues where XCP actually changes hands. Dex-Trade is a single exchange
+ * whose XCP/BTC pair has cleared no meaningful volume in months, and it has
+ * been printing on the order of a third below the chain. Racing them meant the
+ * extension showed one number or the other depending on which host was quicker
+ * to respond, which reads to a user as the price flickering.
+ *
+ * Dex-Trade stays as a genuine last resort, reached only if every canonical
+ * source has failed, because a stale cross-rate beats no price at all. It
+ * needs BTC/USD to convert its XCP/BTC quote, so it is skipped without one.
  */
 export async function getXCPPrice(
   btcPriceUsd?: number | null,
 ): Promise<number | null> {
-  // First try direct USD fetchers
-  const directFetcherPromises = xcpPriceFetchers.map(async (fetcher) => {
-    const data = await fetcher();
-    const price = data.xcp?.usd;
-    if (typeof price !== "number" || Number.isNaN(price)) {
-      throw new DataFetchError(
-        `${fetcher.name} returned invalid XCP price`,
-        "xcp-price",
-      );
+  const usable = (price: unknown): price is number =>
+    typeof price === "number" && Number.isFinite(price) && price > 0;
+
+  for (const fetcher of xcpPriceFetchers) {
+    try {
+      const { xcp } = await fetcher();
+      if (usable(xcp?.usd)) return xcp.usd;
+    } catch {
+      // Fall through to the next source; a failure here is not the answer.
     }
-    return price;
-  });
-
-  // If BTC price is available, add dex-trade as fallback
-  if (btcPriceUsd && typeof btcPriceUsd === "number") {
-    const dexTradePromise = (async () => {
-      const data = await fetchFromDexTrade(btcPriceUsd);
-      const price = data.xcp?.usd;
-      if (typeof price !== "number" || Number.isNaN(price)) {
-        throw new DataFetchError(
-          "fetchFromDexTrade returned invalid XCP price",
-          "dex-trade.com",
-        );
-      }
-      return price;
-    })();
-
-    directFetcherPromises.push(dexTradePromise);
   }
 
-  return Promise.any(directFetcherPromises).catch(() => {
-    console.error("All XCP price fetchers failed");
-    return null;
-  });
+  if (usable(btcPriceUsd)) {
+    try {
+      const { xcp } = await fetchFromDexTrade(btcPriceUsd);
+      if (usable(xcp?.usd)) return xcp.usd;
+    } catch {
+      // Nothing left to try.
+    }
+  }
+
+  console.error("All XCP price fetchers failed");
+  return null;
 }

--- a/src/core/counterparty/price.ts
+++ b/src/core/counterparty/price.ts
@@ -227,53 +227,54 @@ export async function getXcpPriceHistory(): Promise<XcpPriceHistoryData> {
   };
 }
 
-// Future: Add more XCP price sources here if needed
-const xcpPriceFetchers = [
-  fetchFromXCPIO,
-  // fetchFromDexTrade requires BTC price, so it's handled separately in getXCPPrice
-];
+// Future: Add more XCP price sources here if needed. Order is preference order.
+const xcpPriceFetchers = [fetchFromXCPIO];
 
 /**
- * Fetches XCP price from available APIs, returning the first successful result.
- * Includes fallback to dex-trade.com using BTC price conversion.
- * @param {number | null} btcPriceUsd - Optional BTC price for dex-trade fallback.
- * @returns {Promise<number | null>} XCP price in USD or null if all fail.
+ * XCP price in USD, from the first source that answers with a usable quote.
+ *
+ * Tried IN ORDER, and that ordering is the point. This used to race every
+ * source with Promise.any, which resolves with the first to FULFIL rather than
+ * the first in the list — so the Dex-Trade leg, described here as a fallback,
+ * won whenever it answered before xcp.io. Non-deterministic by construction,
+ * and it silently swapped the source of a price the user is shown.
+ *
+ * The two do not agree, so which one wins matters. xcp.io's ticker prices XCP
+ * from executions on its own chain — dispenser fills and DEX order matches,
+ * the venues where XCP actually changes hands. Dex-Trade is a single exchange
+ * whose XCP/BTC pair has cleared no meaningful volume in months, and it has
+ * been printing on the order of a third below the chain. Racing them meant the
+ * extension showed one number or the other depending on which host was quicker
+ * to respond, which reads to a user as the price flickering.
+ *
+ * Dex-Trade stays as a genuine last resort, reached only if every canonical
+ * source has failed, because a stale cross-rate beats no price at all. It
+ * needs BTC/USD to convert its XCP/BTC quote, so it is skipped without one.
  */
 export async function getXCPPrice(
   btcPriceUsd?: number | null,
 ): Promise<number | null> {
-  // First try direct USD fetchers
-  const directFetcherPromises = xcpPriceFetchers.map(async (fetcher) => {
-    const data = await fetcher();
-    const price = data.xcp?.usd;
-    if (typeof price !== "number" || Number.isNaN(price)) {
-      throw new DataFetchError(
-        `${fetcher.name} returned invalid XCP price`,
-        "xcp-price",
-      );
+  const usable = (price: unknown): price is number =>
+    typeof price === "number" && Number.isFinite(price) && price > 0;
+
+  for (const fetcher of xcpPriceFetchers) {
+    try {
+      const { xcp } = await fetcher();
+      if (usable(xcp?.usd)) return xcp.usd;
+    } catch {
+      // Fall through to the next source; a failure here is not the answer.
     }
-    return price;
-  });
-
-  // If BTC price is available, add dex-trade as fallback
-  if (btcPriceUsd && typeof btcPriceUsd === "number") {
-    const dexTradePromise = (async () => {
-      const data = await fetchFromDexTrade(btcPriceUsd);
-      const price = data.xcp?.usd;
-      if (typeof price !== "number" || Number.isNaN(price)) {
-        throw new DataFetchError(
-          "fetchFromDexTrade returned invalid XCP price",
-          "dex-trade.com",
-        );
-      }
-      return price;
-    })();
-
-    directFetcherPromises.push(dexTradePromise);
   }
 
-  return Promise.any(directFetcherPromises).catch(() => {
-    console.error("All XCP price fetchers failed");
-    return null;
-  });
+  if (usable(btcPriceUsd)) {
+    try {
+      const { xcp } = await fetchFromDexTrade(btcPriceUsd);
+      if (usable(xcp?.usd)) return xcp.usd;
+    } catch {
+      // Nothing left to try.
+    }
+  }
+
+  console.error("All XCP price fetchers failed");
+  return null;
 }

--- a/src/core/counterparty/price.ts
+++ b/src/core/counterparty/price.ts
@@ -10,6 +10,8 @@ interface XCPApiResponse {
     xcp: {
       usd: number;
       change_pct: number | null;
+      sats?: number | null;
+      quote?: string;
     } | null;
   };
 }
@@ -125,10 +127,11 @@ export async function fetchFromDexTrade(
 export interface XcpStats {
   price: number;
   change24h: number | null;
+  satsPerXcp: number | null;
 }
 
 /**
- * Fetches current XCP price and 24h change from the xcp.io ticker.
+ * Fetches the current actionable XCP quote from the xcp.io ticker.
  * @returns {Promise<XcpStats | null>} Stats or null if unavailable.
  */
 export async function getXcpStats(): Promise<XcpStats | null> {
@@ -139,6 +142,12 @@ export async function getXcpStats(): Promise<XcpStats | null> {
     return {
       price: xcp.usd,
       change24h: typeof xcp.change_pct === "number" ? xcp.change_pct : null,
+      satsPerXcp:
+        typeof xcp.sats === "number" &&
+        Number.isFinite(xcp.sats) &&
+        xcp.sats > 0
+          ? xcp.sats
+          : null,
     };
   } catch (err) {
     console.error("Failed to fetch XCP ticker:", err);

--- a/src/pages/market/xcp.tsx
+++ b/src/pages/market/xcp.tsx
@@ -1,12 +1,11 @@
 import type { ReactElement } from "react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router";
 import { FiRefreshCw } from "@/components/icons";
 import { PriceChart } from "@/components/ui/charts/price-chart";
 import { Spinner } from "@/components/ui/spinner";
 import { useHeader } from "@/contexts/header-context";
 import type { PricePoint } from "@/core/bitcoin/price";
-import { fetchAssetDispensers } from "@/core/counterparty/api";
 import {
   getXcpPriceHistory,
   getXcpStats,
@@ -14,7 +13,6 @@ import {
   type XcpStats,
 } from "@/core/counterparty/price";
 import { formatAmount } from "@/core/format";
-import { divide, roundDown, toBigNumber, toNumber } from "@/core/numeric";
 import { analytics } from "@/platform/fathom";
 
 // Time range options over the daily history from api.xcp.io
@@ -28,12 +26,6 @@ const TIME_RANGES: { id: XcpTimeRange; label: string; days: number | null }[] = 
 
 // Chart dimensions
 const CHART_HEIGHT = 200;
-
-/** The cheapest open XCP dispenser: the price you can actually pay right now. */
-interface DispenserFloor {
-  satsPerXcp: number;
-  source: string;
-}
 
 function filterHistory(history: PricePoint[], range: XcpTimeRange): PricePoint[] {
   const days = TIME_RANGES.find((t) => t.id === range)?.days;
@@ -53,7 +45,6 @@ export default function XcpPricePage(): ReactElement {
   // Data state
   const [stats, setStats] = useState<XcpStats | null>(null);
   const [historyData, setHistoryData] = useState<XcpPriceHistoryData | null>(null);
-  const [floor, setFloor] = useState<DispenserFloor | null>(null);
   const [loading, setLoading] = useState(true);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [chartError, setChartError] = useState<string | null>(null);
@@ -70,28 +61,6 @@ export default function XcpPricePage(): ReactElement {
       setStats(statsData);
     } else {
       setStatsError("Unable to load price");
-    }
-  }, []);
-
-  // Find the cheapest open XCP dispenser (sats per whole XCP). Checks the first
-  // 100 open dispensers; the true floor could hide beyond that, but in practice
-  // open XCP dispensers number far fewer.
-  const loadFloor = useCallback(async () => {
-    try {
-      const response = await fetchAssetDispensers("XCP", { limit: 100, status: "open" });
-      let best: DispenserFloor | null = null;
-      for (const dispenser of response.result) {
-        const unitsPerDispense = toBigNumber(dispenser.give_quantity_normalized);
-        if (!unitsPerDispense.isGreaterThan(0)) continue;
-        const satsPerXcp = toNumber(roundDown(divide(dispenser.satoshirate, unitsPerDispense)));
-        if (!best || satsPerXcp < best.satsPerXcp) {
-          best = { satsPerXcp, source: dispenser.source };
-        }
-      }
-      setFloor(best);
-    } catch (err) {
-      console.error("Failed to load XCP dispenser floor:", err);
-      setFloor(null);
     }
   }, []);
 
@@ -113,23 +82,23 @@ export default function XcpPricePage(): ReactElement {
     const loadInitial = async () => {
       setLoading(true);
       try {
-        await Promise.all([loadStats(), loadHistory(), loadFloor()]);
+        await Promise.all([loadStats(), loadHistory()]);
       } finally {
         setLoading(false);
       }
     };
     loadInitial();
-  }, [loadStats, loadHistory, loadFloor]);
+  }, [loadStats, loadHistory]);
 
   // Handle refresh
   const handleRefresh = useCallback(async () => {
     setIsRefreshing(true);
     try {
-      await Promise.all([loadStats(), loadHistory(), loadFloor()]);
+      await Promise.all([loadStats(), loadHistory()]);
     } finally {
       setIsRefreshing(false);
     }
-  }, [loadStats, loadHistory, loadFloor]);
+  }, [loadStats, loadHistory]);
 
   // Configure header
   useEffect(() => {
@@ -155,7 +124,33 @@ export default function XcpPricePage(): ReactElement {
   const formatPrice = (price: number) =>
     `$${formatAmount({ value: price, minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
 
-  const chartData = historyData ? filterHistory(historyData.history, range) : [];
+  // Daily history stays historical; only today's endpoint follows the live,
+  // mempool-adjusted dispenser ask used by the ticker headline.
+  const liveHistory = useMemo(() => {
+    const history = historyData?.history ?? [];
+    if (!stats) return history;
+
+    const today = Date.parse(`${new Date().toISOString().slice(0, 10)}T00:00:00Z`);
+    const livePoint = { timestamp: today, price: stats.price };
+    const lastPoint = history[history.length - 1];
+
+    return lastPoint?.timestamp === today
+      ? [...history.slice(0, -1), livePoint]
+      : [...history, livePoint];
+  }, [historyData?.history, stats]);
+  const chartData = useMemo(
+    () => filterHistory(liveHistory, range),
+    [liveHistory, range],
+  );
+  const ath = useMemo(() => {
+    if (!stats || (historyData?.ath && historyData.ath.usd >= stats.price)) {
+      return historyData?.ath ?? null;
+    }
+    return {
+      usd: stats.price,
+      day: new Date().toISOString().slice(0, 10),
+    };
+  }, [historyData?.ath, stats]);
 
   if (loading) {
     return <Spinner message="Loading XCP price…" />;
@@ -260,34 +255,34 @@ export default function XcpPricePage(): ReactElement {
         </div>
 
         {/* Market Stats */}
-        {(floor || historyData?.satsPerXcp || historyData?.ath) && (
+        {(stats?.satsPerXcp || historyData?.satsPerXcp || ath) && (
           <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-3 mt-4">
-            {floor ? (
-              <div className={`flex items-center justify-between ${historyData?.ath ? "pb-2 border-b border-gray-100" : ""}`}>
+            {stats?.satsPerXcp ? (
+              <div className={`flex items-center justify-between ${ath ? "pb-2 border-b border-gray-100" : ""}`}>
                 <span className="text-sm text-gray-600">Floor Price</span>
                 <button type="button"
-                  onClick={() => navigate(`/compose/dispenser/dispense?address=${floor.source}&asset=XCP`)}
+                  onClick={handleBuyXcp}
                   className="text-sm font-medium text-blue-600 hover:text-blue-800 cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
-                  aria-label="Buy from the cheapest open XCP dispenser"
+                  aria-label="View open XCP dispensers"
                 >
-                  1 XCP = {formatAmount({ value: floor.satsPerXcp, maximumFractionDigits: 0 })} sats
+                  1 XCP = {formatAmount({ value: stats.satsPerXcp, maximumFractionDigits: 0 })} sats
                 </button>
               </div>
             ) : historyData?.satsPerXcp ? (
-              <div className={`flex items-center justify-between ${historyData.ath ? "pb-2 border-b border-gray-100" : ""}`}>
+              <div className={`flex items-center justify-between ${ath ? "pb-2 border-b border-gray-100" : ""}`}>
                 <span className="text-sm text-gray-600">DEX Rate</span>
                 <span className="text-sm font-medium text-gray-900">
                   1 XCP = {formatAmount({ value: historyData.satsPerXcp, maximumFractionDigits: 0 })} sats
                 </span>
               </div>
             ) : null}
-            {historyData?.ath && (
-              <div className={`flex items-center justify-between ${(floor || historyData.satsPerXcp) ? "pt-2" : ""}`}>
+            {ath && (
+              <div className={`flex items-center justify-between ${(stats?.satsPerXcp || historyData?.satsPerXcp) ? "pt-2" : ""}`}>
                 <span className="text-sm text-gray-600">All-Time High</span>
                 <span className="text-sm font-medium text-gray-900">
-                  {formatPrice(historyData.ath.usd)}
+                  {formatPrice(ath.usd)}
                   <span className="text-gray-400 font-normal">
-                    {" "}· {new Date(`${historyData.ath.day}T00:00:00Z`).toLocaleDateString("en-US", { year: "numeric", month: "short" })}
+                    {" "}· {new Date(`${ath.day}T00:00:00Z`).toLocaleDateString("en-US", { year: "numeric", month: "short" })}
                   </span>
                 </span>
               </div>


### PR DESCRIPTION
Uses the canonical xcp.io ticker for the displayed XCP/USD price and mempool-adjusted sats floor, replaces today in the price chart with that same live quote, and keeps prior days historical. Removes the extension-side dispenser scan that could drift from Explorer and Exchange. Tested with the focused price suite and TypeScript compile.