### PR TITLE
Distinguish listing reprices in PSBT approvals

### DIFF
--- a/e2e/tests/marketplace-gallery.spec.ts
+++ b/e2e/tests/marketplace-gallery.spec.ts
@@ -19,8 +19,8 @@
 import { createHash } from 'node:crypto';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { Address, OutScript } from '@scure/btc-signer';
 import type { Page, Route } from '@playwright/test';
+import { Address, OutScript } from '@scure/btc-signer';
 import { expect, walletTest } from '../fixtures';
 
 const OUT_DIR = 'test-results/marketplace-gallery';
@@ -238,8 +238,6 @@ function buildScenarios(wallet: string): Scenario[] {
   const ASSET_TXID_TWO = 'cd'.repeat(32);
   const FUNDING_TXID = '11'.repeat(32);
   const BID_TXID = '19'.repeat(32);
-  const FANOUT_FUNDING_TXID = '21'.repeat(32);
-
   const scenarios: Scenario[] = [];
   const seedRecord = (
     id: string,
@@ -340,6 +338,29 @@ function buildScenarios(wallet: string): Scenario[] {
         signInputs: { [wallet]: [1] },
         sighashTypes: [0x01, 0x83],
         marketplaceIntent: intent,
+      }),
+      balances: {
+        [`${ASSET_TXID}:7`]: [{ asset: 'RAREPEPE', quantity: '100000000', quantity_normalized: '1' }],
+      },
+    });
+
+    scenarios.push({
+      name: 'listing-reprice-caution',
+      route: '/requests/psbt/approve',
+      expectFooter: 'Review',
+      record: seedRecord('mk-listing-reprice', {
+        requestKey: 'xcp_signPsbt:mk-listing-reprice',
+        kind: 'sign-psbt',
+        psbtHex,
+        signInputs: { [wallet]: [1] },
+        sighashTypes: [0x01, 0x83],
+        marketplaceIntent: {
+          ...intent,
+          operationId: 'listing-reprice-1',
+          listingContext: {
+            mode: 'reprice',
+          },
+        },
       }),
       balances: {
         [`${ASSET_TXID}:7`]: [{ asset: 'RAREPEPE', quantity: '100000000', quantity_normalized: '1' }],

--- a/src/core/counterparty/__tests__/marketplaceIntent.test.ts
+++ b/src/core/counterparty/__tests__/marketplaceIntent.test.ts
@@ -316,6 +316,17 @@ describe('marketplace intent wire parser', () => {
     expect(parseMarketplaceIntent(intent)).toEqual(intent);
   });
 
+  it('copies bounded reprice display context without changing the signing action', () => {
+    const repriceIntent: CreateListingIntentClaim = {
+      ...intent,
+      listingContext: {
+        mode: 'reprice',
+      },
+    };
+
+    expect(parseMarketplaceIntent(repriceIntent)).toEqual(repriceIntent);
+  });
+
   it('copies a bounded multi-item buy claim', () => {
     expect(parseMarketplaceIntent(buyIntent)).toEqual(buyIntent);
   });
@@ -349,6 +360,7 @@ describe('marketplace intent wire parser', () => {
     { ...intent, action: 'buy_listings' },
     { ...intent, bitcoinExpiresAt: 2_000_000_000 },
     { ...intent, assets: [] },
+    { ...intent, listingContext: { mode: 'replace' } },
   ])('refuses an unsupported or malformed claim', (candidate) => {
     expect(() => parseMarketplaceIntent(candidate)).toThrow();
   });
@@ -496,6 +508,21 @@ describe('create-listing proof', () => {
     expect(review.title).toContain('RAREPEPE');
     expect(review.facts).toContainEqual({ label: 'Seller receives', value: '250,546 sats' });
     expect(review.notices[0]?.message).toContain('choose the detach destination');
+  });
+
+  it('labels a proved replacement authorization as a reprice', () => {
+    const review = analyzeMarketplaceIntent({
+      ...base(),
+      intent: {
+        ...intent,
+        listingContext: {
+          mode: 'reprice',
+        },
+      },
+    });
+
+    expect(review.status).toBe('caution');
+    expect(review.title).toBe('Reprice 1 RAREPEPE to 0.00250000 BTC');
   });
 
   it.each([

--- a/src/core/counterparty/marketplaceIntent.ts
+++ b/src/core/counterparty/marketplaceIntent.ts
@@ -64,6 +64,9 @@ export interface CreateListingIntentClaim {
   signingRequestExpiresAt: number;
   marketplaceExpiresAt: number | null;
   bitcoinExpiresAt: null;
+  listingContext?: {
+    mode: 'reprice';
+  };
 }
 
 export interface BuyListingsIntentClaim {
@@ -288,6 +291,20 @@ const nonNegativeRawInteger = (value: unknown, label: string): string => {
   return raw;
 };
 
+const parseListingContext = (
+  value: unknown,
+): Pick<CreateListingIntentClaim, 'listingContext'> => {
+  if (value === undefined) return {};
+  if (!isRecord(value) || value.mode !== 'reprice') {
+    throw new Error('listingContext must describe a reprice');
+  }
+  return {
+    listingContext: {
+      mode: 'reprice',
+    },
+  };
+};
+
 /** Bound and copy the v1 wire claim. The result remains untrusted until analyzed. */
 export function parseMarketplaceIntent(value: unknown): MarketplaceIntentClaimV1 {
   if (!isRecord(value)) throw new Error('marketplace intent must be an object');
@@ -337,6 +354,7 @@ export function parseMarketplaceIntent(value: unknown): MarketplaceIntentClaimV1
       nullable: true,
     }),
     bitcoinExpiresAt: null,
+    ...parseListingContext(value.listingContext),
   };
 }
 
@@ -690,7 +708,9 @@ function analyzeCreateListingIntent({
   return {
     status,
     family: 'create_listing',
-    title: `List 1 ${claim.asset} for ${(intent.priceSats / 100_000_000).toFixed(8)} BTC`,
+    title: `${intent.listingContext?.mode === 'reprice' ? 'Reprice' : 'List'} 1 ${claim.asset} ` +
+      `${intent.listingContext?.mode === 'reprice' ? 'to' : 'for'} ` +
+      `${(intent.priceSats / 100_000_000).toFixed(8)} BTC`,
     facts: [
       { label: 'Seller receives', value: `${intent.guaranteedSellerPaymentSats.toLocaleString()} sats` },
       { label: 'Quantity', value: `${provedQuantity ?? claim.quantityRaw} ${claim.asset}` },

--- a/src/pages/requests/psbt/approve.tsx
+++ b/src/pages/requests/psbt/approve.tsx
@@ -67,6 +67,11 @@ export default function ApprovePsbtPage() {
   const [isSigning, setIsSigning] = useState(false);
   const [error, setError] = useState<string>('');
   const [showAttention, setShowAttention] = useState(false);
+  const listingContext = request?.marketplaceIntent?.action === 'create_listing'
+    ? request.marketplaceIntent.listingContext
+    : undefined;
+  const isRepriceListing = listingContext?.mode === 'reprice';
+  const listingHeader = isRepriceListing ? 'Reprice Listing' : 'Create Listing';
 
   // Configure header
   useEffect(() => {
@@ -76,7 +81,7 @@ export default function ApprovePsbtPage() {
         : request?.marketplaceIntent?.action === 'attach_for_listing'
           ? 'Attach for Listing'
           : request?.marketplaceIntent?.action === 'create_listing'
-            ? 'Create Listing'
+            ? listingHeader
             : request?.marketplaceIntent?.action === 'buy_listings'
               ? 'Buy Collectibles'
               : request?.marketplaceIntent?.action === 'authorize_exact_offer'
@@ -85,7 +90,7 @@ export default function ApprovePsbtPage() {
                   ? 'Accept Offer'
                   : 'Sign Transaction',
     });
-  }, [request?.marketplaceIntent?.action, request?.signingPurpose, setHeaderProps]);
+  }, [listingHeader, request?.marketplaceIntent?.action, request?.signingPurpose, setHeaderProps]);
 
   useEffect(() => setShowAttention(false), [request?.id]);
 
@@ -300,13 +305,20 @@ export default function ApprovePsbtPage() {
       ? [{
           key: 'marketplace-listing',
           severity: 'warning' as const,
-          title: 'This listing stays open until filled or cancelled',
-          description:
-            'Signing puts this up for sale. Anyone who pays you exactly ' +
-            `${request.marketplaceIntent?.action === 'create_listing'
-              ? request.marketplaceIntent.guaranteedSellerPaymentSats.toLocaleString()
-              : 'the shown'} sats can complete the purchase without asking you again. ` +
-            'To cancel the listing later, spend the asset UTXO.',
+          title: isRepriceListing
+            ? 'This replaces the current listing price'
+            : 'This listing stays open until filled or cancelled',
+          description: isRepriceListing
+            ? `Signing authorizes a new price of ${request.marketplaceIntent?.action === 'create_listing'
+              ? (request.marketplaceIntent.priceSats / 100_000_000).toFixed(8)
+              : 'the shown amount'} BTC. Once the marketplace accepts it, the previous stored ` +
+              'authorization is replaced. You can remove the listing through the marketplace. ' +
+              'Spending the asset UTXO also invalidates the signature.'
+            : 'Signing puts this up for sale. Anyone who pays you exactly ' +
+              `${request.marketplaceIntent?.action === 'create_listing'
+                ? request.marketplaceIntent.guaranteedSellerPaymentSats.toLocaleString()
+                : 'the shown'} sats can complete the purchase without asking you again. ` +
+              'You can remove it through the marketplace. Spending the asset UTXO also invalidates the authorization.',
         }]
       : marketplaceReview.family === 'authorize_exact_offer'
         ? [{
@@ -346,7 +358,7 @@ export default function ApprovePsbtPage() {
   const requiresAttention = !blockSigning && approvalAttentionItems.length > 0;
   const attentionTitle = marketplaceRequiresAttention
     ? marketplaceReview.family === 'create_listing'
-      ? 'Before you list'
+      ? isRepriceListing ? 'Before you reprice' : 'Before you list'
       : marketplaceReview.family === 'authorize_exact_offer'
         ? 'Before you authorize'
         : 'Review before signing'
@@ -354,7 +366,7 @@ export default function ApprovePsbtPage() {
       ? 'Review transaction risk'
       : 'Review before signing';
   const confirmLabel = marketplaceReview?.family === 'create_listing'
-    ? 'Authorize listing'
+    ? isRepriceListing ? 'Authorize reprice' : 'Authorize listing'
     : marketplaceReview?.family === 'authorize_exact_offer'
       ? 'Authorize offer'
       : counterpartyMessage?.messageType === 'destroy'


### PR DESCRIPTION
Adds an optional, untrusted reprice display hint while preserving the existing create_listing action and every independent PSBT safety check. Reprice approvals now use explicit header, review, warning, and confirmation copy and repeat the independently verified new price. Older wallet versions safely ignore the extra hint. Coverage includes parser and analyzer tests plus a real reprice state in the marketplace approval screenshot gallery. Verified with 4,912 unit tests passing, TypeScript compile, production build, focused lint, and the 12-scenario marketplace visual gallery.