### PR TITLE
Authenticate hardware and paired identities during connect

### DIFF
--- a/e2e/pages/keychain/secrets/show-private-key.spec.ts
+++ b/e2e/pages/keychain/secrets/show-private-key.spec.ts
@@ -127,10 +127,10 @@ walletTest.describe('Show Private Key Page (/secrets/show-private-key)', () => {
     await page.goto(page.url().replace(/\/index.*/, '/keychain/secrets/show-private-key/invalid-wallet-id-12345'));
     await page.waitForLoadState('networkidle');
 
-    // Page checks wallet existence on load and shows "Wallet not found." error
-    // (from source: line 37)
-    await expect(common.errorAlert(page)).toBeVisible({ timeout: 5000 });
-    await expect(common.errorAlert(page)).toContainText(/Wallet not found/i);
+    // A global API status alert can appear alongside the page's wallet error.
+    const error = page.getByRole('region', { name: 'Show Private Key', exact: true }).getByRole('alert');
+    await expect(error).toBeVisible({ timeout: 5000 });
+    await expect(error).toContainText(/Wallet not found/i);
   });
 
   walletTest('page shows Private Key title', async ({ page }) => {

--- a/src/services/__tests__/providerService.test.ts
+++ b/src/services/__tests__/providerService.test.ts
@@ -491,6 +491,35 @@ describe('ProviderService', () => {
 
   describe('handleRequest', () => {
     describe('xcp_requestAccounts', () => {
+      const activeAddress = 'bc1qvux25709r4uw6rzc8wyl7wwecjdhrx085hm5ty';
+      const siblingAddress = '1FvyAqqELFiQyaEWdhFbWF8MZapKPZS8J7';
+      const origin = 'https://test.com';
+
+      beforeEach(async () => {
+        const wallet = vi.mocked(walletService.getWalletService)();
+        vi.mocked(walletManager.getActiveWallet).mockReturnValue(await wallet.getActiveWallet());
+        vi.mocked(walletManager.getSettings).mockReturnValue({
+          ...DEFAULT_SETTINGS, connectedWebsites: [origin, 'https://newsite.com'],
+          lastActiveAddress: activeAddress,
+        });
+      });
+
+      const grantPair = () => {
+        const connection = vi.mocked(connectionService.getConnectionService)();
+        vi.mocked(connection.hasPermission).mockResolvedValue(true);
+        vi.mocked(connection.hasPairedAddressPermission).mockResolvedValue(true);
+        vi.mocked(walletManager.getSettings).mockReturnValue({
+          ...walletManager.getSettings(), providerCapabilities: {
+            [origin]: { walletId: 'wallet1', address: activeAddress, pairedAddresses: true },
+          },
+        });
+        const wallet = vi.mocked(walletService.getWalletService)();
+        vi.mocked(wallet.signMessage).mockImplementation(async (_message, address) => ({
+          address, signature: `proof-${address}`,
+        }));
+        return { connection, wallet };
+      };
+
       it('should return accounts if already connected', async () => {
         // Setup: site is already connected
         const mockConnectionService = vi.mocked(connectionService.getConnectionService)();
@@ -504,12 +533,121 @@ describe('ProviderService', () => {
 
         expect(result.accounts).toEqual(['bc1qvux25709r4uw6rzc8wyl7wwecjdhrx085hm5ty']);
         expect(result.proof).toBeDefined();
+        expect(result.proof.verification).toEqual({ method: 'BIP-322', format: 'p2wpkh' });
+        const wallet = vi.mocked(walletService.getWalletService)();
+        expect(wallet.signMessage).toHaveBeenCalledWith(expect.any(String), activeAddress,
+          { walletId: 'wallet1', address: activeAddress });
+        expect(wallet.getPrivateKey).not.toHaveBeenCalled();
+        expect(wallet.getPairedAddresses).not.toHaveBeenCalled();
+      });
+
+      it('returns distinct proofs only for the approved active address and its sibling', async () => {
+        const { wallet } = grantPair();
+        const result = await providerService.handleRequest(origin, 'xcp_requestAccounts', []) as any;
+        expect(result.accounts).toEqual([activeAddress]);
+        expect(result.proof).toMatchObject({ address: activeAddress,
+          verification: { method: 'BIP-322', format: 'p2wpkh' } });
+        expect(result.proofs).toEqual([
+          result.proof,
+          expect.objectContaining({ address: siblingAddress,
+            verification: { method: 'BIP-322', format: 'p2pkh' } }),
+        ]);
+        expect(new Set(result.proofs.map((proof: { message: string }) => proof.message)).size).toBe(2);
+        expect(wallet.signMessage).toHaveBeenCalledWith(expect.any(String), siblingAddress,
+          { walletId: 'wallet1', address: activeAddress });
+        expect(wallet.getPrivateKey).not.toHaveBeenCalled();
+      });
+
+      it.each(['success', 'wrong address', 'declined'] as const)(
+        'uses the guarded hardware signer and handles %s', async outcome => {
+          const { wallet, connection } = grantPair();
+          vi.mocked(connection.hasPairedAddressPermission).mockResolvedValue(false);
+          const hardware = { ...walletManager.getActiveWallet()!, id: 'trezor1', type: 'hardware' as const };
+          vi.mocked(wallet.getActiveWallet).mockResolvedValue(hardware);
+          vi.mocked(walletManager.getActiveWallet).mockReturnValue(hardware);
+          if (outcome === 'wrong address') vi.mocked(wallet.signMessage).mockResolvedValue({
+            address: siblingAddress, signature: 'wrong-proof',
+          });
+          if (outcome === 'declined') vi.mocked(wallet.signMessage).mockRejectedValue(new Error('Device declined'));
+          const result = await providerService.handleRequest(origin, 'xcp_requestAccounts', []) as any;
+          expect(result.accounts).toEqual([activeAddress]);
+          if (outcome === 'success') expect(result.proof).toMatchObject({ address: activeAddress,
+            verification: { method: 'BIP-137', format: 'legacy_recoverable' } });
+          else expect(result.proof).toBeNull();
+          expect(wallet.signMessage).toHaveBeenCalledWith(
+            expect.stringMatching(/^xcp-wallet\norigin:https:\/\/test\.com\nnonce:[0-9a-f]{16}\nissued:\d+$/),
+            activeAddress, { walletId: 'trezor1', address: activeAddress });
+          expect(wallet.getPrivateKey).not.toHaveBeenCalled();
+          expect(wallet.getPairedAddresses).not.toHaveBeenCalled();
+        },
+      );
+
+      it.each(['grant lookup', 'pair derivation'] as const)(
+        'rejects a wallet switch during %s before signing any proof', async boundary => {
+          const { wallet, connection } = grantPair();
+          const other = { ...walletManager.getActiveWallet()!, id: 'other-wallet' };
+          const switchWallet = () => {
+            vi.mocked(wallet.getActiveWallet).mockResolvedValue(other);
+            vi.mocked(walletManager.getActiveWallet).mockReturnValue(other);
+          };
+          if (boundary === 'grant lookup') {
+            vi.mocked(connection.hasPairedAddressPermission).mockImplementationOnce(async () => {
+              switchWallet();
+              return true;
+            });
+          } else {
+            const pair = await wallet.getPairedAddresses();
+            vi.mocked(wallet.getPairedAddresses).mockImplementationOnce(async () => {
+              switchWallet();
+              return pair;
+            });
+          }
+          await expect(providerService.handleRequest(origin, 'xcp_requestAccounts', [])).rejects.toThrow('The active address changed');
+          expect(wallet.signMessage).not.toHaveBeenCalled();
+        },
+      );
+
+      it.each(['lock', 'switch', 'disconnect', 'revoke pair'] as const)(
+        'withholds every proof when a pending signature encounters %s', async mutation => {
+          const { wallet } = grantPair();
+          vi.mocked(wallet.signMessage).mockImplementationOnce(async (_message, address) => {
+            if (mutation === 'lock') session.generation++;
+            if (mutation === 'switch') vi.mocked(walletManager.getActiveWallet).mockReturnValue({
+              ...walletManager.getActiveWallet()!, id: 'other-wallet',
+            });
+            if (mutation === 'disconnect') vi.mocked(walletManager.getSettings).mockReturnValue({
+              ...walletManager.getSettings(), connectedWebsites: [],
+            });
+            if (mutation === 'revoke pair') vi.mocked(walletManager.getSettings).mockReturnValue({
+              ...walletManager.getSettings(), providerCapabilities: {},
+            });
+            return { address, signature: 'must-not-be-disclosed' };
+          });
+          await expect(providerService.handleRequest(origin, 'xcp_requestAccounts', [])).rejects.toThrow();
+          expect(wallet.signMessage).toHaveBeenCalledTimes(1);
+        },
+      );
+
+      it('rechecks a grant revoked during the final asynchronous delivery validation', async () => {
+        const { wallet } = grantPair();
+        vi.mocked(wallet.signMessage).mockImplementation(async (_message, address) => {
+          if (address === siblingAddress) vi.mocked(wallet.getActiveWallet).mockImplementationOnce(async () => {
+            const active = walletManager.getActiveWallet();
+            queueMicrotask(() => vi.mocked(walletManager.getSettings).mockReturnValue({
+              ...walletManager.getSettings(), providerCapabilities: {},
+            }));
+            return active;
+          });
+          return { address, signature: 'must-not-be-disclosed' };
+        });
+        await expect(providerService.handleRequest(origin, 'xcp_requestAccounts', [])).rejects.toThrow('Paired address access was revoked');
+        expect(wallet.signMessage).toHaveBeenCalledTimes(2);
       });
       
       it('should request permission if not connected', async () => {
         // Mock connection service to return false for hasPermission, then connect
         const mockConnectionService = vi.mocked(connectionService.getConnectionService)();
-        mockConnectionService.hasPermission = vi.fn().mockResolvedValue(false);
+        mockConnectionService.hasPermission = vi.fn().mockResolvedValueOnce(false).mockResolvedValue(true);
         mockConnectionService.connect = vi.fn().mockResolvedValue(['bc1qvux25709r4uw6rzc8wyl7wwecjdhrx085hm5ty']);
 
         // Request accounts should call connectionService.connect

--- a/src/services/providerService.ts
+++ b/src/services/providerService.ts
@@ -7,7 +7,7 @@
  * - WalletService: Wallet state and cryptographic operations
  */
 
-import { normalizeAddressForComparison } from '@/core/bitcoin/address';
+import { type AddressFormat, normalizeAddressForComparison } from '@/core/bitcoin/address';
 import { fetchBTCBalance } from '@/core/bitcoin/balance';
 import { parseBitcoinPaymentIntent } from '@/core/bitcoin/providerPayment';
 import { resolveProviderSignInputs } from '@/core/bitcoin/providerSigningPlan';
@@ -41,6 +41,7 @@ import {
 } from '@/platform/provider/signFlow';
 import { defineProxyService } from '@/platform/proxy';
 import { createWriteLock } from '@/platform/storage/mutex';
+import type { AuthorizedRequest } from '@/platform/storage/requestStorage';
 import { keychainExists } from '@/platform/storage/walletStorage';
 import { getApprovalService } from '@/services/approvalService';
 import { getConnectionService } from '@/services/connectionService';
@@ -56,6 +57,23 @@ export type ProviderMetadata = Record<string, unknown>;
 export type ProviderResponse = unknown;
 
 const CONNECTION_PROOF_PREFIX = 'xcp-wallet\n';
+
+type ProviderConnectionProof = {
+  address: string;
+  message: string;
+  signature: string;
+  verification:
+    | { method: 'BIP-322'; format: string }
+    | { method: 'BIP-137'; format: 'legacy_recoverable' };
+};
+
+type ConnectionProofContext = {
+  request: AuthorizedRequest;
+  sessionGeneration: number;
+  hardware: boolean;
+  pairedSupported: boolean;
+  format: AddressFormat;
+};
 
 export interface ProviderService {
   /**
@@ -239,40 +257,36 @@ export function createProviderService(): ProviderService {
    * the user controls the address. No user prompt — they already approved connecting.
    * The message format is locked down so it can't be confused with arbitrary signing.
    */
-  async function generateConnectionProof(origin: string): Promise<{
-    address: string;
-    message: string;
-    signature: string;
-    verification: { method: 'BIP-322'; format: string };
-  } | null> {
+  async function generateConnectionProof(
+    context: ConnectionProofContext,
+    target: { address: string; format: AddressFormat },
+  ): Promise<ProviderConnectionProof | null> {
     try {
       const walletService = getWalletService();
-      const activeAddress = await walletService.getActiveAddress();
-      const activeWallet = await walletService.getActiveWallet();
-      if (!activeAddress || !activeWallet) return null;
 
       const nonce = Array.from(crypto.getRandomValues(new Uint8Array(8)))
         .map(b => b.toString(16).padStart(2, '0')).join('');
       const issued = Math.floor(Date.now() / 1000);
 
-      const message = `xcp-wallet\norigin:${origin}\nnonce:${nonce}\nissued:${issued}`;
-
-      const addressFormat = activeWallet.addressFormat || 'p2tr';
+      const message = `xcp-wallet\norigin:${context.request.origin}\nnonce:${nonce}\nissued:${issued}`;
 
       const result = await walletService.signMessage(
         message,
-        activeAddress.address,
-        { walletId: activeWallet.id, address: activeAddress.address },
+        target.address,
+        { walletId: context.request.walletId, address: context.request.address },
       );
 
+      if (normalizeAddressForComparison(result.address) !== normalizeAddressForComparison(target.address)) {
+        throw new Error('Connection proof signed for a different address');
+      }
+
       return {
-        address: result.address,
+        address: target.address,
         message,
         signature: result.signature,
-        verification: {
-          method: 'BIP-322' as const,
-          format: addressFormat,
-        },
+        verification: context.hardware
+          ? { method: 'BIP-137', format: 'legacy_recoverable' }
+          : { method: 'BIP-322', format: target.format },
       };
     } catch (error) {
       console.warn('[ProviderService] Failed to generate connection proof:', error);
@@ -294,10 +308,49 @@ export function createProviderService(): ProviderService {
     return isConnected ? [activeAddress.address] : [];
   }
 
-  /** Build the standard response for xcp_requestAccounts with proof. */
-  async function buildConnectResponse(origin: string, accounts: string[]) {
-    const proof = accounts.length > 0 ? await generateConnectionProof(origin) : null;
-    return { accounts, proof };
+  /** Sign and deliver only the identity and optional sibling grant approved by this connection. */
+  async function buildConnectResponse(accounts: string[], context: ConnectionProofContext) {
+    if (accounts.length !== 1
+      || normalizeAddressForComparison(accounts[0]!) !== normalizeAddressForComparison(context.request.address)) {
+      throw new Error('The connection identity changed before its proof was generated');
+    }
+    const { request, sessionGeneration } = context;
+    const authorize = (paired: boolean) => assertSignDeliveryAuthorized(request, paired, sessionGeneration);
+    let assertCurrent = await authorize(false);
+    assertCurrent();
+    const paired = context.pairedSupported && await getConnectionService().hasPairedAddressPermission(
+      request.origin, request.walletId, request.address,
+    );
+    assertCurrent();
+
+    const targets = [{ address: request.address, format: context.format }];
+    if (paired) {
+      assertCurrent = await authorize(true);
+      // getPairedAddresses captures the current wallet synchronously. Check the pinned
+      // identity immediately before calling it and again before using the derived pair.
+      assertCurrent();
+      const addresses = await getWalletService().getPairedAddresses();
+      assertCurrent();
+      for (const target of [addresses.legacy, addresses.segwit]) {
+        if (!targets.some(candidate => normalizeAddressForComparison(candidate.address)
+          === normalizeAddressForComparison(target.address))) targets.push(target);
+      }
+    }
+
+    const proofs: ProviderConnectionProof[] = [];
+    let proof: ProviderConnectionProof | null = null;
+    for (const [index, target] of targets.entries()) {
+      assertCurrent();
+      const signed = await generateConnectionProof(context, target);
+      assertCurrent();
+      if (index === 0) proof = signed;
+      if (signed) proofs.push(signed);
+    }
+    // Device refusal may omit a proof. Locking, switching, or revoking a grant
+    // invalidates the entire response, including signatures already produced.
+    const assertDelivery = await authorize(paired);
+    assertDelivery();
+    return { accounts, proof, ...(proofs.length > 1 ? { proofs } : {}) };
   }
 
   /**
@@ -326,11 +379,20 @@ export function createProviderService(): ProviderService {
     const walletService = getWalletService();
     const connectionService = getConnectionService();
 
+    const sessionGeneration = getSessionGeneration();
     const activeAddress = await walletService.getActiveAddress();
     const activeWallet = await walletService.getActiveWallet();
     if (!activeAddress || !activeWallet) {
       throw new Error('No active wallet or address');
     }
+    const context: ConnectionProofContext = {
+      request: { id: generateRequestId('connect-proof'), origin, timestamp: Date.now(),
+        walletId: activeWallet.id, address: activeAddress.address },
+      sessionGeneration,
+      hardware: activeWallet.type === 'hardware',
+      pairedSupported: activeWallet.type === 'mnemonic' && Boolean(getPairedAddressFormats(activeWallet.addressFormat)),
+      format: activeWallet.addressFormat,
+    };
 
     if (await connectionService.hasPermission(origin)) {
       if (pairedAddresses) {
@@ -340,7 +402,7 @@ export function createProviderService(): ProviderService {
           activeWallet.id
         );
       }
-      return buildConnectResponse(origin, await getAccounts(origin));
+      return buildConnectResponse(await getAccounts(origin), context);
     }
 
     await onBeforeConnect?.();
@@ -352,7 +414,7 @@ export function createProviderService(): ProviderService {
       pairedAddresses
     );
     await analytics.track('connection_established');
-    return buildConnectResponse(origin, accounts);
+    return buildConnectResponse(accounts, context);
   }
 
   /**


### PR DESCRIPTION
## Summary

- creates a connect-time proof through the Trezor message signer for supported hardware addresses
- keeps the existing proof field bound to the active account
- when paired-address access was explicitly granted, also returns a proofs array covering the granted Legacy and Native SegWit pair
- requires each signer’s returned address to match the requested identity before returning its proof
- keeps connection successful with no proof when the device declines, the address is unsupported, or the returned signer does not match

## Why

DigiRare uses the paired Native SegWit sibling as its marketplace identity when a mnemonic wallet has Legacy active. Before this change, connect returned only a proof for the active Legacy address. The site then had to request a separate message approval for the SegWit identity.

The pair was already disclosed and approved during connect. Returning proofs for both granted addresses lets the site establish the correct session during that same connection flow. Software wallets still sign these reserved proofs internally without another approval screen. Hardware wallets still require confirmation on the physical device because the extension never possesses their private key.

The original singular proof remains unchanged for existing integrations. proofs is additive and appears only when more than one granted identity was successfully proved.

## Security

- Pair proofs are emitted only for mnemonic wallets with the origin, wallet id, and active address bound paired capability.
- Each proof uses an independent nonce and the existing reserved, origin-bound connection message.
- Any address mismatch fails closed and that proof is omitted.
- Arbitrary dApp message signing still cannot use the reserved connection-proof namespace.
- Connect proof authenticates a web session only. Transaction authorization remains a separate reviewed PSBT operation.

## Verification

- provider service tests: 70 passed
- TypeScript compile: pass
- Biome: pass
- Oxlint: pass with existing warnings only
- lockfile dry run: pass

## QA and integration

Integrated connection proofs with the background signing and delivery authority from PR #382. Pin the wallet/address and session, derive paired proofs only under the bound grant, and recheck authorization after asynchronous work and immediately before returning proofs. Wallet-switch, locking, grant-revocation, and final-delivery races have regressions. The combined tree passed 184 focused tests, TypeScript, lint, a Chrome production build, and browser checks for connection, reviewed message signing, and approval cautions. Independent review passed a separate 116-test group. A signer operation already in progress may finish internally after revocation; its proofs are withheld.

The final published head passed the full CI suite before merging.

The final branch also scopes the Show Private Key invalid-wallet browser assertion to its page region, preventing an unrelated API rate-limit banner from making the alert locator ambiguous. The affected Chromium test passed.

Merged after all 38 checks passed. The merge tree `d5693d199b3aabe10fbf15c97ab9073dbe776e1d` exactly matches the reviewed tree.
