### PR TITLE
Fix Counterparty multisig and compose compatibility

### DIFF
--- a/src/contexts/__tests__/composer-context.test.tsx
+++ b/src/contexts/__tests__/composer-context.test.tsx
@@ -671,4 +671,23 @@ describe('a compose whose message is missing entirely', () => {
     });
     expect(result.current.state.error).toBeNull();
   });
+
+  it('allows a current move-to-UTXO compose, whose protocol action is message-less', async () => {
+    // Core's move.py transfers attached balances to the first non-OP_RETURN output. It does not
+    // emit the historical type-100 UTXO message, so the absence of a payload is expected here.
+    const formData = new FormData();
+    formData.set('sourceUtxo', `${'a'.repeat(64)}:0`);
+    formData.set('destination', OWN_ADDRESS);
+
+    const { result } = composeWith('move', messagelessResponse({ destination: OWN_ADDRESS }));
+
+    await act(async () => {
+      result.current.composeTransaction(formData);
+    });
+
+    await waitFor(() => {
+      expect(result.current.state.step).toBe('review');
+    });
+    expect(result.current.state.error).toBeNull();
+  });
 });

--- a/src/core/counterparty/__tests__/compose.specialized.test.ts
+++ b/src/core/counterparty/__tests__/compose.specialized.test.ts
@@ -346,6 +346,20 @@ describe('Compose Specialized Operations', () => {
       expect(url).toContain('pool_quantity=400000000');
       expect(url).toContain('lp_asset=A95428956661682178');
     });
