### PR TITLE
Cover paired marketplace approvals in gallery

### DIFF
--- a/e2e/tests/marketplace-gallery.spec.ts
+++ b/e2e/tests/marketplace-gallery.spec.ts
@@ -21,7 +21,9 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { Address, OutScript } from '@scure/btc-signer';
 import type { Page, Route } from '@playwright/test';
-import { expect, walletTest } from '../fixtures';
+import { expect, navigateTo, walletTest } from '../fixtures';
+import { ADDRESS_TYPE_DISPLAY_NAMES, type AddressType } from '../test-data';
+import { settings } from '../selectors';
 
 const OUT_DIR = 'test-results/marketplace-gallery';
 
@@ -99,9 +101,11 @@ const fakeAddress = (byte: number): string =>
 interface BuiltInput {
   txid: string; // display order
   vout: number;
-  /** Address whose p2wpkh script the witness_utxo carries; omitted = empty-script placeholder. */
+  /** Address whose script the authenticated prevout carries; omitted = empty-script placeholder. */
   address?: string;
   value: number;
+  /** Full previous transaction, required when the prevout is Legacy P2PKH. */
+  nonWitnessUtxoHex?: string;
   /** Attach a fabricated final witness so the input reads as already signed. */
   signed?: boolean;
 }
@@ -136,10 +140,15 @@ const FAKE_WITNESS = (() => {
 function buildPsbt(inputs: BuiltInput[], outputs: BuiltOutput[]): { psbtHex: string; txid: string } {
   const rawTxHex = buildRawTx(inputs, outputs);
   const inputMaps = inputs.map(input => {
-    const script = input.address ? scriptFor(input.address) : '';
-    const witnessUtxo = le(input.value, 8) + varint(script.length / 2) + script;
+    const authenticatedPrevout = input.nonWitnessUtxoHex
+      ? ['01', '00', varint(input.nonWitnessUtxoHex.length / 2), input.nonWitnessUtxoHex]
+      : (() => {
+          const script = input.address ? scriptFor(input.address) : '';
+          const witnessUtxo = le(input.value, 8) + varint(script.length / 2) + script;
+          return ['01', '01', varint(witnessUtxo.length / 2), witnessUtxo];
+        })();
     return [
-      '01', '01', varint(witnessUtxo.length / 2), witnessUtxo,
+      ...authenticatedPrevout,
       ...(input.signed ? ['01', '08', varint(FAKE_WITNESS.length / 2), FAKE_WITNESS] : []),
       '00',
     ].join('');
@@ -203,18 +212,45 @@ async function stubUtxoBalances(
 const ORIGIN = 'https://marketplace.xcp.io';
 const FUTURE = 2_000_000_000;
 
-/** Read the live wallet address the same way ux-visual-check does. */
+/** Select a standard mnemonic address format through the same UI a user does. */
+async function selectAddressType(page: Page, addressType: Extract<AddressType, 'p2pkh' | 'p2wpkh'>): Promise<void> {
+  await navigateTo(page, 'settings');
+  await settings.addressTypeOption(page).click();
+  await expect(page).toHaveURL(/address-type/);
+  const option = page.locator('[role="radio"]').filter({
+    hasText: ADDRESS_TYPE_DISPLAY_NAMES[addressType],
+  });
+  await expect(option).toBeVisible();
+  await option.click();
+  await navigateTo(page, 'wallet');
+  const expectedPrefix = addressType === 'p2pkh' ? '1' : 'bc1q';
+  await page.waitForFunction(
+    (prefix: string) => {
+      const address = document.querySelector('[aria-label="Current address"] .font-mono');
+      return (address?.textContent ?? '').startsWith(prefix);
+    },
+    expectedPrefix,
+    { timeout: 10_000 },
+  );
+}
+
+/** Read the complete active address from its detail page. */
 async function readActiveAddress(page: Page): Promise<string> {
-  await page.goto(page.url().replace(/\/(index|requests|addresses).*/, '/addresses/details'));
+  const extensionRoot = page.url().split('#')[0];
+  await page.goto(`${extensionRoot}#/addresses/details`);
   await page.waitForLoadState('networkidle');
   const address = await page.evaluate(() => {
     for (const el of Array.from(document.querySelectorAll('*'))) {
-      const m = (el.textContent || '').match(/(bc1|tb1)[0-9a-z]{30,}/);
+      const m = (el.textContent || '').match(
+        /\b(?:bc1|tb1)[0-9a-z]{30,}\b|\b[13mn2][1-9A-HJ-NP-Za-km-z]{25,34}\b/
+      );
       if (m) return m[0];
     }
     return '';
   });
-  expect(address, 'should read the full active address').toMatch(/^(bc1|tb1)/);
+  expect(address, 'should read the full active address').toMatch(
+    /^(?:bc1|tb1|[13mn2][1-9A-HJ-NP-Za-km-z])/
+  );
   return address;
 }
 
@@ -226,9 +262,13 @@ interface Scenario {
   balances: Record<string, StubBalance[] | 'fail'>;
   /** The footer state this scenario is expected to reach — a drifting state fails the run. */
   expectFooter: 'Sign' | 'Review' | 'Blocked';
+  /** Important semantic disclosures that must survive visual refactors. */
+  expectedText?: string[];
+  /** False-positive warnings that would make an ordinary marketplace request look unsafe. */
+  absentText?: string[];
 }
 
-function buildScenarios(wallet: string): Scenario[] {
+function buildScenarios(wallet: string, pairedLegacy: string): Scenario[] {
   const SELLER_A = fakeAddress(0x11);
   const SELLER_B = fakeAddress(0x22);
   const BUYER_EXT = fakeAddress(0x33);
@@ -289,6 +329,84 @@ function buildScenarios(wallet: string): Scenario[] {
           protocolFee: {
             asset: 'XCP',
             quotedAmountRaw: '25000000',
+            actualAmountRaw: null,
+            observedBlock: 900_000,
+            variableUntilConfirmed: true,
+          },
+          operationExpiresAt: FUTURE,
+        },
+      }),
+      balances: {},
+    });
+  }
+
+  // --- attach_for_listing from paired Legacy, with SegWit paying the miner fee --------------
+  // This is the real DigiRare migration shape: Counterparty reads source from input 0, while
+  // the new attached carrier belongs to the active SegWit identity. A second, same-wallet input
+  // pays the fee. Legacy uses nonWitnessUtxo so the gallery cannot accidentally normalize the
+  // forged-amount shape that the signer correctly refuses.
+  {
+    const legacyPrevTx = buildRawTx(
+      [{ txid: '16'.repeat(32), vout: 0, value: 0 }],
+      [{ scriptHex: scriptFor(pairedLegacy), value: 330 }],
+    );
+    const legacySource: BuiltInput = {
+      txid: txidOf(legacyPrevTx),
+      vout: 0,
+      address: pairedLegacy,
+      value: 330,
+      nonWitnessUtxoHex: legacyPrevTx,
+    };
+    const segwitFunding: BuiltInput = {
+      txid: '17'.repeat(32),
+      vout: 1,
+      address: wallet,
+      value: 10_000,
+    };
+    const payload = attachPayload('COLLECTOR', '1', 0);
+    const outputs: BuiltOutput[] = [
+      { scriptHex: scriptFor(wallet), value: 330 },
+      { scriptHex: opReturnScript(payload, legacySource.txid), value: 0 },
+      { scriptHex: scriptFor(wallet), value: 9_000 },
+    ];
+    const { psbtHex, txid } = buildPsbt([legacySource, segwitFunding], outputs);
+    scenarios.push({
+      name: 'listing-attach-paired-legacy-source',
+      route: '/requests/psbt/approve',
+      expectFooter: 'Sign',
+      expectedText: [
+        'Signing addresses (2)',
+        'Asset source',
+        pairedLegacy,
+        'Carrier owner',
+        wallet,
+      ],
+      absentText: [
+        'Blocked: Not a Counterparty Transaction',
+        'BTC Sent to External Address',
+      ],
+      record: seedRecord('mk-attach-paired', {
+        requestKey: 'xcp_signPsbt:mk-attach-paired',
+        kind: 'sign-psbt',
+        psbtHex,
+        signInputs: { [pairedLegacy]: [0], [wallet]: [1] },
+        sighashTypes: [0x01, 0x01],
+        marketplaceIntent: {
+          standard: 'counterparty-marketplace',
+          version: 1,
+          action: 'attach_for_listing',
+          operationId: 'attach-paired-1',
+          protocolVersion: 'counterparty_attach_listing_v1',
+          assets: [{ asset: 'COLLECTOR', quantityRaw: '1' }],
+          seller: wallet,
+          assetSource: pairedLegacy,
+          expectedAttachedOutpoint: { txid, vout: 0 },
+          carrierAddress: wallet,
+          carrierValueSats: 330,
+          networkFeeSats: 1_000,
+          protocolFee: {
+            asset: 'XCP',
+            quotedAmountRaw: '0',
             actualAmountRaw: null,
             observedBlock: 900_000,
             variableUntilConfirmed: true,
@@ -714,8 +832,16 @@ walletTest('captures every marketplace and provider-safety approval screen', asy
   walletTest.setTimeout(300_000);
   fs.mkdirSync(OUT_DIR, { recursive: true });
 
+  // A paired permission is defined for the Legacy and Native SegWit formats at the same wallet
+  // index. Read both through the real wallet UI, then leave SegWit active for every approval.
+  await selectAddressType(page, 'p2pkh');
+  const pairedLegacy = await readActiveAddress(page);
+  await selectAddressType(page, 'p2wpkh');
   const wallet = await readActiveAddress(page);
-  const scenarios = buildScenarios(wallet);
+  expect(pairedLegacy).toMatch(/^1/);
+  expect(wallet).toMatch(/^bc1q/);
+
+  const scenarios = buildScenarios(wallet, pairedLegacy);
   const captured: string[] = [];
   const stateMismatches: string[] = [];
 
@@ -739,10 +865,32 @@ walletTest('captures every marketplace and provider-safety approval screen', asy
       stateMismatches.push(`${scenario.name}: footer reads "${footerLabel}", expected "${scenario.expectFooter}"`);
     }
 
-    // Open every progressive-disclosure surface so the captured state is the full statement.
+    // Capture the paired signer disclosure at the top of the approval before opening lower
+    // transaction details, whose focus movement scrolls the real popup viewport downward.
+    const signerToggle = approval.getByText(/^Signing addresses \(\d+\)$/);
+    if (await signerToggle.count()) {
+      await signerToggle.first().click();
+      await approval.locator('.overflow-y-auto').first().evaluate((element) => {
+        element.scrollTop = 0;
+      });
+      await approval.screenshot({
+        path: path.join(OUT_DIR, `${scenario.name}-signers.png`),
+        fullPage: true,
+      });
+    }
+
+    // Open the lower-level transaction surfaces for the companion detail capture.
     for (const title of [/^Transaction Details$/, /^Linked Transaction Details$/]) {
       const toggle = approval.getByText(title);
       if (await toggle.count()) await toggle.first().click();
+    }
+
+    const body = approval.locator('body');
+    for (const expectedText of scenario.expectedText ?? []) {
+      await expect(body).toContainText(expectedText);
+    }
+    for (const absentText of scenario.absentText ?? []) {
+      await expect(body).not.toContainText(absentText);
     }
     await approval.screenshot({ path: path.join(OUT_DIR, `${scenario.name}.png`), fullPage: true });
 

--- a/e2e/tests/marketplace-gallery.spec.ts
+++ b/e2e/tests/marketplace-gallery.spec.ts
@@ -378,7 +378,7 @@ function buildScenarios(wallet: string, pairedLegacy: string): Scenario[] {
         'Signing addresses (2)',
         'Asset source',
         pairedLegacy,
-        'Carrier owner',
+        'New UTXO owner',
         wallet,
       ],
       absentText: [

--- a/src/core/counterparty/__tests__/marketplaceBatch.test.ts
+++ b/src/core/counterparty/__tests__/marketplaceBatch.test.ts
@@ -68,7 +68,7 @@ describe('marketplace batch aggregate proof', () => {
       family: 'marketplace_batch',
       blockers: [],
     });
-    expect(review.facts).toContainEqual({ label: 'Attach slots', value: '4' });
+    expect(review.facts).toContainEqual({ label: 'New UTXOs', value: '4' });
     expect(review.facts).toContainEqual({ label: 'Total network fees', value: '2,000 sats' });
   });
 

--- a/src/core/counterparty/__tests__/marketplaceIntent.test.ts
+++ b/src/core/counterparty/__tests__/marketplaceIntent.test.ts
@@ -404,7 +404,7 @@ describe('attach-for-listing proof', () => {
     expect(review.status).toBe('caution');
     expect(review.blockers).toEqual([]);
     expect(review.facts).toContainEqual({ label: 'Asset source', value: SELLER });
-    expect(review.facts).toContainEqual({ label: 'Carrier owner', value: SELLER_TWO });
+    expect(review.facts).toContainEqual({ label: 'New UTXO owner', value: SELLER_TWO });
   });
 
   it.each([
@@ -731,7 +731,7 @@ describe('bulk fan-out funding proof', () => {
       family: 'prepare_bulk_fanout',
       blockers: [],
     });
-    expect(review.facts).toContainEqual({ label: 'Attach slots', value: '2 × 10,000 sats' });
+    expect(review.facts).toContainEqual({ label: 'New UTXOs', value: '2 × 10,000 sats' });
     expect(review.notices[0]?.message).toMatch(/no asset moves/i);
   });
 

--- a/src/core/counterparty/marketplaceBatch.ts
+++ b/src/core/counterparty/marketplaceBatch.ts
@@ -123,9 +123,9 @@ export function analyzeMarketplaceBatch(
     const fanouts = intents as PrepareBulkFanoutIntentClaim[];
     const slots = exactSafeSum(fanouts.map(intent => intent.slotCount), 'slot count');
     const fees = exactSafeSum(fanouts.map(intent => intent.networkFeeSats), 'network fee');
-    title = `Prepare ${slots} listing funding slots`;
+    title = `Create ${slots} listing UTXO${slots === 1 ? '' : 's'}`;
     facts.push(
-      { label: 'Attach slots', value: slots.toLocaleString() },
+      { label: 'New UTXOs', value: slots.toLocaleString() },
       { label: 'Total network fees', value: `${fees.toLocaleString()} sats` },
     );
     notice = 'Every fan-out input and same-wallet output was proved before this batch can sign. No Counterparty asset moves in this phase.';
@@ -140,7 +140,7 @@ export function analyzeMarketplaceBatch(
         value: formatXcpRaw(attaches.map(intent => intent.protocolFee.quotedAmountRaw)),
       },
     );
-    notice = 'Every attach proves its source, clean funding, carrier output, miner fee, and local Counterparty message. XCP fees remain block-dependent until confirmation.';
+    notice = 'Every attach proves its source, clean funding, new UTXO, miner fee, and local Counterparty message. XCP fees remain block-dependent until confirmation.';
   } else {
     const listings = intents as CreateListingIntentClaim[];
     const gross = exactSafeSum(listings.map(intent => intent.priceSats), 'listing prices');

--- a/src/core/counterparty/marketplaceIntent.ts
+++ b/src/core/counterparty/marketplaceIntent.ts
@@ -636,12 +636,12 @@ function analyzeCreateListingIntent({
       blockers.push('seller input 1 is not controlled by the claimed seller');
     }
     if (sellerInput.value !== intent.carrierValueSats) {
-      blockers.push('seller input carrier value differs from the claim');
+      blockers.push('the seller input UTXO value differs from the claim');
     }
   }
 
   if (intent.guaranteedSellerPaymentSats !== intent.carrierValueSats + intent.priceSats) {
-    blockers.push('claimed seller payment does not equal carrier plus price');
+    blockers.push('the claimed seller payment does not equal the asset UTXO value plus the price');
   }
   if (!sellerOutput) {
     blockers.push('guaranteed seller output 1 is missing');
@@ -699,9 +699,9 @@ function analyzeCreateListingIntent({
         label: 'Marketplace expiry',
         value: intent.marketplaceExpiresAt === null
           ? 'None requested'
-          : new Date(intent.marketplaceExpiresAt * 1000).toLocaleString(),
+          : formatExpiry(intent.marketplaceExpiresAt),
       },
-      { label: 'Bitcoin expiry', value: 'None — cancel by spending the asset' },
+      { label: 'Cancellation', value: 'Anytime — spend the asset UTXO' },
     ],
     notices: allProblems.length > 0
       ? []
@@ -731,6 +731,14 @@ const formatXcpRaw = (raw: string): string => {
   const fraction = (amount % 100_000_000n).toString().padStart(8, '0').replace(/0+$/, '');
   return fraction ? `${whole}.${fraction} XCP` : `${whole} XCP`;
 };
+
+/** Expiry timestamps share rows with their labels; seconds-precision wraps them into a third line. */
+function formatExpiry(unixSeconds: number): string {
+  return new Date(unixSeconds * 1000).toLocaleString(undefined, {
+    dateStyle: 'short',
+    timeStyle: 'short',
+  });
+}
 
 /** Prove the full-input ALL-signed attach that creates one listable carrier UTXO. */
 function analyzeAttachForListingIntent(
@@ -847,19 +855,19 @@ function analyzeAttachForListingIntent(
 
   const target = outputs[intent.expectedAttachedOutpoint.vout];
   if (!sameAddress(intent.carrierAddress, intent.seller)) {
-    blockers.push('the attached carrier address differs from the claimed seller');
+    blockers.push('the attach destination address differs from the claimed seller');
   }
   if (!target) {
-    blockers.push('the claimed attached carrier output is missing');
+    blockers.push('the claimed new attached UTXO is missing');
   } else {
     if (!sameAddress(target.address, intent.carrierAddress)) {
-      blockers.push('the attached carrier output is not controlled by the claimed carrier address');
+      blockers.push('the new attached UTXO is not controlled by the claimed owner');
     }
     if (target.value !== intent.carrierValueSats) {
-      blockers.push('the attached carrier output value differs from the claim');
+      blockers.push('the new attached UTXO value differs from the claim');
     }
     if (target.type === 'op_return') {
-      blockers.push('the attached carrier destination cannot be an OP_RETURN output');
+      blockers.push('the attach destination cannot be an OP_RETURN output');
     }
   }
   const dataOutputs = outputs.filter(output => output.type === 'op_return');
@@ -903,17 +911,14 @@ function analyzeAttachForListingIntent(
     facts: [
       ...(!sameAddress(assetSource, intent.seller) ? [
         { label: 'Asset source', value: assetSource },
-        { label: 'Carrier owner', value: intent.seller },
+        { label: 'New UTXO owner', value: intent.seller },
       ] : []),
-      { label: 'Carrier value', value: `${intent.carrierValueSats.toLocaleString()} sats` },
+      { label: 'New UTXO value', value: `${intent.carrierValueSats.toLocaleString()} sats` },
       {
         label: 'Quoted XCP fee',
         value: `${formatXcpRaw(intent.protocolFee.quotedAmountRaw)} (finalized at confirmation)`,
       },
-      {
-        label: 'Operation expiry',
-        value: new Date(intent.operationExpiresAt * 1000).toLocaleString(),
-      },
+      { label: 'Operation expiry', value: formatExpiry(intent.operationExpiresAt) },
     ],
     notices: [],
     blockers: allProblems,
@@ -1039,7 +1044,7 @@ function analyzeBuyListingsIntent(
       blockers.push(`item ${itemIndex + 1} does not align with its top-level asset claim`);
     }
     if (item.sellerPaymentSats !== item.carrierValueSats + item.priceSats) {
-      blockers.push(`item ${itemIndex + 1} seller payment is not carrier plus price`);
+      blockers.push(`item ${itemIndex + 1} seller payment is not the asset UTXO value plus the price`);
     }
     if (!sellerInput) {
       blockers.push(`seller input ${sellerInputIndex} is missing`);
@@ -1051,9 +1056,9 @@ function analyzeBuyListingsIntent(
         blockers.push(`seller input ${sellerInputIndex} is not controlled by the claimed seller`);
       }
       if (sellerInput.value === undefined) {
-        retry.push(`seller input ${sellerInputIndex} has no authenticated carrier value`);
+        retry.push(`seller input ${sellerInputIndex} has no authenticated UTXO value`);
       } else if (sellerInput.value !== item.carrierValueSats) {
-        blockers.push(`seller input ${sellerInputIndex} carrier value differs from the claim`);
+        blockers.push(`seller input ${sellerInputIndex} UTXO value differs from the claim`);
       }
     }
     if (!sellerOutput) {
@@ -1149,16 +1154,20 @@ function analyzeBuyListingsIntent(
     family: 'buy_listings',
     title: `Buy ${itemCount} collectible${itemCount === 1 ? '' : 's'} for ${(intent.totalSats / 100_000_000).toFixed(8)} BTC`,
     facts: [
-      { label: 'Items', value: `${itemCount} across ${distinctAssets} asset${distinctAssets === 1 ? '' : 's'}` },
+      // The per-asset "Detached" rows below already name each asset; this row only adds the
+      // distinct-asset count when it differs from the item count.
+      {
+        label: 'Items',
+        value: itemCount === distinctAssets
+          ? `${itemCount}`
+          : `${itemCount} (${distinctAssets} assets)`,
+      },
       // No network-fee row: the money-movement summary beside these facts already states it.
       { label: 'Seller subtotal', value: `${intent.subtotalSats.toLocaleString()} sats` },
       { label: 'Platform fee', value: `${intent.platformFeeSats.toLocaleString()} sats` },
       { label: 'You pay', value: `${intent.totalSats.toLocaleString()} sats` },
       { label: 'Delivery', value: `Detached to ${intent.delivery.address}` },
-      {
-        label: 'Marketplace expiry',
-        value: new Date(intent.marketplaceExpiresAt * 1000).toLocaleString(),
-      },
+      { label: 'Marketplace expiry', value: formatExpiry(intent.marketplaceExpiresAt) },
     ],
     notices: allProblems.length > 0
       ? []
@@ -1286,9 +1295,9 @@ function analyzeExactOfferIntent(
       blockers.push('input 1 is not controlled by the claimed seller');
     }
     if (sellerInput.value === undefined) {
-      retry.push('seller input 1 has no authenticated carrier value');
+      retry.push('seller input 1 has no authenticated UTXO value');
     } else if (sellerInput.value !== intent.carrierValueSats) {
-      blockers.push('seller input 1 carrier value differs from the claim');
+      blockers.push('seller input 1 UTXO value differs from the claim');
     }
   }
 
@@ -1327,7 +1336,7 @@ function analyzeExactOfferIntent(
     -intent.networkFeeSats,
   ]);
   if (claimedProceeds === null || claimedProceeds !== intent.sellerProceedsSats) {
-    blockers.push('claimed seller proceeds do not equal price plus carrier minus miner fee');
+    blockers.push('claimed seller proceeds do not equal the price plus the asset UTXO value minus the miner fee');
   }
   const sellerOutput = outputs[1];
   if (!sellerOutput) {
@@ -1371,20 +1380,17 @@ function analyzeExactOfferIntent(
       { label: 'Offer price', value: `${intent.priceSats.toLocaleString()} sats` },
       { label: 'Seller receives', value: `${intent.sellerProceedsSats.toLocaleString()} sats` },
       { label: 'Delivery', value: `Detached to ${intent.delivery.address}` },
-      { label: 'Funding slot', value: `${fundingOutpoint.txid}:${fundingOutpoint.vout}` },
-      {
-        label: 'Marketplace expiry',
-        value: new Date(intent.marketplaceExpiresAt * 1000).toLocaleString(),
-      },
-      { label: 'Bitcoin expiry', value: 'None — cancel by spending the funding UTXO' },
+      { label: 'Funding UTXO', value: `${fundingOutpoint.txid}:${fundingOutpoint.vout}` },
+      { label: 'Marketplace expiry', value: formatExpiry(intent.marketplaceExpiresAt) },
+      { label: 'Cancellation', value: 'Anytime — spend the funding UTXO' },
     ],
     notices: allProblems.length > 0
       ? []
       : [{
           severity: authorizing ? 'warning' : 'info',
           message: authorizing
-            ? 'After signing, this seller can complete this exact trade without another approval. Other exact offers backed by the same funding slot are alternatives: the first confirmed spend wins and invalidates its siblings.'
-            : 'Your signature completes this exact sale without a buyer callback. If the buyer already spent this shared funding slot, broadcast fails and your asset remains yours.',
+            ? 'After signing, this seller can complete this exact trade without another approval. Other exact offers backed by the same funding UTXO are alternatives: the first confirmed spend wins and invalidates its siblings.'
+            : 'Your signature completes this exact sale without a buyer callback. If the buyer already spent the shared funding UTXO, broadcast fails and your asset remains yours.',
         }],
     blockers: allProblems,
   };
@@ -1491,26 +1497,23 @@ function analyzePrepareBulkFanoutIntent(
   return {
     status: blockers.length > 0 ? 'blocked' : retry.length > 0 ? 'retry' : 'proved',
     family: 'prepare_bulk_fanout',
-    title: `Prepare ${intent.slotCount} listing funding slot${intent.slotCount === 1 ? '' : 's'}`,
+    title: `Create ${intent.slotCount} listing UTXO${intent.slotCount === 1 ? '' : 's'}`,
     facts: [
       { label: 'Funding input', value: `${intent.fundingValueSats.toLocaleString()} sats` },
       {
-        label: 'Attach slots',
+        label: 'New UTXOs',
         value: `${intent.slotCount} × ${intent.slotValueSats.toLocaleString()} sats`,
       },
       { label: 'Change', value: `${intent.changeSats.toLocaleString()} sats` },
       { label: 'Network fee', value: `${intent.networkFeeSats.toLocaleString()} sats` },
-      {
-        label: 'Operation expiry',
-        value: new Date(intent.operationExpiresAt * 1000).toLocaleString(),
-      },
+      { label: 'Operation expiry', value: formatExpiry(intent.operationExpiresAt) },
     ],
     notices: allProblems.length > 0
       ? []
       : [{
           severity: 'info',
           message:
-            'Every output remains controlled by this wallet. These plain-Bitcoin slots fund later Counterparty attach transactions; no asset moves in this phase.',
+            'Every output remains controlled by this wallet. These plain-Bitcoin UTXOs fund later Counterparty attach transactions; no asset moves in this phase.',
         }],
     blockers: allProblems,
   };

--- a/src/pages/requests/psbt/approve.tsx
+++ b/src/pages/requests/psbt/approve.tsx
@@ -424,21 +424,6 @@ export default function ApprovePsbtPage() {
 
           <ApprovalSiteBar origin={request.origin} />
 
-          {isBitcoinPayment && request.bitcoinPaymentIntent && (
-            <BitcoinPaymentCard
-              intent={request.bitcoinPaymentIntent}
-              proof={decodedInfo.bitcoinPaymentProof}
-              failure={decodedInfo.bitcoinPaymentBlockers}
-            />
-          )}
-
-          {/* A gating failure gets exactly one voice: the review card alone carries the
-              blockers, and the generic warning stack below stays silent for it. Proved and
-              caution reviews render through the standard headline and details instead. */}
-          {marketplaceBlocked && marketplaceReview && (
-            <MarketplaceReviewCard review={marketplaceReview} />
-          )}
-
           {error && <ErrorAlert message={error} />}
 
           {/* Transaction action & fee. Skipped when there is nothing to put in it — a gated
@@ -457,6 +442,23 @@ export default function ApprovePsbtPage() {
               ? toFiniteNumber(counterpartyMessage.messageData.fee) ?? null
               : null}
           />
+          )}
+
+          {/* Colored verdict cards sit under the plain summary, matching the app-wide order of
+              summary first, callouts second. */}
+          {isBitcoinPayment && request.bitcoinPaymentIntent && (
+            <BitcoinPaymentCard
+              intent={request.bitcoinPaymentIntent}
+              proof={decodedInfo.bitcoinPaymentProof}
+              failure={decodedInfo.bitcoinPaymentBlockers}
+            />
+          )}
+
+          {/* A gating failure gets exactly one voice: the review card alone carries the
+              blockers, and the generic warning stack below stays silent for it. Proved and
+              caution reviews render through the standard headline and details instead. */}
+          {marketplaceBlocked && marketplaceReview && (
+            <MarketplaceReviewCard review={marketplaceReview} />
           )}
 
           <CounterpartyDetailsCard


### PR DESCRIPTION
## What changed

- derives the real Legacy and Native SegWit addresses at the same wallet index through the extension UI
- adds a proper Legacy nonWitnessUtxo plus SegWit fee input to the attach-for-listing gallery
- asserts both signing addresses, source and carrier ownership, and absence of the old false-positive warnings
- captures a dedicated expanded signer screenshot before the transaction-details view scrolls the popup

## Verification

- TypeScript: pass
- marketplace approval gallery: 12 scenarios, pass