### PR TITLE
Fix nightly tests and main CI

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -88,7 +88,10 @@ jobs:
       # re-raises the failure, so a red E2E run still fails the job and files the issue.
       - name: Run all E2E tests
         id: e2e
-        timeout-minutes: 60
+        # The full suite is intentionally serial because two headed extension profiles can race
+        # Chromium service-worker registration on one runner. It currently needs more than the old
+        # 30-minute Playwright global limit, so this stays below the job's 120-minute hard backstop.
+        timeout-minutes: 105
         run: npx playwright test --retries=3 --workers=1
         env:
           DISPLAY: ':99'
@@ -138,6 +141,38 @@ jobs:
             test-results/
             playwright-report/
           retention-days: 30
+
+      - name: Close resolved nightly failure issues
+        if: success()
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: 'open',
+              labels: 'automated,test-failure',
+              per_page: 100,
+            });
+            const nightlyIssues = issues.filter(
+              issue => !issue.pull_request && issue.title.startsWith('Nightly tests failed')
+            );
+            for (const issue of nightlyIssues) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: issue.number,
+                body: `Resolved by successful nightly run ${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}.`,
+              });
+              await github.rest.issues.update({
+                owner,
+                repo,
+                issue_number: issue.number,
+                state: 'closed',
+                state_reason: 'completed',
+              });
+            }
       
       - name: Notify on failure
         if: failure()
@@ -145,10 +180,30 @@ jobs:
         with:
           script: |
             const { owner, repo } = context.repo;
-            await github.rest.issues.create({
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
               owner,
               repo,
-              title: `Nightly tests failed - ${new Date().toISOString().split('T')[0]}`,
-              body: `The nightly test run failed. Please check the [workflow run](${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}) for details.`,
-              labels: ['automated', 'test-failure']
+              state: 'open',
+              labels: 'automated,test-failure',
+              per_page: 100,
             });
+            const existing = issues.find(
+              issue => !issue.pull_request && issue.title.startsWith('Nightly tests failed')
+            );
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: existing.number,
+                body: `Another nightly run failed: ${runUrl}`,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner,
+                repo,
+                title: `Nightly tests failed - ${new Date().toISOString().split('T')[0]}`,
+                body: `The nightly test run failed. Please check the [workflow run](${runUrl}) for details.`,
+                labels: ['automated', 'test-failure'],
+              });
+            }

