### PR TITLE
Resolve provider change before indexers catch up

### DIFF
--- a/src/core/bitcoin/__tests__/transactionSigner.test.ts
+++ b/src/core/bitcoin/__tests__/transactionSigner.test.ts
@@ -17,6 +17,7 @@ vi.mock('@/core/bitcoin/utxo', () => ({
 const mockFetchUTXOs = vi.mocked(fetchUTXOs);
 const mockGetUtxoByTxid = vi.mocked(getUtxoByTxid);
 const mockFetchPreviousRawTransaction = vi.mocked(fetchPreviousRawTransaction);
+const mockGetTrustedBroadcastPrevout = vi.fn();
 
 // Import necessary functions for test setup
 import { getPublicKey } from '@noble/secp256k1';
@@ -94,6 +95,7 @@ describe('Transaction Signer Utilities', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetTrustedBroadcastPrevout.mockResolvedValue(null);
     
     // Default mock setup for fetchUTXOs to return a valid UTXO
     mockFetchUTXOs.mockResolvedValue([mockUtxo]);
@@ -256,6 +258,60 @@ describe('Transaction Signer Utilities', () => {
       expect(typeof result).toBe('string');
       expect(result.length).toBeGreaterThan(0);
       expect(result).toMatch(/^[0-9a-f]+$/i); // Valid hex string
+    });
+
+    it('signs SegWit pending change from the trusted broadcast journal without network lookups', async () => {
+      const p2wpkhWallet = { ...mockWallet, addressFormat: AddressFormat.P2WPKH };
+      const scriptPubKey = '0014' + pubKeyHashHex;
+      mockGetTrustedBroadcastPrevout.mockResolvedValue({
+        txid: mockTxid,
+        vout: 0,
+        address: mockTargetAddress.address,
+        value: 100000,
+        scriptPubKey,
+        rawTxHex: mockPreviousTransaction,
+      });
+
+      const result = await signTransaction(
+        mockRawTransaction,
+        p2wpkhWallet,
+        mockTargetAddress,
+        mockPrivateKey,
+        true,
+        undefined,
+        undefined,
+        mockGetTrustedBroadcastPrevout
+      );
+
+      expect(result).toMatch(/^[0-9a-f]+$/i);
+      expect(mockFetchUTXOs).not.toHaveBeenCalled();
+      expect(mockFetchPreviousRawTransaction).not.toHaveBeenCalled();
+    });
+
+    it('uses the trusted parent bytes for a legacy pending-change input', async () => {
+      mockGetTrustedBroadcastPrevout.mockResolvedValue({
+        txid: mockTxid,
+        vout: 0,
+        address: mockTargetAddress.address,
+        value: 100000,
+        scriptPubKey: '76a914' + pubKeyHashHex + '88ac',
+        rawTxHex: mockPreviousTransaction,
+      });
+
+      const result = await signTransaction(
+        mockRawTransaction,
+        mockWallet,
+        mockTargetAddress,
+        mockPrivateKey,
+        true,
+        undefined,
+        undefined,
+        mockGetTrustedBroadcastPrevout
+      );
+
+      expect(result).toMatch(/^[0-9a-f]+$/i);
+      expect(mockFetchUTXOs).not.toHaveBeenCalled();
+      expect(mockFetchPreviousRawTransaction).not.toHaveBeenCalled();
     });
 
     it('should successfully sign P2SH_P2WPKH transaction', async () => {

--- a/src/core/bitcoin/transactionSigner.ts
+++ b/src/core/bitcoin/transactionSigner.ts
@@ -2,6 +2,7 @@ import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
 import { getPublicKey } from '@noble/secp256k1';
 import { p2wpkh, SigHash, Transaction } from '@scure/btc-signer';
 import { AddressFormat } from '@/core/bitcoin/address';
+import { noTrustedPrevout, type TrustedPrevoutResolver } from '@/core/bitcoin/trustedPrevout';
 import { hybridSignTransaction } from '@/core/bitcoin/uncompressedSigner';
 import { fetchPreviousRawTransaction, fetchUTXOs, getUtxoByTxid } from '@/core/bitcoin/utxo';
 import { SigningError, UtxoError, ValidationError } from '@/core/errors';
@@ -118,7 +119,8 @@ export async function signTransaction(
   privateKeyHex: string,
   compressed: boolean = true,
   inputValues?: number[],
-  lockScripts?: string[]
+  lockScripts?: string[],
+  resolveTrustedPrevout: TrustedPrevoutResolver = noTrustedPrevout
 ): Promise<string> {
   if (!wallet) {
     throw new ValidationError('INVALID_TRANSACTION', 'Wallet not provided');
@@ -141,11 +143,6 @@ export async function signTransaction(
     const hasApiData = inputValues && lockScripts &&
                        inputValues.length > 0 && lockScripts.length > 0;
 
-    // Fetch UTXOs only when needed (legacy always needs it, SegWit only without API data)
-    // When API data is provided, it's fresh from the compose call - no need to re-verify
-    const needsUtxoFetch = isLegacy || !hasApiData;
-    const utxos = needsUtxoFetch ? await fetchUTXOs(targetAddress.address) : [];
-
     const rawTxBytes = hexToBytes(rawTransaction);
     const parsedTx = Transaction.fromRaw(rawTxBytes, {
       allowUnknownInputs: true,
@@ -153,6 +150,25 @@ export async function signTransaction(
       allowLegacyWitnessUtxo: true,
       disableScriptCheck: true
     });
+
+    // A provider transaction can spend change from a transaction this extension broadcast only
+    // milliseconds earlier. Resolve those inputs from the trusted cross-context journal first;
+    // public indexers are merely the fallback for inputs we did not create ourselves.
+    const shouldResolvePrevouts = isLegacy || !hasApiData;
+    const trustedPrevouts = shouldResolvePrevouts
+      ? await Promise.all(Array.from({ length: parsedTx.inputsLength }, async (_, index) => {
+          const input = parsedTx.getInput(index);
+          if (!input?.txid || input.index === undefined) return null;
+          return resolveTrustedPrevout(
+            bytesToHex(input.txid),
+            input.index,
+            targetAddress.address
+          );
+        }))
+      : [];
+    const needsUtxoFetch = shouldResolvePrevouts
+      && trustedPrevouts.some((prevout) => prevout === null);
+    const utxos = needsUtxoFetch ? await fetchUTXOs(targetAddress.address) : [];
     // Carry the version and lock time across. Rebuilding without them silently rewrote the
     // transaction the user reviewed: @scure defaults to version 2 and lockTime 0, so a transaction
     // presented as "not valid until block N" was signed as immediately spendable, and the txid shown
@@ -192,10 +208,12 @@ export async function signTransaction(
         throw new ValidationError('INVALID_TRANSACTION', `Invalid input at index ${i}: missing txid or index`);
       }
       const txidHex = bytesToHex(input.txid);
+      const trustedPrevout = trustedPrevouts[i] ?? null;
 
-      // Verify UTXO exists when we fetched UTXOs (legacy or no API data)
-      // Skip check when using API data - it's fresh from the compose call
-      if (needsUtxoFetch) {
+      // A locally journalled output was parsed from a transaction this extension successfully
+      // broadcast and was classified as safe wallet-owned change. Other inputs retain the
+      // existing live UTXO check.
+      if (shouldResolvePrevouts && !trustedPrevout) {
         const utxo = getUtxoByTxid(utxos, txidHex, input.index);
         if (!utxo) {
           throw new UtxoError('UTXO_NOT_FOUND', `UTXO not found for input ${i}: ${txidHex}:${input.index}`, {
@@ -224,7 +242,8 @@ export async function signTransaction(
 
       if (isLegacy) {
         // Legacy P2PKH needs full previous transaction for nonWitnessUtxo
-        const rawPrevTx = await fetchPreviousRawTransaction(txidHex);
+        const rawPrevTx = trustedPrevout?.rawTxHex
+          ?? await fetchPreviousRawTransaction(txidHex);
         if (!rawPrevTx) {
           throw new UtxoError('UTXO_NOT_FOUND', `Failed to fetch previous transaction: ${txidHex}`, {
             txid: txidHex,
@@ -260,6 +279,17 @@ export async function signTransaction(
           if (redeemScript) {
             inputData.redeemScript = redeemScript;
           }
+        }
+      } else if (trustedPrevout) {
+        // SegWit prevout data comes directly from the parent bytes we already broadcast, so the
+        // signature does not wait for mempool.space or blockstream.info to index that parent.
+        inputData.witnessUtxo = {
+          script: hexToBytes(trustedPrevout.scriptPubKey),
+          amount: BigInt(trustedPrevout.value),
+        };
+        if (wallet.addressFormat === AddressFormat.P2SH_P2WPKH) {
+          const redeemScript = p2wpkh(pubkeyBytes).script;
+          if (redeemScript) inputData.redeemScript = redeemScript;
         }
       } else {
         // SegWit without API data - fetch previous transaction (fallback)

--- a/src/core/bitcoin/trustedPrevout.ts
+++ b/src/core/bitcoin/trustedPrevout.ts
@@ -1,0 +1,18 @@
+/** A locally trusted previous output, independent of how it is persisted. */
+export interface TrustedBroadcastPrevout {
+  txid: string;
+  vout: number;
+  address: string;
+  value: number;
+  scriptPubKey: string;
+  rawTxHex: string;
+}
+
+/** Platform-supplied lookup used by core without depending on extension storage. */
+export type TrustedPrevoutResolver = (
+  txid: string,
+  vout: number,
+  address?: string
+) => Promise<TrustedBroadcastPrevout | null>;
+
+export const noTrustedPrevout: TrustedPrevoutResolver = async () => null;

--- a/src/core/counterparty/__tests__/inputAssets.test.ts
+++ b/src/core/counterparty/__tests__/inputAssets.test.ts
@@ -11,6 +11,7 @@ import {
 vi.mock('@/core/counterparty/api');
 
 const mockedFetch = vi.mocked(fetchUtxoBalances);
+const mockedTrustedPrevout = vi.fn();
 
 function page(result: unknown[]) {
   return { result, next_cursor: null, result_count: result.length } as never;
@@ -25,6 +26,7 @@ const input = (index: number, txid = `${index}`.repeat(64).slice(0, 64), vout = 
 describe('fetchInputsAttachedAssets', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockedTrustedPrevout.mockResolvedValue(null);
   });
 
   it('returns only inputs that carry assets, keyed by input index', async () => {
@@ -102,6 +104,13 @@ describe('fetchInputsAttachedAssets', () => {
     mockedFetch.mockResolvedValue(page([]));
     await fetchInputsAttachedAssets([input(3, 'dead'.repeat(16), 2)]);
     expect(mockedFetch).toHaveBeenCalledWith(`${'dead'.repeat(16)}:2`);
+  });
+
+  it('treats trusted recent change as attachment-free without waiting for Core', async () => {
+    mockedTrustedPrevout.mockResolvedValue({} as never);
+
+    expect(await fetchInputsAttachedAssets([input(0)], undefined, mockedTrustedPrevout)).toEqual([]);
+    expect(mockedFetch).not.toHaveBeenCalled();
   });
 
   it('caps the number of lookups', async () => {

--- a/src/core/counterparty/__tests__/transaction.test.ts
+++ b/src/core/counterparty/__tests__/transaction.test.ts
@@ -39,11 +39,13 @@ vi.mock('../api', () => ({
 
 const mockedApiClient = vi.mocked(apiClient, true);
 const mockedGetSettings = vi.mocked(getActiveSettings);
+const mockedGetTrustedBroadcastPrevout = vi.fn();
 
 const mockApiBase = 'https://api.counterparty.io';
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockedGetTrustedBroadcastPrevout.mockResolvedValue(null);
   mockedGetSettings.mockReturnValue({
     counterpartyApiBase: mockApiBase,
   } as any);
@@ -433,6 +435,25 @@ describe('decodeRawTransaction', () => {
 // ── fetchInputValues ────────────────────────────────────────────────
 
 describe('fetchInputPrevouts', () => {
+  it('prefers a trusted just-broadcast prevout without calling a public indexer', async () => {
+    mockedGetTrustedBroadcastPrevout.mockResolvedValueOnce({
+      txid: 'tx1',
+      vout: 0,
+      value: 50000,
+      address: 'bc1qowner',
+      scriptPubKey: '0014' + '11'.repeat(20),
+      rawTxHex: '00',
+    });
+
+    const result = await fetchInputPrevouts(
+      [{ txid: 'tx1', vout: 0 }],
+      mockedGetTrustedBroadcastPrevout
+    );
+
+    expect(result.get('tx1:0')).toEqual({ value: 50000, address: 'bc1qowner' });
+    expect(mockedApiClient.get).not.toHaveBeenCalled();
+  });
+
   it('returns the owning address alongside the value', async () => {
     mockedApiClient.get.mockResolvedValue({
       status: 200,

--- a/src/core/counterparty/inputAssets.ts
+++ b/src/core/counterparty/inputAssets.ts
@@ -7,6 +7,7 @@
  * surface them (and distinguish a failed lookup from a confirmed-empty one).
  */
 
+import { noTrustedPrevout, type TrustedPrevoutResolver } from '@/core/bitcoin/trustedPrevout';
 import { fetchUtxoBalances } from '@/core/counterparty/api';
 
 /**
@@ -44,7 +45,8 @@ export const MAX_ASSET_LOOKUP_INPUTS = 30;
  */
 export async function fetchInputsAttachedAssets(
   inputs: Array<{ index: number; txid: string; vout: number }>,
-  signedInputIndices?: number[]
+  signedInputIndices?: number[],
+  resolveTrustedPrevout: TrustedPrevoutResolver = noTrustedPrevout
 ): Promise<InputAttachedAssets[]> {
   // Stable sort, so inputs keep their order within the signed and unsigned groups.
   const signed = new Set(signedInputIndices ?? []);
@@ -58,6 +60,10 @@ export async function fetchInputsAttachedAssets(
     checked.map(async (input): Promise<InputAttachedAssets | null> => {
       const utxo = `${input.txid}:${input.vout}`;
       try {
+        // A journal entry is inductively attachment-free: it came from a transaction whose
+        // signed inputs were all checked clean, and whose own payload does not bind an asset to
+        // this output. Do not turn Counterparty's indexing lag into an "unknown asset" blocker.
+        if (await resolveTrustedPrevout(input.txid, input.vout)) return null;
         const res = await fetchUtxoBalances(utxo);
         const assets = (res.result ?? [])
           .filter((b) => b.asset && b.quantity_normalized)

--- a/src/core/counterparty/pendingChange.ts
+++ b/src/core/counterparty/pendingChange.ts
@@ -18,6 +18,7 @@
  * used to.
  */
 
+import { normalizeAddressForComparison } from '@/core/bitcoin/address';
 import { parseRawTransactionLocally } from '@/core/bitcoin/localTransactionParse';
 import { recordPendingChange } from '@/core/bitcoin/spentUtxoCache';
 import { unpackCounterpartyMessage } from '@/core/counterparty/unpack';
@@ -32,6 +33,51 @@ import { extractPayloadFromOutputs } from '@/core/counterparty/unpack/opReturn';
  */
 const BINDS_ASSETS_TO_OUTPUTS = new Set(['utxo', 'attach', 'detach']);
 
+export interface SafeOwnChangeOutput {
+  txid: string;
+  vout: number;
+  address: string;
+  value: number;
+  scriptPubKey: string;
+}
+
+/**
+ * Return only outputs that are both owned by this wallet and safe to treat as plain BTC change.
+ *
+ * Kept separate from the in-memory compose cache because provider broadcasts happen in the
+ * extension background while their next signing approval happens in a popup. Both callers need
+ * exactly the same fail-closed classification before sharing an output across that boundary.
+ */
+export function extractSafeOwnChangeOutputs(
+  rawTxHex: string,
+  ownAddresses: Iterable<string>
+): SafeOwnChangeOutput[] {
+  const parsed = parseRawTransactionLocally(rawTxHex);
+  if (!parsed || parsed.inputs.length === 0 || !parsed.inputs[0]?.txid) return [];
+
+  const outputScripts = parsed.outputs.map((output) => output.script ?? output.opReturnData ?? '');
+  const payload = extractPayloadFromOutputs(outputScripts, parsed.inputs[0].txid);
+  if (payload) {
+    const unpacked = unpackCounterpartyMessage(payload);
+    if (!unpacked.success || !unpacked.messageType) return [];
+    if (BINDS_ASSETS_TO_OUTPUTS.has(unpacked.messageType)) return [];
+  }
+
+  const own = new Set([...ownAddresses].map(normalizeAddressForComparison));
+  return parsed.outputs
+    .filter((output) => output.address
+      && own.has(normalizeAddressForComparison(output.address))
+      && output.value > 0
+      && output.script)
+    .map((output) => ({
+      txid: parsed.txid,
+      vout: output.index,
+      address: output.address!,
+      value: output.value,
+      scriptPubKey: output.script!,
+    }));
+}
+
 /**
  * Register the outputs of a just-broadcast transaction that pay our own addresses.
  *
@@ -42,31 +88,7 @@ export function recordOwnChangeFromRawTx(
   rawTxHex: string,
   ownAddresses: Iterable<string>
 ): void {
-  const parsed = parseRawTransactionLocally(rawTxHex);
-  if (!parsed || parsed.inputs.length === 0 || !parsed.inputs[0]?.txid) return;
-
-  // The safety gate: a Counterparty payload that names an asset-binding type — or one that does
-  // not decode — means these outputs are not ours to call plain change. The parse above already
-  // holds the scripts and the ARC4 key (first input txid, display order), so the payload is read
-  // from those rather than parsing the same bytes a second time. An op_return output carries its
-  // script in `opReturnData`.
-  const outputScripts = parsed.outputs.map((output) => output.script ?? output.opReturnData ?? '');
-  const payload = extractPayloadFromOutputs(outputScripts, parsed.inputs[0].txid);
-  if (payload) {
-    const unpacked = unpackCounterpartyMessage(payload);
-    if (!unpacked.success || !unpacked.messageType) return;
-    if (BINDS_ASSETS_TO_OUTPUTS.has(unpacked.messageType)) return;
-  }
-
-  const own = new Set(ownAddresses);
-  const entries = parsed.outputs
-    .filter((output) => output.address && own.has(output.address) && output.value > 0)
-    .map((output) => ({
-      txid: parsed.txid,
-      vout: output.index,
-      address: output.address!,
-      value: output.value,
-    }));
+  const entries = extractSafeOwnChangeOutputs(rawTxHex, ownAddresses);
 
   if (entries.length > 0) recordPendingChange(entries);
 }

--- a/src/core/counterparty/transaction.ts
+++ b/src/core/counterparty/transaction.ts
@@ -6,6 +6,7 @@
  */
 
 import { API_TIMEOUTS, apiClient } from '@/core/api/client';
+import { noTrustedPrevout, type TrustedPrevoutResolver } from '@/core/bitcoin/trustedPrevout';
 import { fetchAssetDetails } from '@/core/counterparty/api';
 import { type DescribableMessage, describeMessage } from '@/core/counterparty/describe';
 import { fromSatoshis } from '@/core/numeric';
@@ -122,9 +123,10 @@ export interface InputPrevout {
  * Returns a map of "txid:vout" → satoshi value.
  */
 export async function fetchInputValues(
-  inputs: Array<{ txid: string; vout: number }>
+  inputs: Array<{ txid: string; vout: number }>,
+  resolveTrustedPrevout: TrustedPrevoutResolver = noTrustedPrevout
 ): Promise<Map<string, number>> {
-  const prevouts = await fetchInputPrevouts(inputs);
+  const prevouts = await fetchInputPrevouts(inputs, resolveTrustedPrevout);
   return new Map([...prevouts].map(([key, prevout]) => [key, prevout.value]));
 }
 
@@ -134,12 +136,26 @@ export async function fetchInputValues(
  * whose input it is has to report the net effect as undetermined.
  */
 export async function fetchInputPrevouts(
-  inputs: Array<{ txid: string; vout: number }>
+  inputs: Array<{ txid: string; vout: number }>,
+  resolveTrustedPrevout: TrustedPrevoutResolver = noTrustedPrevout
 ): Promise<Map<string, InputPrevout>> {
   const values = new Map<string, InputPrevout>();
 
+  // Resolve our own just-broadcast change locally first. The provider broadcast path stores these
+  // prevouts from the signed parent bytes, so fee and movement review do not briefly become
+  // unknown while public Bitcoin indexers catch up.
+  await Promise.all(inputs.map(async (input) => {
+    const prevout = await resolveTrustedPrevout(input.txid, input.vout);
+    if (!prevout) return;
+    values.set(`${input.txid}:${input.vout}`, {
+      value: prevout.value,
+      address: prevout.address,
+    });
+  }));
+
   // Deduplicate by txid to minimize API calls
-  const uniqueTxids = [...new Set(inputs.map(i => i.txid))];
+  const unresolvedInputs = inputs.filter((input) => !values.has(`${input.txid}:${input.vout}`));
+  const uniqueTxids = [...new Set(unresolvedInputs.map(i => i.txid))];
 
   await Promise.all(uniqueTxids.map(async (txid) => {
     const endpoints = [
@@ -154,7 +170,7 @@ export async function fetchInputPrevouts(
         }>(url, { retries: 0 });
         if (response.data?.vout) {
           // Store all vout values for this txid
-          for (const input of inputs) {
+          for (const input of unresolvedInputs) {
             const prevout = input.txid === txid ? response.data.vout[input.vout] : undefined;
             if (prevout) {
               values.set(`${txid}:${input.vout}`, {

--- a/src/hooks/useSignTransactionRequest.ts
+++ b/src/hooks/useSignTransactionRequest.ts
@@ -20,6 +20,7 @@ import {
 import { fetchInputPrevouts } from '@/core/counterparty/transaction';
 import { extractCounterpartyPayload } from '@/core/counterparty/unpack/opReturn';
 import { emitToBackground } from '@/platform/provider/emitToBackground';
+import { getTrustedBroadcastPrevout } from '@/platform/provider/recentBroadcasts';
 import { getSignFlow, recordSignOutcome, type SignTransactionRequest } from '@/platform/provider/signFlow';
 
 /**
@@ -78,7 +79,9 @@ export function useSignTransactionRequest(signerAddress?: string) {
     // decodes below rather than adding a serial round-trip. Inputs have no index
     // field here, so the array position is the index.
     const attachedAssetsPromise = fetchInputsAttachedAssets(
-      inputs.map((input, index) => ({ index, txid: input.txid, vout: input.vout }))
+      inputs.map((input, index) => ({ index, txid: input.txid, vout: input.vout })),
+      undefined,
+      getTrustedBroadcastPrevout
     );
 
     const outputs: DecodedTransactionInfo['outputs'] = parsed.outputs.map((output) => ({
@@ -97,7 +100,7 @@ export function useSignTransactionRequest(signerAddress?: string) {
     // all of them, and unresolved inputs silently counted as zero, understating the fee.
     if (inputs.length > 0) {
       try {
-        const prevouts = await fetchInputPrevouts(inputs);
+        const prevouts = await fetchInputPrevouts(inputs, getTrustedBroadcastPrevout);
         for (const input of inputs) {
           const prevout = prevouts.get(`${input.txid}:${input.vout}`);
           if (prevout == null) continue;
@@ -194,10 +197,10 @@ export function useSignTransactionRequest(signerAddress?: string) {
   }, [requestId, decodeTransaction, signerAddress]);
 
   // Handle completion - called when user approves and signs
-  const handleSuccess = useCallback(async (signedTxHex: string) => {
+  const handleSuccess = useCallback(async (signedTxHex: string, safeOwnChange = false) => {
     if (requestId) {
       // Persist the outcome so the dApp can recover it after a worker restart.
-      await recordSignOutcome(requestId, 'completed', { signedTxHex });
+      await recordSignOutcome(requestId, 'completed', { signedTxHex, safeOwnChange });
       // Notify the background that transaction signing is complete
       emitToBackground(`sign-tx-complete-${requestId}`, { signedTxHex });
 

--- a/src/pages/requests/transaction/approve.tsx
+++ b/src/pages/requests/transaction/approve.tsx
@@ -116,7 +116,12 @@ export default function ApproveTransactionPage() {
         request.address
       );
 
-      await handleSuccess(signedTxHex);
+      await handleSuccess(
+        signedTxHex,
+        signerInputIndices.length === decodedInfo.inputs.length
+          && signedInputsWithAssets.length === 0
+          && signedInputsUnknownStatus.length === 0
+      );
       window.close();
     } catch (err) {
       console.error('Failed to sign transaction:', err);

--- a/src/platform/provider/__tests__/recentBroadcasts.test.ts
+++ b/src/platform/provider/__tests__/recentBroadcasts.test.ts
@@ -1,0 +1,53 @@
+import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
+import { Transaction } from '@scure/btc-signer';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { fakeBrowser } from 'wxt/testing/fake-browser';
+import { decodeAddressFromScript } from '@/core/bitcoin/address';
+import {
+  clearRecentBroadcasts,
+  getTrustedBroadcastPrevout,
+  rememberSuccessfulBroadcast,
+} from '@/platform/provider/recentBroadcasts';
+
+const OWN_SCRIPT = `0014${'11'.repeat(20)}`;
+const OWN_ADDRESS = decodeAddressFromScript(OWN_SCRIPT)!;
+
+function buildTransaction(outputScript: string, value = 5000n): string {
+  const tx = new Transaction({ allowUnknownInputs: true, allowUnknownOutputs: true });
+  tx.addInput({ txid: new Uint8Array(32).fill(1), index: 0 });
+  tx.addOutput({ script: hexToBytes(outputScript), amount: value });
+  return bytesToHex(tx.unsignedTx);
+}
+
+describe('recent broadcast prevouts', () => {
+  beforeEach(async () => {
+    fakeBrowser.reset();
+    (global as any).browser = fakeBrowser;
+    (global as any).chrome = fakeBrowser;
+    await clearRecentBroadcasts();
+  });
+
+  it('persists a safe wallet-owned output across extension contexts', async () => {
+    const rawTxHex = buildTransaction(OWN_SCRIPT);
+
+    await rememberSuccessfulBroadcast(rawTxHex, [OWN_ADDRESS.toUpperCase()]);
+
+    const stored = await fakeBrowser.storage.session.get('recent_safe_broadcast_prevouts');
+    const records = stored.recent_safe_broadcast_prevouts as Array<{ txid: string }>;
+    expect(records).toHaveLength(1);
+    const prevout = await getTrustedBroadcastPrevout(records[0]!.txid, 0, OWN_ADDRESS.toUpperCase());
+    expect(prevout).toMatchObject({
+      vout: 0,
+      address: OWN_ADDRESS,
+      value: 5000,
+      scriptPubKey: OWN_SCRIPT,
+      rawTxHex,
+    });
+  });
+
+  it('does not persist an output that is not owned by the broadcasting wallet', async () => {
+    await rememberSuccessfulBroadcast(buildTransaction(OWN_SCRIPT), ['bc1qnotours']);
+
+    expect(await fakeBrowser.storage.session.get('recent_safe_broadcast_prevouts')).toEqual({});
+  });
+});

--- a/src/platform/provider/__tests__/signFlow.test.ts
+++ b/src/platform/provider/__tests__/signFlow.test.ts
@@ -4,6 +4,7 @@ import {
   beginSignFlow,
   computeRequestKey,
   findActiveFlowByKey,
+  findSafeChangeSigningAddress,
   getSignFlow,
   recordSignOutcome,
   removeSignFlow,
@@ -47,10 +48,17 @@ describe('signFlow', () => {
       expect(flow?.id).toBe('id-1');
       expect(flow?.status).toBe('pending');
 
-      await recordSignOutcome('id-1', 'completed', { signedTxHex: 'deadbeef' });
+      await recordSignOutcome('id-1', 'completed', {
+        signedTxHex: 'deadbeef',
+        safeOwnChange: true,
+      });
       flow = await getSignFlow('id-1');
       expect(flow?.status).toBe('completed');
-      expect(flow?.result).toEqual({ signedTxHex: 'deadbeef' });
+      expect(flow?.result).toEqual({ signedTxHex: 'deadbeef', safeOwnChange: true });
+      expect(await findSafeChangeSigningAddress('deadbeef', 'https://x.com'))
+        .toBe('bc1qexample');
+      expect(await findSafeChangeSigningAddress('deadbeef', 'https://elsewhere.com'))
+        .toBeNull();
 
       await removeSignFlow('id-1');
       expect(await getSignFlow('id-1')).toBeNull();

--- a/src/platform/provider/recentBroadcasts.ts
+++ b/src/platform/provider/recentBroadcasts.ts
@@ -1,0 +1,122 @@
+/**
+ * Trusted, cross-context prevouts from transactions this extension successfully broadcast.
+ *
+ * Provider requests are handled in the MV3 background worker, while raw-transaction approvals
+ * and signing run in a popup. Session storage bridges that boundary and survives worker suspension.
+ */
+
+import { normalizeAddressForComparison } from '@/core/bitcoin/address';
+import type { TrustedBroadcastPrevout } from '@/core/bitcoin/trustedPrevout';
+import { extractSafeOwnChangeOutputs } from '@/core/counterparty/pendingChange';
+import { createWriteLock, isExpired } from '@/platform/storage/mutex';
+
+const STORAGE_KEY = 'recent_safe_broadcast_prevouts';
+const TTL_MS = 15 * 60 * 1000;
+const MAX_TRANSACTIONS = 50;
+const TXID_PATTERN = /^[a-f0-9]{64}$/i;
+const HEX_PATTERN = /^(?:[a-f0-9]{2})+$/i;
+
+interface RecentBroadcastTransaction {
+  txid: string;
+  rawTxHex: string;
+  timestamp: number;
+  outputs: Array<{
+    vout: number;
+    address: string;
+    value: number;
+    scriptPubKey: string;
+  }>;
+}
+
+const withWriteLock = createWriteLock();
+
+function isRecentBroadcastOutput(value: unknown): value is RecentBroadcastTransaction['outputs'][number] {
+  if (!value || typeof value !== 'object') return false;
+  const output = value as Partial<RecentBroadcastTransaction['outputs'][number]>;
+  return Number.isSafeInteger(output.vout)
+    && output.vout! >= 0
+    && typeof output.address === 'string'
+    && output.address.length > 0
+    && Number.isSafeInteger(output.value)
+    && output.value! > 0
+    && typeof output.scriptPubKey === 'string'
+    && HEX_PATTERN.test(output.scriptPubKey);
+}
+
+function isRecentBroadcastTransaction(value: unknown): value is RecentBroadcastTransaction {
+  if (!value || typeof value !== 'object') return false;
+  const item = value as Partial<RecentBroadcastTransaction>;
+  return typeof item.txid === 'string'
+    && TXID_PATTERN.test(item.txid)
+    && typeof item.rawTxHex === 'string'
+    && HEX_PATTERN.test(item.rawTxHex)
+    && typeof item.timestamp === 'number'
+    && Number.isFinite(item.timestamp)
+    && Array.isArray(item.outputs)
+    && item.outputs.every(isRecentBroadcastOutput);
+}
+
+async function readRecent(): Promise<RecentBroadcastTransaction[]> {
+  try {
+    const result = await chrome.storage.session.get(STORAGE_KEY);
+    const stored = result[STORAGE_KEY];
+    if (!Array.isArray(stored)) return [];
+    return stored
+      .filter(isRecentBroadcastTransaction)
+      .filter((item) => !isExpired(item.timestamp, TTL_MS));
+  } catch {
+    return [];
+  }
+}
+
+/** Persist safe outputs only after the containing transaction has broadcast successfully. */
+export async function rememberSuccessfulBroadcast(
+  rawTxHex: string,
+  ownAddresses: Iterable<string>
+): Promise<void> {
+  const safeOutputs = extractSafeOwnChangeOutputs(rawTxHex, ownAddresses);
+  if (safeOutputs.length === 0) return;
+
+  const txid = safeOutputs[0]!.txid;
+  const transaction: RecentBroadcastTransaction = {
+    txid,
+    rawTxHex,
+    timestamp: Date.now(),
+    outputs: safeOutputs.map(({ vout, address, value, scriptPubKey }) => ({
+      vout,
+      address,
+      value,
+      scriptPubKey,
+    })),
+  };
+
+  await withWriteLock(async () => {
+    const existing = await readRecent();
+    const next = [transaction, ...existing.filter((item) => item.txid !== txid)]
+      .slice(0, MAX_TRANSACTIONS);
+    await chrome.storage.session.set({ [STORAGE_KEY]: next });
+  });
+}
+
+/** Resolve an input without waiting for a public Bitcoin indexer to observe its parent. */
+export async function getTrustedBroadcastPrevout(
+  txid: string,
+  vout: number,
+  address?: string
+): Promise<TrustedBroadcastPrevout | null> {
+  const transactions = await readRecent();
+  const transaction = transactions.find((item) => item.txid === txid);
+  const output = transaction?.outputs.find((item) => item.vout === vout);
+  if (
+    !transaction
+    || !output
+    || (address !== undefined
+      && normalizeAddressForComparison(output.address) !== normalizeAddressForComparison(address))
+  ) return null;
+  return { txid, rawTxHex: transaction.rawTxHex, ...output };
+}
+
+/** Test/debug reset. */
+export async function clearRecentBroadcasts(): Promise<void> {
+  await chrome.storage.session.remove(STORAGE_KEY);
+}

--- a/src/platform/provider/signFlow.ts
+++ b/src/platform/provider/signFlow.ts
@@ -128,6 +128,33 @@ export async function recordSignOutcome(
 }
 
 /**
+ * Return the address that safely signed this exact raw transaction for this
+ * origin, or null when the broadcast is unrelated to a completed provider
+ * signing approval. The explicit eligibility bit is set only after the
+ * approval screen resolved every signed input and found no attached assets.
+ */
+export async function findSafeChangeSigningAddress(
+  signedTxHex: string,
+  origin: string
+): Promise<string | null> {
+  const now = Date.now();
+  const all = await signFlowStorage.getAll();
+  const flow = all.find((entry) => {
+    if (
+      entry.kind !== 'sign-transaction'
+      || entry.status !== 'completed'
+      || entry.origin !== origin
+      || now - entry.timestamp >= SIGN_FLOW_TTL_MS
+      || !entry.result
+      || typeof entry.result !== 'object'
+    ) return false;
+    const result = entry.result as Record<string, unknown>;
+    return result.signedTxHex === signedTxHex && result.safeOwnChange === true;
+  });
+  return flow?.address ?? null;
+}
+
+/**
  * Find a non-stale flow for a request key (for dedup/rejoin/recovery).
  * Origin is matched explicitly so a djb2 requestKey collision from another
  * origin can never rejoin or recover this origin's flow.

--- a/src/platform/walletManager.ts
+++ b/src/platform/walletManager.ts
@@ -36,6 +36,7 @@ import {
   clearUnlockAttempts,
   recordFailedUnlockAttempt,
 } from '@/platform/auth/unlockRateLimiter';
+import { getTrustedBroadcastPrevout } from '@/platform/provider/recentBroadcasts';
 import {
   assertNoKeychainRecord,
   deleteKeychain,
@@ -1503,7 +1504,8 @@ export class WalletManager {
       privateKeyResult.hex,
       privateKeyResult.compressed,
       inputValues,
-      lockScripts
+      lockScripts,
+      getTrustedBroadcastPrevout
     );
   }
 

--- a/src/services/__tests__/providerService.test.ts
+++ b/src/services/__tests__/providerService.test.ts
@@ -28,10 +28,10 @@ vi.mock('@/core/hardware/trezorAdapter', () => ({
   TrezorAdapter: vi.fn()
 }));
 
-
 import * as replayPrevention from '@/core/replayPrevention';
 import { DEFAULT_SETTINGS } from '@/core/settings';
 import * as rateLimiter from '@/platform/provider/rateLimiter';
+import { rememberSuccessfulBroadcast } from '@/platform/provider/recentBroadcasts';
 import * as signFlow from '@/platform/provider/signFlow';
 import { walletManager } from '@/platform/walletManager';
 import * as updateService from '@/services/updateService';
@@ -223,6 +223,7 @@ vi.mock('@/core/bitcoin/messageSigner', () => ({
 vi.mock('@/platform/provider/signFlow', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@/platform/provider/signFlow')>()),
   beginSignFlow: vi.fn().mockResolvedValue(undefined),
+  findSafeChangeSigningAddress: vi.fn().mockResolvedValue(null),
 }));
 vi.mock('@/services/updateService');
 vi.mock('@/platform/provider/rateLimiter');
@@ -238,6 +239,9 @@ vi.mock('@/platform/fathom', () => ({
   },
 }));
 vi.mock('@/core/replayPrevention');
+vi.mock('@/platform/provider/recentBroadcasts', () => ({
+  rememberSuccessfulBroadcast: vi.fn().mockResolvedValue(undefined),
+}));
 vi.mock('@/platform/storage/walletStorage', () => ({
   keychainExists: vi.fn().mockResolvedValue(true),
 }));
@@ -421,6 +425,7 @@ describe('ProviderService', () => {
     vi.mocked(updateService.getUpdateService).mockReturnValue(mockUpdateService as any);
 
     vi.mocked(signFlow.beginSignFlow).mockResolvedValue(undefined);
+    vi.mocked(signFlow.findSafeChangeSigningAddress).mockResolvedValue(null);
     
     // Setup settings mocks - default to no connected sites
     // (Already set up above with DEFAULT_SETTINGS)
@@ -753,6 +758,38 @@ describe('ProviderService', () => {
             []
           )
         ).rejects.toThrow('Signed transaction is required');
+      });
+
+      it('remembers safe wallet-owned outputs before returning a successful broadcast', async () => {
+        const mockConnectionService = vi.mocked(connectionService.getConnectionService)();
+        mockConnectionService.hasPermission = vi.fn().mockResolvedValue(true);
+        const mockWalletService = vi.mocked(walletService.getWalletService)();
+        mockWalletService.broadcastTransaction = vi.fn().mockResolvedValue({ txid: 'ab'.repeat(32) });
+        const signedTx = '01000000000000000000';
+        vi.mocked(signFlow.findSafeChangeSigningAddress).mockResolvedValue('bc1qtest123');
+
+        await providerService.handleRequest(
+          'https://connected.com',
+          'xcp_broadcastTransaction',
+          [signedTx]
+        );
+
+        expect(rememberSuccessfulBroadcast).toHaveBeenCalledWith(signedTx, ['bc1qtest123']);
+      });
+
+      it('does not trust change from a transaction the extension did not safely sign', async () => {
+        const mockConnectionService = vi.mocked(connectionService.getConnectionService)();
+        mockConnectionService.hasPermission = vi.fn().mockResolvedValue(true);
+        const mockWalletService = vi.mocked(walletService.getWalletService)();
+        mockWalletService.broadcastTransaction = vi.fn().mockResolvedValue({ txid: 'ab'.repeat(32) });
+
+        await providerService.handleRequest(
+          'https://connected.com',
+          'xcp_broadcastTransaction',
+          ['01000000000000000000']
+        );
+
+        expect(rememberSuccessfulBroadcast).not.toHaveBeenCalled();
       });
     });
   });

--- a/src/services/providerService.ts
+++ b/src/services/providerService.ts
@@ -26,10 +26,12 @@ import { getPairedAddressFormats } from '@/core/wallet/addressDeriver';
 import { analytics } from '@/platform/fathom';
 import { openExtensionPopup } from '@/platform/popup';
 import { apiRateLimiter, connectionRateLimiter, transactionRateLimiter } from '@/platform/provider/rateLimiter';
+import { rememberSuccessfulBroadcast } from '@/platform/provider/recentBroadcasts';
 import {
   beginSignFlow,
   computeRequestKey,
   findActiveFlowByKey,
+  findSafeChangeSigningAddress,
   getSignFlow,
   removeSignFlow,
 } from '@/platform/provider/signFlow';
@@ -1126,6 +1128,16 @@ export function createProviderService(): ProviderService {
             throw new Error('Signed transaction must be a hex string');
           }
 
+          // Broadcasting is intentionally open to any signed transaction, so broadcasting alone
+          // cannot make its outputs trusted. Only an exact transaction this origin just had the
+          // extension sign, after every input was resolved as attachment-free, may seed change.
+          let safeChangeAddress: string | null = null;
+          try {
+            safeChangeAddress = await findSafeChangeSigningAddress(signedTx, origin);
+          } catch (error) {
+            console.warn('[ProviderService] Failed to verify broadcast signing flow:', error);
+          }
+
           // Check for replay attempt before broadcasting
           const replayCheck = await checkReplayAttempt(
             origin,
@@ -1157,6 +1169,21 @@ export function createProviderService(): ProviderService {
           // Mark as successfully broadcasted
           if (result.txid) {
             markTransactionBroadcasted(pendingKey);
+
+            // The next provider signing request may spend this transaction's change before any
+            // public Bitcoin indexer can return it. Persist only outputs that are both owned by
+            // this wallet and safe plain-BTC change. Storage is best-effort because the broadcast
+            // has already happened and must never be reported as failed after the fact.
+            if (safeChangeAddress) {
+              try {
+                await rememberSuccessfulBroadcast(
+                  signedTx,
+                  [safeChangeAddress]
+                );
+              } catch (error) {
+                console.warn('[ProviderService] Failed to remember broadcast change:', error);
+              }
+            }
           }
 
           // Track successful broadcast


### PR DESCRIPTION
## Summary

- persist safe wallet-owned outputs from provider transactions in `chrome.storage.session` after successful broadcast
- resolve those trusted prevouts in raw-transaction review, attached-asset checks, and software signing before querying public indexers
- support both SegWit witness metadata and legacy full-parent `nonWitnessUtxo` signing
- trust only exact transactions approved and signed for the same origin after every signed input was resolved attachment-free
- keep storage in the platform layer and inject the resolver into portable core code

This is the wallet half of the xcp.fun cross-tab transaction chain. The paired launchpad PR supplies complete Counterparty `inputs_set` metadata and serializes tabs; this PR ensures the approval popup and signer can resolve the new parent before public Bitcoin indexers see it.

## Safety

- attach, detach, legacy UTXO move, and unreadable Counterparty payloads never seed the journal
- arbitrary provider broadcasts do not seed the journal
- attached or unresolved inputs do not seed the journal
- all existing network lookups remain as fallback
- journal failures after broadcast never turn a successful broadcast into a retryable error

## Verification

- `npx vitest run src` — 289 files passed, 4,923 tests passed, 2 files / 60 tests skipped
- `npm run compile`
- `npm run lint` (existing warnings only)
- `npm run build`