### PR TITLE
Release 0.10.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xcp-wallet",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xcp-wallet",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "xcp-wallet",
   "description": "Counterparty Web3 Wallet",
   "private": true,
-  "version": "0.10.0",
+  "version": "0.10.1",
   "license": "MIT",
   "type": "module",
   "engines": {


### PR DESCRIPTION
Bump the extension and lockfile versions to 0.10.1. The release ZIP builds successfully and its embedded manifest reports 0.10.1.