+
+    it('should include an explicit subasset parent', async () => {
+      await composeFairminter({
+        sourceAddress: mockAddress,
+        sat_per_vbyte: mockSatPerVbyte,
+        ...defaultParams,
+        asset: 'A95428956661682177',
+        asset_parent: 'PEPECASH',
+      });
+
+      const url = mockedApiClient.get.mock.calls[0]![0] as string;
+      expect(url).toContain('asset=A95428956661682177');
+      expect(url).toContain('asset_parent=PEPECASH');
+    });
   });
 
   describe('composeFairmint', () => {

--- a/src/core/counterparty/compose.ts
+++ b/src/core/counterparty/compose.ts
@@ -131,11 +131,7 @@ export interface BaseComposeOptions {
   sourceAddress: string;
   sat_per_vbyte: number;
   max_fee?: number;
-  encoding?: 'auto' | 'opreturn' | 'multisig' | 'pubkeyhash' | 'taproot';
-  change_address?: string;
-  more_outputs?: string;
-  use_all_inputs_set?: boolean;
-  multisig_pubkey?: string;
+  encoding?: 'auto' | 'opreturn' | 'multisig' | 'taproot';
 }
 
 // Transaction-specific options
@@ -231,16 +227,19 @@ export interface SendOptions extends BaseComposeOptions {
   memo?: string;
   memo_is_hex?: boolean;
   no_dispense?: boolean;
+  more_outputs?: string;
 }
 
 export interface SweepOptions extends BaseComposeOptions {
   destination: string;
   flags: number;
   memo?: string;
+  more_outputs?: string;
 }
 
 export interface FairminterOptions extends BaseComposeOptions {
   asset: string;
+  asset_parent?: string;
   lot_price?: number;
   lot_size?: string | number;
   max_mint_per_tx?: string | number;
@@ -1042,6 +1041,7 @@ export async function composeFairminter(options: FairminterOptions): Promise<Api
   const {
     sourceAddress,
     asset,
+    asset_parent,
     lot_price = 0,
     lot_size = 1,
     max_mint_per_tx = 0,
@@ -1070,6 +1070,7 @@ export async function composeFairminter(options: FairminterOptions): Promise<Api
   // Boolean values are normalized upstream - convert to API string format
   const paramsObj = {
     asset,
+    ...(asset_parent && { asset_parent }),
     lot_price: lot_price.toString(),
     lot_size: lot_size.toString(),
     max_mint_per_tx: max_mint_per_tx.toString(),

--- a/src/core/counterparty/pack/__tests__/coreOracle.test.ts
+++ b/src/core/counterparty/pack/__tests__/coreOracle.test.ts
@@ -322,6 +322,22 @@ const CASES: OracleCase[] = [
     query: { asset: 'PEPECASH', quantity: '1' },
   },
   {
+    label: 'fairminter',
+    composeType: 'fairminter',
+    params: { asset: 'PEPECASH', max_mint_per_tx: 1 },
+    query: { asset: 'PEPECASH', max_mint_per_tx: '1' },
+  },
+  {
+    label: 'subasset fairminter with an explicit parent',
+    composeType: 'fairminter',
+    params: {
+      asset: 'A95428956661682177', asset_parent: 'PEPECASH', max_mint_per_tx: 1,
+    },
+    query: {
+      asset: 'A95428956661682177', asset_parent: 'PEPECASH', max_mint_per_tx: '1',
+    },
+  },
+  {
     label: 'pool withdraw',
     composeType: 'poolwithdraw',
     params: {

--- a/src/core/counterparty/pack/__tests__/messages.test.ts
+++ b/src/core/counterparty/pack/__tests__/messages.test.ts
@@ -308,6 +308,23 @@ describe('inscription composes pack the same message, only carried differently',
 });
 
 describe('borrowing only what the request cannot determine', () => {
+  it('packs the explicit parent of a subasset fairminter', () => {
+    const packed = packComposeMessage('fairminter', {
+      asset: 'A95428956661682177',
+      asset_parent: 'PEPECASH',
+      max_mint_per_tx: 1,
+    });
+
+    expect(packed).not.toBeNull();
+    const decoded = unpackCounterpartyMessage(packed!.bytes);
+    expect(decoded.success).toBe(true);
+    expect(decoded.data).toMatchObject({
+      asset: 'A95428956661682177',
+      assetParent: 'PEPECASH',
+      maxMintPerTx: 1n,
+    });
+  });
+
   it('packs a reissuance by taking divisibility from the composed message', () => {
     // update-description and transfer-ownership omit `divisible` because the asset already fixes
     // it. Borrowing that one field keeps the rest of the message byte-verified instead of falling
@@ -464,6 +481,11 @@ describe('refusing to pack is not the same as agreeing', () => {
     }],
     ['a quantity that is not whole base units', 'send', {
       asset: 'XCP', destination: TAPROOT_DESTINATION, quantity: asBaseUnits('1.5'),
+    }],
+    // Current Core's `/compose/movetoutxo` action is message-less (`move.py`); type 100 belongs to
+    // the historical `utxo.py` message and must not be expected from this compose route.
+    ['a current move-to-UTXO compose', 'move', {
+      source: `${'a'.repeat(64)}:0`, destination: TAPROOT_DESTINATION, asset: 'XCP', quantity: 1,
     }],
   ])('returns null for %s', (_label, composeType, params) => {
     expect(packComposeMessage(composeType, params as Record<string, unknown>)).toBeNull();

--- a/src/core/counterparty/pack/messages.ts
+++ b/src/core/counterparty/pack/messages.ts
@@ -434,12 +434,15 @@ function packFairmint(params: Params): PackedMessage | null {
  *
  * The form's names differ from the wire's — `lot_price` is `price`, `lot_size` is
  * `quantity_by_price` — and the defaults must match `composeFairminter`, where lot size is 1 and
- * divisible is true. Subassets are declined: their parent id comes from a ledger lookup of the
- * existing asset's longname.
+ * divisible is true. A new subasset is expressible when the request supplies its numeric child
+ * asset and `asset_parent`, matching the current API surface; a dotted longname still requires a
+ * ledger lookup and is declined.
  */
 function packFairminter(params: Params): PackedMessage | null {
   const asset = requireString(params, 'asset');
   if (!asset || asset.includes('.')) return null;
+  const assetParent = requireString(params, 'asset_parent');
+  if (assetParent?.includes('.')) return null;
 
   const num = (key: string, fallback: bigint): bigint | null => {
     const value = params[key];
@@ -483,9 +486,11 @@ function packFairminter(params: Params): PackedMessage | null {
   const mimeType = typeof params.mime_type === 'string' ? params.mime_type : '';
 
   let assetId: bigint;
+  let assetParentId = 0n;
   let lpAssetId = 0n;
   try {
     assetId = assetNameToId(asset);
+    if (assetParent) assetParentId = assetNameToId(assetParent);
     if (lpAsset) lpAssetId = assetNameToId(lpAsset);
   } catch {
     return null;
@@ -493,7 +498,7 @@ function packFairminter(params: Params): PackedMessage | null {
 
   const fields: CborEncodable[] = [
     assetId,
-    0n, // asset_parent_id — zero for a non-subasset, which is all this packs
+    assetParentId,
     price!, quantityByPrice!, maxMintPerTx!, maxMintPerAddress!,
     hardCap!, premintQuantity!, startBlock!, endBlock!, softCap!, softCapDeadlineBlock!,
     BigInt(commissionInt),
@@ -841,7 +846,7 @@ function packDetach(params: Params): PackedMessage | null {
   );
 }
 
-/** utxo move: `source|destination|asset|quantity` (utxo.py). */
+/** Historical type-100 UTXO message: `source|destination|asset|quantity` (utxo.py). */
 function packUtxoMove(params: Params): PackedMessage | null {
   const source = requireString(params, 'source');
   const asset = requireString(params, 'asset');
@@ -1055,8 +1060,13 @@ export function packComposeMessage(
     case 'detach':
       return packDetach(params);
     case 'utxo':
-    case 'move':
       return packUtxoMove(params);
+    case 'move':
+      // The current `/compose/movetoutxo` route uses `move.py`: it carries no protocol message.
+      // Counterparty instead moves every balance on the spent UTXO to the first non-OP_RETURN
+      // output. Returning the historical type-100 message here made the compose screen demand
+      // bytes Core correctly does not emit, so every current move was rejected before review.
+      return null;
     case 'btcpay':
       return packBtcPay(params);
     case 'dispenser':

--- a/src/core/counterparty/transactionSafety.ts
+++ b/src/core/counterparty/transactionSafety.ts
@@ -6,9 +6,14 @@
  * that could indicate a malicious site trying to drain the wallet.
  */
 
+import { Point } from '@noble/secp256k1';
 import { normalizeAddressForComparison } from '@/core/bitcoin/address';
 import { getSourcePubkey } from '@/core/counterparty/sourcePubkey';
-import { bareMultisigRecoveryPubkey } from '@/core/counterparty/unpack/multisig';
+import { bytesToHex, hexToBytes } from '@/core/counterparty/unpack/binary';
+import {
+  bareMultisigRecoveryPubkey,
+  isBareMultisigDataOutput,
+} from '@/core/counterparty/unpack/multisig';
 
 /** Severity of a security warning */
 export type WarningSeverity = 'block' | 'danger' | 'warning' | 'info';
@@ -46,13 +51,6 @@ export interface AnalyzableOutput {
 }
 
 /**
- * Counterparty's bare-multisig data encoding: 1-of-2 or 1-of-3 with 33-byte
- * pushes, where the payload rides in the fake keys and the last key is the
- * sender's real pubkey (which is what makes the sats recoverable later).
- */
-const CP_MULTISIG_DATA_SCRIPT = /^51(21[0-9a-f]{66}){2,3}5[23]ae$/i;
-
-/**
  * True when the script matches the Counterparty multisig data-encoding shape.
  *
  * The embedded recovery key is checked separately: compose accepts a
@@ -64,7 +62,7 @@ const CP_MULTISIG_DATA_SCRIPT = /^51(21[0-9a-f]{66}){2,3}5[23]ae$/i;
  * be exact because that path also *sent* the key).
  */
 export function isCounterpartyDataScript(script: string | undefined): boolean {
-  return !!script && CP_MULTISIG_DATA_SCRIPT.test(script);
+  return !!script && isBareMultisigDataOutput(script);
 }
 
 /**
@@ -152,6 +150,21 @@ const DATA_CARRYING_OUTPUT_TYPES = new Set([
   'multisig',    // node scriptPubKey type
   'nonstandard', // node scriptPubKey type
 ]);
+
+/**
+ * Compare SEC public keys by curve point, not by their serialized form.
+ *
+ * A legacy P2PKH key may be represented as either 33-byte compressed SEC or 65-byte
+ * uncompressed SEC. Both encodings are spendable by the same private key. Falling back to the
+ * lower-cased input preserves fail-closed behaviour for malformed keys used by callers/tests.
+ */
+function comparablePubkey(pubkey: string): string {
+  try {
+    return bytesToHex(Point.fromBytes(hexToBytes(pubkey)).toBytes(true));
+  } catch {
+    return pubkey.toLowerCase();
+  }
+}
 
 /**
  * Analyze a decoded transaction for security risks.
@@ -243,8 +256,9 @@ export function analyzeTransactionSafety(
   // and with no keys known the recovery check below stays silent rather than guessing.
   const signerPubkeys = new Set(
     (Array.isArray(signerAddress) ? signerAddress : [signerAddress])
-      .map((address) => getSourcePubkey(address)?.toLowerCase())
+      .map((address) => getSourcePubkey(address))
       .filter((pubkey): pubkey is string => !!pubkey)
+      .map(comparablePubkey)
   );
   let misdirectedRecoveryKeys = 0;
   /** Non-dust outputs whose script could not be resolved to any address. */
@@ -262,7 +276,7 @@ export function analyzeTransactionSafety(
     if (!output.address && messageType && isCounterpartyDataScript(output.script)) {
       dataOutputs.push({ value: output.value });
       const recoveryKey = output.script ? bareMultisigRecoveryPubkey(output.script) : null;
-      if (recoveryKey && signerPubkeys.size > 0 && !signerPubkeys.has(recoveryKey)) {
+      if (recoveryKey && signerPubkeys.size > 0 && !signerPubkeys.has(comparablePubkey(recoveryKey))) {
         misdirectedRecoveryKeys += 1;
       }
       continue;

--- a/src/core/counterparty/unpack/__tests__/multisig-encoding.test.ts
+++ b/src/core/counterparty/unpack/__tests__/multisig-encoding.test.ts
@@ -8,6 +8,7 @@
  * and classified, so the block applies regardless of encoding.
  */
 
+import { getPublicKey } from '@noble/secp256k1';
 import { afterEach, describe, expect, it } from 'vitest';
 import { setSourcePubkeyProvider } from '../../sourcePubkey';
 import { analyzeTransactionSafety } from '../../transactionSafety';
@@ -15,8 +16,8 @@ import { packAddress } from '../address';
 import { arc4, bytesToHex, hexToBytes } from '../binary';
 import { unpackCounterpartyMessage } from '../index';
 import { COUNTERPARTY_PREFIX_HEX } from '../messageTypes';
-import { bareMultisigRecoveryPubkey } from '../multisig';
-import { extractPayloadFromOutputs } from '../opReturn';
+import { bareMultisigRecoveryPubkey, isBareMultisigDataOutput } from '../multisig';
+import { extractCounterpartyPayload, extractPayloadFromOutputs } from '../opReturn';
 import { verifyTransaction } from '../verify';
 
 const FIRST_INPUT_TXID = 'a'.repeat(64);
@@ -25,6 +26,11 @@ const SWEEP_DESTINATION = '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa';
 const DATA_BYTES_PER_OUTPUT = 62;
 /** Payload bytes per output: the 62 carried bytes minus the length byte and the prefix. */
 const CHUNK_SIZE = DATA_BYTES_PER_OUTPUT - 1 - 8;
+
+// Live mainnet compose response for a description-only issuance of CUBINAKAMOTO.15. The source
+// uses an uncompressed public key, so Core emits 137-byte data scripts with a 65-byte third key.
+const UNCOMPRESSED_ISSUANCE_RAW = '02000000014f6d9766e3fd264be529010a41cc4dc3c16eca0d5951d7ee89dd9c9bae6a760b0000000000ffffffff03e803000000000000895121021a398525a97059dd8421bde390e827f3ea541a0ccce4a4c1a2670734105982e721036354980e97242517e0cdae37fdcb2dcda14ef18b271ee40c07e2fa0ebd87d0794104fc476ca68d25d4a1a6e2b7909b8c10458bcdc6862028f30aeb55d6c1189a6515e02434fe65aaeeb259a364c958e9a073d4cfba1298bbfb8bd4f57d92fa43fe0253aee8030000000000008951210303398525a97059dd844456bed75398efa5d5da909d401661a875151e0e74ca6c2102450b80549103527281bbcb1993ae59e2957da9c0787cb57869db997af4d6fdbf4104fc476ca68d25d4a1a6e2b7909b8c10458bcdc6862028f30aeb55d6c1189a6515e02434fe65aaeeb259a364c958e9a073d4cfba1298bbfb8bd4f57d92fa43fe0253aee02e0000000000001976a9147dcd4447c9ec509bcf77ae9ed18e1c9be8271a7588ac00000000';
+const UNCOMPRESSED_ISSUANCE_DATA = '434e54525052545916871b2089ee4508eff9a900f4f4f460583f68747470733a2f2f617277656176652e6e65742f3433584b5f6251746e39637449512d736c4667325159476e3935515046546a4a2d426a5938556537756755';
 
 /** Encode one message chunk as a bare-multisig output script, as core's composer does. */
 function multisigOutputScript(chunk: Uint8Array, txid: string): string {
@@ -117,6 +123,21 @@ describe('a message split across encodings is read whole', () => {
 });
 
 describe('extractPayloadFromOutputs, over multisig data outputs', () => {
+  it('recovers a real issuance whose recovery pubkey is uncompressed', () => {
+    const payload = extractCounterpartyPayload(UNCOMPRESSED_ISSUANCE_RAW);
+
+    expect(payload).toBe(UNCOMPRESSED_ISSUANCE_DATA);
+    const unpacked = unpackCounterpartyMessage(payload!);
+    expect(unpacked.success).toBe(true);
+    expect(unpacked.messageType).toBe('issuance');
+    expect(unpacked.data).toMatchObject({
+      asset: 'A2344667061293152681',
+      quantity: 0n,
+      divisible: false,
+      description: 'https://arweave.net/43XK_bQtn9ctIQ-slFg2QYGn95QPFTjJ-BjY8Ue7ugU',
+    });
+  });
+
   it('recovers a single-output payload', () => {
     const message = sweepMessage();
     const payload = extractPayloadFromOutputs(
@@ -330,6 +351,7 @@ describe('unclassified transactions fail toward unknown', () => {
 
 describe('the recovery key rides in the third slot', () => {
   const signerPubkey = '02' + '11'.repeat(32);
+  const uncompressedSignerPubkey = '04' + '11'.repeat(64);
   const strangerPubkey = '03' + '22'.repeat(32);
 
   /** A data script embedding `recovery` where core puts the source pubkey. */
@@ -338,7 +360,7 @@ describe('the recovery key rides in the third slot', () => {
       0x51,
       0x21, ...new Uint8Array(33).fill(0x02),
       0x21, ...new Uint8Array(33).fill(0x04),
-      0x21, ...hexToBytes(recovery),
+      hexToBytes(recovery).length, ...hexToBytes(recovery),
       0x53,
       0xae,
     ]));
@@ -347,6 +369,12 @@ describe('the recovery key rides in the third slot', () => {
 
   it('reads the third slot back out of a data script', () => {
     expect(bareMultisigRecoveryPubkey(scriptWithRecoveryKey(signerPubkey))).toBe(signerPubkey);
+  });
+
+  it('accepts and returns an uncompressed recovery key', () => {
+    const script = scriptWithRecoveryKey(uncompressedSignerPubkey);
+    expect(isBareMultisigDataOutput(script)).toBe(true);
+    expect(bareMultisigRecoveryPubkey(script)).toBe(uncompressedSignerPubkey);
   });
 
   it.each([
@@ -376,6 +404,19 @@ describe('the recovery key rides in the third slot', () => {
     const safety = analyzeTransactionSafety('send', [
       { value: 546, type: 'multisig', script: scriptWithRecoveryKey(signerPubkey) },
     ], 'bc1qsigner');
+
+    expect(safety.warnings.some((w) => w.title === 'Data Outputs Not Recoverable By You')).toBe(false);
+  });
+
+  it('recognizes compressed and uncompressed encodings of the same recovery key', () => {
+    const privateKey = hexToBytes('01'.repeat(32));
+    const compressed = bytesToHex(getPublicKey(privateKey, true));
+    const uncompressed = bytesToHex(getPublicKey(privateKey, false));
+    setSourcePubkeyProvider(() => uncompressed);
+
+    const safety = analyzeTransactionSafety('send', [
+      { value: 546, type: 'multisig', script: scriptWithRecoveryKey(compressed) },
+    ], '1legacySigner');
 
     expect(safety.warnings.some((w) => w.title === 'Data Outputs Not Recoverable By You')).toBe(false);
   });

--- a/src/core/counterparty/unpack/multisig.ts
+++ b/src/core/counterparty/unpack/multisig.ts
@@ -19,10 +19,13 @@
 import { arc4, bytesToHex, hexToBytes } from '@/core/counterparty/unpack/binary';
 import { COUNTERPARTY_PREFIX_HEX } from '@/core/counterparty/unpack/messageTypes';
 
-/** Byte length of a bare-multisig data output script. */
-const MULTISIG_SCRIPT_LENGTH = 105;
 /** Data bytes carried by one fake pubkey (33 minus sign and nonce). */
 const DATA_BYTES_PER_PUBKEY = 31;
+
+interface ParsedMultisigDataOutput {
+  dataBytes: Uint8Array;
+  recoveryPubkey: Uint8Array;
+}
 
 /**
  * Pull the 62 obfuscated data bytes out of a bare-multisig data output.
@@ -31,7 +34,7 @@ const DATA_BYTES_PER_PUBKEY = 31;
  * @returns The data bytes, or null if this is not a bare-multisig data output
  */
 export function isBareMultisigDataOutput(scriptHex: string): boolean {
-  return extractMultisigDataBytes(scriptHex) !== null;
+  return parseMultisigDataOutput(scriptHex) !== null;
 }
 
 /**
@@ -45,12 +48,11 @@ export function isBareMultisigDataOutput(scriptHex: string): boolean {
  * recognize is one it must not claim to have read.
  */
 export function bareMultisigRecoveryPubkey(scriptHex: string): string | null {
-  if (extractMultisigDataBytes(scriptHex) === null) return null;
-  // OP_1 (1) + [push33 + key] ×2 (68) + push33 (1) → third key at bytes 70..102.
-  return scriptHex.slice(70 * 2, 103 * 2).toLowerCase();
+  const parsed = parseMultisigDataOutput(scriptHex);
+  return parsed ? bytesToHex(parsed.recoveryPubkey) : null;
 }
 
-function extractMultisigDataBytes(scriptHex: string): Uint8Array | null {
+function parseMultisigDataOutput(scriptHex: string): ParsedMultisigDataOutput | null {
   let bytes: Uint8Array;
   try {
     bytes = hexToBytes(scriptHex);
@@ -58,16 +60,27 @@ function extractMultisigDataBytes(scriptHex: string): Uint8Array | null {
     return null;
   }
 
-  if (bytes.length !== MULTISIG_SCRIPT_LENGTH) return null;
-  // OP_1 ... OP_3 OP_CHECKMULTISIG, with three 33-byte pushes between.
-  if (bytes[0] !== 0x51 || bytes[103] !== 0x53 || bytes[104] !== 0xae) return null;
-  if (bytes[1] !== 0x21 || bytes[35] !== 0x21 || bytes[69] !== 0x21) return null;
+  // The two data carriers are always compressed-key-sized pushes. The recovery key is the
+  // source's real key, and legacy P2PKH sources may have revealed it in either its compressed
+  // (33-byte) or uncompressed (65-byte) encoding. Core preserves that encoding in the third slot.
+  if (bytes[0] !== 0x51 || bytes[1] !== 0x21 || bytes[35] !== 0x21) return null;
+  const recoveryLength = bytes[69];
+  if (recoveryLength !== 33 && recoveryLength !== 65) return null;
 
-  const data = new Uint8Array(DATA_BYTES_PER_PUBKEY * 2);
+  const recoveryStart = 70;
+  const countOpcodeIndex = recoveryStart + recoveryLength;
+  const checkMultisigIndex = countOpcodeIndex + 1;
+  if (bytes.length !== checkMultisigIndex + 1) return null;
+  if (bytes[countOpcodeIndex] !== 0x53 || bytes[checkMultisigIndex] !== 0xae) return null;
+
+  const dataBytes = new Uint8Array(DATA_BYTES_PER_PUBKEY * 2);
   // Skip each pubkey's leading sign byte and trailing nonce byte.
-  data.set(bytes.slice(3, 3 + DATA_BYTES_PER_PUBKEY), 0);
-  data.set(bytes.slice(37, 37 + DATA_BYTES_PER_PUBKEY), DATA_BYTES_PER_PUBKEY);
-  return data;
+  dataBytes.set(bytes.slice(3, 3 + DATA_BYTES_PER_PUBKEY), 0);
+  dataBytes.set(bytes.slice(37, 37 + DATA_BYTES_PER_PUBKEY), DATA_BYTES_PER_PUBKEY);
+  return {
+    dataBytes,
+    recoveryPubkey: bytes.slice(recoveryStart, recoveryStart + recoveryLength),
+  };
 }
 
 /**
@@ -78,12 +91,12 @@ function extractMultisigDataBytes(scriptHex: string): Uint8Array | null {
  * @returns The chunk hex without the CNTRPRTY prefix, or null
  */
 export function decodeMultisigChunk(scriptHex: string, firstInputTxid: string): string | null {
-  const dataBytes = extractMultisigDataBytes(scriptHex);
-  if (!dataBytes) return null;
+  const parsed = parseMultisigDataOutput(scriptHex);
+  if (!parsed) return null;
 
   let decrypted: Uint8Array;
   try {
-    decrypted = arc4(hexToBytes(firstInputTxid), dataBytes);
+    decrypted = arc4(hexToBytes(firstInputTxid), parsed.dataBytes);
   } catch {
     return null;
   }

--- a/src/core/counterparty/unpack/verify.ts
+++ b/src/core/counterparty/unpack/verify.ts
@@ -839,6 +839,9 @@ function verifyFairminter(
       'Wrong asset = creating a mint for something you do not own');
   }
 
+  verifyOptional(result, 'asset_parent', params.asset_parent, data.assetParent, '', 'critical',
+    'Wrong parent = creating a mint under a different asset namespace');
+
   // What a buyer pays and what they get for it.
   verifyOptional(result, 'lot_price', params.lot_price, data.price, 0, 'critical',
     'Wrong price = minters pay an amount you did not set');


### PR DESCRIPTION
## Summary

- accept both 33-byte compressed and 65-byte uncompressed recovery pubkeys in Counterparty bare-multisig data outputs
- compare recovery pubkeys by secp256k1 curve point so equivalent compressed/uncompressed serializations are recognized as the same wallet key
- treat the current movetoutxo compose action as message-less while retaining support for historical type-100 UTXO messages
- align compose options with current Core and add explicit fairminter asset_parent packing and verification
- expand the live Core byte-equivalence oracle and regression coverage

## Reproduction

A description-only issuance for CUBINAKAMOTO.15 composed by current Counterparty Core with encoding=multisig used an uncompressed source/recovery pubkey. Core therefore emitted 137-byte bare-multisig scripts. The wallet parser assumed a 105-byte script with a 33-byte third key, failed to recover the payload, and reported that the transaction was not Counterparty.

Passing the compressed serialization worked around payload extraction, but then the provider safety check compared the compressed recovery key to the wallet's uncompressed key as literal hex. Those are different serializations of the same EC point, so it incorrectly reported Data Outputs Not Recoverable By You.

## Verification

- 63 Counterparty test files passed; 1 skipped (1,153 tests passed, 51 skipped)
- 157 focused compose/parser tests passed
- 30 live Counterparty Core oracle cases matched byte-for-byte
- TypeScript compilation passed
- Oxlint passed
- git diff --check passed

Biome could not start because the existing nested .claude/worktrees/paired-connect-ui/biome.json is also marked as a root configuration; CI remains the authoritative full lint run.