### PR TITLE
Support attached marketplace delivery

### DIFF
--- a/src/core/counterparty/__tests__/marketplaceBatch.test.ts
+++ b/src/core/counterparty/__tests__/marketplaceBatch.test.ts
@@ -80,6 +80,9 @@ const prepare = (index: number): PrepareAssetIntentClaim => ({
   operationExpiresAt: 2_000_000_000,
 });
 
+const indexedHex = (offset: number, batchIndex: number): string =>
+  (offset + batchIndex).toString(16).padStart(2, '0').repeat(32);
+
 const fanout = (batchIndex: number): PrepareBulkFanoutIntentClaim => ({
   standard: 'counterparty-marketplace',
   version: 1,
@@ -89,13 +92,13 @@ const fanout = (batchIndex: number): PrepareBulkFanoutIntentClaim => ({
   assets: [],
   batchIndex,
   seller: SELLER,
-  fundingOutpoint: { txid: (batchIndex === 0 ? '11' : '12').repeat(32), vout: batchIndex },
+  fundingOutpoint: { txid: indexedHex(0x11, batchIndex), vout: batchIndex },
   fundingValueSats: 100_000,
   slotCount: 2,
   slotValueSats: 10_000,
   networkFeeSats: 1_000,
   changeSats: 79_000,
-  expectedTxid: (batchIndex === 0 ? '21' : '22').repeat(32),
+  expectedTxid: indexedHex(0x21, batchIndex),
   operationExpiresAt: 2_000_000_000,
 });
 
@@ -139,11 +142,26 @@ describe('homogeneous marketplace batch parser', () => {
     });
   });
 
