### PR TITLE
Allow resumed fanout approval batches

### DIFF
--- a/src/core/counterparty/__tests__/marketplaceBatch.test.ts
+++ b/src/core/counterparty/__tests__/marketplaceBatch.test.ts
@@ -80,6 +80,9 @@ const prepare = (index: number): PrepareAssetIntentClaim => ({
   operationExpiresAt: 2_000_000_000,
 });
 
+const indexedHex = (offset: number, batchIndex: number): string =>
+  ((offset + batchIndex) % 256).toString(16).padStart(2, '0').repeat(32);
+
 const fanout = (batchIndex: number): PrepareBulkFanoutIntentClaim => ({
   standard: 'counterparty-marketplace',
   version: 1,
@@ -89,13 +92,13 @@ const fanout = (batchIndex: number): PrepareBulkFanoutIntentClaim => ({
   assets: [],
   batchIndex,
   seller: SELLER,
-  fundingOutpoint: { txid: (batchIndex === 0 ? '11' : '12').repeat(32), vout: batchIndex },
+  fundingOutpoint: { txid: indexedHex(0x11, batchIndex), vout: batchIndex },
   fundingValueSats: 100_000,
   slotCount: 2,
   slotValueSats: 10_000,
   networkFeeSats: 1_000,
   changeSats: 79_000,
-  expectedTxid: (batchIndex === 0 ? '21' : '22').repeat(32),
+  expectedTxid: indexedHex(0x21, batchIndex),
   operationExpiresAt: 2_000_000_000,
 });
 
@@ -139,11 +142,19 @@ describe('homogeneous marketplace batch parser', () => {
     });
   });
 
+  it('accepts an ordered remaining fan-out subset after an earlier parent was submitted', () => {
+    expect(parseMarketplaceBatchIntents([fanout(1), fanout(2)])).toEqual({
+      kind: 'bulk-fanout',
+      intents: [fanout(1), fanout(2)],
+    });
+  });
+
   it.each([
     ['empty', []],
     ['mixed actions', [fanout(0), { ...fanout(1), action: 'attach_for_listing' }]],
     ['different operation', [fanout(0), { ...fanout(1), operationId: 'bulk-2' }]],
     ['wrong order', [fanout(1), fanout(0)]],
+    ['duplicate index', [fanout(1), { ...fanout(2), batchIndex: 1 }]],
     ['duplicate funding', [fanout(0), { ...fanout(1), fundingOutpoint: fanout(0).fundingOutpoint }]],
   ])('refuses a %s batch', (_label, intents) => {
     expect(() => parseMarketplaceBatchIntents(intents)).toThrow();

--- a/src/core/counterparty/marketplaceBatch.ts
+++ b/src/core/counterparty/marketplaceBatch.ts
@@ -87,8 +87,9 @@ export function parseMarketplaceBatchIntents(values: unknown[]): {
     if (!fanouts.every(intent => intent.operationId === operationId)) {
       throw new Error('bulk fan-out parents must belong to one operation');
     }
-    if (fanouts.some((intent, index) => intent.batchIndex !== index)) {
-      throw new Error('bulk fan-out batch indices must be ordered from zero');
+    if (fanouts.some((intent, index) =>
+      index > 0 && intent.batchIndex <= fanouts[index - 1]!.batchIndex)) {
+      throw new Error('bulk fan-out batch indices must be strictly increasing');
     }
     if (new Set(fanouts.map(intent => intent.fundingOutpoint.txid + ':' + intent.fundingOutpoint.vout)).size
       !== fanouts.length) {


### PR DESCRIPTION
## Problem

A marketplace operation can submit the first fanout parent successfully and later resume with only the remaining parents. The wallet rejected that safe suffix because it required every approval request to begin at batch index 0.

## Change

- Accept fanout batches whose indexes are strictly increasing, even when the first remaining index is greater than 0.
- Continue rejecting reordering, duplicate indexes, mixed operations, and duplicate funding outpoints.
- Add focused parser coverage for a resumed suffix and duplicate-index rejection.

## Verification

- Focused marketplace batch, provider, and signing-phase tests: 94 passed.
- TypeScript compile passed.
- Oxlint passed.
- Marketplace cross-repo signer contract: 50 passed.
- Real Bitcoin Core and Counterparty regtest: 24-card fanout, attach, and listing flow passed in bounded 8-item approval batches.

Biome could not start because the repository contains a separate local nested worktree with its own root biome.json. No files in that worktree were changed.