### PR TITLE
Fix recurring nightly test failures

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -76,6 +76,13 @@ jobs:
         env:
           NODE_OPTIONS: --max-old-space-size=6144
         run: npx vitest run src --config vitest.fuzz.config.ts
+
+      # Extension tests must launch Chromium headed so Manifest V3 service workers and extension
+      # pages are available. Give those windows a virtual display, as the PR E2E job does.
+      - name: Configure Xvfb
+        run: |
+          Xvfb -ac :99 -screen 0 1280x1024x16 &
+          sleep 2
       
       # continue-on-error so the report and artifact steps below still run; the report step
       # re-raises the failure, so a red E2E run still fails the job and files the issue.
@@ -83,6 +90,8 @@ jobs:
         id: e2e
         timeout-minutes: 60
         run: npx playwright test --retries=3 --workers=1
+        env:
+          DISPLAY: ':99'
         continue-on-error: true
       
       # The Playwright image does not ship jq, so the stats are read with node. A missing
@@ -95,7 +104,10 @@ jobs:
             echo "# Nightly Test Report"
             echo "Date: $(date)"
             echo ""
-            if [ -f "test-results.json" ]; then
+            if [ "${{ steps.e2e.outcome }}" = "skipped" ]; then
+              echo "## E2E Results"
+              echo "Skipped because an earlier test step failed."
+            elif [ -f "test-results.json" ]; then
               echo "## E2E Results"
               echo '```json'
               node -e 'console.log(JSON.stringify(require("./test-results.json").stats, null, 2))'
@@ -105,6 +117,9 @@ jobs:
               echo "No test-results.json was written: Playwright did not run."
             fi
           } >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ steps.e2e.outcome }}" = "skipped" ]; then
+            exit 0
+          fi
           if [ ! -f "test-results.json" ]; then
             echo "::error::Playwright produced no test-results.json"
             exit 1

--- a/src/core/counterparty/pack/__tests__/coreOracle.test.ts
+++ b/src/core/counterparty/pack/__tests__/coreOracle.test.ts
@@ -32,6 +32,7 @@ import { asBaseUnits } from '@/core/numeric';
 import { unpackCounterpartyMessage } from '../../unpack';
 import { bytesToHex } from '../../unpack/binary';
 import { packComposeMessage } from '../messages';
+import { fetchOracle } from './oracleRequest';
 
 const API_URL = process.env.COUNTERPARTY_API_URL;
 /** A funded mainnet address is only needed to satisfy the endpoint's shape; nothing is broadcast. */
