### PR TITLE
Make paired connect permission explicit

### DIFF
--- a/src/pages/requests/connect/__tests__/approve.test.tsx
+++ b/src/pages/requests/connect/__tests__/approve.test.tsx
@@ -6,7 +6,7 @@
  * the wallet context finished loading.
  */
 
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import '@testing-library/jest-dom/vitest';
@@ -14,6 +14,8 @@ import '@testing-library/jest-dom/vitest';
 const approvalMocks = vi.hoisted(() => ({
   getCurrentApproval: vi.fn(),
   getPairedAddresses: vi.fn(),
+  resolveApproval: vi.fn(),
+  rejectApproval: vi.fn(),
 }));
 
 // Mock webext-bridge before any imports that might use it
@@ -44,8 +46,8 @@ vi.mock('@/services/walletService', () => ({
 // Mock the approval service
 vi.mock('@/services/approvalService', () => ({
   getApprovalService: () => ({
-    resolveApproval: vi.fn(),
-    rejectApproval: vi.fn(),
+    resolveApproval: approvalMocks.resolveApproval,
+    rejectApproval: approvalMocks.rejectApproval,
     getCurrentApproval: approvalMocks.getCurrentApproval,
   }),
 }));
@@ -80,6 +82,8 @@ describe('ApproveConnection', () => {
     vi.clearAllMocks();
     approvalMocks.getCurrentApproval.mockReturnValue(null);
     approvalMocks.getPairedAddresses.mockResolvedValue(null);
+    approvalMocks.resolveApproval.mockResolvedValue(true);
+    approvalMocks.rejectApproval.mockResolvedValue(true);
   });
 
   afterEach(() => {
@@ -202,7 +206,7 @@ describe('ApproveConnection', () => {
       expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
     });
 
-    it('shows requested paired addresses behind an unchecked opt-in', async () => {
+    it('shows both requested addresses before Connect and grants the displayed pair', async () => {
       setupWalletContext({
         activeWallet: {
           id: 'test-wallet',
@@ -227,12 +231,80 @@ describe('ApproveConnection', () => {
 
       renderWithRouter();
 
-      const checkbox = await screen.findByRole('checkbox');
-      expect(checkbox).not.toBeChecked();
       await waitFor(() => {
-        expect(screen.getByText(/Legacy: 1legacy/)).toBeInTheDocument();
-        expect(screen.getByText(/SegWit: bc1qsegwit/)).toBeInTheDocument();
-        expect(checkbox).toBeEnabled();
+        expect(screen.getByText('1legacy')).toBeInTheDocument();
+        expect(screen.getByText('bc1qsegwit')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /connect/i })).toBeEnabled();
+      });
+      expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+      expect(screen.getByText(/paired account/i)).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole('button', { name: /connect/i }));
+      await waitFor(() => {
+        expect(approvalMocks.resolveApproval).toHaveBeenCalledWith('test-123', {
+          approved: true,
+          updatedParams: { pairedAddresses: true },
+        });
+      });
+    });
+
+    it('does not allow a paired grant whose addresses failed to load', async () => {
+      setupWalletContext({
+        activeWallet: {
+          id: 'test-wallet',
+          type: 'mnemonic',
+          addressFormat: 'p2wpkh',
+        } as any,
+        activeAddress: { address: 'bc1qtest123' },
+        isLoading: false,
+      });
+      approvalMocks.getCurrentApproval.mockReturnValue({
+        id: 'test-123',
+        params: [{
+          capabilities: { pairedAddresses: true },
+          address: 'bc1qtest123',
+          walletId: 'test-wallet',
+        }],
+      });
+      approvalMocks.getPairedAddresses.mockRejectedValue(new Error('derivation failed'));
+
+      renderWithRouter();
+
+      expect(await screen.findByText(/paired addresses are unavailable/i)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /connect/i })).toBeDisabled();
+      expect(approvalMocks.resolveApproval).not.toHaveBeenCalled();
+    });
+
+    it('clearly falls back to the current address when the account cannot provide a pair', async () => {
+      setupWalletContext({
+        activeWallet: {
+          id: 'test-wallet',
+          type: 'mnemonic',
+          addressFormat: 'p2tr',
+        } as any,
+        activeAddress: { address: 'bc1ptest123' },
+        isLoading: false,
+      });
+      approvalMocks.getCurrentApproval.mockReturnValue({
+        id: 'test-123',
+        params: [{
+          capabilities: { pairedAddresses: true },
+          address: 'bc1ptest123',
+          walletId: 'test-wallet',
+        }],
+      });
+
+      renderWithRouter();
+
+      expect(await screen.findByText(/only the current address will be shared/i)).toBeInTheDocument();
+      const connect = screen.getByRole('button', { name: /connect/i });
+      expect(connect).toBeEnabled();
+      fireEvent.click(connect);
+      await waitFor(() => {
+        expect(approvalMocks.resolveApproval).toHaveBeenCalledWith('test-123', {
+          approved: true,
+          updatedParams: { pairedAddresses: false },
+        });
       });
     });
 

--- a/src/pages/requests/connect/approve.tsx
+++ b/src/pages/requests/connect/approve.tsx
@@ -37,7 +37,6 @@ export default function ApproveConnectionPage(): ReactElement {
   const [isProcessing, setIsProcessing] = useState(false);
   const [faviconError, setFaviconError] = useState(false);
   const [pairedAddressesRequested, setPairedAddressesRequested] = useState(false);
-  const [grantPairedAddresses, setGrantPairedAddresses] = useState(false);
   const [pairedAddresses, setPairedAddresses] = useState<PairedAddresses | null>(null);
   const [approvalError, setApprovalError] = useState<string | null>(null);
   const [pairedAddressError, setPairedAddressError] = useState(false);
@@ -57,6 +56,11 @@ export default function ApproveConnectionPage(): ReactElement {
 
   const domain = getDomain(origin);
   const faviconUrl = `https://www.google.com/s2/favicons?domain=${domain}&sz=64`;
+  const pairedAddressesSupported = pairedAddressesRequested &&
+    activeWallet?.type === 'mnemonic' &&
+    Boolean(getPairedAddressFormats(activeWallet.addressFormat));
+  const pairedAddressesLoading =
+    pairedAddressesSupported && !pairedAddresses && !pairedAddressError;
 
   useEffect(() => {
     if (!requestId || !activeAddress || !activeWallet) return;
@@ -134,7 +138,7 @@ export default function ApproveConnectionPage(): ReactElement {
       const resolved = await approvalService.resolveApproval(requestId, {
         approved: true,
         updatedParams: {
-          pairedAddresses: pairedAddressesRequested && grantPairedAddresses && Boolean(pairedAddresses),
+          pairedAddresses: pairedAddressesSupported && Boolean(pairedAddresses),
         },
       });
       if (!resolved) {
@@ -224,10 +228,51 @@ export default function ApproveConnectionPage(): ReactElement {
             <h2 className="text-lg font-bold text-gray-900 mb-0.5">{domain}</h2>
             <p className="text-xs text-gray-400 break-all">{origin}</p>
 
-            <div className="mt-4 p-2.5 bg-yellow-50 rounded-lg border border-yellow-200">
-              <p className="text-sm text-yellow-800">
-                This site is requesting access to view your wallet address
+            <div className="mt-4 rounded-lg border border-blue-200 bg-blue-50 p-3 text-left">
+              <p className="text-sm font-medium text-blue-900">
+                {pairedAddressesSupported
+                  ? 'This site is requesting access to your paired account'
+                  : 'This site is requesting access to your wallet address'}
               </p>
+              {pairedAddressesSupported && (
+                <div className="mt-2 space-y-2">
+                  {pairedAddressError && (
+                    <p className="text-xs font-medium text-red-700">
+                      Paired addresses are unavailable. Switch accounts or reopen this request to
+                      try again.
+                    </p>
+                  )}
+                  {pairedAddressesLoading && (
+                    <p className="text-xs text-blue-700">Loading Legacy and SegWit addresses…</p>
+                  )}
+                  {pairedAddresses && (
+                    <dl className="space-y-2">
+                      <div>
+                        <dt className="text-[11px] font-medium uppercase tracking-wide text-blue-700">
+                          Legacy
+                        </dt>
+                        <dd className="m-0 break-all font-mono text-xs text-blue-950">
+                          {pairedAddresses.legacy.address}
+                        </dd>
+                      </div>
+                      <div>
+                        <dt className="text-[11px] font-medium uppercase tracking-wide text-blue-700">
+                          SegWit
+                        </dt>
+                        <dd className="m-0 break-all font-mono text-xs text-blue-950">
+                          {pairedAddresses.segwit.address}
+                        </dd>
+                      </div>
+                    </dl>
+                  )}
+                </div>
+              )}
+              {pairedAddressesRequested && !pairedAddressesSupported && (
+                <p className="mt-2 text-xs text-blue-700">
+                  Paired Legacy and SegWit access is not available for this account. Only the
+                  current address will be shared.
+                </p>
+              )}
             </div>
           </div>
 
@@ -237,11 +282,19 @@ export default function ApproveConnectionPage(): ReactElement {
             <ul className="space-y-1.5">
               <li className="flex items-center">
                 <FaCheck className="size-3.5 text-green-500 mr-2 flex-shrink-0" aria-hidden="true" />
-                <span className="text-sm text-gray-600">View your wallet address</span>
+                <span className="text-sm text-gray-600">
+                  {pairedAddressesSupported
+                    ? 'View both addresses shown above'
+                    : 'View your wallet address'}
+                </span>
               </li>
               <li className="flex items-center">
                 <FaCheck className="size-3.5 text-green-500 mr-2 flex-shrink-0" aria-hidden="true" />
-                <span className="text-sm text-gray-600">Request transaction signatures</span>
+                <span className="text-sm text-gray-600">
+                  {pairedAddressesSupported
+                    ? 'Request transaction signatures from either address'
+                    : 'Request transaction signatures'}
+                </span>
               </li>
               <li className="flex items-center">
                 <FaCheck className="size-3.5 text-green-500 mr-2 flex-shrink-0" aria-hidden="true" />
@@ -252,40 +305,11 @@ export default function ApproveConnectionPage(): ReactElement {
 
           {approvalError && <ErrorAlert message={approvalError} />}
 
-          {pairedAddressesRequested && activeWallet.type === 'mnemonic' &&
-            getPairedAddressFormats(activeWallet.addressFormat) && (
-            <label className="mt-4 flex items-start gap-3 rounded-xl border border-blue-200 bg-blue-50 p-4 cursor-pointer">
-              <input
-                type="checkbox"
-                checked={grantPairedAddresses}
-                disabled={!pairedAddresses || Boolean(approvalError)}
-                onChange={(event) => setGrantPairedAddresses(event.target.checked)}
-                className="mt-1 size-4"
-              />
-              <span>
-                <span className="block text-sm font-medium text-blue-900">
-                  Share paired Legacy and SegWit addresses
-                </span>
-                <span className="mt-1 block text-xs text-blue-800">
-                  The site can then request signatures spending inputs from either address. Access
-                  lasts until you disconnect the site.
-                </span>
-                {pairedAddressError && (
-                  <span className="mt-2 block text-xs font-medium text-red-700">
-                    Paired addresses are unavailable. This additional permission cannot be granted.
-                  </span>
-                )}
-                {!pairedAddresses && !pairedAddressError && (
-                  <span className="mt-2 block text-xs text-blue-700">Loading paired addresses…</span>
-                )}
-                {pairedAddresses && (
-                  <span className="mt-2 block space-y-1 text-xs text-blue-900">
-                    <span className="block break-all font-mono">Legacy: {pairedAddresses.legacy.address}</span>
-                    <span className="block break-all font-mono">SegWit: {pairedAddresses.segwit.address}</span>
-                  </span>
-                )}
-              </span>
-            </label>
+          {pairedAddressesSupported && pairedAddresses && (
+            <p className="mt-4 px-1 text-xs leading-relaxed text-gray-500">
+              Connecting grants access to the displayed pair until you disconnect this site. Every
+              transaction and message signature still requires a separate wallet approval.
+            </p>
           )}
         </div>
       </div>
@@ -304,7 +328,12 @@ export default function ApproveConnectionPage(): ReactElement {
           <Button
             color="blue"
             onClick={handleApprove}
-            disabled={isProcessing || Boolean(approvalError)}
+            disabled={
+              isProcessing ||
+              Boolean(approvalError) ||
+              pairedAddressesLoading ||
+              (pairedAddressesSupported && pairedAddressError)
+            }
             fullWidth
           >
             {isProcessing ? "Processing…" : "Connect"}

--- a/src/services/providerService.ts
+++ b/src/services/providerService.ts
@@ -269,9 +269,9 @@ export function createProviderService(): ProviderService {
    * ADR-018: Paired-address provider capability
    *
    * A connection authorizes only its active address. A dApp may opt in to the
-   * active derivation index's Legacy/SegWit sibling pair through explicit,
-   * unchecked-by-default consent. The grant is bound to origin, wallet ID, and
-   * active address, and is removed on disconnect.
+   * active derivation index's Legacy/SegWit sibling pair through explicit
+   * approval that displays both addresses before Connect. The grant is bound
+   * to origin, wallet ID, and active address, and is removed on disconnect.
    *
    * Signing fails closed before approval storage: requested signer addresses
    * must be the active address or its exact sibling pair, input indices must be


### PR DESCRIPTION
Replaces the below-fold paired-address checkbox with one explicit connection permission. For supported mnemonic accounts, the approval screen displays both Legacy and SegWit addresses before Connect and grants exactly that displayed pair. Connect remains disabled while the pair loads or if derivation fails. Accounts that cannot provide the pair clearly disclose that only the current address will be shared.

Validation:
- focused approval UI tests: 16 passed
- TypeScript compile passed
- Chrome MV3 production build passed
- local Biome was blocked by another untracked nested .claude worktree config; GitHub CI runs in a clean checkout