--- a/e2e/pages/assets/[asset]/index.spec.ts
+++ b/e2e/pages/assets/[asset]/index.spec.ts
@@ -174,62 +174,16 @@ walletTest.describe('View Asset Page (/assets/:asset)', () => {
   // Actions Tests
   // ============================================================================
 
-  walletTest('shows action buttons for XCP', async ({ page }) => {
+  walletTest('does not offer ownership actions for protocol asset XCP', async ({ page }) => {
     await navigateToAsset(page, 'XCP');
 
     await expect(page.locator('text="Asset Details"')).toBeVisible({ timeout: 10000 });
 
-    // XCP should have common actions - at minimum Lock Description and Update Description
-    const lockDescriptionAction = page.locator('text="Lock Description"');
-    const updateDescriptionAction = page.locator('text="Update Description"');
-
-    await expect(lockDescriptionAction).toBeVisible({ timeout: 5000 });
-    await expect(updateDescriptionAction).toBeVisible({ timeout: 5000 });
-  });
-
-  walletTest('shows Transfer Ownership action', async ({ page }) => {
-    await navigateToAsset(page, 'XCP');
-
-    await expect(page.locator('text="Asset Details"')).toBeVisible({ timeout: 10000 });
-
-    const transferAction = page.locator('text="Transfer Ownership"');
-    await expect(transferAction).toBeVisible({ timeout: 5000 });
-  });
-
-  walletTest('Lock Description action navigates to compose/issuance/lock-description', async ({ page }) => {
-    await navigateToAsset(page, 'XCP');
-
-    await expect(page.locator('text="Asset Details"')).toBeVisible({ timeout: 10000 });
-
-    const lockDescriptionAction = page.locator('button:has-text("Lock Description"), div[role="button"]:has-text("Lock Description")').first();
-    await expect(lockDescriptionAction).toBeVisible({ timeout: 5000 });
-    await lockDescriptionAction.click();
-
-    await expect(page).toHaveURL(/compose\/issuance\/lock-description\/XCP/, { timeout: 5000 });
-  });
-
-  walletTest('Update Description action navigates to compose/issuance/update-description', async ({ page }) => {
-    await navigateToAsset(page, 'XCP');
-
-    await expect(page.locator('text="Asset Details"')).toBeVisible({ timeout: 10000 });
-
-    const updateDescriptionAction = page.locator('button:has-text("Update Description"), div[role="button"]:has-text("Update Description")').first();
-    await expect(updateDescriptionAction).toBeVisible({ timeout: 5000 });
-    await updateDescriptionAction.click();
-
-    await expect(page).toHaveURL(/compose\/issuance\/update-description\/XCP/, { timeout: 5000 });
-  });
-
-  walletTest('Transfer Ownership action navigates to compose/issuance/transfer-ownership', async ({ page }) => {
-    await navigateToAsset(page, 'XCP');
-
-    await expect(page.locator('text="Asset Details"')).toBeVisible({ timeout: 10000 });
-
-    const transferAction = page.locator('button:has-text("Transfer Ownership"), div[role="button"]:has-text("Transfer Ownership")').first();
-    await expect(transferAction).toBeVisible({ timeout: 5000 });
-    await transferAction.click();
-
-    await expect(page).toHaveURL(/compose\/issuance\/transfer-ownership\/XCP/, { timeout: 5000 });
+    // BTC and XCP are protocol assets without an owner. Issuance-management actions would lead
+    // to transactions Counterparty Core rejects, so the page deliberately withholds them.
+    for (const action of ['Lock Description', 'Update Description', 'Transfer Ownership']) {
+      await expect(page.getByText(action, { exact: true })).toHaveCount(0);
+    }
   });
 
   // ============================================================================

--- a/e2e/pages/assets/utxos/[txHash].spec.ts
+++ b/e2e/pages/assets/utxos/[txHash].spec.ts
@@ -1,8 +1,8 @@
 /**
- * View UTXO Page Tests (/assets/utxo/:utxo)
+ * View UTXO Page Tests (/assets/utxos/:txHash)
  *
  * Tests for viewing details of a specific UTXO and its attached assets.
- * Component: src/pages/assets/utxo/[txHash].tsx
+ * Component: src/pages/assets/utxos/[txHash].tsx
  *
  * The page shows:
  * - Loading state: "Loading UTXO details…"
@@ -10,56 +10,69 @@
  * - Success state: "Details" heading with UTXO info
  */
 
-import { walletTest, expect } from '@e2e/fixtures';
+import type { Page } from '@playwright/test';
+import { expect, walletTest } from '@e2e/fixtures';
 
-walletTest.describe('View UTXO Page (/assets/utxo/:utxo)', () => {
-  // Use a valid UTXO format (txid:vout) - API will likely return error for non-existent
-  const testUtxo = '0000000000000000000000000000000000000000000000000000000000000000:0';
+walletTest.describe('View UTXO Page (/assets/utxos/:txHash)', () => {
+  const testTxid = '0000000000000000000000000000000000000000000000000000000000000000';
+  const testUtxo = `${testTxid}:0`;
 
-  // Helper to navigate to UTXO page and wait for content
-  async function navigateToUtxo(page: any, utxo: string) {
-    await page.goto(page.url().replace(/\/index.*/, `/assets/utxo/${encodeURIComponent(utxo)}`));
-    await page.waitForLoadState('domcontentloaded');
-    // Wait for loading to complete - either UTXO Details heading or error alert appears
-    const detailsHeading = page.getByRole('heading', { name: 'UTXO Details' });
-    const errorAlert = page.locator('[role="alert"]');
-    await expect(detailsHeading.or(errorAlert).first()).toBeVisible({ timeout: 15000 });
+  async function installUtxoStubs(page: Page) {
+    await page.route(/\/v2\/utxos\/.*\/balances/, (route) =>
+      route.fulfill({ json: { result: [], result_count: 0, next_cursor: null } })
+    );
+    await page.route(/\/v2\/bitcoin\/transactions\//, (route) =>
+      route.fulfill({
+        json: {
+          result: {
+            tx_hash: testTxid,
+            block_index: 1,
+            block_time: 1_700_000_000,
+            confirmations: 1,
+            vout_list: [{ value_int: 10_000 }],
+          },
+        },
+      })
+    );
+    await page.route(`https://mempool.space/api/tx/${testTxid}/status`, (route) =>
+      route.fulfill({ json: { confirmed: true, block_time: 1_700_000_000 } })
+    );
   }
 
-  walletTest('page loads and shows Details or error', async ({ page }) => {
+  async function navigateToUtxo(page: Page, utxo: string) {
+    const path = `/assets/utxos/${encodeURIComponent(utxo)}`;
+    await page.evaluate((nextPath) => {
+      window.location.hash = nextPath;
+    }, path);
+    await expect.poll(() => page.evaluate(() => window.location.hash)).toBe(`#${path}`);
+  }
+
+  walletTest.beforeEach(async ({ page }) => {
+    await installUtxoStubs(page);
+  });
+
+  walletTest('page loads and shows details', async ({ page }) => {
     await navigateToUtxo(page, testUtxo);
 
-    // Component shows either Details heading (success) or ErrorAlert (API failure)
-    const detailsHeading = page.locator('text="Details"');
-    await expect(detailsHeading).toBeVisible({ timeout: 5000 });
+    await expect(page.getByRole('heading', { name: 'Details', exact: true })).toBeVisible();
   });
 
   walletTest('displays Output field with UTXO identifier', async ({ page }) => {
     await navigateToUtxo(page, testUtxo);
 
-    // Should show the Output field with formatted UTXO
-    const outputLabel = page.locator('text="Output"');
-    await expect(outputLabel).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('Output', { exact: true })).toBeVisible();
   });
 
   walletTest('shows Move and Detach action buttons', async ({ page }) => {
     await navigateToUtxo(page, testUtxo);
 
-    // Action buttons should be visible
-    const moveButton = page.locator('text="Move"');
-    const detachButton = page.locator('text="Detach"');
-
-    await expect(moveButton).toBeVisible({ timeout: 5000 });
-    await expect(detachButton).toBeVisible({ timeout: 5000 });
+    await expect(page.getByRole('button', { name: /Move/ })).toBeVisible();
+    await expect(page.getByRole('button', { name: /Detach/ })).toBeVisible();
   });
 
   walletTest('handles invalid UTXO format gracefully', async ({ page }) => {
-    // Navigate with invalid UTXO format (missing :vout)
-    await page.goto(page.url().replace(/\/index.*/, '/assets/utxo/invalid-utxo-format'));
-    await page.waitForLoadState('domcontentloaded');
+    await navigateToUtxo(page, 'invalid-utxo-format');
 
-    // Page should load and show the UTXO Details header (even for invalid UTXO)
-    const utxoHeading = page.getByRole('heading', { name: 'UTXO Details' });
-    await expect(utxoHeading).toBeVisible({ timeout: 15000 });
+    await expect(page.getByRole('alert')).toContainText('Invalid UTXO identifier');
   });
 });

--- a/e2e/pages/index.spec.ts
+++ b/e2e/pages/index.spec.ts
@@ -74,6 +74,9 @@ walletTest.describe('Index Page', () => {
     });
 
     walletTest('keeps the app shell and footer inside the popup viewport', async ({ page }) => {
+      await expect(page.locator('#root')).toBeVisible();
+      await expect(page.locator('footer[aria-label="Primary"]')).toBeVisible();
+
       const metrics = await page.evaluate(() => {
         const root = document.querySelector<HTMLElement>('#root');
         const footer = document.querySelector<HTMLElement>('footer[aria-label="Primary"]');

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -24,7 +24,9 @@ export default defineConfig({
   
   // Timeout settings
   timeout: 120000,
-  globalTimeout: isCI ? 30 * 60 * 1000 : undefined, // 30 min limit in CI
+  // PR batches have their own 15-minute job limit. The nightly runs every file serially in one
+  // invocation, so its global budget must cover the complete suite rather than stopping halfway.
+  globalTimeout: isCI ? 100 * 60 * 1000 : undefined,
   
   expect: {
     timeout: 10000,


### PR DESCRIPTION
Fixes the main CI popup-shell race, removes stale protocol-asset action expectations, corrects and stabilizes UTXO routing tests, and gives the serial nightly suite enough time to finish. Nightly failures are now deduplicated and automatically closed by the next successful run. Validated with the production build, TypeScript, oxlint, 12/12 main-page E2Es, and 24/24 asset/UTXO E2Es. Closes #341. Closes #342. Closes #343. Closes #345. Closes #357. Closes #358.