### PR TITLE
Keep one-unit swap minimum positive

### DIFF
--- a/src/core/counterparty/__tests__/pool.fuzz.test.ts
+++ b/src/core/counterparty/__tests__/pool.fuzz.test.ts
@@ -94,6 +94,16 @@ describe('Pool Math Fuzz Tests', () => {
       }), { numRuns: 300 });
     });
 
+    it('keeps a positive quote positive below 100% slippage', () => {
+      fc.assert(fc.property(
+        satPositive,
+        fc.double({ min: 0, max: 99.999999, noNaN: true, noDefaultInfinity: true }),
+        (value, s) => {
+          expect(BigInt(applyPoolSlippage(value.toString(), s.toString()))).toBeGreaterThan(0n);
+        }
+      ), { numRuns: 300 });
+    });
+
     it('floors the result to zero at >= 100% slippage', () => {
       fc.assert(fc.property(sat, fc.double({ min: 100, max: 500, noNaN: true, noDefaultInfinity: true }), (value, s) => {
         expect(applyPoolSlippage(value.toString(), s.toString())).toBe('0');

--- a/src/core/counterparty/__tests__/pool.test.ts
+++ b/src/core/counterparty/__tests__/pool.test.ts
@@ -88,6 +88,9 @@ describe("counterparty pool utilities", () => {
   it("applies pool slippage to raw integer quantities", () => {
     expect(applyPoolSlippage("100000000", "2.5")).toBe("97500000");
     expect(applyPoolSlippage("100", "0.5")).toBe("99");
+    // One indivisible unit cannot absorb a fractional haircut. Returning zero here creates an
+    // invalid DEX order (`non-positive get quantity`) instead of preserving the quoted fill.
+    expect(applyPoolSlippage("1", "3")).toBe("1");
     expect(applyPoolSlippage(undefined, "1")).toBe("0");
   });
 

--- a/src/core/counterparty/pool.ts
+++ b/src/core/counterparty/pool.ts
@@ -105,12 +105,20 @@ export function applyPoolSlippage(value: number | string | null | undefined, sli
 
   const bps = toBigNumber(slippagePercent || "0").times(100);
   const multiplier = BigNumber.maximum(0, toBigNumber(10000).minus(bps));
-
-  return toBigNumber(value)
+  const quoted = toBigNumber(value);
+  const minimum = quoted
     .times(multiplier)
     .div(10000)
-    .integerValue(BigNumber.ROUND_DOWN)
-    .toString();
+    .integerValue(BigNumber.ROUND_DOWN);
+
+  // Core rejects a DEX order whose minimum receive quantity is zero. A percentage haircut on a
+  // one-base-unit quote (most visibly one indivisible collectible) otherwise floors 1 to 0 even
+  // though the quote is perfectly fillable. There is no fractional unit in which to express
+  // slippage here, so the only valid minimum is the quoted unit itself. Keep 100%+ slippage at
+  // zero for the generic helper's existing contract; signing forms never allow that range.
+  if (quoted.isGreaterThan(0) && multiplier.isGreaterThan(0) && minimum.isZero()) return "1";
+
+  return minimum.toString();
 }
 
 export function calculateInitialLpEstimate(quantityA: string, quantityB: string): string {


### PR DESCRIPTION
## What changed

- keep a positive minimum receive quantity when slippage is applied to a one-base-unit quote
- preserve the existing zero result for 100% or greater slippage
- add unit and property-based regression coverage

## Why

A live quote for spending 5.15 XCP to receive 1 indivisible EGGPLANTPEPE was valid, but applying roughly 3% slippage floored 1 times 0.97 to 0. That produced get_quantity=0, which Counterparty Core correctly rejected with non-positive get quantity; zero give or zero get.

For one indivisible unit there is no fractional minimum to express, so the only valid positive minimum is one.

## Validation

- focused pool unit and fuzz tests: 46 passed
- TypeScript: passed
- oxlint: passed
- Chrome MV3 production build: passed