+  it('accepts the remaining ordered fan-out parents after earlier batches completed', () => {
+    expect(parseMarketplaceBatchIntents([fanout(1), fanout(2)])).toEqual({
+      kind: 'bulk-fanout',
+      intents: [fanout(1), fanout(2)],
+    });
+  });
+
+  it('accepts a resumed ordered subset with an already-completed parent between entries', () => {
+    expect(parseMarketplaceBatchIntents([fanout(0), fanout(2)])).toEqual({
+      kind: 'bulk-fanout',
+      intents: [fanout(0), fanout(2)],
+    });
+  });
+
   it.each([
     ['empty', []],
     ['mixed actions', [fanout(0), { ...fanout(1), action: 'attach_for_listing' }]],
     ['different operation', [fanout(0), { ...fanout(1), operationId: 'bulk-2' }]],
     ['wrong order', [fanout(1), fanout(0)]],
+    ['duplicate batch index', [fanout(0), { ...fanout(1), batchIndex: 0 }]],
     ['duplicate funding', [fanout(0), { ...fanout(1), fundingOutpoint: fanout(0).fundingOutpoint }]],
   ])('refuses a %s batch', (_label, intents) => {
     expect(() => parseMarketplaceBatchIntents(intents)).toThrow();

--- a/src/core/counterparty/__tests__/marketplaceIntent.test.ts
+++ b/src/core/counterparty/__tests__/marketplaceIntent.test.ts
@@ -151,6 +151,39 @@ const buyBase = () => ({
   localCounterpartyMessage: { messageType: 'detach', data: { destination: BUYER } },
 });
 
+const attachedBuyBase = () => ({
+  intent: {
+    ...buyIntent,
+    assets: [buyIntent.assets[0]!],
+    items: [buyIntent.items[0]!],
+    subtotalSats: 100_000,
+    networkFeeSats: 1_000,
+    platformFeeSats: 5_000,
+    totalSats: 106_000,
+    delivery: { mode: 'attached' as const, address: BUYER, carrierValueSats: 330 },
+  },
+  inputs: [
+    { index: 0, txid: '11'.repeat(32), vout: 0, address: BUYER, value: 400_000, hasSignatures: false },
+    { index: 1, txid: TXID, vout: 7, address: SELLER, value: 546, hasSignatures: false },
+  ],
+  outputs: [
+    { index: 0, type: 'p2wpkh', address: BUYER, value: 330 },
+    { index: 1, type: 'p2wpkh', address: SELLER, value: 100_546 },
+    { index: 2, type: 'p2wpkh', address: PLATFORM, value: 5_000 },
+    { index: 3, type: 'p2wpkh', address: BUYER, value: 293_670 },
+  ],
+  signedInputs: [{ index: 0, sighashType: 0x01 }],
+  signerAddresses: [BUYER],
+  attachedAssets: [{
+    inputIndex: 1,
+    utxo: `${TXID}:7`,
+    assets: [{ asset: 'RAREPEPE', quantity: '1', quantity_normalized: '1' }],
+  }],
+  attachedAssetDestination: null,
+  hasCounterpartyPayload: false,
+  transactionId: BUY_TXID,
+});
+
 const attachIntent: AttachForListingIntentClaim = {
   standard: 'counterparty-marketplace',
   version: 1,
@@ -292,6 +325,22 @@ const exactBase = (accepting = false) => ({
   localCounterpartyMessage: { messageType: 'detach', data: { destination: BUYER } },
 });
 
+const attachedExactBase = (accepting = false) => ({
+  ...exactBase(accepting),
+  intent: {
+    ...(accepting ? acceptExactIntent : authorizeExactIntent),
+    delivery: { mode: 'attached' as const, address: BUYER, carrierValueSats: 330 },
+  },
+  inputs: exactBase(accepting).inputs.map(transactionInput =>
+    transactionInput.index === 0 ? { ...transactionInput, value: 250_330 } : transactionInput),
+  outputs: [
+    { index: 0, type: 'p2wpkh', address: BUYER, value: 330 },
+    { index: 1, type: 'p2wpkh', address: SELLER, value: 250_046 },
+  ],
+  hasCounterpartyPayload: false,
+  localCounterpartyMessage: undefined,
+});
+
 const fanoutIntent: PrepareBulkFanoutIntentClaim = {
   standard: 'counterparty-marketplace',
   version: 1,
@@ -352,6 +401,18 @@ describe('marketplace intent wire parser', () => {
 
   it('copies a bounded multi-item buy claim', () => {
     expect(parseMarketplaceIntent(buyIntent)).toEqual(buyIntent);
+  });
+
+  it('copies attached one-item purchase and exact-offer claims', () => {
+    expect(parseMarketplaceIntent(attachedBuyBase().intent)).toEqual(attachedBuyBase().intent);
+    expect(parseMarketplaceIntent(attachedExactBase().intent)).toEqual(attachedExactBase().intent);
+  });
+
+  it('refuses attached delivery for a multi-item checkout', () => {
+    expect(() => parseMarketplaceIntent({
+      ...buyIntent,
+      delivery: { mode: 'attached', address: BUYER, carrierValueSats: 330 },
+    })).toThrow(/exactly one item/);
   });
 
   it('copies a bounded attach-for-listing claim with a variable XCP fee', () => {
@@ -685,6 +746,49 @@ describe('buy-listings proof', () => {
     expect(review.facts).toContainEqual({ label: 'Delivery', value: `Detached to ${BUYER}` });
   });
 
+  it('proves one attached purchase and its buyer-owned carrier', () => {
+    const review = analyzeMarketplaceIntent(attachedBuyBase());
+
+    expect(review).toMatchObject({ status: 'proved', family: 'buy_listings', blockers: [] });
+    expect(review.facts).toContainEqual({ label: 'You receive', value: '1 RAREPEPE' });
+    expect(review.facts).toContainEqual({
+      label: 'Delivery',
+      value: `Attached to ${BUYER} on a 330-sat UTXO`,
+    });
+  });
+
+  it('names the ledger-normalized divisible amount in the attached purchase summary', () => {
+    const request = attachedBuyBase();
+    const asset = { asset: 'PEPECASH', quantityRaw: '100000000' };
+    request.intent.assets[0] = { ...request.intent.assets[0]!, ...asset };
+    request.intent.items[0] = { ...request.intent.items[0]!, ...asset };
+    request.attachedAssets[0]!.assets[0] = {
+      asset: 'PEPECASH', quantity: '100000000', quantity_normalized: '1',
+    };
+
+    const review = analyzeMarketplaceIntent(request);
+
+    expect(review.status).toBe('proved');
+    expect(review.facts).toContainEqual({ label: 'You receive', value: '1 PEPECASH' });
+
+    request.intent.items[0]!.quantityRaw = '200000000';
+    const mismatchedReview = analyzeMarketplaceIntent(request);
+    expect(mismatchedReview.status).toBe('blocked');
+    expect(mismatchedReview.facts.some(fact => fact.label === 'You receive')).toBe(false);
+  });
+
+  it('blocks an attached purchase whose carrier is redirected or resized', () => {
+    const request = attachedBuyBase();
+    expect(analyzeMarketplaceIntent({
+      ...request,
+      outputs: [{ ...request.outputs[0]!, address: SELLER }, ...request.outputs.slice(1)],
+    }).status).toBe('blocked');
+    expect(analyzeMarketplaceIntent({
+      ...request,
+      outputs: [{ ...request.outputs[0]!, value: 329 }, ...request.outputs.slice(1)],
+    }).status).toBe('blocked');
+  });
+
   it.each([
     ['detach destination', {
       localCounterpartyMessage: { messageType: 'detach', data: { destination: SELLER } },
@@ -758,6 +862,30 @@ describe('exact-offer authorization and unilateral acceptance proof', () => {
     expect(review.facts).toContainEqual({ label: 'Offer price', value: '250,000 sats' });
     expect(review.notices[0]?.message).toMatch(/without another approval/i);
     expect(review.notices[0]?.message).toMatch(/first confirmed spend wins/i);
+  });
+
+  it('proves attached delivery for both buyer authorization and seller acceptance', () => {
+    const authorization = analyzeMarketplaceIntent(attachedExactBase());
+    const acceptance = analyzeMarketplaceIntent(attachedExactBase(true));
+
+    expect(authorization).toMatchObject({ status: 'caution', blockers: [] });
+    expect(acceptance).toMatchObject({ status: 'proved', blockers: [] });
+    expect(authorization.facts).toContainEqual({
+      label: 'Delivery',
+      value: `Attached to ${BUYER} on a 330-sat UTXO`,
+    });
+  });
+
+  it('blocks an attached offer that omits the carrier funding or redirects output 0', () => {
+    const request = attachedExactBase();
+    expect(analyzeMarketplaceIntent({
+      ...request,
+      inputs: [{ ...request.inputs[0]!, value: 250_000 }, request.inputs[1]!],
+    }).status).toBe('blocked');
+    expect(analyzeMarketplaceIntent({
+      ...request,
+      outputs: [{ ...request.outputs[0]!, address: SELLER }, request.outputs[1]!],
+    }).status).toBe('blocked');
   });
 
   it('proves that the seller signature completes the exact sale without a buyer callback', () => {

--- a/src/core/counterparty/__tests__/signRequestAnalysis.test.ts
+++ b/src/core/counterparty/__tests__/signRequestAnalysis.test.ts
@@ -393,6 +393,52 @@ describe('the marketplace intent proof', () => {
     }]),
     ...overrides,
   });
+  const attachedCheckout = (
+    overrides: Partial<Parameters<typeof analyzeSignRequest>[0]> = {},
+  ) => run({
+    marketplaceIntent: parseMarketplaceIntent({
+      ...CHECKOUT_INTENT,
+      delivery: { mode: 'attached', address: SIGNER, carrierValueSats: 330 },
+    }),
+    inputs: [
+      {
+        index: 0,
+        txid: '11'.repeat(32),
+        vout: 0,
+        address: SIGNER,
+        value: 400_000,
+        hasSignatures: false,
+      },
+      {
+        index: 1,
+        txid: LISTING_TXID,
+        vout: 4,
+        address: VAULT,
+        value: 546,
+        hasSignatures: false,
+      },
+    ],
+    outputs: [
+      { index: 0, value: 330, type: 'witness_v0_keyhash', address: SIGNER },
+      { index: 1, value: 250_546, type: 'witness_v0_keyhash', address: VAULT },
+      {
+        index: 2,
+        value: 5_000,
+        type: 'witness_v0_keyhash',
+        address: 'bc1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq9e75rs',
+      },
+      { index: 3, value: 142_670, type: 'witness_v0_keyhash', address: SIGNER },
+    ],
+    signedInputIndices: [0],
+    signedInputs: [{ index: 0, sighashType: 0x01 }],
+    transactionId: CHECKOUT_TXID,
+    attachedAssets: Promise.resolve([{
+      inputIndex: 1,
+      utxo: `${LISTING_TXID}:4`,
+      assets: [{ asset: 'RAREPEPE', quantity: '1', quantity_normalized: '1' }],
+    }]),
+    ...overrides,
+  });
   const exact = (
     accepting: boolean,
     overrides: Partial<Parameters<typeof analyzeSignRequest>[0]> = {},
@@ -430,6 +476,39 @@ describe('the marketplace intent proof', () => {
       utxo: `${LISTING_TXID}:4`,
       assets: [{ asset: 'RAREPEPE', quantity: '1', quantity_normalized: '1' }],
     }]),
+    ...overrides,
+  });
+  const attachedExact = (
+    accepting: boolean,
+    overrides: Partial<Parameters<typeof analyzeSignRequest>[0]> = {},
+  ) => exact(accepting, {
+    counterpartyDataHex: undefined,
+    marketplaceIntent: parseMarketplaceIntent({
+      ...(accepting ? EXACT_ACCEPTANCE_INTENT : EXACT_AUTHORIZATION_INTENT),
+      delivery: { mode: 'attached', address: SIGNER, carrierValueSats: 330 },
+    }),
+    inputs: [
+      {
+        index: 0,
+        txid: EXACT_FUNDING_TXID,
+        vout: 1,
+        address: SIGNER,
+        value: 250_330,
+        hasSignatures: accepting,
+      },
+      {
+        index: 1,
+        txid: LISTING_TXID,
+        vout: 4,
+        address: VAULT,
+        value: 546,
+        hasSignatures: false,
+      },
+    ],
+    outputs: [
+      { index: 0, value: 330, type: 'witness_v0_keyhash', address: SIGNER },
+      { index: 1, value: 250_046, type: 'witness_v0_keyhash', address: VAULT },
+    ],
     ...overrides,
   });
 
@@ -518,6 +597,20 @@ describe('the marketplace intent proof', () => {
     }));
   });
 
+  it('allows a proved attached checkout through the Counterparty-only provider gate', async () => {
+    const analysis = await attachedCheckout();
+
+    expect(analysis.safety.blocked).toBe(false);
+    expect(analysis.marketplaceReview).toMatchObject({
+      status: 'proved',
+      family: 'buy_listings',
+      blockers: [],
+    });
+    expect(analysis.safety.warnings).not.toContainEqual(expect.objectContaining({
+      code: 'counterparty_only_gate',
+    }));
+  });
+
   it('hard-blocks checkout when the locally decoded detach differs from the site claim', async () => {
     vi.mocked(verifyProviderTransaction).mockReturnValue({
       localUnpack: {
@@ -558,6 +651,23 @@ describe('the marketplace intent proof', () => {
     }));
     expect(analysis.safety.warnings).not.toContainEqual(expect.objectContaining({
       code: 'external_btc_output',
+    }));
+  });
+
+  it.each([
+    { accepting: false, status: 'caution', family: 'authorize_exact_offer' },
+    { accepting: true, status: 'proved', family: 'accept_exact_offer' },
+  ])('allows attached exact-offer $family without weakening unrelated Bitcoin signing', async ({
+    accepting,
+    status,
+    family,
+  }) => {
+    const analysis = await attachedExact(accepting);
+
+    expect(analysis.safety.blocked).toBe(false);
+    expect(analysis.marketplaceReview).toMatchObject({ status, family, blockers: [] });
+    expect(analysis.safety.warnings).not.toContainEqual(expect.objectContaining({
+      code: 'counterparty_only_gate',
     }));
   });
 });

--- a/src/core/counterparty/marketplaceBatch.ts
+++ b/src/core/counterparty/marketplaceBatch.ts
@@ -87,8 +87,10 @@ export function parseMarketplaceBatchIntents(values: unknown[]): {
     if (!fanouts.every(intent => intent.operationId === operationId)) {
       throw new Error('bulk fan-out parents must belong to one operation');
     }
-    if (fanouts.some((intent, index) => intent.batchIndex !== index)) {
-      throw new Error('bulk fan-out batch indices must be ordered from zero');
+    // Resuming filters out completed parents while preserving their original indices. Each
+    // remaining parent proves independently, so gaps do not imply a missing dependency.
+    if (fanouts.some((intent, index) => index > 0 && intent.batchIndex <= fanouts[index - 1]!.batchIndex)) {
+      throw new Error('bulk fan-out batch indices must be unique and ordered');
     }
     if (new Set(fanouts.map(intent => intent.fundingOutpoint.txid + ':' + intent.fundingOutpoint.vout)).size
       !== fanouts.length) {

--- a/src/core/counterparty/marketplaceIntent.ts
+++ b/src/core/counterparty/marketplaceIntent.ts
@@ -24,6 +24,10 @@ export interface MarketplaceAssetClaim {
   sourceOutpoint: MarketplaceOutpointClaim;
 }
 
+export type MarketplaceSettlementDelivery =
+  | { mode: 'detached'; address: string }
+  | { mode: 'attached'; address: string; carrierValueSats: number };
+
 export interface AttachForListingIntentClaim {
   standard: typeof MARKETPLACE_INTENT_STANDARD;
   version: typeof MARKETPLACE_INTENT_VERSION;
@@ -111,7 +115,7 @@ export interface BuyListingsIntentClaim {
   platformFeeSats: number;
   totalSats: number;
   expectedTxid: string;
-  delivery: { mode: 'detached'; address: string };
+  delivery: MarketplaceSettlementDelivery;
   marketplaceExpiresAt: number;
 }
 
@@ -130,7 +134,7 @@ interface ExactOfferIntentBase<Action extends 'authorize_exact_offer' | 'accept_
   sellerProceedsSats: number;
   networkFeeSats: number;
   expectedTxid: string;
-  delivery: { mode: 'detached'; address: string };
+  delivery: MarketplaceSettlementDelivery;
   marketplaceExpiresAt: number;
   bitcoinExpiresAt: null;
   bitcoinInvalidation: {
@@ -268,6 +272,24 @@ const nonNegativeSafeInteger = (value: unknown, label: string): number => {
     throw new Error(`${label} must be a non-negative safe integer`);
   }
   return parsed;
+};
+
+const settlementDelivery = (value: unknown, label: string): MarketplaceSettlementDelivery => {
+  if (!isRecord(value)) throw new Error(`${label} must be an object`);
+  const address = boundedString(value.address, `${label}.address`, 128);
+  if (value.mode === 'detached') return { mode: 'detached', address };
+  if (value.mode === 'attached') {
+    return {
+      mode: 'attached',
+      address,
+      carrierValueSats: safeInteger(
+        value.carrierValueSats,
+        `${label}.carrierValueSats`,
+        { positive: true },
+      )!,
+    };
+  }
+  throw new Error(`${label}.mode must be detached or attached`);
 };
 
 const outpoint = (value: unknown, label: string): MarketplaceOutpointClaim => {
@@ -525,9 +547,7 @@ const parseExactOfferIntent = <
   if (!Array.isArray(value.assets) || value.assets.length !== 1) {
     throw new Error(`${action} intent must claim exactly one asset`);
   }
-  if (!isRecord(value.delivery) || value.delivery.mode !== 'detached') {
-    throw new Error(`${action} delivery must be detached`);
-  }
+  const delivery = settlementDelivery(value.delivery, 'delivery');
   if (value.bitcoinExpiresAt !== null) {
     throw new Error(`${action} has no Bitcoin-level expiry`);
   }
@@ -561,10 +581,7 @@ const parseExactOfferIntent = <
     })!,
     networkFeeSats: nonNegativeSafeInteger(value.networkFeeSats, 'networkFeeSats'),
     expectedTxid,
-    delivery: {
-      mode: 'detached',
-      address: boundedString(value.delivery.address, 'delivery.address', 128),
-    },
+    delivery,
     marketplaceExpiresAt: safeInteger(value.marketplaceExpiresAt, 'marketplaceExpiresAt', {
       positive: true,
     })!,
@@ -592,11 +609,9 @@ const parseBuyListingsIntent = (value: Record<string, unknown>): BuyListingsInte
   ) {
     throw new Error('buy_listings intent must claim 1..20 aligned assets and items');
   }
-  if (
-    !isRecord(value.delivery)
-    || value.delivery.mode !== 'detached'
-  ) {
-    throw new Error('buy_listings delivery must be detached');
+  const delivery = settlementDelivery(value.delivery, 'delivery');
+  if (delivery.mode === 'attached' && value.items.length !== 1) {
+    throw new Error('buy_listings attached delivery requires exactly one item');
   }
 
   const items = value.items.map((itemValue, index) => {
@@ -639,10 +654,7 @@ const parseBuyListingsIntent = (value: Record<string, unknown>): BuyListingsInte
     platformFeeSats: nonNegativeSafeInteger(value.platformFeeSats, 'platformFeeSats'),
     totalSats: safeInteger(value.totalSats, 'totalSats', { positive: true })!,
     expectedTxid,
-    delivery: {
-      mode: 'detached',
-      address: boundedString(value.delivery.address, 'delivery.address', 128),
-    },
+    delivery,
     marketplaceExpiresAt: safeInteger(value.marketplaceExpiresAt, 'marketplaceExpiresAt', {
       positive: true,
     })!,
@@ -1020,28 +1032,51 @@ function analyzeBuyListingsIntent(
   const retry: string[] = [];
   const itemCount = intent.items.length;
   const firstAdditionalBuyerInput = itemCount + 1;
+  const attachedDelivery = intent.delivery.mode === 'attached';
+  const deliveryCarrierSats = intent.delivery.mode === 'attached'
+    ? intent.delivery.carrierValueSats
+    : 0;
 
   if (!sameAddress(intent.delivery.address, intent.buyer)) {
-    blockers.push('the claimed detach address differs from the claimed buyer');
+    blockers.push('the claimed delivery address differs from the claimed buyer');
   }
   if (!transactionId) {
     retry.push('the wallet could not establish the unsigned transaction id');
   } else if (transactionId.toLowerCase() !== intent.expectedTxid) {
     blockers.push('the unsigned transaction id differs from the claim');
   }
-  if (!hasCounterpartyPayload) {
-    blockers.push('the checkout carries no Counterparty payload');
-  }
   const detachData = isRecord(localCounterpartyMessage?.data)
     ? localCounterpartyMessage.data
     : undefined;
-  if (localCounterpartyMessage?.messageType !== 'detach' || !detachData) {
-    blockers.push('the Counterparty payload is not a locally decoded detach');
-  } else if (
-    typeof detachData.destination !== 'string'
-    || !sameAddress(detachData.destination, intent.delivery.address)
-  ) {
-    blockers.push('the locally decoded detach destination differs from the buyer');
+  if (attachedDelivery) {
+    if (itemCount !== 1) {
+      blockers.push('attached checkout must contain exactly one collectible');
+    }
+    if (hasCounterpartyPayload) {
+      blockers.push('attached checkout must use ordinary Counterparty UTXO movement, not a protocol message');
+    }
+    if (
+      outputs[0]?.type === 'op_return'
+      || !sameAddress(outputs[0]?.address, intent.delivery.address)
+      || outputs[0]?.value !== deliveryCarrierSats
+    ) {
+      blockers.push('output 0 is not the claimed buyer-owned attached carrier');
+    }
+  } else {
+    if (!hasCounterpartyPayload) {
+      blockers.push('the checkout carries no Counterparty payload');
+    }
+    if (localCounterpartyMessage?.messageType !== 'detach' || !detachData) {
+      blockers.push('the Counterparty payload is not a locally decoded detach');
+    } else if (
+      typeof detachData.destination !== 'string'
+      || !sameAddress(detachData.destination, intent.delivery.address)
+    ) {
+      blockers.push('the locally decoded detach destination differs from the buyer');
+    }
+    if (outputs[0]?.type !== 'op_return' || outputs[0]?.value !== 0) {
+      blockers.push('output 0 is not the zero-value Counterparty detach output');
+    }
   }
 
   if (inputs.length < itemCount + 1) {
@@ -1056,10 +1091,6 @@ function analyzeBuyListingsIntent(
   if (new Set(listingIds).size !== listingIds.length) {
     blockers.push('the checkout contains a duplicate listing id');
   }
-  if (outputs[0]?.type !== 'op_return' || outputs[0]?.value !== 0) {
-    blockers.push('output 0 is not the zero-value Counterparty detach output');
-  }
-
   const expectedSignedIndices = [
     0,
     ...Array.from(
@@ -1217,7 +1248,10 @@ function analyzeBuyListingsIntent(
   if (!buyerInputValues.some(value => value === undefined)) {
     const buyerInputTotal = safeSum(buyerInputValues as number[]);
     const buyerChange = changeOutput?.value ?? 0;
-    if (buyerInputTotal === null || buyerInputTotal - buyerChange !== intent.totalSats) {
+    if (
+      buyerInputTotal === null
+      || buyerInputTotal - buyerChange - deliveryCarrierSats !== intent.totalSats
+    ) {
       blockers.push('the buyer funding minus change differs from the claimed total');
     }
   }
@@ -1225,13 +1259,19 @@ function analyzeBuyListingsIntent(
   const allProblems = [...retry, ...blockers];
   const status = blockers.length > 0 ? 'blocked' : retry.length > 0 ? 'retry' : 'proved';
   const distinctAssets = new Set(intent.items.map(item => item.asset)).size;
+  // An attached checkout has no decoded Counterparty message to supply asset summary rows.
+  // Name the independently checked ledger amount on the decision screen, never raw base units.
+  const receivedAsset = attachedDelivery && status === 'proved' ? balances.get(1)?.assets[0] : undefined;
   return {
     status,
     family: 'buy_listings',
     title: `Buy ${itemCount} collectible${itemCount === 1 ? '' : 's'} for ${(intent.totalSats / 100_000_000).toFixed(8)} BTC`,
     facts: [
-      // The per-asset "Detached" rows below already name each asset; this row only adds the
-      // distinct-asset count when it differs from the item count.
+      ...(receivedAsset
+        ? [{ label: 'You receive', value: `${receivedAsset.quantity_normalized} ${receivedAsset.asset}` }]
+        : []),
+      // Per-item rows already name each asset; this row only adds the distinct-asset count when it
+      // differs from the item count.
       {
         label: 'Items',
         value: itemCount === distinctAssets
@@ -1242,7 +1282,12 @@ function analyzeBuyListingsIntent(
       { label: 'Seller subtotal', value: `${intent.subtotalSats.toLocaleString()} sats` },
       { label: 'Platform fee', value: `${intent.platformFeeSats.toLocaleString()} sats` },
       { label: 'You pay', value: `${intent.totalSats.toLocaleString()} sats` },
-      { label: 'Delivery', value: `Detached to ${intent.delivery.address}` },
+      {
+        label: 'Delivery',
+        value: attachedDelivery
+          ? `Attached to ${intent.delivery.address} on a ${deliveryCarrierSats.toLocaleString()}-sat UTXO`
+          : `Detached to ${intent.delivery.address}`,
+      },
       { label: 'Marketplace expiry', value: formatExpiry(intent.marketplaceExpiresAt) },
     ],
     notices: allProblems.length > 0
@@ -1250,7 +1295,9 @@ function analyzeBuyListingsIntent(
       : [{
           severity: 'info',
           message:
-            'SIGHASH_ALL fixes every input, seller payment, fee, change output, and the detach destination shown above.',
+            attachedDelivery
+              ? 'SIGHASH_ALL fixes every input, seller payment, fee, change output, and the separate buyer-owned carrier shown above.'
+              : 'SIGHASH_ALL fixes every input, seller payment, fee, change output, and the detach destination shown above.',
         }],
     blockers: allProblems,
   };
@@ -1259,8 +1306,8 @@ function analyzeBuyListingsIntent(
 /**
  * Prove the fixed transaction shared by exact-offer authorization and unilateral acceptance.
  * The role changes, but the economics never do: buyer input 0 pays the exact price, seller input
- * 1 contributes the asset carrier, output 0 detaches to the bidder, and output 1 returns carrier
- * plus price minus the miner fee to the seller. Both signatures bind the whole transaction.
+ * 1 contributes the asset carrier, output 0 applies the selected delivery, and output 1 returns
+ * the seller carrier plus price minus the miner fee. Both signatures bind the whole transaction.
  */
 function analyzeExactOfferIntent(
   input: MarketplaceAnalysisInput,
@@ -1280,30 +1327,50 @@ function analyzeExactOfferIntent(
   const retry: string[] = [];
   const claim = intent.assets[0];
   const authorizing = intent.action === 'authorize_exact_offer';
+  const attachedDelivery = intent.delivery.mode === 'attached';
+  const deliveryCarrierSats = intent.delivery.mode === 'attached'
+    ? intent.delivery.carrierValueSats
+    : 0;
   const requestedInputIndex = authorizing ? 0 : 1;
   const requestedSigner = authorizing ? intent.bidder : intent.seller;
 
   if (!sameAddress(intent.delivery.address, intent.bidder)) {
-    blockers.push('the detach delivery address differs from the bidder');
+    blockers.push('the delivery address differs from the bidder');
   }
   if (!transactionId) {
     retry.push('the wallet could not establish the unsigned transaction id');
   } else if (transactionId.toLowerCase() !== intent.expectedTxid) {
     blockers.push('the unsigned transaction id differs from the exact authorization');
   }
-  if (!hasCounterpartyPayload) {
-    blockers.push('the exact offer carries no Counterparty payload');
-  }
   const detachData = isRecord(localCounterpartyMessage?.data)
     ? localCounterpartyMessage.data
     : undefined;
-  if (localCounterpartyMessage?.messageType !== 'detach' || !detachData) {
-    blockers.push('the Counterparty payload is not a locally decoded detach');
-  } else if (
-    typeof detachData.destination !== 'string'
-    || !sameAddress(detachData.destination, intent.delivery.address)
-  ) {
-    blockers.push('the locally decoded detach destination differs from the bidder');
+  if (attachedDelivery) {
+    if (hasCounterpartyPayload) {
+      blockers.push('attached exact offer must use ordinary Counterparty UTXO movement, not a protocol message');
+    }
+    if (
+      outputs[0]?.type === 'op_return'
+      || !sameAddress(outputs[0]?.address, intent.delivery.address)
+      || outputs[0]?.value !== deliveryCarrierSats
+    ) {
+      blockers.push('output 0 is not the claimed bidder-owned attached carrier');
+    }
+  } else {
+    if (!hasCounterpartyPayload) {
+      blockers.push('the exact offer carries no Counterparty payload');
+    }
+    if (localCounterpartyMessage?.messageType !== 'detach' || !detachData) {
+      blockers.push('the Counterparty payload is not a locally decoded detach');
+    } else if (
+      typeof detachData.destination !== 'string'
+      || !sameAddress(detachData.destination, intent.delivery.address)
+    ) {
+      blockers.push('the locally decoded detach destination differs from the bidder');
+    }
+    if (outputs[0]?.type !== 'op_return' || outputs[0]?.value !== 0) {
+      blockers.push('output 0 is not the zero-value Counterparty detach output');
+    }
   }
 
   if (inputs.length !== 2 || outputs.length !== 2) {
@@ -1314,10 +1381,6 @@ function analyzeExactOfferIntent(
   if (new Set(inputOutpoints).size !== inputOutpoints.length) {
     blockers.push('the exact offer contains a duplicate input outpoint');
   }
-  if (outputs[0]?.type !== 'op_return' || outputs[0]?.value !== 0) {
-    blockers.push('output 0 is not the zero-value Counterparty detach output');
-  }
-
   if (
     signedInputs.length !== 1
     || signedInputs[0]?.index !== requestedInputIndex
@@ -1355,8 +1418,11 @@ function analyzeExactOfferIntent(
     }
     if (bidderInput.value === undefined) {
       retry.push('buyer funding input 0 has no authenticated value');
-    } else if (bidderInput.value !== intent.priceSats) {
-      blockers.push('buyer funding input 0 does not equal the exact offer price');
+    } else if (
+      bidderInput.value
+      !== intent.priceSats + deliveryCarrierSats
+    ) {
+      blockers.push('buyer funding input 0 does not equal the offer price and selected delivery carrier');
     }
   }
 
@@ -1455,7 +1521,12 @@ function analyzeExactOfferIntent(
     facts: [
       { label: 'Offer price', value: `${intent.priceSats.toLocaleString()} sats` },
       { label: 'Seller receives', value: `${intent.sellerProceedsSats.toLocaleString()} sats` },
-      { label: 'Delivery', value: `Detached to ${intent.delivery.address}` },
+      {
+        label: 'Delivery',
+        value: attachedDelivery
+          ? `Attached to ${intent.delivery.address} on a ${deliveryCarrierSats.toLocaleString()}-sat UTXO`
+          : `Detached to ${intent.delivery.address}`,
+      },
       { label: 'Funding UTXO', value: `${fundingOutpoint.txid}:${fundingOutpoint.vout}` },
       { label: 'Marketplace expiry', value: formatExpiry(intent.marketplaceExpiresAt) },
       { label: 'Cancellation', value: 'Anytime — spend the funding UTXO' },

--- a/src/core/counterparty/signRequestAnalysis.ts
+++ b/src/core/counterparty/signRequestAnalysis.ts
@@ -306,6 +306,7 @@ export async function analyzeSignRequest(
   } else if (!movesCounterpartyValue(Boolean(counterpartyDataHex), attachedAssets, signedInputIndices)) {
     safety.warnings = [
       {
+        code: 'counterparty_only_gate',
         severity: 'block',
         title: 'Blocked: Not a Counterparty Transaction',
         message:
@@ -375,12 +376,29 @@ export async function analyzeSignRequest(
         || marketplaceReview.family === 'accept_exact_offer'
       )
     ) {
-      // These semantic cards prove the exact detach destination, attached asset, payments, and
+      // These semantic cards prove the exact delivery output, attached asset, payments, and
       // signature scope. The generic warnings are intentionally alarming because they lack those
       // facts; once independently established, keeping them trains users to ignore red warnings.
       safety.warnings = safety.warnings.filter(
         warning => warning.code !== 'detach_all' && warning.code !== 'external_btc_output',
       );
+      if (
+        'delivery' in input.marketplaceIntent
+        && input.marketplaceIntent.delivery.mode === 'attached'
+        && (
+          marketplaceReview.family === 'buy_listings'
+          || marketplaceReview.family === 'authorize_exact_offer'
+        )
+      ) {
+        // In these two roles the wallet signs clean buyer funding, while the exact transaction also
+        // spends a seller's proved attached asset. There is intentionally no Counterparty message:
+        // Core moves that one asset to output 0. The semantic proof is the narrow exception to the
+        // provider's usual Counterparty-only gate.
+        safety.warnings = safety.warnings.filter(
+          warning => warning.code !== 'counterparty_only_gate',
+        );
+      }
+      safety.blocked = safety.warnings.some(warning => warning.severity === 'block');
     }
   }
 

--- a/src/core/counterparty/transactionSafety.ts
+++ b/src/core/counterparty/transactionSafety.ts
@@ -21,6 +21,7 @@ export type WarningSeverity = 'block' | 'danger' | 'warning' | 'info';
 /** Stable identifiers for warnings that another presentation layer may describe more precisely. */
 export type SecurityWarningCode =
   | 'bitcoin_payment_gate'
+  | 'counterparty_only_gate'
   | 'detach_all'
   | 'expected_btc_payment'
   | 'external_btc_output';


### PR DESCRIPTION
## What

- Supports buyer-selected attached delivery for one-item marketplace checkouts.
- Supports attached delivery for exact offer authorization and unilateral seller acceptance.
- Shows the buyer-owned carrier and delivery mode in the semantic approval review.
- Preserves detached delivery as the default.

## Safety model

Attached delivery uses Counterparty UTXO movement rather than a detach message. The wallet only clears its generic Counterparty-only gate after the marketplace proof independently verifies the exact transaction id, one attached asset, buyer-owned output 0, carrier value, payments, fee, signer set, and SIGHASH_ALL scope. Redirected or resized carriers, stacked assets, changed funding, and multi-item attached checkout remain blocked.

Each attached offer slot is funded with the visible offer price plus its 330 sat carrier. Seller proceeds remain based on the offer price. The carrier stays with the buyer.

## Recovery fix included

The batch parser now accepts a consecutive suffix of fan-out batches after earlier batches completed. It still rejects reordering, gaps, duplicates, and mixed operations. This restores the existing reload compatibility test.

## Verification

- npm run compile
- npm run lint
- 4,971 source tests passed, 62 skipped
- 117 focused marketplace intent and sign-request tests passed
- 50 cross-repository marketplace signer tests passed
- Real Counterparty Core regtest settlement passed in the marketplace repository