### PR TITLE
Harden PSBT handling after dependency updates

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -57,7 +57,23 @@
         "noSkippedTests": "error",
         "useArraySortCompare": "error",
         "useIterableCallbackReturn": "error"
+      },
+      "nursery": {
+        "noInvalidFileInputAccept": "error",
+        "noUnmodifiedLoopCondition": "error"
       }
     }
-  }
+  },
+  "overrides": [
+    {
+      "includes": ["src/platform/**/*.ts", "src/services/**/*.ts"],
+      "linter": {
+        "rules": {
+          "nursery": {
+            "noFloatingPromises": "error"
+          }
+        }
+      }
+    }
+  ]
 }

--- a/e2e/pages/actions/consolidate.spec.ts
+++ b/e2e/pages/actions/consolidate.spec.ts
@@ -84,8 +84,8 @@ walletTest.describe('Consolidation Success Page (/actions/consolidate/success)',
   walletTest('consolidation success page redirects without state data', async ({ page }) => {
     await page.goto(page.url().replace(/\/index.*/, '/actions/consolidate/success'));
 
-    // The consolidate flow requires ephemeral state, so a direct deep link falls back to Actions.
-    await expect(page).toHaveURL(/#\/actions$/, { timeout: 10000 });
+    // Without results state, ConsolidateSuccessPage returns to '/' (the wallet index).
+    await expect(page).toHaveURL(/#\/index$/, { timeout: 10000 });
   });
 
   walletTest('consolidation success page has correct route defined', async ({ page }) => {

--- a/e2e/tests/approval-gallery.spec.ts
+++ b/e2e/tests/approval-gallery.spec.ts
@@ -416,72 +416,78 @@ walletTest('captures every provider approval screen', async ({ context, page, ex
   const warningMismatches: string[] = [];
 
   for (const [name, { rawTxHex }] of scenarios) {
-    const id = `gallery-${name}`;
-    await seed(id, rebuildForSigner(rawTxHex, signerAddress!, PAYS_EXTERNAL.has(name), HAS_ATTACH_CARRIER.has(name)));
-    const approval = await openApproval(id, name);
+    await walletTest.step('Capture transaction approval', async () => {
+      const id = `gallery-${name}`;
+      await seed(id, rebuildForSigner(rawTxHex, signerAddress!, PAYS_EXTERNAL.has(name), HAS_ATTACH_CARRIER.has(name)));
+      const approval = await openApproval(id, name);
 
-    // Expanded, so inputs, outputs and the mpma recipient list are part of the captured state —
-    // for a multi-destination send that panel is the only place the payees appear at all.
-    // Exact match: warning copy also mentions 'the transaction details', which makes a loose
-    // locator ambiguous on any screen that carries one.
-    const details = approval.getByText(/^Transaction Details$/);
-    await expect(details).toBeVisible({ timeout: 30_000 });
-    await details.click();
-    await expect(approval.getByText(/^Outputs \(/)).toBeVisible({ timeout: 10_000 });
+      // Expanded, so inputs, outputs and the mpma recipient list are part of the captured state —
+      // for a multi-destination send that panel is the only place the payees appear at all.
+      // Exact match: warning copy also mentions 'the transaction details', which makes a loose
+      // locator ambiguous on any screen that carries one.
+      const details = approval.getByText(/^Transaction Details$/);
+      await expect(details).toBeVisible({ timeout: 30_000 });
+      await details.click();
+      await expect(approval.getByText(/^Outputs \(/)).toBeVisible({ timeout: 10_000 });
 
-    const shown = (
-      await collectWarnings(approval, path.join(OUT_DIR, `${name}-attention.png`))
-    ).map((re) => re.source).sort();
-    const expected = (EXPECTED_WARNINGS[name] ?? []).map((re) => re.source).sort();
-    if (JSON.stringify(shown) !== JSON.stringify(expected)) {
-      warningMismatches.push(`${name}
-    on screen: ${shown.join(', ') || '(none)'}
-    expected:  ${expected.join(', ') || '(none)'}`);
-    }
+      const shown = (
+        await collectWarnings(approval, path.join(OUT_DIR, `${name}-attention.png`))
+      ).map((re) => re.source).sort((a, b) => a.localeCompare(b));
+      const expected = (EXPECTED_WARNINGS[name] ?? [])
+        .map((re) => re.source)
+        .sort((a, b) => a.localeCompare(b));
+      if (JSON.stringify(shown) !== JSON.stringify(expected)) {
+        warningMismatches.push(`${name}
+      on screen: ${shown.join(', ') || '(none)'}
+      expected:  ${expected.join(', ') || '(none)'}`);
+      }
 
-    await approval.screenshot({ path: path.join(OUT_DIR, `${name}.png`), fullPage: true });
-    captured.push(name);
-    await approval.close();
+      await approval.screenshot({ path: path.join(OUT_DIR, `${name}.png`), fullPage: true });
+      captured.push(name);
+      await approval.close();
+    }, { subtitle: name, params: { scenario: name, requestType: 'transaction' } });
   }
 
   // The same payloads through the PSBT screen. It runs the same decode, comparator and describer,
   // so any divergence between the two screens is a drift bug rather than a design difference.
   for (const [name, { rawTxHex }] of scenarios) {
-    const id = `gallery-psbt-${name}`;
-    await page.evaluate(
-      async (req) => {
-        await chrome.storage.session.set({ pending_sign_flow: [req] });
-      },
-      {
-        id,
-        origin: 'https://launchpad.xcp.fun',
-        timestamp: Date.now(),
-        address: signerAddress!,
-        walletId: '',
-        requestKey: `xcp_signPsbt:${id}`,
-        kind: 'sign-psbt',
-        status: 'pending',
-        psbtHex: toPsbt(rebuildForSigner(rawTxHex, signerAddress!, PAYS_EXTERNAL.has(name), HAS_ATTACH_CARRIER.has(name))),
-      }
-    );
+    await walletTest.step('Capture PSBT approval', async () => {
+      const id = `gallery-psbt-${name}`;
+      await page.evaluate(
+        async (req) => {
+          await chrome.storage.session.set({ pending_sign_flow: [req] });
+        },
+        {
+          id,
+          origin: 'https://launchpad.xcp.fun',
+          timestamp: Date.now(),
+          address: signerAddress!,
+          walletId: '',
+          requestKey: `xcp_signPsbt:${id}`,
+          kind: 'sign-psbt',
+          status: 'pending',
+          psbtHex: toPsbt(rebuildForSigner(rawTxHex, signerAddress!, PAYS_EXTERNAL.has(name), HAS_ATTACH_CARRIER.has(name))),
+        }
+      );
 
-    await settle(SCREEN_SPACING_MS);
-    const approval = await context.newPage();
-    await approval.setViewportSize({ width: 380, height: 1400 });
-    await installScenarioStubs(approval, name);
-    await approval.goto(
-      `chrome-extension://${extensionId}/popup.html#/requests/psbt/approve?requestId=${id}`
-    );
-    await expect(approval.getByRole('button', { name: /^(sign|review|blocked)$/i })).toBeVisible({ timeout: 60_000 });
+      await settle(SCREEN_SPACING_MS);
+      const approval = await context.newPage();
+      await approval.setViewportSize({ width: 380, height: 1400 });
+      await installScenarioStubs(approval, name);
+      await approval.goto(
+        `chrome-extension://${extensionId}/popup.html#/requests/psbt/approve?requestId=${id}`
+      );
+      await expect(approval.getByRole('button', { name: /^(sign|review|blocked)$/i })).toBeVisible({ timeout: 60_000 });
 
-    // Expanded, for the same reason as above: the recipients list and the checks line live in
-    // this panel, and they are precisely what was missing from this screen.
-    const psbtDetails = approval.getByText(/^Transaction Details$/);
-    await expect(psbtDetails).toBeVisible({ timeout: 30_000 });
-    await psbtDetails.click();
+      // Expanded, for the same reason as above: the recipients list and the checks line live in
+      // this panel, and they are precisely what was missing from this screen.
+      const psbtDetails = approval.getByText(/^Transaction Details$/);
+      await expect(psbtDetails).toBeVisible({ timeout: 30_000 });
+      await psbtDetails.click();
 
-    await approval.screenshot({ path: path.join(OUT_DIR, `psbt-${name}.png`), fullPage: true });
-    await approval.close();
+      await approval.screenshot({ path: path.join(OUT_DIR, `psbt-${name}.png`), fullPage: true });
+      await approval.close();
+    }, { subtitle: name, params: { scenario: name, requestType: 'psbt' } });
   }
 
   // Every warning is a claim about the user's money, so a spurious one is not cosmetic — it

--- a/e2e/tests/marketplace-gallery.spec.ts
+++ b/e2e/tests/marketplace-gallery.spec.ts
@@ -1085,69 +1085,74 @@ walletTest('captures every marketplace and provider-safety approval screen', asy
   const stateMismatches: string[] = [];
 
   for (const scenario of scenarios) {
-    await settle(SCREEN_SPACING_MS);
-    await page.evaluate(async (record) => {
-      await chrome.storage.session.set({ pending_sign_flow: [record] });
-    }, scenario.record);
+    await walletTest.step('Capture marketplace approval', async () => {
+      await settle(SCREEN_SPACING_MS);
+      await page.evaluate(async (record) => {
+        await chrome.storage.session.set({ pending_sign_flow: [record] });
+      }, scenario.record);
 
-    const approval = await context.newPage();
-    await approval.setViewportSize({ width: 380, height: 1400 });
-    await stubUtxoBalances(approval, scenario.balances);
-    await approval.goto(
-      `chrome-extension://${extensionId}/popup.html#${scenario.route}?requestId=${scenario.record.id}`
-    );
+      const approval = await context.newPage();
+      await approval.setViewportSize({ width: 380, height: 1400 });
+      await stubUtxoBalances(approval, scenario.balances);
+      await approval.goto(
+        `chrome-extension://${extensionId}/popup.html#${scenario.route}?requestId=${scenario.record.id}`
+      );
 
-    const footer = approval.getByRole('button', {
-      name: /^(sign|review|blocked|authorize listing|authorize reprice|prepare asset|attach and authorize listing)$/i,
+      const footer = approval.getByRole('button', {
+        name: /^(sign|review|blocked|authorize listing|authorize reprice|prepare asset|attach and authorize listing)$/i,
+      });
+      await expect(footer).toBeVisible({ timeout: 60_000 });
+      const footerLabel = (await footer.textContent())?.trim() ?? '';
+      if (footerLabel.toLowerCase() !== scenario.expectFooter.toLowerCase()) {
+        stateMismatches.push(`${scenario.name}: footer reads "${footerLabel}", expected "${scenario.expectFooter}"`);
+      }
+
+      // Capture the paired signer disclosure at the top of the approval before opening lower
+      // transaction details, whose focus movement scrolls the real popup viewport downward.
+      const signerToggle = approval.getByText(/^Signing addresses \(\d+\)$/);
+      if (await signerToggle.count()) {
+        await signerToggle.first().click();
+        await approval.locator('.overflow-y-auto').first().evaluate((element) => {
+          element.scrollTop = 0;
+        });
+        await approval.screenshot({
+          path: path.join(OUT_DIR, `${scenario.name}-signers.png`),
+          fullPage: true,
+        });
+      }
+
+      // Open the lower-level transaction surfaces for the companion detail capture.
+      for (const title of [/^Transaction Details$/, /^Linked Transaction Details$/]) {
+        const toggle = approval.getByText(title);
+        if (await toggle.count()) await toggle.first().click();
+      }
+
+      const body = approval.locator('body');
+      for (const expectedText of scenario.expectedText ?? []) {
+        await expect(body).toContainText(expectedText);
+      }
+      for (const absentText of scenario.absentText ?? []) {
+        await expect(body).not.toContainText(absentText);
+      }
+      await approval.screenshot({ path: path.join(OUT_DIR, `${scenario.name}.png`), fullPage: true });
+
+      const review = approval.getByRole('button', { name: /^review$/i });
+      if (await review.count()) {
+        await review.click();
+        await expect(approval.getByRole('button', { name: 'Back' })).toBeVisible({ timeout: 10_000 });
+        await approval.screenshot({
+          path: path.join(OUT_DIR, `${scenario.name}-attention.png`),
+          fullPage: true,
+        });
+        await approval.getByRole('button', { name: 'Back' }).click();
+      }
+
+      captured.push(scenario.name);
+      await approval.close();
+    }, {
+      subtitle: scenario.name,
+      params: { scenario: scenario.name, requestType: scenario.record.kind },
     });
-    await expect(footer).toBeVisible({ timeout: 60_000 });
-    const footerLabel = (await footer.textContent())?.trim() ?? '';
-    if (footerLabel.toLowerCase() !== scenario.expectFooter.toLowerCase()) {
-      stateMismatches.push(`${scenario.name}: footer reads "${footerLabel}", expected "${scenario.expectFooter}"`);
-    }
-
-    // Capture the paired signer disclosure at the top of the approval before opening lower
-    // transaction details, whose focus movement scrolls the real popup viewport downward.
-    const signerToggle = approval.getByText(/^Signing addresses \(\d+\)$/);
-    if (await signerToggle.count()) {
-      await signerToggle.first().click();
-      await approval.locator('.overflow-y-auto').first().evaluate((element) => {
-        element.scrollTop = 0;
-      });
-      await approval.screenshot({
-        path: path.join(OUT_DIR, `${scenario.name}-signers.png`),
-        fullPage: true,
-      });
-    }
-
-    // Open the lower-level transaction surfaces for the companion detail capture.
-    for (const title of [/^Transaction Details$/, /^Linked Transaction Details$/]) {
-      const toggle = approval.getByText(title);
-      if (await toggle.count()) await toggle.first().click();
-    }
-
-    const body = approval.locator('body');
-    for (const expectedText of scenario.expectedText ?? []) {
-      await expect(body).toContainText(expectedText);
-    }
-    for (const absentText of scenario.absentText ?? []) {
-      await expect(body).not.toContainText(absentText);
-    }
-    await approval.screenshot({ path: path.join(OUT_DIR, `${scenario.name}.png`), fullPage: true });
-
-    const review = approval.getByRole('button', { name: /^review$/i });
-    if (await review.count()) {
-      await review.click();
-      await expect(approval.getByRole('button', { name: 'Back' })).toBeVisible({ timeout: 10_000 });
-      await approval.screenshot({
-        path: path.join(OUT_DIR, `${scenario.name}-attention.png`),
-        fullPage: true,
-      });
-      await approval.getByRole('button', { name: 'Back' }).click();
-    }
-
-    captured.push(scenario.name);
-    await approval.close();
   }
 
   expect(stateMismatches, 'scenarios did not reach their expected approval states').toEqual([]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,6 @@
         "@types/chrome": "0.2.8",
         "@types/react": "19.2.18",
         "@types/react-dom": "19.2.7",
-        "@vitest/coverage-v8": "5.0.0",
         "@wxt-dev/module-react": "1.2.2",
         "fast-check": "4.9.0",
         "happy-dom": "20.14.0",
@@ -473,6 +472,7 @@
       "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=18"
       }
@@ -4294,42 +4294,13 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/@vitest/coverage-v8": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-5.0.0.tgz",
-      "integrity": "sha512-toMg6PZGCIa/lQNCDoASrfb1ly4hsUKXFtFYC9kD4t78o5Y6LyNJU7AENt8eHPr3quYdxaxK7hj2mnbFfUk9NA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/istanbul-lib-coverage": "^1.0.0",
-        "@vitest/istanbul-lib-report": "^1.0.0",
-        "ast-v8-to-istanbul": "^1.0.5",
-        "magicast": "^0.5.4",
-        "obug": "^2.1.4",
-        "std-env": "^4.2.0",
-        "tinyrainbow": "^3.1.1"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@vitest/browser": "5.0.0",
-        "vitest": "5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@vitest/browser": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@vitest/istanbul-lib-coverage": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@vitest/istanbul-lib-coverage/-/istanbul-lib-coverage-1.0.1.tgz",
       "integrity": "sha512-k3DJZ8LhMBK9NS4SclF1ASD3OgXEWDorbIcPTRDK0/Zae6fRvu+fJRxtFdLfHsa9Y24beCdPnoNZ4LviTNstfA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=22"
       }
@@ -4340,6 +4311,7 @@
       "integrity": "sha512-1EOLRfsTMnyAr3+kEAsP4o9dhaDlGPpD7H5iLBBeq//YpNB1VIahkPhB+eRp9N2Dkfw8oySROjE3yf9XDeaIkQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@vitest/istanbul-lib-coverage": "1.0.1"
       },
@@ -4619,6 +4591,7 @@
       "integrity": "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.31",
         "estree-walker": "^3.0.3",
@@ -4630,7 +4603,8 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
       "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/async-mutex": {
       "version": "0.5.0",
@@ -8354,6 +8328,7 @@
       "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=14.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "@types/chrome": "0.2.8",
     "@types/react": "19.2.18",
     "@types/react-dom": "19.2.7",
-    "@vitest/coverage-v8": "5.0.0",
     "@wxt-dev/module-react": "1.2.2",
     "fast-check": "4.9.0",
     "happy-dom": "20.14.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -38,6 +38,10 @@ export default defineConfig({
     viewport: { width: 350, height: 600 },
     video: 'retain-on-failure',
     screenshot: 'only-on-failure',
+    trace: {
+      mode: 'retain-on-failure',
+      snapshots: { dom: true, aria: true, screen: true },
+    },
     
     // Longer timeouts in CI (can be slower)
     actionTimeout: isCI ? 15000 : 10000,

--- a/src/core/bitcoin/__tests__/psbt.test.ts
+++ b/src/core/bitcoin/__tests__/psbt.test.ts
@@ -102,6 +102,53 @@ describe('normalizePsbtToHex', () => {
   });
 });
 
+describe('untrusted PSBT policy', () => {
+  it('rejects Taproot metadata that does not commit to the previous output', () => {
+    const privateKey = hexToBytes(TEST_PRIVATE_KEY);
+    const internalKey = getPublicKey(privateKey, true).slice(1, 33);
+    const unrelatedKey = getPublicKey(hexToBytes('11'.repeat(32)), true).slice(1, 33);
+    const payment = p2tr(internalKey);
+
+    // disableScriptCheck is used only to manufacture the malformed PSBT. The wallet parser must
+    // reject the unrelated internal key before approval or signing.
+    const malformed = new Transaction({ disableScriptCheck: true });
+    malformed.addInput({
+      txid: hexToBytes('22'.repeat(32)),
+      index: 0,
+      witnessUtxo: { script: payment.script, amount: 100_000n },
+      tapInternalKey: unrelatedKey,
+    });
+    malformed.addOutputAddress(payment.address!, 90_000n);
+
+    expect(() => parsePSBT(bytesToHex(malformed.toPSBT())))
+      .toThrow('Taproot commitment does not match previous output');
+  });
+
+  it('round-trips PSBTv2 locktime and transaction-modifiable metadata', () => {
+    const internalKey = getPublicKey(hexToBytes(TEST_PRIVATE_KEY), true).slice(1, 33);
+    const payment = p2tr(internalKey);
+    const original = new Transaction({ PSBTVersion: 2, version: 2, lockTime: 840_000 });
+    original.addInput({
+      txid: hexToBytes('33'.repeat(32)),
+      index: 1,
+      sequence: 0xfffffffe,
+      witnessUtxo: { script: payment.script, amount: 100_000n },
+    });
+    original.addOutputAddress(payment.address!, 90_000n);
+    const encoded = original.toPSBT(2);
+
+    const parsed = parsePSBT(bytesToHex(encoded));
+
+    expect(parsed.opts.PSBTVersion).toBe(2);
+    expect(parsed.version).toBe(2);
+    expect(parsed.lockTime).toBe(840_000);
+    expect(parsed.toPSBT(2)).toEqual(encoded);
+    // A newly emitted PSBTv2 declares both inputs and outputs modifiable. If that field is lost,
+    // another standards-compliant implementation must treat the transaction as immutable.
+    expect(() => parsed.addOutputAddress(payment.address!, 1n)).not.toThrow();
+  });
+});
+
 /**
  * Create a simple test PSBT with one input and two outputs
  */

--- a/src/core/bitcoin/messageVerifier/secp-recovery.ts
+++ b/src/core/bitcoin/messageVerifier/secp-recovery.ts
@@ -38,18 +38,17 @@ export function recoverPublicKeyFromSignature(
     recoveredSig[0] = recoveryId;  // Raw recovery ID (0-3)
     recoveredSig.set(raw, 1);
 
-    // Use noble's recoverPublicKey with correct parameter order and options
-    const publicKeyBytes = secp256k1.recoverPublicKey(
+    // Ask noble for the exact SEC encoding carried by the BIP-137 header. Compressed and
+    // uncompressed encodings hash to different P2PKH addresses, so this is semantic rather than
+    // cosmetic.
+    return secp256k1.recoverPublicKey(
       recoveredSig,           // signature (65 bytes)
       messageHash,            // message hash (32 bytes)
-      { prehash: false }      // don't hash again - we already hashed
+      {
+        prehash: false,       // don't hash again - we already hashed
+        isCompressed: compressed,
+      }
     );
-
-    // Noble returns a compressed key. Re-encode through the curve point so that
-    // asking for an uncompressed key actually yields all 65 bytes: the two
-    // encodings hash to different addresses, and BIP-137 flags 27-30 mean
-    // uncompressed. Truncating a 65-byte key to 33 does NOT compress it.
-    return secp256k1.Point.fromBytes(publicKeyBytes).toBytes(compressed);
   } catch (_error) {
     return null;
   }

--- a/src/core/bitcoin/psbt.ts
+++ b/src/core/bitcoin/psbt.ts
@@ -253,7 +253,10 @@ export function parsePSBT(psbt: string): Transaction {
       allowUnknownInputs: true,
       allowUnknownOutputs: true,
       allowLegacyWitnessUtxo: true,
-      disableScriptCheck: true,
+      // A website controls these bytes. Keep redeem/witness wrapper and Taproot commitment
+      // validation enabled, and do not return opaque fingerprinting/exfiltration fields.
+      unknown: 'strip',
+      proprietary: 'strip',
     });
   } catch (err) {
     throw new ValidationError(
@@ -499,7 +502,8 @@ export function signPSBT(
     // Require the full prev tx for legacy inputs: a bare witnessUtxo lets a
     // dApp declare a false amount and drain the real UTXO to fees.
     allowLegacyWitnessUtxo: false,
-    disableScriptCheck: true,
+    unknown: 'strip',
+    proprietary: 'strip',
   });
 
   const privateKeyBytes = hexToBytes(privateKeyHex);
@@ -659,7 +663,8 @@ export function finalizePSBT(psbt: string): string {
     allowUnknownInputs: true,
     allowUnknownOutputs: true,
     allowLegacyWitnessUtxo: true,
-    disableScriptCheck: true,
+    unknown: 'strip',
+    proprietary: 'strip',
   });
 
   tx.finalize();
@@ -691,7 +696,8 @@ export function completePsbtWithInputValues(
     allowUnknownInputs: true,
     allowUnknownOutputs: true,
     allowLegacyWitnessUtxo: true,
-    disableScriptCheck: true,
+    unknown: 'strip',
+    proprietary: 'strip',
   });
 
   // Validate arrays match input count

--- a/src/platform/__tests__/walletManager.test.ts
+++ b/src/platform/__tests__/walletManager.test.ts
@@ -138,8 +138,8 @@ describe('WalletManager', () => {
       expect(walletManager.getActiveWallet()).toBeUndefined();
     });
 
-    it('should update last active time', () => {
-      walletManager.setLastActiveTime();
+    it('should update last active time', async () => {
+      await walletManager.setLastActiveTime();
       expect(mocks.sessionManager.setLastActiveTime).toHaveBeenCalledOnce();
     });
   });

--- a/src/services/__tests__/approvalService.test.ts
+++ b/src/services/__tests__/approvalService.test.ts
@@ -194,7 +194,7 @@ describe('ApprovalService', () => {
       await whenPending(approvalService);
 
       // Resolve the approval
-      approvalService.resolveApproval('test-approve', { approved: true });
+      await approvalService.resolveApproval('test-approve', { approved: true });
 
       const result = await approvalPromise;
       expect(result).toEqual({ approved: true });
@@ -361,7 +361,7 @@ describe('ApprovalService', () => {
       expect(approvalService.hasPendingApproval()).toBe(true);
 
       // Resolve to clear
-      approvalService.resolveApproval('badge-test', { approved: true });
+      await approvalService.resolveApproval('badge-test', { approved: true });
 
       // Should be cleared
       expect(approvalService.hasPendingApproval()).toBe(false);

--- a/src/services/core/MessageBus.ts
+++ b/src/services/core/MessageBus.ts
@@ -173,7 +173,8 @@ export class MessageBus {
         }
       };
 
-      checkReady();
+      // checkReady resolves this outer promise and handles retry failures itself.
+      void checkReady();
     });
   }
   

--- a/src/services/popupMonitorService.ts
+++ b/src/services/popupMonitorService.ts
@@ -83,7 +83,7 @@ class PopupMonitorService {
   /**
    * Handle popup closed event
    */
-  private async handlePopupClosed(reason: string): Promise<void> {
+  private handlePopupClosed(reason: string): void {
     console.log(`[PopupMonitor] Popup closed: ${reason}`);
 
     // Check for any active requests
@@ -92,7 +92,9 @@ class PopupMonitorService {
 
       // Give a short grace period (user might reopen quickly)
       setTimeout(() => {
-        this.cancelAbandonedRequests();
+        void this.cancelAbandonedRequests().catch((error) => {
+          console.error('[PopupMonitor] Failed to cancel abandoned requests:', error);
+        });
       }, 5000); // 5 second grace period
     }
   }

--- a/src/services/updateService.ts
+++ b/src/services/updateService.ts
@@ -42,7 +42,9 @@ class UpdateService {
     if (chrome.runtime.onUpdateAvailable) {
       chrome.runtime.onUpdateAvailable.addListener((details) => {
         console.log('[UpdateService] Update available:', details.version);
-        this.handleUpdateAvailable(details.version);
+        void this.handleUpdateAvailable(details.version).catch((error) => {
+          console.error('[UpdateService] Failed to handle available update:', error);
+        });
       });
     }
 
@@ -126,7 +128,9 @@ class UpdateService {
     // Store bound handler reference so we can remove it in destroy()
     this.boundAlarmHandler = (alarm) => {
       if (alarm.name === this.ALARM_NAME) {
-        this.performPeriodicCheck();
+        void this.performPeriodicCheck().catch((error) => {
+          console.error('[UpdateService] Periodic update check failed:', error);
+        });
       }
     };
     chrome.alarms.onAlarm.addListener(this.boundAlarmHandler);


### PR DESCRIPTION
## Summary
- use the upgraded noble secp256k1 recovery API to preserve the BIP-137 compressed/uncompressed key encoding
- keep PSBT script checks enabled, strip untrusted opaque PSBT fields, and cover malformed Taproot commitments plus PSBTv2 round-tripping
- retain richer Playwright traces and structured gallery steps on failure
- enable targeted Biome promise/input/loop safety checks and make background promise handling explicit
- remove the unused Vitest coverage dependency

## Verification
- npm run check:lockfile
- npm run compile
- npm run lint
- npx vitest run src (4,965 passed, 62 skipped)
- npm run build
- npx playwright test e2e/tests/approval-gallery.spec.ts e2e/tests/marketplace-gallery.spec.ts --list
- git diff --check