### PR TITLE
Use one-screen approval for proved marketplace listings

### DIFF
--- a/e2e/tests/marketplace-gallery.spec.ts
+++ b/e2e/tests/marketplace-gallery.spec.ts
@@ -261,7 +261,7 @@ interface Scenario {
   record: Record<string, unknown>;
   balances: Record<string, StubBalance[] | 'fail'>;
   /** The footer state this scenario is expected to reach — a drifting state fails the run. */
-  expectFooter: 'Sign' | 'Review' | 'Blocked';
+  expectFooter: 'Sign' | 'Review' | 'Blocked' | 'Authorize listing' | 'Authorize reprice';
   /** Important semantic disclosures that must survive visual refactors. */
   expectedText?: string[];
   /** False-positive warnings that would make an ordinary marketplace request look unsafe. */

--- a/src/components/domain/approval/money-movement-view.test.tsx
+++ b/src/components/domain/approval/money-movement-view.test.tsx
@@ -21,14 +21,14 @@ describe('MoneyMovementView', () => {
     expect(screen.getByText(/0\.00060000/)).toBeInTheDocument(); // headline net, distinct from the 0.00070000 row
   });
 
-  it('lists an external destination, change, and fee', () => {
+  it('lists an external destination, wallet return, and fee', () => {
     render(
       <MoneyMovementView
         movement={movement({ net: -95000, external: [{ address: 'bc1qexternaldestinationaddr', value: 90000 }], backToYou: 5000, fee: 5000 })}
       />
     );
     expect(screen.getByText(/^bc1q/)).toBeInTheDocument(); // the external destination (truncated)
-    expect(screen.getByText('Change')).toBeInTheDocument();
+    expect(screen.getByText('Returned to wallet')).toBeInTheDocument();
     expect(screen.getByText('Network fee')).toBeInTheDocument();
   });
 

--- a/src/components/domain/approval/money-movement-view.tsx
+++ b/src/components/domain/approval/money-movement-view.tsx
@@ -94,9 +94,9 @@ export function MoneyMovementView({
         </div>
         {backToYou > 0 && (
           <div className="flex items-center justify-between gap-2">
-            {/* "Change", not "to your wallet": on a dispense or a send the only such row is the
-                change, and calling it an arrival reads as though the transaction pays you. */}
-            <span className="text-gray-400">Change</span>
+            {/* This can include more than a conventional change output, such as a paired-address
+                asset destination, so name the ownership fact without misclassifying the outputs. */}
+            <span className="text-gray-400">Returned to wallet</span>
             <span className="text-gray-400 font-medium flex-shrink-0">{btc(backToYou)} BTC</span>
           </div>
         )}

--- a/src/core/counterparty/__tests__/marketplaceBatch.test.ts
+++ b/src/core/counterparty/__tests__/marketplaceBatch.test.ts
@@ -4,11 +4,34 @@ import {
   parseMarketplaceBatchIntents,
 } from '@/core/counterparty/marketplaceBatch';
 import type {
+  CreateListingIntentClaim,
   MarketplaceApprovalReview,
   PrepareBulkFanoutIntentClaim,
 } from '@/core/counterparty/marketplaceIntent';
 
 const SELLER = 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4';
+
+const listing = (index: number, reprice = false): CreateListingIntentClaim => ({
+  standard: 'counterparty-marketplace',
+  version: 1,
+  action: 'create_listing',
+  operationId: 'bulk-listing-1',
+  protocolVersion: 'counterparty_attach_listing_v1',
+  assets: [{
+    asset: 'RAREPEPE',
+    quantityRaw: '1',
+    sourceOutpoint: { txid: (index === 0 ? '31' : '32').repeat(32), vout: index },
+  }],
+  seller: SELLER,
+  priceSats: 100_000,
+  carrierValueSats: 546,
+  guaranteedSellerPaymentSats: 100_546,
+  delivery: { mode: 'buyer_selected_detach' },
+  signingRequestExpiresAt: 2_000_000_000,
+  marketplaceExpiresAt: 2_000_003_600,
+  bitcoinExpiresAt: null,
+  ...(reprice ? { listingContext: { mode: 'reprice' as const } } : {}),
+});
 
 const fanout = (batchIndex: number): PrepareBulkFanoutIntentClaim => ({
   standard: 'counterparty-marketplace',
@@ -70,6 +93,49 @@ describe('marketplace batch aggregate proof', () => {
     });
     expect(review.facts).toContainEqual({ label: 'New UTXOs', value: '4' });
     expect(review.facts).toContainEqual({ label: 'Total network fees', value: '2,000 sats' });
+  });
+
+  // The bulk-listing screen has no attention interstitial: these facts are the only place the
+  // durable, buyer-completable nature of the signatures is disclosed, so they are pinned here.
+  it('discloses the durable-signature boundary on a bulk listing batch', () => {
+    const review = analyzeMarketplaceBatch(
+      'bulk-listing',
+      [listing(0), listing(1)],
+      [proved({ family: 'create_listing' }), proved({ family: 'create_listing' })],
+    );
+
+    expect(review.status).toBe('proved');
+    expect(review.title).toBe('Authorize 2 marketplace listings');
+    expect(review.facts).toContainEqual({ label: 'Combined asking prices', value: '200,000 sats' });
+    expect(review.facts).toContainEqual({
+      label: 'Buyer controls',
+      value: 'Funding, fees, and detach destination',
+    });
+    expect(review.facts).toContainEqual({ label: 'Broadcast now', value: 'None' });
+    expect(review.facts).toContainEqual({
+      label: 'Signature invalidation',
+      value: 'Spend each attached asset UTXO',
+    });
+  });
+
+  it('titles an all-reprice batch as reprices, not new listings', () => {
+    const review = analyzeMarketplaceBatch(
+      'bulk-listing',
+      [listing(0, true), listing(1, true)],
+      [proved({ family: 'create_listing' }), proved({ family: 'create_listing' })],
+    );
+
+    expect(review.title).toBe('Authorize 2 listing reprices');
+  });
+
+  it('keeps the generic listings title when only some items are reprices', () => {
+    const review = analyzeMarketplaceBatch(
+      'bulk-listing',
+      [listing(0, true), listing(1)],
+      [proved({ family: 'create_listing' }), proved({ family: 'create_listing' })],
+    );
+
+    expect(review.title).toBe('Authorize 2 marketplace listings');
   });
 
   it.each([

--- a/src/core/counterparty/__tests__/marketplaceIntent.test.ts
+++ b/src/core/counterparty/__tests__/marketplaceIntent.test.ts
@@ -404,7 +404,7 @@ describe('attach-for-listing proof', () => {
     expect(review.status).toBe('caution');
     expect(review.blockers).toEqual([]);
     expect(review.facts).toContainEqual({ label: 'Asset source', value: SELLER });
-    expect(review.facts).toContainEqual({ label: 'Carrier owner', value: SELLER_TWO });
+    expect(review.facts).toContainEqual({ label: 'Asset destination', value: SELLER_TWO });
   });
 
   it.each([
@@ -488,14 +488,19 @@ describe('attach-for-listing proof', () => {
 });
 
 describe('create-listing proof', () => {
-  it('proves exact seller payment while stating buyer-selected detach flexibility', () => {
+  it('proves exact seller payment and explains the bounded listing authorization', () => {
     const review = analyzeMarketplaceIntent(base());
 
-    expect(review.status).toBe('caution');
+    expect(review.status).toBe('proved');
     expect(review.blockers).toEqual([]);
     expect(review.title).toContain('RAREPEPE');
-    expect(review.facts).toContainEqual({ label: 'Seller receives', value: '250,546 sats' });
-    expect(review.notices[0]?.message).toContain('choose the detach destination');
+    expect(review.facts).toContainEqual({ label: 'Price', value: '250,000 sats' });
+    expect(review.facts).toContainEqual({
+      label: 'Seller receives',
+      value: '250,546 sats (price + 546-sat asset output)',
+    });
+    expect(review.facts).toContainEqual({ label: 'Broadcast now', value: 'None' });
+    expect(review.notices).toEqual([]);
   });
 
   it.each([

--- a/src/core/counterparty/__tests__/signRequestAnalysis.test.ts
+++ b/src/core/counterparty/__tests__/signRequestAnalysis.test.ts
@@ -438,10 +438,16 @@ describe('the marketplace intent proof', () => {
 
     expect(analysis.safety.blocked).toBe(false);
     expect(analysis.marketplaceReview).toMatchObject({
-      status: 'caution',
+      status: 'proved',
       family: 'create_listing',
       blockers: [],
     });
+    expect(analysis.marketplaceReview?.facts).toEqual(expect.arrayContaining([
+      { label: 'Price', value: '250,000 sats' },
+      { label: 'Broadcast now', value: 'None' },
+      { label: 'Marketplace cancellation', value: 'Delist without a transaction' },
+      { label: 'Signature invalidation', value: 'Spend the asset output' },
+    ]));
     expect(analysis.attachedAssetDestination).toMatchObject({
       destinationCommitted: false,
       mode: 'flexible',
@@ -469,6 +475,11 @@ describe('the marketplace intent proof', () => {
       label: 'Quoted XCP fee',
       value: '0.25 XCP (finalized at confirmation)',
     });
+    expect(analysis.marketplaceReview?.facts).toEqual(expect.arrayContaining([
+      { label: 'Asset source', value: SIGNER },
+      { label: 'Asset destination', value: SIGNER },
+      { label: 'Destination UTXO', value: '546 sats' },
+    ]));
   });
 
   it('hard-blocks a site claim whose seller payment differs from the PSBT', async () => {

--- a/src/core/counterparty/marketplaceBatch.ts
+++ b/src/core/counterparty/marketplaceBatch.ts
@@ -154,6 +154,7 @@ export function analyzeMarketplaceBatch(
     // live here — the same rows the single-listing screen shows.
     facts.push(
       { label: 'Combined asking prices', value: `${gross.toLocaleString()} sats` },
+      { label: 'Buyer controls', value: 'Funding, fees, and detach destination' },
       { label: 'Broadcast now', value: 'None' },
       { label: 'Signature invalidation', value: 'Spend each attached asset UTXO' },
     );

--- a/src/core/counterparty/marketplaceBatch.ts
+++ b/src/core/counterparty/marketplaceBatch.ts
@@ -144,7 +144,12 @@ export function analyzeMarketplaceBatch(
   } else {
     const listings = intents as CreateListingIntentClaim[];
     const gross = exactSafeSum(listings.map(intent => intent.priceSats), 'listing prices');
-    title = `Authorize ${listings.length} marketplace listings`;
+    // A batch where every item replaces an existing authorization is a reprice, and saying
+    // "listings" would describe it as putting new items up for sale. Mixed batches stay generic.
+    const allReprice = listings.every(intent => intent.listingContext?.mode === 'reprice');
+    title = allReprice
+      ? `Authorize ${listings.length} listing reprice${listings.length === 1 ? '' : 's'}`
+      : `Authorize ${listings.length} marketplace listings`;
     // Proved reviews speak through facts, not notices, so the durable-signature boundary has to
     // live here — the same rows the single-listing screen shows.
     facts.push(

--- a/src/core/counterparty/marketplaceBatch.ts
+++ b/src/core/counterparty/marketplaceBatch.ts
@@ -145,7 +145,13 @@ export function analyzeMarketplaceBatch(
     const listings = intents as CreateListingIntentClaim[];
     const gross = exactSafeSum(listings.map(intent => intent.priceSats), 'listing prices');
     title = `Authorize ${listings.length} marketplace listings`;
-    facts.push({ label: 'Combined asking prices', value: `${gross.toLocaleString()} sats` });
+    // Proved reviews speak through facts, not notices, so the durable-signature boundary has to
+    // live here — the same rows the single-listing screen shows.
+    facts.push(
+      { label: 'Combined asking prices', value: `${gross.toLocaleString()} sats` },
+      { label: 'Broadcast now', value: 'None' },
+      { label: 'Signature invalidation', value: 'Spend each attached asset UTXO' },
+    );
     notice = 'Every listing independently guarantees its seller payment. Each flexible signature remains valid until its attached asset outpoint is spent.';
   }
 

--- a/src/core/counterparty/marketplaceIntent.ts
+++ b/src/core/counterparty/marketplaceIntent.ts
@@ -686,31 +686,32 @@ function analyzeCreateListingIntent({
   }
 
   const allProblems = [...retry, ...blockers];
-  const status = blockers.length > 0 ? 'blocked' : retry.length > 0 ? 'retry' : 'caution';
+  const status = blockers.length > 0 ? 'blocked' : retry.length > 0 ? 'retry' : 'proved';
   return {
     status,
     family: 'create_listing',
     title: `List 1 ${claim.asset} for ${(intent.priceSats / 100_000_000).toFixed(8)} BTC`,
     facts: [
-      { label: 'Seller receives', value: `${intent.guaranteedSellerPaymentSats.toLocaleString()} sats` },
+      { label: 'Price', value: `${intent.priceSats.toLocaleString()} sats` },
+      {
+        label: 'Seller receives',
+        value:
+          `${intent.guaranteedSellerPaymentSats.toLocaleString()} sats ` +
+          `(price + ${intent.carrierValueSats.toLocaleString()}-sat asset output)`,
+      },
       { label: 'Quantity', value: `${provedQuantity ?? claim.quantityRaw} ${claim.asset}` },
       { label: 'Delivery', value: 'Detached to the eventual buyer' },
+      { label: 'Broadcast now', value: 'None' },
       {
         label: 'Marketplace expiry',
         value: intent.marketplaceExpiresAt === null
           ? 'None requested'
           : new Date(intent.marketplaceExpiresAt * 1000).toLocaleString(),
       },
-      { label: 'Bitcoin expiry', value: 'None — cancel by spending the asset' },
+      { label: 'Marketplace cancellation', value: 'Delist without a transaction' },
+      { label: 'Signature invalidation', value: 'Spend the asset output' },
     ],
-    notices: allProblems.length > 0
-      ? []
-      : [{
-          severity: 'warning',
-          message:
-            'The buyer may add funding inputs and choose the detach destination. Your signature ' +
-            'remains valid only when output 1 pays you the exact amount shown.',
-        }],
+    notices: [],
     blockers: allProblems,
   };
 }
@@ -901,11 +902,9 @@ function analyzeAttachForListingIntent(
     // says each thing once.
     title: `Attach ${claim.asset} for listing`,
     facts: [
-      ...(!sameAddress(assetSource, intent.seller) ? [
-        { label: 'Asset source', value: assetSource },
-        { label: 'Carrier owner', value: intent.seller },
-      ] : []),
-      { label: 'Carrier value', value: `${intent.carrierValueSats.toLocaleString()} sats` },
+      { label: 'Asset source', value: assetSource },
+      { label: 'Asset destination', value: intent.seller },
+      { label: 'Destination UTXO', value: `${intent.carrierValueSats.toLocaleString()} sats` },
       {
         label: 'Quoted XCP fee',
         value: `${formatXcpRaw(intent.protocolFee.quotedAmountRaw)} (finalized at confirmation)`,

--- a/src/core/counterparty/marketplaceIntent.ts
+++ b/src/core/counterparty/marketplaceIntent.ts
@@ -721,6 +721,8 @@ function analyzeCreateListingIntent({
       },
       { label: 'Quantity', value: `${provedQuantity ?? claim.quantityRaw} ${claim.asset}` },
       { label: 'Delivery', value: 'Detached to the eventual buyer' },
+      // The signature commits only the seller-payment output; state who controls the rest.
+      { label: 'Buyer controls', value: 'Funding, fees, and detach destination' },
       { label: 'Broadcast now', value: 'None' },
       {
         label: 'Marketplace expiry',

--- a/src/pages/requests/psbt/approve.tsx
+++ b/src/pages/requests/psbt/approve.tsx
@@ -406,7 +406,7 @@ export default function ApprovePsbtPage() {
           {usesPairedAddress && (
             <Collapsible variant="card" title={`Signing addresses (${requestedAddressSpends.length})`}>
               <p className="text-xs text-gray-500">
-                The request explicitly selects inputs from paired Legacy and SegWit addresses in this wallet.
+                Only the inputs shown below will be signed with their matching addresses in this wallet.
               </p>
               <div className="space-y-2">
                 {requestedAddressSpends.map(({ address, indices, value }) => (
@@ -498,13 +498,17 @@ export default function ApprovePsbtPage() {
         busy={isSigning}
         blocked={blockSigning}
         isHardware={activeWallet.type === 'hardware'}
-        signLabel={requiresAttention ? 'Review' : 'Sign'}
+        signLabel={requiresAttention
+          ? 'Review'
+          : marketplaceReview?.family === 'create_listing'
+            ? 'Authorize listing'
+            : 'Sign'}
       />
 
       {showAttention && requiresAttention && (
         <ApprovalAttentionScreen
           title={attentionTitle}
-          description="Confirm the exceptional authorization below before the wallet adds your signature."
+          description="Confirm the authorization details below before the wallet adds your signature."
           items={approvalAttentionItems}
           confirmLabel={confirmLabel}
           busy={isSigning}

--- a/src/pages/requests/psbt/approve.tsx
+++ b/src/pages/requests/psbt/approve.tsx
@@ -299,43 +299,26 @@ export default function ApprovePsbtPage() {
     && marketplaceReview.family !== 'attach_for_listing';
   // Plain-language consequences per family: what signing does, and how to undo it. The analyzer's
   // notices state the same facts in protocol terms; this screen is where a person decides.
+  // create_listing is absent here on purpose: a fully proved listing is 'proved', never
+  // 'caution', so its consequences live in the review facts on the one screen.
   const marketplaceAttention: WarningItem[] = !marketplaceRequiresAttention
     ? []
-    : marketplaceReview.family === 'create_listing'
+    : marketplaceReview.family === 'authorize_exact_offer'
       ? [{
-          key: 'marketplace-listing',
+          key: 'marketplace-offer',
           severity: 'warning' as const,
-          title: isRepriceListing
-            ? 'This replaces the current listing price'
-            : 'This listing stays open until filled or cancelled',
-          description: isRepriceListing
-            ? `Signing authorizes a new price of ${request.marketplaceIntent?.action === 'create_listing'
-              ? (request.marketplaceIntent.priceSats / 100_000_000).toFixed(8)
-              : 'the shown amount'} BTC. Once the marketplace accepts it, the previous stored ` +
-              'authorization is replaced. You can remove the listing through the marketplace. ' +
-              'Spending the asset UTXO also invalidates the signature.'
-            : 'Signing puts this up for sale. Anyone who pays you exactly ' +
-              `${request.marketplaceIntent?.action === 'create_listing'
-                ? request.marketplaceIntent.guaranteedSellerPaymentSats.toLocaleString()
-                : 'the shown'} sats can complete the purchase without asking you again. ` +
-              'You can remove it through the marketplace. Spending the asset UTXO also invalidates the authorization.',
+          title: 'The seller can complete this sale at any time',
+          description:
+            'Signing lets the seller finish this exact trade without asking you again — the ' +
+            'first confirmed spend of your funding wins. To withdraw the offer, spend your ' +
+            'funding UTXO.',
         }]
-      : marketplaceReview.family === 'authorize_exact_offer'
-        ? [{
-            key: 'marketplace-offer',
-            severity: 'warning' as const,
-            title: 'The seller can complete this sale at any time',
-            description:
-              'Signing lets the seller finish this exact trade without asking you again — the ' +
-              'first confirmed spend of your funding wins. To withdraw the offer, spend your ' +
-              'funding UTXO.',
-          }]
-        : marketplaceReview.notices.map((notice, index) => ({
-            key: `marketplace-${index}`,
-            severity: notice.severity,
-            title: 'This authorization remains usable after signing',
-            description: notice.message,
-          }));
+      : marketplaceReview.notices.map((notice, index) => ({
+          key: `marketplace-${index}`,
+          severity: notice.severity,
+          title: 'This authorization remains usable after signing',
+          description: notice.message,
+        }));
   const approvalAttentionItems: WarningItem[] = [
     ...marketplaceAttention,
     ...genericAttention,
@@ -357,11 +340,9 @@ export default function ApprovePsbtPage() {
   ];
   const requiresAttention = !blockSigning && approvalAttentionItems.length > 0;
   const attentionTitle = marketplaceRequiresAttention
-    ? marketplaceReview.family === 'create_listing'
-      ? isRepriceListing ? 'Before you reprice' : 'Before you list'
-      : marketplaceReview.family === 'authorize_exact_offer'
-        ? 'Before you authorize'
-        : 'Review before signing'
+    ? marketplaceReview.family === 'authorize_exact_offer'
+      ? 'Before you authorize'
+      : 'Review before signing'
     : approvalAttentionItems.some(item => item.severity === 'danger')
       ? 'Review transaction risk'
       : 'Review before signing';

--- a/src/pages/requests/psbts/approve.tsx
+++ b/src/pages/requests/psbts/approve.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import { ApprovalAttentionScreen } from '@/components/domain/approval/approval-attention';
 import {
   ApprovalExpired,
   ApprovalFooter,
@@ -11,7 +10,6 @@ import {
 import { MarketplaceReviewCard } from '@/components/domain/approval/marketplace-review-card';
 import { Collapsible } from '@/components/ui/collapsible';
 import { ErrorAlert } from '@/components/ui/error-alert';
-import type { WarningItem } from '@/components/ui/warning-stack';
 import { useHeader } from '@/contexts/header-context';
 import { useWallet } from '@/contexts/wallet-context';
 import { usePopupLifecycle } from '@/hooks/usePopupLifecycle';
@@ -32,7 +30,6 @@ export default function ApprovePsbtsPage() {
   usePopupLifecycle(request?.id, 'sign-psbts');
   const [isSigning, setIsSigning] = useState(false);
   const [error, setError] = useState('');
-  const [showAttention, setShowAttention] = useState(false);
 
   useEffect(() => {
     // "Accept Offer", not "Accept Offer + Fee Bump": the longer form truncates at popup width,
@@ -48,8 +45,6 @@ export default function ApprovePsbtsPage() {
             : 'Review Transaction Batch';
     setHeaderProps({ title });
   }, [request?.bundleKind, setHeaderProps]);
-
-  useEffect(() => setShowAttention(false), [request?.id]);
 
   const handleSign = async () => {
     if (!request || !decodedInfo || !activeAddress || !activeWallet) return;
@@ -121,26 +116,11 @@ export default function ApprovePsbtsPage() {
   if (!activeAddress || !activeWallet) return <ApprovalNoWallet />;
 
   const blocked = decodedInfo.review.status === 'blocked' || decodedInfo.review.status === 'retry';
-  // Bulk attach quotes are inherently block-dependent and already visible in the summary. The
-  // durable listing signatures are the exceptional phase that deserves a second decision.
-  const requiresAttention = !blocked
-    && decodedInfo.review.status === 'caution'
-    && request.bundleKind === 'bulk-listing';
-  const attentionItems: WarningItem[] = requiresAttention
-    ? decodedInfo.review.notices.map((notice, index) => ({
-        key: `marketplace-${index}`,
-        severity: notice.severity,
-        title: 'Each listing remains valid after signing',
-        description: notice.message,
-      }))
-    : [];
-  const handleApprovalAction = () => {
-    if (requiresAttention) {
-      setShowAttention(true);
-      return;
-    }
-    void handleSign();
-  };
+  // A proved bulk-listing batch is a one-screen decision like the single listing: the review
+  // facts carry the durable-signature boundary, and the footer names what signing authorizes.
+  const signLabel = request.bundleKind === 'bulk-listing'
+    ? `Authorize ${request.items.length} listing${request.items.length === 1 ? '' : 's'}`
+    : 'Sign';
   return (
     <div className="flex flex-col h-full bg-gray-50">
       <div className="flex-1 overflow-y-auto p-4">
@@ -175,24 +155,12 @@ export default function ApprovePsbtsPage() {
       </div>
       <ApprovalFooter
         onCancel={handleReject}
-        onSign={handleApprovalAction}
+        onSign={() => void handleSign()}
         busy={isSigning}
         blocked={blocked}
         isHardware={activeWallet.type === 'hardware'}
-        signLabel={requiresAttention ? 'Review' : 'Sign'}
+        signLabel={signLabel}
       />
-      {showAttention && requiresAttention && (
-        <ApprovalAttentionScreen
-          title="Review listing authorizations"
-          description="These signatures can be completed later without another seller approval."
-          items={attentionItems}
-          confirmLabel={`Authorize ${request.items.length} listings`}
-          busy={isSigning}
-          isHardware={activeWallet.type === 'hardware'}
-          onBack={() => setShowAttention(false)}
-          onConfirm={() => void handleSign()}
-        />
-      )}
     </div>
   );
 }

--- a/src/pages/requests/psbts/approve.tsx
+++ b/src/pages/requests/psbts/approve.tsx
@@ -117,9 +117,13 @@ export default function ApprovePsbtsPage() {
 
   const blocked = decodedInfo.review.status === 'blocked' || decodedInfo.review.status === 'retry';
   // A proved bulk-listing batch is a one-screen decision like the single listing: the review
-  // facts carry the durable-signature boundary, and the footer names what signing authorizes.
+  // facts carry the durable-signature boundary, and the footer names what signing authorizes —
+  // including whether that is new listings or reprices of existing ones.
+  const allReprice = request.bundleKind === 'bulk-listing'
+    && request.items.every(item => item.marketplaceIntent.action === 'create_listing'
+      && item.marketplaceIntent.listingContext?.mode === 'reprice');
   const signLabel = request.bundleKind === 'bulk-listing'
-    ? `Authorize ${request.items.length} listing${request.items.length === 1 ? '' : 's'}`
+    ? `Authorize ${request.items.length} ${allReprice ? 'reprice' : 'listing'}${request.items.length === 1 ? '' : 's'}`
     : 'Sign';
   return (
     <div className="flex flex-col h-full bg-gray-50">


### PR DESCRIPTION
## Summary

- treats a fully proved listing or reprice as a normal one-screen authorization
- labels the primary action `Authorize listing` or `Authorize reprice`
- shows exact price, seller payment, no immediate broadcast, marketplace removal, and the asset-UTXO signature invalidation boundary on that screen
- uses `Returned to wallet` when wallet-owned outputs are not necessarily conventional change

## Reconciliation with #362 and #363

This branch now includes current `main`.

- #362 remains the source of truth for paired-address gallery coverage, summary-first card order, and `New UTXO owner` / `New UTXO value` terminology.
- #363 remains the source of truth for detecting and naming reprices.
- This PR supplies the independent behavior they did not add: a completely proved listing contract no longer triggers a duplicate generic attention screen.
- The gallery now asserts one-screen create and reprice approvals alongside paired-address signing.

## Safety

The proof requirements are unchanged. Mutated payments, source outpoints, signature scope, payloads, asset contents, unknown ledger states, and malformed requests still block or require retry. A real high-fee or unrelated safety warning can still trigger the attention screen. Only the duplicate warning created solely by the already-proved listing authorization is removed.

## Verification

- TypeScript compile: pass
- focused unit tests: 111 passed
- full unit suite: 4,912 passed, 60 skipped
- marketplace approval gallery: 13 scenarios passed
- Biome on touched files: pass
- Oxlint on touched source: pass with the existing `set-state-in-effect` warning at `approve.tsx:95`