### PR TITLE
Name both paired addresses in the request, not a checkbox below the fold

### DIFF
--- a/src/pages/requests/connect/__tests__/approve.test.tsx
+++ b/src/pages/requests/connect/__tests__/approve.test.tsx
@@ -202,7 +202,7 @@ describe('ApproveConnection', () => {
       expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
     });
 
-    it('shows requested paired addresses behind an unchecked opt-in', async () => {
+    it('grants requested paired addresses without an opt-in the user can miss', async () => {
       setupWalletContext({
         activeWallet: {
           id: 'test-wallet',
@@ -227,13 +227,41 @@ describe('ApproveConnection', () => {
 
       renderWithRouter();
 
-      const checkbox = await screen.findByRole('checkbox');
-      expect(checkbox).not.toBeChecked();
+      // Both addresses are named in the request itself, not hidden behind a checkbox below the fold.
+      expect(await screen.findByText('1leg...gacy')).toBeInTheDocument();
+      expect(screen.getByText('bc1q...gwit')).toBeInTheDocument();
+      expect(screen.getByText('View your wallet addresses')).toBeInTheDocument();
+      expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
       await waitFor(() => {
-        expect(screen.getByText(/Legacy: 1legacy/)).toBeInTheDocument();
-        expect(screen.getByText(/SegWit: bc1qsegwit/)).toBeInTheDocument();
-        expect(checkbox).toBeEnabled();
+        expect(screen.getByRole('button', { name: /connect both/i })).toBeEnabled();
       });
+    });
+
+    it('falls back to single-address consent when paired addresses cannot be loaded', async () => {
+      setupWalletContext({
+        activeWallet: {
+          id: 'test-wallet',
+          type: 'mnemonic',
+          addressFormat: 'p2wpkh',
+        } as any,
+        activeAddress: { address: 'bc1qtest123' },
+        isLoading: false,
+      });
+      approvalMocks.getCurrentApproval.mockReturnValue({
+        id: 'test-123',
+        params: [{
+          capabilities: { pairedAddresses: true },
+          address: 'bc1qtest123',
+          walletId: 'test-wallet',
+        }],
+      });
+      approvalMocks.getPairedAddresses.mockRejectedValue(new Error('locked'));
+
+      renderWithRouter();
+
+      expect(await screen.findByText(/Paired addresses are unavailable/i)).toBeInTheDocument();
+      expect(screen.getByText('View your wallet address')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /^connect$/i })).toBeEnabled();
     });
 
     it('blocks approval if the active wallet identity changed', async () => {

--- a/src/pages/requests/connect/__tests__/approve.test.tsx
+++ b/src/pages/requests/connect/__tests__/approve.test.tsx
@@ -6,7 +6,7 @@
  * the wallet context finished loading.
  */
 
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import '@testing-library/jest-dom/vitest';
@@ -14,6 +14,8 @@ import '@testing-library/jest-dom/vitest';
 const approvalMocks = vi.hoisted(() => ({
   getCurrentApproval: vi.fn(),
   getPairedAddresses: vi.fn(),
+  resolveApproval: vi.fn(),
+  rejectApproval: vi.fn(),
 }));
 
 // Mock webext-bridge before any imports that might use it
@@ -44,8 +46,8 @@ vi.mock('@/services/walletService', () => ({
 // Mock the approval service
 vi.mock('@/services/approvalService', () => ({
   getApprovalService: () => ({
-    resolveApproval: vi.fn(),
-    rejectApproval: vi.fn(),
+    resolveApproval: approvalMocks.resolveApproval,
+    rejectApproval: approvalMocks.rejectApproval,
     getCurrentApproval: approvalMocks.getCurrentApproval,
   }),
 }));
@@ -80,6 +82,8 @@ describe('ApproveConnection', () => {
     vi.clearAllMocks();
     approvalMocks.getCurrentApproval.mockReturnValue(null);
     approvalMocks.getPairedAddresses.mockResolvedValue(null);
+    approvalMocks.resolveApproval.mockResolvedValue(true);
+    approvalMocks.rejectApproval.mockResolvedValue(true);
   });
 
   afterEach(() => {
@@ -235,6 +239,13 @@ describe('ApproveConnection', () => {
       await waitFor(() => {
         expect(screen.getByRole('button', { name: /connect both/i })).toBeEnabled();
       });
+      fireEvent.click(screen.getByRole('button', { name: /connect both/i }));
+      await waitFor(() => {
+        expect(approvalMocks.resolveApproval).toHaveBeenCalledWith('test-123', {
+          approved: true,
+          updatedParams: { pairedAddresses: true },
+        });
+      });
     });
 
     it('falls back to single-address consent when paired addresses cannot be loaded', async () => {
@@ -261,7 +272,49 @@ describe('ApproveConnection', () => {
 
       expect(await screen.findByText(/Paired addresses are unavailable/i)).toBeInTheDocument();
       expect(screen.getByText('View your wallet address')).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: /^connect$/i })).toBeEnabled();
+      const connect = screen.getByRole('button', { name: /^connect$/i });
+      expect(connect).toBeEnabled();
+      fireEvent.click(connect);
+      await waitFor(() => {
+        expect(approvalMocks.resolveApproval).toHaveBeenCalledWith('test-123', {
+          approved: true,
+          updatedParams: { pairedAddresses: false },
+        });
+      });
+    });
+
+    it('uses ordinary single-address consent when the requested account cannot pair', async () => {
+      setupWalletContext({
+        activeWallet: {
+          id: 'test-wallet',
+          type: 'mnemonic',
+          addressFormat: 'p2tr',
+        } as any,
+        activeAddress: { address: 'bc1ptest123' },
+        isLoading: false,
+      });
+      approvalMocks.getCurrentApproval.mockReturnValue({
+        id: 'test-123',
+        params: [{
+          capabilities: { pairedAddresses: true },
+          address: 'bc1ptest123',
+          walletId: 'test-wallet',
+        }],
+      });
+
+      renderWithRouter();
+
+      expect(await screen.findByText('View your wallet address')).toBeInTheDocument();
+      expect(screen.queryByText(/Paired addresses are unavailable/i)).not.toBeInTheDocument();
+      expect(approvalMocks.getPairedAddresses).not.toHaveBeenCalled();
+      const connect = screen.getByRole('button', { name: /^connect$/i });
+      fireEvent.click(connect);
+      await waitFor(() => {
+        expect(approvalMocks.resolveApproval).toHaveBeenCalledWith('test-123', {
+          approved: true,
+          updatedParams: { pairedAddresses: false },
+        });
+      });
     });
 
     it('blocks approval if the active wallet identity changed', async () => {

--- a/src/pages/requests/connect/approve.tsx
+++ b/src/pages/requests/connect/approve.tsx
@@ -12,6 +12,12 @@ import { getWalletService } from "@/services/walletService";
 import type { ApprovalRequest } from "@/types/provider";
 import type { PairedAddresses } from "@/types/wallet";
 
+// The paired banner names both addresses in one sentence, where a shorter abbreviation than the
+// six-character one used elsewhere keeps the line readable.
+function abbreviateAddress(address: string): string {
+  return `${address.slice(0, 4)}...${address.slice(-4)}`;
+}
+
 function getApprovalIdentityError(
   approval: ApprovalRequest | null,
   requestId: string,
@@ -37,7 +43,6 @@ export default function ApproveConnectionPage(): ReactElement {
   const [isProcessing, setIsProcessing] = useState(false);
   const [faviconError, setFaviconError] = useState(false);
   const [pairedAddressesRequested, setPairedAddressesRequested] = useState(false);
-  const [grantPairedAddresses, setGrantPairedAddresses] = useState(false);
   const [pairedAddresses, setPairedAddresses] = useState<PairedAddresses | null>(null);
   const [approvalError, setApprovalError] = useState<string | null>(null);
   const [pairedAddressError, setPairedAddressError] = useState(false);
@@ -57,6 +62,18 @@ export default function ApproveConnectionPage(): ReactElement {
 
   const domain = getDomain(origin);
   const faviconUrl = `https://www.google.com/s2/favicons?domain=${domain}&sz=64`;
+
+  // A paired request states both addresses in the request itself rather than adding an opt-in
+  // below the fold that is easy to miss: what the screen says is what Connect grants.
+  const pairedRequestSupported =
+    pairedAddressesRequested &&
+    activeWallet?.type === 'mnemonic' &&
+    Boolean(getPairedAddressFormats(activeWallet.addressFormat));
+  // Without the addresses the extra access cannot be granted, so fall back to the ordinary
+  // single-address screen and say so rather than listing access the connection will not carry.
+  const showPairedConsent = pairedRequestSupported && !pairedAddressError;
+  const pairedAddressesPending = showPairedConsent && !pairedAddresses;
+  const grantsPairedAddresses = pairedRequestSupported && Boolean(pairedAddresses);
 
   useEffect(() => {
     if (!requestId || !activeAddress || !activeWallet) return;
@@ -79,11 +96,7 @@ export default function ApproveConnectionPage(): ReactElement {
   }, [requestId, activeAddress, activeWallet]);
 
   useEffect(() => {
-    if (
-      !pairedAddressesRequested ||
-      activeWallet?.type !== 'mnemonic' ||
-      !getPairedAddressFormats(activeWallet.addressFormat)
-    ) {
+    if (!pairedRequestSupported) {
       setPairedAddresses(null);
       setPairedAddressError(false);
       return;
@@ -95,7 +108,7 @@ export default function ApproveConnectionPage(): ReactElement {
         setPairedAddresses(null);
         setPairedAddressError(true);
       });
-  }, [pairedAddressesRequested, activeWallet]);
+  }, [pairedRequestSupported, activeWallet]);
 
   // Configure header
   useEffect(() => {
@@ -134,7 +147,7 @@ export default function ApproveConnectionPage(): ReactElement {
       const resolved = await approvalService.resolveApproval(requestId, {
         approved: true,
         updatedParams: {
-          pairedAddresses: pairedAddressesRequested && grantPairedAddresses && Boolean(pairedAddresses),
+          pairedAddresses: grantsPairedAddresses,
         },
       });
       if (!resolved) {
@@ -226,7 +239,21 @@ export default function ApproveConnectionPage(): ReactElement {
 
             <div className="mt-4 p-2.5 bg-yellow-50 rounded-lg border border-yellow-200">
               <p className="text-sm text-yellow-800">
-                This site is requesting access to view your wallet address
+                {pairedAddresses && showPairedConsent ? (
+                  <>
+                    This site is requesting access to view{" "}
+                    <span className="font-bold">{abbreviateAddress(pairedAddresses.legacy.address)}</span>
+                    {" "}and{" "}
+                    <span className="font-bold">{abbreviateAddress(pairedAddresses.segwit.address)}</span>
+                  </>
+                ) : showPairedConsent ? (
+                  <>
+                    This site is requesting access to view{" "}
+                    <span className="font-bold">both of your wallet addresses</span>
+                  </>
+                ) : (
+                  'This site is requesting access to view your wallet address'
+                )}
               </p>
             </div>
           </div>
@@ -237,56 +264,31 @@ export default function ApproveConnectionPage(): ReactElement {
             <ul className="space-y-1.5">
               <li className="flex items-center">
                 <FaCheck className="size-3.5 text-green-500 mr-2 flex-shrink-0" aria-hidden="true" />
-                <span className="text-sm text-gray-600">View your wallet address</span>
+                <span className="text-sm text-gray-600">
+                  {showPairedConsent ? 'View your wallet addresses' : 'View your wallet address'}
+                </span>
               </li>
               <li className="flex items-center">
                 <FaCheck className="size-3.5 text-green-500 mr-2 flex-shrink-0" aria-hidden="true" />
-                <span className="text-sm text-gray-600">Request transaction signatures</span>
+                <span className="text-sm text-gray-600">
+                  {showPairedConsent
+                    ? 'Request signatures from either address'
+                    : 'Request transaction signatures'}
+                </span>
               </li>
               <li className="flex items-center">
                 <FaCheck className="size-3.5 text-green-500 mr-2 flex-shrink-0" aria-hidden="true" />
                 <span className="text-sm text-gray-600">Request message signatures</span>
               </li>
             </ul>
+            {pairedAddressError && (
+              <p className="mt-2 text-xs font-medium text-red-700">
+                Paired addresses are unavailable. Connecting grants access to this address only.
+              </p>
+            )}
           </div>
 
           {approvalError && <ErrorAlert message={approvalError} />}
-
-          {pairedAddressesRequested && activeWallet.type === 'mnemonic' &&
-            getPairedAddressFormats(activeWallet.addressFormat) && (
-            <label className="mt-4 flex items-start gap-3 rounded-xl border border-blue-200 bg-blue-50 p-4 cursor-pointer">
-              <input
-                type="checkbox"
-                checked={grantPairedAddresses}
-                disabled={!pairedAddresses || Boolean(approvalError)}
-                onChange={(event) => setGrantPairedAddresses(event.target.checked)}
-                className="mt-1 size-4"
-              />
-              <span>
-                <span className="block text-sm font-medium text-blue-900">
-                  Share paired Legacy and SegWit addresses
-                </span>
-                <span className="mt-1 block text-xs text-blue-800">
-                  The site can then request signatures spending inputs from either address. Access
-                  lasts until you disconnect the site.
-                </span>
-                {pairedAddressError && (
-                  <span className="mt-2 block text-xs font-medium text-red-700">
-                    Paired addresses are unavailable. This additional permission cannot be granted.
-                  </span>
-                )}
-                {!pairedAddresses && !pairedAddressError && (
-                  <span className="mt-2 block text-xs text-blue-700">Loading paired addresses…</span>
-                )}
-                {pairedAddresses && (
-                  <span className="mt-2 block space-y-1 text-xs text-blue-900">
-                    <span className="block break-all font-mono">Legacy: {pairedAddresses.legacy.address}</span>
-                    <span className="block break-all font-mono">SegWit: {pairedAddresses.segwit.address}</span>
-                  </span>
-                )}
-              </span>
-            </label>
-          )}
         </div>
       </div>
 
@@ -304,10 +306,10 @@ export default function ApproveConnectionPage(): ReactElement {
           <Button
             color="blue"
             onClick={handleApprove}
-            disabled={isProcessing || Boolean(approvalError)}
+            disabled={isProcessing || Boolean(approvalError) || pairedAddressesPending}
             fullWidth
           >
-            {isProcessing ? "Processing…" : "Connect"}
+            {isProcessing ? "Processing…" : showPairedConsent ? "Connect both" : "Connect"}
           </Button>
         </div>
       </div>

--- a/src/services/providerService.ts
+++ b/src/services/providerService.ts
@@ -269,9 +269,9 @@ export function createProviderService(): ProviderService {
    * ADR-018: Paired-address provider capability
    *
    * A connection authorizes only its active address. A dApp may opt in to the
-   * active derivation index's Legacy/SegWit sibling pair through explicit,
-   * unchecked-by-default consent. The grant is bound to origin, wallet ID, and
-   * active address, and is removed on disconnect.
+   * active derivation index's Legacy/SegWit sibling pair through explicit
+   * approval that displays both addresses before Connect. The grant is bound
+   * to origin, wallet ID, and active address, and is removed on disconnect.
    *
    * Signing fails closed before approval storage: requested signer addresses
    * must be the active address or its exact sibling pair, input indices must be


### PR DESCRIPTION
## The problem, measured

The paired-address grant was an opt-in checkbox rendered after the permission list. The popup content area is 463px, while that screen needed 501px, leaving the checkbox about 38px below the fold.

## The change

When a site requests paired access, the existing callout names both abbreviated addresses, the permission list describes access to both, and the button says `Connect both`. Approving grants exactly what the screen displays.

- Pairing remains an explicit ADR-018 capability request.
- Connect stays disabled while a supported pair resolves.
- If the account cannot pair, the ordinary single-address approval is shown.
- If derivation unexpectedly fails, the existing callout reports the single-address fallback without adding layout height.
- Provider semantics and response shapes are unchanged.
- The ADR-018 implementation comment now matches the visible approval behavior.

The paired layout measures 436px against the 463px viewport.

## Validation

- Focused approval tests: 16 passed
- TypeScript compile passed
- CI runs the complete unit, E2E, lint, security, and CodeQL checks

Supersedes #355 with the preferred compact approval design and the missing functional grant assertions.