@@ -377,7 +378,7 @@ async function composeDataFromCore(testCase: OracleCase): Promise<string> {
     ? `utxos/${testCase.sourceUtxo}`
     : `addresses/${SOURCE}`;
   const url = `${API_URL}/v2/${from}/compose/${testCase.composeType}?${query}`;
-  const response = await fetch(url);
+  const response = await fetchOracle(url);
   if (!response.ok) {
     throw new Error(`core returned ${response.status} for ${testCase.label}: ${await response.text()}`);
   }

--- a/src/core/counterparty/pack/__tests__/onchainRoundTrip.test.ts
+++ b/src/core/counterparty/pack/__tests__/onchainRoundTrip.test.ts
@@ -25,6 +25,7 @@ import { unpackCounterpartyMessage } from '../../unpack';
 import { bytesToHex } from '../../unpack/binary';
 import { COUNTERPARTY_PREFIX_HEX } from '../../unpack/messageTypes';
 import { packComposeMessage } from '../messages';
+import { fetchOracle } from './oracleRequest';
 
 const API_URL = process.env.COUNTERPARTY_API_URL;
 /**
@@ -38,6 +39,26 @@ interface OnChainTransaction {
   /** The Counterparty message: type id byte followed by the body, without the CNTRPRTY prefix. */
   data: string;
   block_index: number;
+}
+
+/**
+ * Core's composer uses cbor2's default float64 representation, but consensus accepts other valid
+ * CBOR representations too. Those messages are readable without being byte-reproducible by this
+ * wallet's compose path. Compare the decoded fields so the on-chain oracle can distinguish that
+ * harmless encoding variation from a packer that changed the message's meaning.
+ *
+ * This exception is deliberately broadcast-only. Broadcast is also covered by `coreOracle`, which
+ * still requires the local packer to match core's own composer bytes exactly.
+ */
+function sameBroadcastFields(
+  original: Record<string, any>,
+  rebuilt: Record<string, any>
+): boolean {
+  return original.timestamp === rebuilt.timestamp
+    && original.value === rebuilt.value
+    && original.feeFractionInt === rebuilt.feeFractionInt
+    && original.text === rebuilt.text
+    && original.mimeType === rebuilt.mimeType;
 }
 
 /**
@@ -197,7 +218,7 @@ const COMPOSE_TYPE_FOR: Record<string, string> = {
 
 async function recentTransactions(type: string): Promise<OnChainTransaction[]> {
   const url = `${API_URL}/v2/transactions?type=${type}&limit=${SAMPLE_SIZE}&valid=true`;
-  const response = await fetch(url);
+  const response = await fetchOracle(url);
   if (!response.ok) throw new Error(`core returned ${response.status} listing ${type}`);
   const body = await response.json() as { result?: OnChainTransaction[] };
   return (body.result ?? []).filter((tx) => typeof tx.data === 'string' && tx.data.length > 0);
@@ -242,12 +263,29 @@ describe.skipIf(!API_URL)('rebuilding real on-chain messages', () => {
         continue;
       }
 
-      compared += 1;
       const rebuilt = bytesToHex(packed.bytes).toLowerCase();
       const original = (COUNTERPARTY_PREFIX_HEX + transaction.data).toLowerCase();
       if (rebuilt !== original) {
+        const rebuiltMessage = unpackCounterpartyMessage(rebuilt);
+        if (
+          apiType === 'broadcast'
+          && rebuiltMessage.success
+          && rebuiltMessage.messageType === 'broadcast'
+          && rebuiltMessage.data
+          && sameBroadcastFields(
+            unpacked.data as Record<string, any>,
+            rebuiltMessage.data as Record<string, any>
+          )
+        ) {
+          // A third-party composer may choose float16/32 or another valid CBOR representation. The
+          // wallet intentionally emits core's default float64 form, so this sample is readable but
+          // not one its compose path claims it can reproduce byte-for-byte.
+          declined += 1;
+          continue;
+        }
         failures.push(`${transaction.tx_hash} (block ${transaction.block_index})\n  on-chain: ${original}\n  rebuilt:  ${rebuilt}`);
       }
+      compared += 1;
     }
 
     expect(failures, `rebuilt bytes differ from chain:\n${failures.join('\n')}`).toEqual([]);
@@ -270,4 +308,31 @@ describe.skipIf(!API_URL)('rebuilding real on-chain messages', () => {
       return;
     }
   }, 30_000);
+});
+
+describe('on-chain broadcast sample classification', () => {
+  it('declines an equivalent non-core float16 encoding', () => {
+    // CBOR [1, 0.0, 0, "text/html", h'6869']; cbor2/core emits the value as float64 instead.
+    const original = COUNTERPARTY_PREFIX_HEX + '1e8501f900000069746578742f68746d6c426869';
+    const unpacked = unpackCounterpartyMessage(original);
+    expect(unpacked.success).toBe(true);
+
+    const packed = packComposeMessage('broadcast', {
+      timestamp: 1,
+      value: '0',
+      fee_fraction: '0',
+      mime_type: 'text/html',
+      text: 'hi',
+    });
+    expect(packed).not.toBeNull();
+    const rebuilt = bytesToHex(packed!.bytes);
+    expect(rebuilt).not.toBe(original);
+
+    const rebuiltMessage = unpackCounterpartyMessage(rebuilt);
+    expect(rebuiltMessage.success).toBe(true);
+    expect(sameBroadcastFields(
+      unpacked.data as Record<string, any>,
+      rebuiltMessage.data as Record<string, any>
+    )).toBe(true);
+  });
 });

--- a/src/core/counterparty/pack/__tests__/oracleRequest.test.ts
+++ b/src/core/counterparty/pack/__tests__/oracleRequest.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fetchOracle } from './oracleRequest';
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe('fetchOracle', () => {
+  it('retries transient server failures', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response('busy', { status: 503 }))
+      .mockResolvedValueOnce(new Response('busy', { status: 503 }))
+      .mockResolvedValueOnce(new Response('{}', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const request = fetchOracle('https://oracle.example/test');
+    await vi.advanceTimersByTimeAsync(1_500);
+
+    await expect(request).resolves.toMatchObject({ status: 200 });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('returns a non-retryable response immediately', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('bad request', { status: 400 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(fetchOracle('https://oracle.example/test')).resolves.toMatchObject({ status: 400 });
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+});

--- a/src/core/counterparty/pack/__tests__/oracleRequest.ts
+++ b/src/core/counterparty/pack/__tests__/oracleRequest.ts
@@ -1,0 +1,21 @@
+/** Retry the transient failures a live nightly oracle can encounter without hiding real errors. */
+export async function fetchOracle(url: string): Promise<Response> {
+  const attempts = 3;
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    try {
+      const response = await fetch(url);
+      const retryable = response.status === 429 || response.status >= 500;
+      if (response.ok || !retryable || attempt === attempts - 1) return response;
+    } catch (error) {
+      lastError = error;
+      if (attempt === attempts - 1) throw error;
+    }
+
+    // Keep the whole request comfortably inside each oracle case's 30-second timeout.
+    await new Promise((resolve) => setTimeout(resolve, 500 * 2 ** attempt));
+  }
+
+  throw lastError ?? new Error('oracle request failed without a response');
+}


### PR DESCRIPTION
Fixes #350. Starts Xvfb before headed extension E2E tests, retries transient live-oracle 429/5xx responses, treats semantically identical non-Core CBOR broadcast encodings as declined samples while retaining the exact Core compose oracle, and avoids a misleading missing-Playwright-results error when E2E was skipped after an earlier failure. Verified with the complete live pack/oracle stage (109 tests), targeted regressions, TypeScript, Biome, and diff checks.