### PR TITLE
Align Counterparty signing with btc-signer safeguards

### DIFF
--- a/.github/workflows/trezor-emulator-tests.yml
+++ b/.github/workflows/trezor-emulator-tests.yml
@@ -76,7 +76,9 @@ jobs:
         timeout-minutes: 2
         run: |
           echo "Installing ws for WebSocket communication..."
-          npm install ws@8.21.0
+          # Keep this direct helper install aligned with the pinned security override in
+          # package.json; npm rejects a different direct version with EOVERRIDE.
+          npm install --no-save ws@8.21.3
           echo "Starting emulator and bridge via WebSocket API..."
           node e2e/hardware/init-trezor-emulator.js
 

--- a/e2e/pages/keychain/setup/import-private-key.spec.ts
+++ b/e2e/pages/keychain/setup/import-private-key.spec.ts
@@ -191,7 +191,7 @@ walletTest.describe('Import Private Key Page - With Existing Wallet (/keychain/s
     await navigateToImportPrivateKey(page);
 
     // Click dropdown to open options
-    const dropdown = page.locator('[role="listbox"] button, button:has-text("Legacy")').first();
+    const dropdown = page.getByRole('button', { name: /Native SegWit/ }).first();
     await expect(dropdown).toBeVisible({ timeout: 5000 });
     await dropdown.click();
 
@@ -204,16 +204,16 @@ walletTest.describe('Import Private Key Page - With Existing Wallet (/keychain/s
   walletTest('selecting address type updates displayed selection', async ({ page }) => {
     await navigateToImportPrivateKey(page);
 
-    // Default is Legacy
-    const dropdown = page.locator('[role="listbox"] button, button:has-text("Legacy")').first();
+    // New imports share the wallet-wide Native SegWit default.
+    const dropdown = page.getByRole('button', { name: /Native SegWit/ }).first();
     await expect(dropdown).toBeVisible({ timeout: 5000 });
     await dropdown.click();
 
-    // Select Native SegWit
-    await page.locator('[role="option"]:has-text("Native SegWit")').click();
+    // Select Legacy
+    await page.getByRole('option', { name: /Legacy/ }).click();
 
-    // Dropdown button should now show Native SegWit
-    await expect(page.locator('button:has-text("Native SegWit")')).toBeVisible({ timeout: 3000 });
+    // Dropdown button should now show Legacy
+    await expect(page.getByRole('button', { name: /Legacy/ })).toBeVisible({ timeout: 3000 });
   });
 
   walletTest('YouTube tutorial button visible before confirmation', async ({ page }) => {

--- a/src/contexts/wallet-context.tsx
+++ b/src/contexts/wallet-context.tsx
@@ -45,7 +45,7 @@ import {
   useState
 } from "react";
 import { onMessage } from 'webext-bridge/popup'; // Import for popup context
-import { AddressFormat } from '@/core/bitcoin/address';
+import { type AddressFormat, DEFAULT_ADDRESS_FORMAT } from '@/core/bitcoin/address';
 import { recordSpentInputsFromRawTx } from '@/core/bitcoin/spentUtxoCache';
 import { recordOwnChangeFromRawTx } from '@/core/counterparty/pendingChange';
 import { setSourcePubkeyProvider } from '@/core/counterparty/sourcePubkey';
@@ -598,7 +598,7 @@ export function WalletProvider({ children }: { children: ReactNode }): ReactElem
           mnemonic,
           password,
           name,
-          addressFormat ?? AddressFormat.P2WPKH
+          addressFormat ?? DEFAULT_ADDRESS_FORMAT
         )
       );
       setWalletState((prev) => ({ ...prev, authState: AuthState.Unlocked }));
@@ -611,7 +611,7 @@ export function WalletProvider({ children }: { children: ReactNode }): ReactElem
           privateKey,
           password,
           name,
-          addressFormat ?? AddressFormat.P2TR
+          addressFormat ?? DEFAULT_ADDRESS_FORMAT
         )
       );
       setWalletState((prev) => ({ ...prev, authState: AuthState.Unlocked }));

--- a/src/core/bitcoin/__tests__/addressTypeDetector.test.ts
+++ b/src/core/bitcoin/__tests__/addressTypeDetector.test.ts
@@ -126,12 +126,12 @@ describe('Address Type Detector', () => {
       expect(result).toBe(AddressFormat.P2SH_P2WPKH);
     });
 
-    it('should default to P2TR (Taproot) when no activity found', async () => {
+    it('should default to Native SegWit when no activity is found', async () => {
       vi.mocked(fetchTokenBalances).mockResolvedValue([]);
       vi.mocked(hasAddressActivity).mockResolvedValue(false);
 
       const result = await detectAddressFormat(testMnemonic);
-      expect(result).toBe(AddressFormat.P2TR);
+      expect(result).toBe(AddressFormat.P2WPKH);
     });
 
     it('should detect based on Counterparty token activity', async () => {
@@ -176,25 +176,24 @@ describe('Address Type Detector', () => {
       expect(result).toBe(AddressFormat.P2WPKH);
     });
 
-    it('should handle API failures gracefully', async () => {
+    it('should distinguish a total provider outage from an empty wallet', async () => {
       vi.mocked(fetchTokenBalances).mockRejectedValue(new Error('API failed'));
       vi.mocked(hasAddressActivity).mockRejectedValue(new Error('API failed'));
 
-      const result = await detectAddressFormat(testMnemonic);
-      expect(result).toBe(AddressFormat.P2TR);
+      await expect(detectAddressFormat(testMnemonic)).rejects.toThrow(/providers are unavailable/);
     });
 
-    it('should skip Taproot checking since it is the fallback', async () => {
+    it('should detect Taproot activity explicitly', async () => {
       vi.mocked(fetchTokenBalances).mockResolvedValue([]);
-      vi.mocked(hasAddressActivity).mockResolvedValue(false);
+      vi.mocked(hasAddressActivity)
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(true);
 
       const result = await detectAddressFormat(testMnemonic);
-
-      // Should default to Taproot when no activity is found
       expect(result).toBe(AddressFormat.P2TR);
-
-      // Verify hasAddressActivity was called for the non-Taproot formats
-      expect(hasAddressActivity).toHaveBeenCalledTimes(5);
+      expect(hasAddressActivity).toHaveBeenCalledTimes(4);
     });
   });
 
@@ -232,7 +231,7 @@ describe('Address Type Detector', () => {
       expect(hasAddressActivity).toHaveBeenCalledWith('preview-p2wpkh');
     });
 
-    it('should default to P2TR when no activity found', async () => {
+    it('should default to Native SegWit when no activity is found', async () => {
       const previews = {
         [AddressFormat.P2PKH]: 'preview-p2pkh',
         [AddressFormat.P2WPKH]: 'preview-p2wpkh',
@@ -242,7 +241,7 @@ describe('Address Type Detector', () => {
       vi.mocked(hasAddressActivity).mockResolvedValue(false);
 
       const result = await detectAddressFormatFromPreviews(previews);
-      expect(result).toBe(AddressFormat.P2TR);
+      expect(result).toBe(AddressFormat.P2WPKH);
     });
   });
 

--- a/src/core/bitcoin/__tests__/psbt.test.ts
+++ b/src/core/bitcoin/__tests__/psbt.test.ts
@@ -12,6 +12,7 @@ import {
   completePsbtWithInputValues,
   extractPsbtDetails,
   finalizePSBT,
+  MAX_PSBT_BYTES,
   normalizePsbtToHex,
   parsePSBT,
   resolvePsbtSighashType,
@@ -34,6 +35,10 @@ const _REAL_HEX_PSBT = '70736274ff01008b020000000177a7cdb03fc6edd50d1958b87f1bba
   '8ee663788aecaf762200000000000000';
 
 describe('normalizePsbtToHex', () => {
+  it('rejects oversized PSBTs before decoding', () => {
+    expect(() => normalizePsbtToHex(`70736274${'00'.repeat(MAX_PSBT_BYTES)}`))
+      .toThrow(/parsing limit/);
+  });
   it('should pass through valid hex PSBT unchanged', () => {
     const hexPsbt = createTestPsbt();
     const normalized = normalizePsbtToHex(hexPsbt);

--- a/src/core/bitcoin/__tests__/psbtPrevouts.test.ts
+++ b/src/core/bitcoin/__tests__/psbtPrevouts.test.ts
@@ -1,0 +1,115 @@
+import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
+import { getPublicKey } from '@noble/secp256k1';
+import { p2wpkh, Transaction } from '@scure/btc-signer';
+import { describe, expect, it, vi } from 'vitest';
+import { verifyPsbtPrevouts } from '@/core/bitcoin/psbtPrevouts';
+
+const PUBLIC_KEY = getPublicKey(hexToBytes('01'.padStart(64, '0')), true);
+const SCRIPT = p2wpkh(PUBLIC_KEY).script;
+
+function fixture(witnessAmount = 25_000n) {
+  const parent = new Transaction();
+  parent.addInput({ txid: hexToBytes('ab'.repeat(32)), index: 0 });
+  parent.addOutput({ script: SCRIPT, amount: 25_000n });
+
+  const spending = new Transaction();
+  spending.addInput({
+    txid: hexToBytes(parent.id),
+    index: 0,
+    witnessUtxo: { script: SCRIPT, amount: witnessAmount },
+  });
+  spending.addOutput({ script: SCRIPT, amount: 24_000n });
+
+  return {
+    parent,
+    parentHex: bytesToHex(parent.toBytes(true, true)),
+    psbtHex: bytesToHex(spending.toPSBT()),
+  };
+}
+
+describe('verifyPsbtPrevouts', () => {
+  it('resolves every outpoint from its raw parent transaction', async () => {
+    const { parent, parentHex, psbtHex } = fixture();
+    const fetchRawTransaction = vi.fn(async () => parentHex);
+
+    const verified = await verifyPsbtPrevouts(psbtHex, { fetchRawTransaction });
+
+    expect(fetchRawTransaction).toHaveBeenCalledWith(parent.id);
+    expect(verified.prevouts).toHaveLength(1);
+    expect(verified.prevouts[0]).toMatchObject({
+      txid: parent.id,
+      vout: 0,
+      amount: 25_000n,
+    });
+    expect(bytesToHex(verified.prevouts[0]!.script)).toBe(bytesToHex(SCRIPT));
+  });
+
+  it('rejects a forged witness amount', async () => {
+    const { parentHex, psbtHex } = fixture(99_000n);
+    await expect(verifyPsbtPrevouts(psbtHex, {
+      fetchRawTransaction: async () => parentHex,
+    })).rejects.toThrow(/does not match its real previous output/);
+  });
+
+  it('rejects raw transaction bytes for a different txid', async () => {
+    const { psbtHex } = fixture();
+    const other = fixture();
+    other.parent.addOutput({ script: SCRIPT, amount: 1n });
+    await expect(verifyPsbtPrevouts(psbtHex, {
+      fetchRawTransaction: async () => bytesToHex(other.parent.toBytes(true, true)),
+    })).rejects.toThrow(/does not match PSBT input/);
+  });
+
+  it('accepts an explicitly supplied unbroadcast package parent', async () => {
+    const { parent, parentHex, psbtHex } = fixture();
+    const fetchRawTransaction = vi.fn(async () => null);
+    const verified = await verifyPsbtPrevouts(psbtHex, {
+      packageTransactions: new Map([[parent.id, parentHex]]),
+      fetchRawTransaction,
+    });
+
+    expect(verified.prevouts[0]!.txid).toBe(parent.id);
+    expect(fetchRawTransaction).not.toHaveBeenCalled();
+  });
+
+  it('uses a txid-bound non-witness parent without a network lookup', async () => {
+    const { parent } = fixture();
+    const spending = new Transaction();
+    spending.addInput({
+      txid: hexToBytes(parent.id),
+      index: 0,
+      nonWitnessUtxo: parent.toBytes(true, true),
+    });
+    spending.addOutput({ script: SCRIPT, amount: 24_000n });
+    const fetchRawTransaction = vi.fn(async () => null);
+
+    const verified = await verifyPsbtPrevouts(bytesToHex(spending.toPSBT()), {
+      fetchRawTransaction,
+    });
+
+    expect(verified.prevouts[0]!.amount).toBe(25_000n);
+    expect(fetchRawTransaction).not.toHaveBeenCalled();
+  });
+
+  it('can verify only the inputs requested for a partial marketplace signature', async () => {
+    const { parent, parentHex } = fixture();
+    const spending = new Transaction();
+    spending.addInput({
+      txid: hexToBytes('00'.repeat(32)),
+      index: 0,
+      witnessUtxo: { script: SCRIPT, amount: 1n },
+    });
+    spending.addInput({
+      txid: hexToBytes(parent.id),
+      index: 0,
+      witnessUtxo: { script: SCRIPT, amount: 25_000n },
+    });
+    spending.addOutput({ script: SCRIPT, amount: 24_000n });
+
+    const verified = await verifyPsbtPrevouts(bytesToHex(spending.toPSBT()), {
+      inputIndices: [1],
+      fetchRawTransaction: async (txid) => txid === parent.id ? parentHex : null,
+    });
+    expect(verified.prevouts.map(({ index }) => index)).toEqual([1]);
+  });
+});

--- a/src/core/bitcoin/__tests__/publicKeyIdentity.test.ts
+++ b/src/core/bitcoin/__tests__/publicKeyIdentity.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import {
+  parseSecPublicKey,
+  publicKeyMatchesAddress,
+  publicKeyPointId,
+} from '@/core/bitcoin/publicKeyIdentity';
+
+const COMPRESSED = '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798';
+const UNCOMPRESSED =
+  '0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798' +
+  '483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8';
+
+describe('SEC public-key identity', () => {
+  it('treats compressed and uncompressed serialization as the same signing point', () => {
+    expect(publicKeyPointId(COMPRESSED)).toBe(publicKeyPointId(UNCOMPRESSED));
+  });
+
+  it('keeps exact serialization significant when binding a P2PKH address', () => {
+    expect(publicKeyMatchesAddress(COMPRESSED, '1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH')).toBe(true);
+    expect(publicKeyMatchesAddress(UNCOMPRESSED, '1EHNa6Q4Jz2uvNExL497mE43ikXhwF6kZm')).toBe(true);
+    expect(publicKeyMatchesAddress(COMPRESSED, '1EHNa6Q4Jz2uvNExL497mE43ikXhwF6kZm')).toBe(false);
+    expect(publicKeyMatchesAddress(UNCOMPRESSED, '1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH')).toBe(false);
+  });
+
+  it('validates that SEC-shaped bytes are actually on secp256k1', () => {
+    expect(parseSecPublicKey(`02${'00'.repeat(32)}`)).toBeNull();
+    expect(parseSecPublicKey('not-a-key')).toBeNull();
+  });
+});

--- a/src/core/bitcoin/__tests__/rawTransaction.test.ts
+++ b/src/core/bitcoin/__tests__/rawTransaction.test.ts
@@ -1,0 +1,26 @@
+import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
+import { Transaction } from '@scure/btc-signer';
+import { describe, expect, it } from 'vitest';
+import {
+  decodeRawTransaction,
+  MAX_RAW_TRANSACTION_BYTES,
+  parseTransactionForSigning,
+} from '@/core/bitcoin/rawTransaction';
+
+describe('bounded raw transaction parsing', () => {
+  it('rejects oversized hex before decoder allocation', () => {
+    expect(() => decodeRawTransaction('00'.repeat(MAX_RAW_TRANSACTION_BYTES + 1)))
+      .toThrow(/no larger than/);
+  });
+
+  it('rejects signing transactions with excessive output fan-out', () => {
+    const transaction = new Transaction({ allowUnknownOutputs: true });
+    transaction.addInput({ txid: hexToBytes('ab'.repeat(32)), index: 0 });
+    for (let index = 0; index < 1_001; index++) {
+      transaction.addOutput({ script: new Uint8Array([0x6a]), amount: 0n });
+    }
+
+    expect(() => parseTransactionForSigning(bytesToHex(transaction.toBytes(true, true))))
+      .toThrow(/too many outputs/);
+  });
+});

--- a/src/core/bitcoin/__tests__/transactionSigner.test.ts
+++ b/src/core/bitcoin/__tests__/transactionSigner.test.ts
@@ -21,7 +21,7 @@ const mockGetTrustedBroadcastPrevout = vi.fn();
 
 // Import necessary functions for test setup
 import { getPublicKey } from '@noble/secp256k1';
-import { p2tr, Transaction } from '@scure/btc-signer';
+import { p2sh, p2tr, p2wpkh, Transaction } from '@scure/btc-signer';
 import { hash160 } from '@scure/btc-signer/utils.js';
 
 describe('Transaction Signer Utilities', () => {
@@ -320,12 +320,17 @@ describe('Transaction Signer Utilities', () => {
 
     it('should successfully sign P2SH_P2WPKH transaction', async () => {
       const p2shWallet = { ...mockWallet, addressFormat: AddressFormat.P2SH_P2WPKH };
-      
-      mockFetchUTXOs.mockResolvedValue([mockUtxo]);
-      mockGetUtxoByTxid.mockReturnValue(mockUtxo);
-      mockFetchPreviousRawTransaction.mockResolvedValue(mockPreviousTransaction);
+      const nestedScript = bytesToHex(p2sh(p2wpkh(publicKey)).script);
 
-      const result = await signTransaction(mockRawTransaction, p2shWallet, mockTargetAddress, mockPrivateKey);
+      const result = await signTransaction(
+        mockRawTransaction,
+        p2shWallet,
+        mockTargetAddress,
+        mockPrivateKey,
+        true,
+        [100000],
+        [nestedScript],
+      );
 
       expect(typeof result).toBe('string');
       expect(result.length).toBeGreaterThan(0);
@@ -567,7 +572,17 @@ describe('Transaction Signer Utilities', () => {
         mockGetUtxoByTxid.mockReturnValue(mockUtxo);
         mockFetchPreviousRawTransaction.mockResolvedValue(mockPreviousTransaction);
 
-        const result = await signTransaction(mockRawTransaction, wallet, mockTargetAddress, mockPrivateKey);
+        const result = addressFormat === AddressFormat.P2SH_P2WPKH
+          ? await signTransaction(
+              mockRawTransaction,
+              wallet,
+              mockTargetAddress,
+              mockPrivateKey,
+              true,
+              [100000],
+              [bytesToHex(p2sh(p2wpkh(publicKey)).script)],
+            )
+          : await signTransaction(mockRawTransaction, wallet, mockTargetAddress, mockPrivateKey);
         expect(typeof result).toBe('string');
         expect(result).toMatch(/^[0-9a-f]+$/i); // Valid hex string
 

--- a/src/core/bitcoin/address.ts
+++ b/src/core/bitcoin/address.ts
@@ -38,6 +38,9 @@ export const AddressFormat = {
  */
 export type AddressFormat = typeof AddressFormat[keyof typeof AddressFormat];
 
+/** One product default shared by every new-wallet and ambiguous-import entry point. */
+export const DEFAULT_ADDRESS_FORMAT: AddressFormat = AddressFormat.P2WPKH;
+
 /** Normalize only Bech32/Bech32m addresses; Base58 addresses remain case-sensitive. */
 export function normalizeAddressForComparison(address: string): string {
   const lower = address.toLowerCase();
@@ -373,28 +376,22 @@ export async function probeAddressActivity(
 }
 
 /**
- * Check if an address has any transaction history using existing API utilities
- * Returns true if any provider confirms transactions or token balances
- */
-async function checkAddressActivity(address: string): Promise<boolean> {
-  return (await probeAddressActivity(address)).active;
-}
-
-/**
  * Detect the most likely address format for a mnemonic by checking blockchain activity
  * @param mnemonic The mnemonic phrase to check
  * @param cachedPreviews Optional cached address previews to avoid re-derivation
- * @returns The detected address format, or P2TR as default
+ * @returns The detected address format, or the wallet-wide Native SegWit default
  */
 export async function detectAddressFormat(
   mnemonic: string,
   cachedPreviews?: Partial<Record<AddressFormat, string>>
 ): Promise<AddressFormat> {
-  // Check these formats for activity (skip Taproot since it's the fallback)
+  // Probe every supported derivation. Taproot must be checked explicitly rather than selected by
+  // accident whenever every earlier address is empty or an API is unavailable.
   const addressFormatsToCheck: AddressFormat[] = [
     AddressFormat.P2PKH,              // Legacy (most common)
     AddressFormat.P2WPKH,             // Native SegWit (bc1)
     AddressFormat.P2SH_P2WPKH,        // Nested SegWit (3)
+    AddressFormat.P2TR,               // Taproot (bc1p)
     AddressFormat.Counterwallet,      // Counterwallet P2PKH
     AddressFormat.CounterwalletSegwit,// Counterwallet SegWit
     AddressFormat.FreewalletBIP39,    // FreeWallet BIP39 P2PKH
@@ -420,11 +417,14 @@ export async function detectAddressFormat(
     }
   }
 
-  // Check each address for activity in order of priority
+  // Check each address for activity in order of priority. Keep provider availability separate
+  // from an authoritative "empty" response so callers can surface an outage if they choose.
+  let anyProviderReachable = false;
   for (const [format, address] of formatAddressMap.entries()) {
     try {
-      const hasActivity = await checkAddressActivity(address);
-      if (hasActivity) {
+      const result = await probeAddressActivity(address);
+      anyProviderReachable ||= result.reachable;
+      if (result.active) {
         console.log(`Detected address format: ${format}`);
         return format;
       }
@@ -433,9 +433,12 @@ export async function detectAddressFormat(
     }
   }
 
-  // Default to P2TR (Taproot) for best efficiency
-  console.log('No activity detected or API failed, defaulting to P2TR');
-  return AddressFormat.P2TR;
+  if (formatAddressMap.size > 0 && !anyProviderReachable) {
+    throw new Error('Could not detect address format because activity providers are unavailable');
+  }
+
+  console.log('No address activity detected, defaulting to Native SegWit');
+  return DEFAULT_ADDRESS_FORMAT;
 }
 
 /**
@@ -478,11 +481,12 @@ export function getPreviewAddresses(mnemonic: string): Partial<Record<AddressFor
 export async function detectAddressFormatFromPreviews(
   previews: Partial<Record<AddressFormat, string>>
 ): Promise<AddressFormat> {
-  // Check these formats for activity (skip Taproot since it's the fallback)
+  // Check every format represented by the previews, including Taproot.
   const addressFormatsToCheck: AddressFormat[] = [
     AddressFormat.P2PKH,              // Legacy (most common)
     AddressFormat.P2WPKH,             // Native SegWit (bc1)
     AddressFormat.P2SH_P2WPKH,        // Nested SegWit (3)
+    AddressFormat.P2TR,               // Taproot (bc1p)
     AddressFormat.Counterwallet,      // Counterwallet P2PKH
     AddressFormat.CounterwalletSegwit,// Counterwallet SegWit
     AddressFormat.FreewalletBIP39,    // FreeWallet BIP39 P2PKH
@@ -490,13 +494,17 @@ export async function detectAddressFormatFromPreviews(
   ];
 
   // Check each preview address for activity
+  let anyProviderReachable = false;
+  let previewCount = 0;
   for (const format of addressFormatsToCheck) {
     const address = previews[format];
     if (!address) continue;
+    previewCount++;
 
     try {
-      const hasActivity = await checkAddressActivity(address);
-      if (hasActivity) {
+      const result = await probeAddressActivity(address);
+      anyProviderReachable ||= result.reachable;
+      if (result.active) {
         console.log(`Detected format ${format} from cached preview`);
         return format;
       }
@@ -505,6 +513,9 @@ export async function detectAddressFormatFromPreviews(
     }
   }
 
-  // Default to P2TR (Taproot) for best efficiency
-  return AddressFormat.P2TR;
+  if (previewCount > 0 && !anyProviderReachable) {
+    throw new Error('Could not detect address format because activity providers are unavailable');
+  }
+
+  return DEFAULT_ADDRESS_FORMAT;
 }

--- a/src/core/bitcoin/consolidateBatch.ts
+++ b/src/core/bitcoin/consolidateBatch.ts
@@ -8,6 +8,7 @@ import { getPublicKey } from '@noble/secp256k1';
 import { Transaction } from '@scure/btc-signer';
 import type { ConsolidationData, ConsolidationUTXO } from '@/core/bitcoin/consolidationApi';
 import { assertSignableBareMultisig, signAndFinalizeBareMultisig } from '@/core/bitcoin/multisigSigner';
+import { parseConsensusTransaction } from '@/core/bitcoin/rawTransaction';
 import { multiply, roundUp, toSafeInteger } from '@/core/numeric';
 
 // RBF-enabled sequence number
@@ -21,12 +22,6 @@ const DUST_LIMIT_SATS = 546n;
 const BYTES_PER_INPUT = 115;
 const BASE_OVERHEAD = 10;
 const BYTES_PER_OUTPUT = 34;
-
-const PREV_TX_PARSE_OPTS = {
-  allowUnknownInputs: true,
-  allowUnknownOutputs: true,
-  disableScriptCheck: true,
-} as const;
 
 export interface ConsolidationResult {
   signedTxHex: string;
@@ -61,7 +56,7 @@ function verifyUtxoAgainstPrevTx(
     // Equally binding: if the parser's re-serialization hashes to the claimed txid, collision
     // resistance says the parser's view of the outputs IS that transaction's — which is the only
     // thing the amount and script checks below rely on.
-    const parsed = Transaction.fromRaw(hexToBytes(utxo.prev_tx_hex), PREV_TX_PARSE_OPTS);
+    const parsed = parseConsensusTransaction(utxo.prev_tx_hex);
     if (parsed.id !== utxo.txid.toLowerCase()) {
       throw new Error(
         `Previous transaction data does not match its txid for UTXO ${utxo.txid}:${utxo.vout}`
@@ -118,7 +113,7 @@ export async function consolidateBareMultisigBatch(
   try {
     const ourPubkeys = [getPublicKey(privateKeyBytes, true), getPublicKey(privateKeyBytes, false)];
 
-    const tx = new Transaction();
+    const tx = new Transaction({ lowR: true });
     const scripts: Uint8Array[] = [];
     const prevTxCache = new Map<string, Transaction>();
     let totalInputSats = 0n;

--- a/src/core/bitcoin/feeVerification.ts
+++ b/src/core/bitcoin/feeVerification.ts
@@ -17,8 +17,9 @@
  * reasoned about. See ADR-019.
  */
 
-import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
-import { Transaction } from '@scure/btc-signer';
+import { bytesToHex } from '@noble/hashes/utils.js';
+import type { Transaction } from '@scure/btc-signer';
+import { decodeRawTransaction, parseTransactionForSigning } from '@/core/bitcoin/rawTransaction';
 import { divide, maximum, multiply, roundDown, roundUp, toFiniteNumber, toSafeInteger } from "@/core/numeric";
 
 /**
@@ -159,13 +160,8 @@ export async function checkTransactionFee(
   let tx: Transaction;
   let rawBytes: Uint8Array;
   try {
-    rawBytes = hexToBytes(rawTransaction);
-    tx = Transaction.fromRaw(rawBytes, {
-      allowUnknownInputs: true,
-      allowUnknownOutputs: true,
-      allowLegacyWitnessUtxo: true,
-      disableScriptCheck: true,
-    });
+    rawBytes = decodeRawTransaction(rawTransaction);
+    tx = parseTransactionForSigning(rawBytes);
   } catch {
     // An unparseable transaction can't be signed either (the signer uses the
     // same parser), so it is not a drain risk — skip the fee check rather than

--- a/src/core/bitcoin/legacySighash.ts
+++ b/src/core/bitcoin/legacySighash.ts
@@ -1,0 +1,32 @@
+import type { Transaction } from '@scure/btc-signer';
+
+interface LegacySighashAccess {
+  preimageLegacy?: (
+    inputIndex: number,
+    script: Uint8Array,
+    sighash: number,
+  ) => Uint8Array;
+  opts?: { lowR?: boolean };
+}
+
+/**
+ * Narrow compatibility boundary for Counterparty legacy scripts that btc-signer deliberately
+ * cannot decode. Keep the private library access in one pinned, signature-tested adapter rather
+ * than spreading casts through each custom signer.
+ */
+export function getLegacySighash(
+  transaction: Transaction,
+  inputIndex: number,
+  script: Uint8Array,
+  sighash: number,
+): Uint8Array {
+  const access = transaction as unknown as LegacySighashAccess;
+  if (typeof access.preimageLegacy !== 'function') {
+    throw new Error('btc-signer legacy sighash routine is unavailable');
+  }
+  return access.preimageLegacy(inputIndex, script, sighash);
+}
+
+export function getLowRPreference(transaction: Transaction): boolean | undefined {
+  return (transaction as unknown as LegacySighashAccess).opts?.lowR;
+}

--- a/src/core/bitcoin/localTransactionParse.ts
+++ b/src/core/bitcoin/localTransactionParse.ts
@@ -15,9 +15,10 @@
  */
 
 import { sha256 } from '@noble/hashes/sha2.js';
-import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
-import { Transaction } from '@scure/btc-signer';
+import { bytesToHex } from '@noble/hashes/utils.js';
+import type { Transaction } from '@scure/btc-signer';
 import { decodeAddressFromScript } from '@/core/bitcoin/address';
+import { decodeRawTransaction, parseTransactionForSigning } from '@/core/bitcoin/rawTransaction';
 import { toSafeInteger } from '@/core/numeric';
 
 export interface LocalParsedInput {
@@ -83,13 +84,8 @@ export function parseRawTransactionLocally(rawTxHex: string): LocalParsedTransac
   let rawBytes: Uint8Array;
   let tx: Transaction;
   try {
-    rawBytes = hexToBytes(rawTxHex.replace(/^0x/, ''));
-    tx = Transaction.fromRaw(rawBytes, {
-      allowUnknownInputs: true,
-      allowUnknownOutputs: true,
-      allowLegacyWitnessUtxo: true,
-      disableScriptCheck: true,
-    });
+    rawBytes = decodeRawTransaction(rawTxHex);
+    tx = parseTransactionForSigning(rawBytes);
   } catch {
     return null;
   }

--- a/src/core/bitcoin/multisigSigner.ts
+++ b/src/core/bitcoin/multisigSigner.ts
@@ -15,6 +15,7 @@
 import { bytesToHex } from '@noble/hashes/utils.js';
 import { SigHash, type Transaction } from '@scure/btc-signer';
 import { signECDSA } from '@scure/btc-signer/utils.js';
+import { getLegacySighash, getLowRPreference } from '@/core/bitcoin/legacySighash';
 
 export interface ParsedBareMultisig {
   requiredSignatures: number;
@@ -109,21 +110,12 @@ export async function signAndFinalizeBareMultisig(
     throw new Error(`Input count mismatch: tx has ${tx.inputsLength}, provided ${scripts.length} scripts`);
   }
 
-  // preimageLegacy is private API: the public sign()/finalize() path refuses
-  // inputs whose multisig pubkeys are not valid curve points. The pinned
-  // dependency plus the real-signature tests in multisigSigner.test.ts guard
-  // this access across library upgrades.
-  const preimageLegacy = (tx as any).preimageLegacy;
-  if (typeof preimageLegacy !== 'function') {
-    throw new Error('preimageLegacy method not accessible');
-  }
-
   for (let i = 0; i < scripts.length; i++) {
     if (i > 0 && i % 25 === 0) {
       await new Promise((resolve) => setTimeout(resolve, 0));
     }
-    const hash = preimageLegacy.call(tx, i, scripts[i], SigHash.ALL);
-    const signature = signECDSA(hash, privateKey, (tx as any).opts?.lowR);
+    const hash = getLegacySighash(tx, i, scripts[i]!, SigHash.ALL);
+    const signature = signECDSA(hash, privateKey, getLowRPreference(tx));
 
     // scriptSig: OP_0 <sig||sighash> (OP_0 feeds CHECKMULTISIG's extra pop)
     const scriptSig = new Uint8Array(2 + signature.length + 1);

--- a/src/core/bitcoin/psbt.ts
+++ b/src/core/bitcoin/psbt.ts
@@ -13,6 +13,25 @@ import { AddressFormat, decodeAddressFromScript, encodeAddress, normalizeAddress
 import { SigningError, ValidationError } from '@/core/errors';
 import { toSafeInteger } from '@/core/numeric';
 
+export const MAX_PSBT_BYTES = 2_000_000;
+export const MAX_PSBT_INPUTS = 1_000;
+export const MAX_PSBT_OUTPUTS = 1_000;
+const MAX_PSBT_BASE64_LENGTH = Math.ceil(MAX_PSBT_BYTES / 3) * 4 + 4;
+const MAX_TAPLEAVES_PER_INPUT = 128;
+const MAX_PSBT_SCRIPT_BYTES = 10_000;
+
+function assertPsbtEncodedSize(length: number, encoding: 'hex' | 'base64'): void {
+  const tooLarge = encoding === 'hex'
+    ? length > MAX_PSBT_BYTES * 2
+    : length > MAX_PSBT_BASE64_LENGTH;
+  if (tooLarge) {
+    throw new ValidationError(
+      'INVALID_PSBT',
+      `PSBT exceeds the ${MAX_PSBT_BYTES}-byte parsing limit`,
+    );
+  }
+}
+
 /** Resolve the exact sighash the signer will use for one PSBT input. */
 export function resolvePsbtSighashType(
   explicitSighashType?: number,
@@ -110,14 +129,17 @@ export function normalizePsbtToHex(psbt: string): string {
   // Check if it's already hex (starts with PSBT magic bytes in hex)
   // PSBT magic: 0x70736274 = "psbt" in ASCII
   if (psbt.startsWith('70736274')) {
+    assertPsbtEncodedSize(psbt.length, 'hex');
     return psbt;
   }
 
   // Check if it looks like base64 (PSBT magic in base64 is "cHNidP")
   if (psbt.startsWith('cHNidP')) {
     try {
+      assertPsbtEncodedSize(psbt.length, 'base64');
       // Decode base64 to bytes, then convert to hex
       const binary = atob(psbt);
+      assertPsbtEncodedSize(binary.length * 2, 'hex');
       let hex = '';
       for (let i = 0; i < binary.length; i++) {
         hex += binary.charCodeAt(i).toString(16).padStart(2, '0');
@@ -130,6 +152,7 @@ export function normalizePsbtToHex(psbt: string): string {
 
   // Try to determine format by checking if it's valid hex with PSBT magic
   if (/^[0-9a-fA-F]*$/.test(psbt) && psbt.length % 2 === 0) {
+    assertPsbtEncodedSize(psbt.length, 'hex');
     const lowercased = psbt.toLowerCase();
     // Must start with PSBT magic bytes
     if (lowercased.startsWith('70736274')) {
@@ -140,7 +163,9 @@ export function normalizePsbtToHex(psbt: string): string {
 
   // Last resort: try base64 decode
   try {
+    assertPsbtEncodedSize(psbt.length, 'base64');
     const binary = atob(psbt);
+    assertPsbtEncodedSize(binary.length * 2, 'hex');
     let hex = '';
     for (let i = 0; i < binary.length; i++) {
       hex += binary.charCodeAt(i).toString(16).padStart(2, '0');
@@ -237,6 +262,29 @@ export interface SignPsbtParams {
   sighashTypes?: number[];
 }
 
+function assertPsbtComplexity(transaction: Transaction): void {
+  if (transaction.inputsLength > MAX_PSBT_INPUTS) {
+    throw new Error(`PSBT has too many inputs (${transaction.inputsLength}; maximum ${MAX_PSBT_INPUTS})`);
+  }
+  if (transaction.outputsLength > MAX_PSBT_OUTPUTS) {
+    throw new Error(`PSBT has too many outputs (${transaction.outputsLength}; maximum ${MAX_PSBT_OUTPUTS})`);
+  }
+  for (let index = 0; index < transaction.inputsLength; index += 1) {
+    const input = transaction.getInput(index);
+    if ((input.tapLeafScript?.length ?? 0) > MAX_TAPLEAVES_PER_INPUT) {
+      throw new Error(`PSBT input ${index} has too many Taproot leaves`);
+    }
+    const scripts = [
+      input.redeemScript,
+      input.witnessScript,
+      ...(input.tapLeafScript?.map(([, script]) => script) ?? []),
+    ];
+    if (scripts.some((script) => (script?.length ?? 0) > MAX_PSBT_SCRIPT_BYTES)) {
+      throw new Error(`PSBT input ${index} contains an oversized script`);
+    }
+  }
+}
+
 /**
  * Parse a PSBT string and return Transaction object.
  * Accepts both hex and base64 formats - normalizes internally.
@@ -249,15 +297,20 @@ export function parsePSBT(psbt: string): Transaction {
     // Normalize to hex (handles both hex and base64 input)
     const psbtHex = normalizePsbtToHex(psbt);
     const psbtBytes = hexToBytes(psbtHex);
-    return Transaction.fromPSBT(psbtBytes, {
+    const transaction = Transaction.fromPSBT(psbtBytes, {
       allowUnknownInputs: true,
       allowUnknownOutputs: true,
       allowLegacyWitnessUtxo: true,
+      // BIP370 treats an absent transaction-modifiable field as immutable. Do not inherit the
+      // library's legacy compatibility mode when a website supplies a new PSBTv2.
+      allowMissingTxModifiable: false,
       // A website controls these bytes. Keep redeem/witness wrapper and Taproot commitment
       // validation enabled, and do not return opaque fingerprinting/exfiltration fields.
       unknown: 'strip',
       proprietary: 'strip',
     });
+    assertPsbtComplexity(transaction);
+    return transaction;
   } catch (err) {
     throw new ValidationError(
       'INVALID_TRANSACTION',
@@ -504,7 +557,10 @@ export function signPSBT(
     allowLegacyWitnessUtxo: false,
     unknown: 'strip',
     proprietary: 'strip',
+    allowMissingTxModifiable: false,
+    lowR: true,
   });
+  assertPsbtComplexity(tx);
 
   const privateKeyBytes = hexToBytes(privateKeyHex);
   const pubkeyBytes = getPublicKey(privateKeyBytes, true);
@@ -665,7 +721,9 @@ export function finalizePSBT(psbt: string): string {
     allowLegacyWitnessUtxo: true,
     unknown: 'strip',
     proprietary: 'strip',
+    allowMissingTxModifiable: false,
   });
+  assertPsbtComplexity(tx);
 
   tx.finalize();
   return tx.hex;
@@ -698,7 +756,9 @@ export function completePsbtWithInputValues(
     allowLegacyWitnessUtxo: true,
     unknown: 'strip',
     proprietary: 'strip',
+    allowMissingTxModifiable: false,
   });
+  assertPsbtComplexity(tx);
 
   // Validate arrays match input count
   if (inputValues.length !== tx.inputsLength) {

--- a/src/core/bitcoin/psbtPrevouts.ts
+++ b/src/core/bitcoin/psbtPrevouts.ts
@@ -1,0 +1,137 @@
+import { bytesToHex } from '@noble/hashes/utils.js';
+import { RawTx } from '@scure/btc-signer';
+import { decodeAddressFromScript } from '@/core/bitcoin/address';
+import { normalizePsbtToHex, parsePSBT } from '@/core/bitcoin/psbt';
+import { decodeRawTransaction, parseConsensusTransaction } from '@/core/bitcoin/rawTransaction';
+import {
+  noTrustedPrevout,
+  type TrustedPrevoutResolver,
+} from '@/core/bitcoin/trustedPrevout';
+import { fetchPreviousRawTransaction } from '@/core/bitcoin/utxo';
+import { ValidationError } from '@/core/errors';
+
+export interface VerifiedPsbtPrevout {
+  index: number;
+  txid: string;
+  vout: number;
+  amount: bigint;
+  script: Uint8Array;
+  address?: string;
+  rawTransaction: Uint8Array;
+}
+
+export interface VerifiedPsbt {
+  hex: string;
+  prevouts: VerifiedPsbtPrevout[];
+}
+
+export type PreviousRawTransactionResolver = (txid: string) => Promise<string | null>;
+
+export interface VerifyPsbtPrevoutsOptions {
+  resolveTrustedPrevout?: TrustedPrevoutResolver;
+  fetchRawTransaction?: PreviousRawTransactionResolver;
+  /** Signed package parents which are intentionally not on chain yet, keyed by txid. */
+  packageTransactions?: ReadonlyMap<string, string>;
+  /** Verify only inputs this wallet is being asked to sign; useful for marketplace placeholders. */
+  inputIndices?: readonly number[];
+}
+
+const sameBytes = (left: Uint8Array, right: Uint8Array): boolean =>
+  left.length === right.length && left.every((byte, index) => byte === right[index]);
+
+/**
+ * Resolve each requested PSBT input from the transaction it actually spends, then compare any
+ * host-provided witness UTXO data. This gives signing one chain-rooted view instead of trusting
+ * amounts and scripts supplied by the same website or compose API that requested the signature.
+ */
+export async function verifyPsbtPrevouts(
+  psbt: string,
+  options: VerifyPsbtPrevoutsOptions = {},
+): Promise<VerifiedPsbt> {
+  const transaction = parsePSBT(psbt);
+  const resolveTrustedPrevout = options.resolveTrustedPrevout ?? noTrustedPrevout;
+  const fetchRawTransaction = options.fetchRawTransaction ?? fetchPreviousRawTransaction;
+  const rawCache = new Map<string, Uint8Array>();
+  const inputIndices = options.inputIndices
+    ?? Array.from({ length: transaction.inputsLength }, (_, index) => index);
+  if (
+    new Set(inputIndices).size !== inputIndices.length
+    || inputIndices.some((index) =>
+      !Number.isSafeInteger(index) || index < 0 || index >= transaction.inputsLength
+    )
+  ) {
+    throw new ValidationError('INVALID_PSBT', 'PSBT prevout verification indices are invalid');
+  }
+
+  const prevouts = await Promise.all(
+    inputIndices.map(async (index): Promise<VerifiedPsbtPrevout> => {
+      const input = transaction.getInput(index);
+      if (!input?.txid || input.index === undefined) {
+        throw new ValidationError('INVALID_PSBT', `PSBT input ${index} has no outpoint`);
+      }
+
+      const txid = bytesToHex(input.txid).toLowerCase();
+      let rawTransaction = rawCache.get(txid);
+      if (!rawTransaction) {
+        if (input.nonWitnessUtxo) {
+          rawTransaction = RawTx.encode(input.nonWitnessUtxo);
+        } else {
+          const packaged = options.packageTransactions?.get(txid);
+          const trusted = packaged ? null : await resolveTrustedPrevout(txid, input.index);
+          const rawHex = packaged ?? trusted?.rawTxHex ?? await fetchRawTransaction(txid);
+          if (!rawHex) {
+            throw new ValidationError(
+              'INVALID_PSBT',
+              `Could not independently verify previous transaction ${txid}`,
+            );
+          }
+          // Validate before caching, but preserve the exact transaction bytes. Re-serializing here
+          // can change whether witness data is included even though the txid is unchanged.
+          parseConsensusTransaction(rawHex);
+          rawTransaction = decodeRawTransaction(rawHex);
+        }
+        rawCache.set(txid, rawTransaction);
+      }
+
+      const previous = parseConsensusTransaction(rawTransaction);
+      if (previous.id !== txid) {
+        throw new ValidationError(
+          'INVALID_PSBT',
+          `Previous transaction data does not match PSBT input ${index}`,
+        );
+      }
+      const output = previous.getOutput(input.index);
+      if (!output?.script || output.amount === undefined) {
+        throw new ValidationError(
+          'INVALID_PSBT',
+          `Previous output ${txid}:${input.index} does not exist`,
+        );
+      }
+      if (
+        input.witnessUtxo
+        && (
+          input.witnessUtxo.amount !== output.amount
+          || !sameBytes(input.witnessUtxo.script, output.script)
+        )
+      ) {
+        throw new ValidationError(
+          'INVALID_PSBT',
+          `PSBT input ${index} does not match its real previous output`,
+        );
+      }
+
+      const address = decodeAddressFromScript(bytesToHex(output.script)) ?? undefined;
+      return {
+        index,
+        txid,
+        vout: input.index,
+        amount: output.amount,
+        script: output.script,
+        ...(address ? { address } : {}),
+        rawTransaction,
+      };
+    }),
+  );
+
+  return { hex: normalizePsbtToHex(psbt), prevouts };
+}

--- a/src/core/bitcoin/publicKeyIdentity.ts
+++ b/src/core/bitcoin/publicKeyIdentity.ts
@@ -1,0 +1,67 @@
+import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
+import { Point } from '@noble/secp256k1';
+import {
+  AddressFormat,
+  encodeAddress,
+  normalizeAddressForComparison,
+} from '@/core/bitcoin/address';
+
+export type SecPublicKeyEncoding = 'compressed' | 'uncompressed';
+
+export interface SecPublicKeyIdentity {
+  /** Exact SEC bytes. This encoding is part of a P2PKH address's identity. */
+  bytes: Uint8Array;
+  hex: string;
+  encoding: SecPublicKeyEncoding;
+  /** Canonical compressed encoding for comparisons that ask only whether the EC point is equal. */
+  pointId: string;
+}
+
+/** Parse and validate one exact compressed or uncompressed SEC public-key serialization. */
+export function parseSecPublicKey(value: string): SecPublicKeyIdentity | null {
+  if (typeof value !== 'string' || !/^[0-9a-f]+$/i.test(value)) return null;
+  const normalized = value.toLowerCase();
+  const isCompressed = normalized.length === 66 && /^(02|03)/.test(normalized);
+  const isUncompressed = normalized.length === 130 && normalized.startsWith('04');
+  if (!isCompressed && !isUncompressed) return null;
+
+  try {
+    const bytes = hexToBytes(normalized);
+    const point = Point.fromBytes(bytes);
+    return {
+      bytes,
+      hex: normalized,
+      encoding: isCompressed ? 'compressed' : 'uncompressed',
+      pointId: bytesToHex(point.toBytes(true)),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** EC-point identity for capability checks such as "can this private key recover the output?". */
+export function publicKeyPointId(value: string): string | null {
+  return parseSecPublicKey(value)?.pointId ?? null;
+}
+
+/**
+ * Exact address binding for identity checks. Unlike point equality, compressed and uncompressed
+ * P2PKH serializations deliberately produce different addresses.
+ */
+export function publicKeyMatchesAddress(value: string, address: string): boolean {
+  const parsed = parseSecPublicKey(value);
+  if (!parsed || !address) return false;
+
+  const formats: AddressFormat[] = parsed.encoding === 'compressed'
+    ? [AddressFormat.P2PKH, AddressFormat.P2WPKH, AddressFormat.P2SH_P2WPKH, AddressFormat.P2TR]
+    : [AddressFormat.P2PKH];
+
+  return formats.some((format) => {
+    try {
+      return normalizeAddressForComparison(encodeAddress(parsed.bytes, format))
+        === normalizeAddressForComparison(address);
+    } catch {
+      return false;
+    }
+  });
+}

--- a/src/core/bitcoin/rawTransaction.ts
+++ b/src/core/bitcoin/rawTransaction.ts
@@ -1,0 +1,80 @@
+import { hexToBytes } from '@noble/hashes/utils.js';
+import { Transaction } from '@scure/btc-signer';
+import { ValidationError } from '@/core/errors';
+
+/**
+ * Browser-facing transaction parsing must be bounded before allocating decoder structures. This
+ * covers the largest serialized transaction permitted by Bitcoin's standard weight limit while
+ * preventing a site or API from handing the extension an arbitrarily large parsing job.
+ */
+export const MAX_RAW_TRANSACTION_BYTES = 4_000_000;
+export const MAX_TRANSACTION_INPUTS = 1_000;
+export const MAX_TRANSACTION_OUTPUTS = 1_000;
+
+const RAW_TRANSACTION_OPTIONS = {
+  // These are the same raw-history allowances used by btc-signer's Esplora adapter. Historical
+  // consensus transactions may contain scripts or versions a wallet would never construct.
+  allowUnknownInputs: true,
+  allowUnknownOutputs: true,
+  disableScriptCheck: true,
+  allowUnknownVersion: true,
+} as const;
+
+export function decodeRawTransaction(raw: string | Uint8Array): Uint8Array {
+  if (raw instanceof Uint8Array) {
+    if (raw.length === 0 || raw.length > MAX_RAW_TRANSACTION_BYTES) {
+      throw new ValidationError(
+        'INVALID_TRANSACTION',
+        `Raw transaction must be between 1 and ${MAX_RAW_TRANSACTION_BYTES} bytes`,
+      );
+    }
+    return raw;
+  }
+
+  if (typeof raw !== 'string') {
+    throw new ValidationError('INVALID_TRANSACTION', 'Raw transaction must be hex bytes');
+  }
+  const normalized = raw.replace(/^0x/i, '');
+  if (
+    normalized.length === 0
+    || normalized.length % 2 !== 0
+    || normalized.length > MAX_RAW_TRANSACTION_BYTES * 2
+    || !/^[0-9a-f]+$/i.test(normalized)
+  ) {
+    throw new ValidationError(
+      'INVALID_TRANSACTION',
+      `Raw transaction must be valid hex no larger than ${MAX_RAW_TRANSACTION_BYTES} bytes`,
+    );
+  }
+  return hexToBytes(normalized);
+}
+
+/**
+ * Parse consensus/history bytes without treating unusual output scripts as wallet-approved.
+ *
+ * `disableScriptCheck` is intentionally confined here. Raw transactions contain no PSBT
+ * redeemScript, witnessScript, or Taproot commitment metadata for that option to authenticate;
+ * the permissive setting only lets us inspect historical and Counterparty script shapes. Signing
+ * decisions must still pass the separate input/output/fee policies.
+ */
+export function parseConsensusTransaction(raw: string | Uint8Array): Transaction {
+  return Transaction.fromRaw(decodeRawTransaction(raw), RAW_TRANSACTION_OPTIONS);
+}
+
+/** Parse a browser/API supplied transaction and bound the work downstream screens perform. */
+export function parseTransactionForSigning(raw: string | Uint8Array): Transaction {
+  const transaction = parseConsensusTransaction(raw);
+  if (transaction.inputsLength > MAX_TRANSACTION_INPUTS) {
+    throw new ValidationError(
+      'INVALID_TRANSACTION',
+      `Transaction has too many inputs (${transaction.inputsLength}; maximum ${MAX_TRANSACTION_INPUTS})`,
+    );
+  }
+  if (transaction.outputsLength > MAX_TRANSACTION_OUTPUTS) {
+    throw new ValidationError(
+      'INVALID_TRANSACTION',
+      `Transaction has too many outputs (${transaction.outputsLength}; maximum ${MAX_TRANSACTION_OUTPUTS})`,
+    );
+  }
+  return transaction;
+}

--- a/src/core/bitcoin/transactionBroadcaster.ts
+++ b/src/core/bitcoin/transactionBroadcaster.ts
@@ -1,7 +1,7 @@
-import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
-import { Transaction } from '@scure/btc-signer';
+import { bytesToHex } from '@noble/hashes/utils.js';
 import { type ApiResponse, apiClient, isApiError, withRetry } from '@/core/api/client';
 import { clearBalanceCache } from '@/core/bitcoin/balance';
+import { parseTransactionForSigning } from '@/core/bitcoin/rawTransaction';
 import { recordSpentUtxos } from '@/core/bitcoin/spentUtxoCache';
 import { clearBitcoinCaches } from '@/core/bitcoin/utxo';
 import { clearApiCache } from '@/core/counterparty/api';
@@ -86,11 +86,7 @@ const formatResponse = (endpoint: BroadcastEndpoint, response: ApiResponse): Tra
  */
 export function computeTxid(signedTxHex: string): string | null {
   try {
-    const tx = Transaction.fromRaw(hexToBytes(signedTxHex), {
-      allowUnknownInputs: true,
-      allowUnknownOutputs: true,
-      disableScriptCheck: true,
-    });
+    const tx = parseTransactionForSigning(signedTxHex);
     return tx.id;
   } catch {
     return null;
@@ -99,7 +95,7 @@ export function computeTxid(signedTxHex: string): string | null {
 
 export function extractInputsFromRawTx(signedTxHex: string): { txid: string; vout: number }[] {
   try {
-    const tx = Transaction.fromRaw(hexToBytes(signedTxHex), { allowUnknownInputs: true, allowUnknownOutputs: true, disableScriptCheck: true });
+    const tx = parseTransactionForSigning(signedTxHex);
     const inputs: { txid: string; vout: number }[] = [];
     for (let i = 0; i < tx.inputsLength; i++) {
       const input = tx.getInput(i);

--- a/src/core/bitcoin/transactionSigner.ts
+++ b/src/core/bitcoin/transactionSigner.ts
@@ -2,6 +2,7 @@ import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
 import { getPublicKey } from '@noble/secp256k1';
 import { p2wpkh, SigHash, Transaction } from '@scure/btc-signer';
 import { AddressFormat } from '@/core/bitcoin/address';
+import { parseConsensusTransaction, parseTransactionForSigning } from '@/core/bitcoin/rawTransaction';
 import { noTrustedPrevout, type TrustedPrevoutResolver } from '@/core/bitcoin/trustedPrevout';
 import { hybridSignTransaction } from '@/core/bitcoin/uncompressedSigner';
 import { fetchPreviousRawTransaction, fetchUTXOs, getUtxoByTxid } from '@/core/bitcoin/utxo';
@@ -143,13 +144,7 @@ export async function signTransaction(
     const hasApiData = inputValues && lockScripts &&
                        inputValues.length > 0 && lockScripts.length > 0;
 
-    const rawTxBytes = hexToBytes(rawTransaction);
-    const parsedTx = Transaction.fromRaw(rawTxBytes, {
-      allowUnknownInputs: true,
-      allowUnknownOutputs: true,
-      allowLegacyWitnessUtxo: true,
-      disableScriptCheck: true
-    });
+    const parsedTx = parseTransactionForSigning(rawTransaction);
 
     // A provider transaction can spend change from a transaction this extension broadcast only
     // milliseconds earlier. Resolve those inputs from the trusted cross-context journal first;
@@ -179,8 +174,9 @@ export async function signTransaction(
       allowUnknownInputs: true,
       allowUnknownOutputs: true,
       allowLegacyWitnessUtxo: true,
-      disableScriptCheck: true,
-      unknown: 'ignore'
+      // Standard inputs stay on btc-signer's validated path. Counterparty's unusual bare-multisig
+      // data appears in outputs, which is covered narrowly by allowUnknownOutputs.
+      lowR: true,
     });
 
     // For legacy uncompressed key signing, we need previous output scripts
@@ -250,7 +246,7 @@ export async function signTransaction(
             userMessage: 'Could not retrieve transaction data from the network. Please try again.',
           });
         }
-        const prevTx = Transaction.fromRaw(hexToBytes(rawPrevTx), { allowUnknownInputs: true, allowUnknownOutputs: true, disableScriptCheck: true });
+        const prevTx = parseConsensusTransaction(rawPrevTx);
         const prevOutput = prevTx.getOutput(input.index);
         if (!prevOutput) {
           throw new UtxoError('UTXO_NOT_FOUND', `Output not found in previous transaction: ${txidHex}:${input.index}`, {
@@ -300,7 +296,7 @@ export async function signTransaction(
             userMessage: 'Could not retrieve transaction data from the network. Please try again.',
           });
         }
-        const prevTx = Transaction.fromRaw(hexToBytes(rawPrevTx), { allowUnknownInputs: true, allowUnknownOutputs: true, disableScriptCheck: true });
+        const prevTx = parseConsensusTransaction(rawPrevTx);
         const prevOutput = prevTx.getOutput(input.index);
         if (!prevOutput) {
           throw new UtxoError('UTXO_NOT_FOUND', `Output not found in previous transaction: ${txidHex}:${input.index}`, {

--- a/src/core/bitcoin/uncompressedSigner.ts
+++ b/src/core/bitcoin/uncompressedSigner.ts
@@ -8,6 +8,7 @@
 
 import { SigHash, type Transaction } from '@scure/btc-signer';
 import { signECDSA } from '@scure/btc-signer/utils.js';
+import { getLegacySighash, getLowRPreference } from '@/core/bitcoin/legacySighash';
 
 /**
  * Concatenates multiple Uint8Arrays into a single Uint8Array.
@@ -42,17 +43,11 @@ export function signInputWithUncompressedKey(
   prevOutputScript: Uint8Array,
   sighash: number = SigHash.ALL
 ): void {
-  // Access the transaction's legacy preimage routine
-  const preimageLegacy = (tx as any).preimageLegacy;
-  if (typeof preimageLegacy !== 'function') {
-    throw new Error('preimageLegacy method not accessible');
-  }
-  
   // Get the hash to sign using the previous output's script
-  const hash: Uint8Array = preimageLegacy.call(tx, idx, prevOutputScript, sighash);
+  const hash = getLegacySighash(tx, idx, prevOutputScript, sighash);
   
   // Sign the hash using signECDSA
-  const sig: Uint8Array = signECDSA(hash, privateKey, (tx as any).opts?.lowR);
+  const sig = signECDSA(hash, privateKey, getLowRPreference(tx));
   
   // Append the sighash type byte
   const sigWithHash: Uint8Array = concatBytes(

--- a/src/core/counterparty/__tests__/compose.multisigPubkey.test.ts
+++ b/src/core/counterparty/__tests__/compose.multisigPubkey.test.ts
@@ -19,7 +19,6 @@ import { composeBroadcast, composeSend } from '../compose';
 import { setSourcePubkeyProvider } from '../sourcePubkey';
 import {
   createMockComposeResponse,
-  mockAddress,
   mockDestAddress,
   mockSatPerVbyte,
   mockSettings,
@@ -43,6 +42,7 @@ const mockedApiClient = vi.mocked(apiClientUtils.apiClient, true);
 const mockedGetSettings = vi.mocked(getActiveSettings);
 
 const PUBKEY = '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798';
+const SOURCE_ADDRESS = '1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH';
 
 const composedUrl = (): string => mockedApiClient.get.mock.calls[0]![0] as string;
 
@@ -56,10 +56,10 @@ describe('multisig_pubkey on compose requests', () => {
   afterEach(() => setSourcePubkeyProvider(null));
 
   it('sends the source pubkey when the wallet holds it', async () => {
-    setSourcePubkeyProvider((address) => (address === mockAddress ? PUBKEY : null));
+    setSourcePubkeyProvider((address) => (address === SOURCE_ADDRESS ? PUBKEY : null));
 
     await composeBroadcast({
-      sourceAddress: mockAddress,
+      sourceAddress: SOURCE_ADDRESS,
       text: 'hello',
       sat_per_vbyte: mockSatPerVbyte,
     });
@@ -72,7 +72,7 @@ describe('multisig_pubkey on compose requests', () => {
   // and core falls back to its own history scan.
   it('omits the parameter when no provider is registered', async () => {
     await composeBroadcast({
-      sourceAddress: mockAddress,
+      sourceAddress: SOURCE_ADDRESS,
       text: 'hello',
       sat_per_vbyte: mockSatPerVbyte,
     });
@@ -84,7 +84,7 @@ describe('multisig_pubkey on compose requests', () => {
     setSourcePubkeyProvider(() => null);
 
     await composeSend({
-      sourceAddress: mockAddress,
+      sourceAddress: SOURCE_ADDRESS,
       destination: mockDestAddress,
       asset: 'XCP',
       quantity: 100,
@@ -101,7 +101,7 @@ describe('multisig_pubkey on compose requests', () => {
     setSourcePubkeyProvider(() => PUBKEY);
 
     await composeSend({
-      sourceAddress: mockAddress,
+      sourceAddress: SOURCE_ADDRESS,
       destination: mockDestAddress,
       asset: 'XCP',
       quantity: 100,

--- a/src/core/counterparty/__tests__/sourcePubkey.test.ts
+++ b/src/core/counterparty/__tests__/sourcePubkey.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { getSourcePubkey, setSourcePubkeyProvider } from '../sourcePubkey';
 
-const ADDRESS = '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa';
+const ADDRESS = '1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH';
+const UNCOMPRESSED_ADDRESS = '1EHNa6Q4Jz2uvNExL497mE43ikXhwF6kZm';
 const PUBKEY = '0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798';
 
 describe('sourcePubkey provider', () => {
@@ -84,7 +85,17 @@ describe('anything that is not a public key', () => {
       '0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798' +
       '483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8';
     setSourcePubkeyProvider(() => UNCOMPRESSED);
-    expect(getSourcePubkey(ADDRESS)).toBe(UNCOMPRESSED);
+    expect(getSourcePubkey(UNCOMPRESSED_ADDRESS)).toBe(UNCOMPRESSED);
+  });
+
+  it('refuses the other serialization of the same point for a P2PKH source', () => {
+    const UNCOMPRESSED =
+      '0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798' +
+      '483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8';
+    setSourcePubkeyProvider(() => PUBKEY);
+    expect(getSourcePubkey(UNCOMPRESSED_ADDRESS)).toBeNull();
+    setSourcePubkeyProvider(() => UNCOMPRESSED);
+    expect(getSourcePubkey(ADDRESS)).toBeNull();
   });
 });
 

--- a/src/core/counterparty/inputPolicy.ts
+++ b/src/core/counterparty/inputPolicy.ts
@@ -12,8 +12,9 @@
  * freely, and there is nothing to compare against — see `checkInputPolicy`.
  */
 
-import { Transaction } from '@scure/btc-signer';
-import { bytesToHex, hexToBytes } from '@/core/counterparty/unpack/binary';
+import type { Transaction } from '@scure/btc-signer';
+import { parseTransactionForSigning } from '@/core/bitcoin/rawTransaction';
+import { bytesToHex } from '@/core/counterparty/unpack/binary';
 
 export interface InputPolicyInput {
   rawTransaction: string;
@@ -59,12 +60,7 @@ export function checkInputPolicy(input: InputPolicyInput): InputPolicyResult {
 
   let tx: Transaction;
   try {
-    tx = Transaction.fromRaw(hexToBytes(input.rawTransaction), {
-      allowUnknownInputs: true,
-      allowUnknownOutputs: true,
-      allowLegacyWitnessUtxo: true,
-      disableScriptCheck: true,
-    });
+    tx = parseTransactionForSigning(input.rawTransaction);
   } catch {
     // Signing parses the same bytes and will fail there instead; see `checkOutputPolicy`.
     return { ok: true, unoffered: [] };

--- a/src/core/counterparty/inscriptionEnvelope.ts
+++ b/src/core/counterparty/inscriptionEnvelope.ts
@@ -32,8 +32,9 @@
  */
 
 import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
-import { p2tr, Transaction } from '@scure/btc-signer';
+import { p2tr, type Transaction } from '@scure/btc-signer';
 import { decodeAddressFromScript } from '@/core/bitcoin/address';
+import { parseTransactionForSigning } from '@/core/bitcoin/rawTransaction';
 import { type CborEncodable, encodeCbor } from '@/core/counterparty/pack/cbor';
 import { decodeCbor } from '@/core/counterparty/unpack/cbor';
 import { COUNTERPARTY_PREFIX_HEX } from '@/core/counterparty/unpack/messageTypes';
@@ -247,12 +248,7 @@ export function verifyRevealTransaction(
 ): { ok: boolean; error?: string } {
   let tx: Transaction;
   try {
-    tx = Transaction.fromRaw(hexToBytes(revealHex), {
-      allowUnknownInputs: true,
-      allowUnknownOutputs: true,
-      allowLegacyWitnessUtxo: true,
-      disableScriptCheck: true,
-    });
+    tx = parseTransactionForSigning(revealHex);
   } catch {
     return { ok: false, error: 'The inscription reveal transaction could not be read.' };
   }

--- a/src/core/counterparty/outputPolicy.ts
+++ b/src/core/counterparty/outputPolicy.ts
@@ -52,9 +52,10 @@
  * why the added-recipient half is the half enforced here.
  */
 
-import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
-import { Transaction } from '@scure/btc-signer';
+import { bytesToHex } from '@noble/hashes/utils.js';
+import type { Transaction } from '@scure/btc-signer';
 import { decodeAddressFromScript, normalizeAddressForComparison } from '@/core/bitcoin/address';
+import { parseTransactionForSigning } from '@/core/bitcoin/rawTransaction';
 import { bareMultisigRecoveryPubkey, isBareMultisigDataOutput } from '@/core/counterparty/unpack/multisig';
 import { toSafeInteger } from '@/core/numeric';
 
@@ -273,12 +274,7 @@ function checkPositionalDestination(tx: Transaction, expected: string): string |
 export function checkOutputPolicy(input: OutputPolicyInput): OutputPolicyResult {
   let tx: Transaction;
   try {
-    tx = Transaction.fromRaw(hexToBytes(input.rawTransaction), {
-      allowUnknownInputs: true,
-      allowUnknownOutputs: true,
-      allowLegacyWitnessUtxo: true,
-      disableScriptCheck: true,
-    });
+    tx = parseTransactionForSigning(input.rawTransaction);
   } catch {
     // An unparseable transaction cannot be signed either — the signer uses the same parser — so it
     // is not a value-routing risk. Let signing surface the real error.

--- a/src/core/counterparty/sourcePubkey.ts
+++ b/src/core/counterparty/sourcePubkey.ts
@@ -22,6 +22,8 @@
  * recover from a taproot witness.
  */
 
+import { publicKeyMatchesAddress } from '@/core/bitcoin/publicKeyIdentity';
+
 type SourcePubkeyProvider = (address: string) => string | null;
 
 let provider: SourcePubkeyProvider | null = null;
@@ -47,11 +49,9 @@ export function setSourcePubkeyProvider(nextProvider: SourcePubkeyProvider | nul
  * account, not an address. Deriving the child would be the real fix; refusing to send an account
  * key is the part that must be true either way.
  */
-const COMPRESSED = /^0[23][0-9a-fA-F]{64}$/;
-const UNCOMPRESSED = /^04[0-9a-fA-F]{128}$/;
 
 /**
- * The compressed public key for an address this wallet holds, or null.
+ * The exact SEC public key for an address this wallet holds, or null.
  *
  * Null degrades to today's behaviour — the parameter is omitted and core falls back to its own
  * history scan, which still succeeds for any address that has spent. Test-only wallets store an
@@ -63,5 +63,7 @@ export function getSourcePubkey(address: string): string | null {
   if (!provider || !address) return null;
   const pubkey = provider(address);
   if (!pubkey) return null;
-  return COMPRESSED.test(pubkey) || UNCOMPRESSED.test(pubkey) ? pubkey : null;
+  // Address identity uses the exact SEC serialization. Re-encoding the same point changes a
+  // P2PKH hash and was the cause of "Data Outputs Not Recoverable By You" for uncompressed keys.
+  return publicKeyMatchesAddress(pubkey, address) ? pubkey.toLowerCase() : null;
 }

--- a/src/core/counterparty/transactionSafety.ts
+++ b/src/core/counterparty/transactionSafety.ts
@@ -6,10 +6,9 @@
  * that could indicate a malicious site trying to drain the wallet.
  */
 
-import { Point } from '@noble/secp256k1';
 import { normalizeAddressForComparison } from '@/core/bitcoin/address';
+import { publicKeyPointId } from '@/core/bitcoin/publicKeyIdentity';
 import { getSourcePubkey } from '@/core/counterparty/sourcePubkey';
-import { bytesToHex, hexToBytes } from '@/core/counterparty/unpack/binary';
 import {
   bareMultisigRecoveryPubkey,
   isBareMultisigDataOutput,
@@ -160,11 +159,7 @@ const DATA_CARRYING_OUTPUT_TYPES = new Set([
  * lower-cased input preserves fail-closed behaviour for malformed keys used by callers/tests.
  */
 function comparablePubkey(pubkey: string): string {
-  try {
-    return bytesToHex(Point.fromBytes(hexToBytes(pubkey)).toBytes(true));
-  } catch {
-    return pubkey.toLowerCase();
-  }
+  return publicKeyPointId(pubkey) ?? pubkey.toLowerCase();
 }
 
 /**

--- a/src/core/counterparty/unpack/__tests__/multisig-encoding.test.ts
+++ b/src/core/counterparty/unpack/__tests__/multisig-encoding.test.ts
@@ -10,6 +10,7 @@
 
 import { getPublicKey } from '@noble/secp256k1';
 import { afterEach, describe, expect, it } from 'vitest';
+import { AddressFormat, encodeAddress } from '@/core/bitcoin/address';
 import { setSourcePubkeyProvider } from '../../sourcePubkey';
 import { analyzeTransactionSafety } from '../../transactionSafety';
 import { packAddress } from '../address';
@@ -350,9 +351,12 @@ describe('unclassified transactions fail toward unknown', () => {
 });
 
 describe('the recovery key rides in the third slot', () => {
-  const signerPubkey = '02' + '11'.repeat(32);
-  const uncompressedSignerPubkey = '04' + '11'.repeat(64);
-  const strangerPubkey = '03' + '22'.repeat(32);
+  const signerPrivateKey = hexToBytes('01'.padStart(64, '0'));
+  const strangerPrivateKey = hexToBytes('02'.padStart(64, '0'));
+  const signerPubkey = bytesToHex(getPublicKey(signerPrivateKey, true));
+  const uncompressedSignerPubkey = bytesToHex(getPublicKey(signerPrivateKey, false));
+  const strangerPubkey = bytesToHex(getPublicKey(strangerPrivateKey, true));
+  const signerAddress = encodeAddress(hexToBytes(signerPubkey), AddressFormat.P2PKH);
 
   /** A data script embedding `recovery` where core puts the source pubkey. */
   const scriptWithRecoveryKey = (recovery: string): string =>
@@ -389,11 +393,11 @@ describe('the recovery key rides in the third slot', () => {
   // multisig_pubkey override, so a hostile composer can point every data output's dust at a key
   // that is not the signer's. Checkable exactly when the wallet holds the signer's key.
   it('warns when a data output embeds a recovery key that is not the signers own', () => {
-    setSourcePubkeyProvider((address) => (address === 'bc1qsigner' ? signerPubkey : null));
+    setSourcePubkeyProvider((address) => (address === signerAddress ? signerPubkey : null));
 
     const safety = analyzeTransactionSafety('send', [
       { value: 546, type: 'multisig', script: scriptWithRecoveryKey(strangerPubkey) },
-    ], 'bc1qsigner');
+    ], signerAddress);
 
     expect(safety.warnings.some((w) => w.title === 'Data Outputs Not Recoverable By You')).toBe(true);
   });
@@ -403,7 +407,7 @@ describe('the recovery key rides in the third slot', () => {
 
     const safety = analyzeTransactionSafety('send', [
       { value: 546, type: 'multisig', script: scriptWithRecoveryKey(signerPubkey) },
-    ], 'bc1qsigner');
+    ], signerAddress);
 
     expect(safety.warnings.some((w) => w.title === 'Data Outputs Not Recoverable By You')).toBe(false);
   });
@@ -412,11 +416,12 @@ describe('the recovery key rides in the third slot', () => {
     const privateKey = hexToBytes('01'.repeat(32));
     const compressed = bytesToHex(getPublicKey(privateKey, true));
     const uncompressed = bytesToHex(getPublicKey(privateKey, false));
+    const uncompressedAddress = encodeAddress(hexToBytes(uncompressed), AddressFormat.P2PKH);
     setSourcePubkeyProvider(() => uncompressed);
 
     const safety = analyzeTransactionSafety('send', [
       { value: 546, type: 'multisig', script: scriptWithRecoveryKey(compressed) },
-    ], '1legacySigner');
+    ], uncompressedAddress);
 
     expect(safety.warnings.some((w) => w.title === 'Data Outputs Not Recoverable By You')).toBe(false);
   });

--- a/src/core/counterparty/unpack/opReturn.ts
+++ b/src/core/counterparty/unpack/opReturn.ts
@@ -9,7 +9,8 @@
  * instead — see extractPayloadFromOutputs.
  */
 
-import { Transaction } from '@scure/btc-signer';
+import type { Transaction } from '@scure/btc-signer';
+import { parseTransactionForSigning } from '@/core/bitcoin/rawTransaction';
 import { arc4, bytesToHex, hexToBytes } from '@/core/counterparty/unpack/binary';
 import { COUNTERPARTY_PREFIX_HEX } from '@/core/counterparty/unpack/messageTypes';
 import { decodeMultisigChunk } from '@/core/counterparty/unpack/multisig';
@@ -153,12 +154,7 @@ export function extractPayloadFromOutputs(
 export function extractCounterpartyPayload(rawTxHex: string): string | null {
   let tx: Transaction;
   try {
-    tx = Transaction.fromRaw(hexToBytes(rawTxHex), {
-      allowUnknownInputs: true,
-      allowUnknownOutputs: true,
-      allowLegacyWitnessUtxo: true,
-      disableScriptCheck: true,
-    });
+    tx = parseTransactionForSigning(rawTxHex);
   } catch {
     return null;
   }

--- a/src/core/hardware/__tests__/inputPaths.test.ts
+++ b/src/core/hardware/__tests__/inputPaths.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { mapVerifiedInputPaths } from '@/core/hardware/inputPaths';
+
+const prevout = (index: number, address?: string) => ({
+  index,
+  txid: `${index}`.padStart(64, '0'),
+  vout: 0,
+  amount: 1n,
+  script: new Uint8Array([index]),
+  rawTransaction: new Uint8Array([index]),
+  ...(address ? { address } : {}),
+});
+
+describe('mapVerifiedInputPaths', () => {
+  it('uses the owning derivation path for each input', () => {
+    const paths = mapVerifiedInputPaths(
+      [prevout(0, 'bc1qfirst'), prevout(1, 'bc1qsecond')],
+      [
+        { address: 'bc1qfirst', path: 'm/84/0' },
+        { address: 'bc1qsecond', path: 'm/84/1' },
+      ],
+      (path) => path.endsWith('/0') ? [84, 0] : [84, 1],
+    );
+
+    expect(paths.get(0)).toEqual([84, 0]);
+    expect(paths.get(1)).toEqual([84, 1]);
+  });
+
+  it('rejects foreign or unattributable inputs', () => {
+    expect(() => mapVerifiedInputPaths(
+      [prevout(0, 'bc1qforeign')],
+      [{ address: 'bc1qours', path: 'm/84/0' }],
+      () => [84, 0],
+    )).toThrow(/does not belong/);
+    expect(() => mapVerifiedInputPaths(
+      [prevout(0)],
+      [{ address: 'bc1qours', path: 'm/84/0' }],
+      () => [84, 0],
+    )).toThrow(/does not belong/);
+  });
+});

--- a/src/core/hardware/inputPaths.ts
+++ b/src/core/hardware/inputPaths.ts
@@ -1,0 +1,31 @@
+import { normalizeAddressForComparison } from '@/core/bitcoin/address';
+import type { VerifiedPsbtPrevout } from '@/core/bitcoin/psbtPrevouts';
+
+export interface HardwareDerivedAddress {
+  address: string;
+  path: string;
+}
+
+/** Bind every hardware input to the derivation path that owns its verified prevout. */
+export function mapVerifiedInputPaths(
+  prevouts: VerifiedPsbtPrevout[],
+  addresses: HardwareDerivedAddress[],
+  parsePath: (path: string) => number[],
+): Map<number, number[]> {
+  const paths = new Map<number, number[]>();
+  for (const prevout of prevouts) {
+    const owner = prevout.address
+      ? addresses.find((candidate) =>
+          normalizeAddressForComparison(candidate.address)
+          === normalizeAddressForComparison(prevout.address!)
+        )
+      : undefined;
+    if (!owner) {
+      throw new Error(
+        `PSBT input ${prevout.index} does not belong to a derived address in this hardware wallet`,
+      );
+    }
+    paths.set(prevout.index, parsePath(owner.path));
+  }
+  return paths;
+}

--- a/src/core/validation/__tests__/privateKey.test.ts
+++ b/src/core/validation/__tests__/privateKey.test.ts
@@ -18,7 +18,7 @@ describe('Private Key Validation Security Tests', () => {
       
       expect(result.isValid).toBe(true);
       expect(result.format).toBe('hex');
-      expect(result.suggestedAddressFormat).toBe(AddressFormat.P2TR);
+      expect(result.suggestedAddressFormat).toBe(AddressFormat.P2WPKH);
     });
 
     it('should accept valid WIF private keys', () => {
@@ -28,7 +28,7 @@ describe('Private Key Validation Security Tests', () => {
       
       expect(result1.isValid).toBe(true);
       expect(result1.format).toBe('wif-compressed');
-      expect(result1.suggestedAddressFormat).toBe(AddressFormat.P2SH_P2WPKH);
+      expect(result1.suggestedAddressFormat).toBe(AddressFormat.P2WPKH);
 
       // Valid WIF uncompressed (starts with 5)
       const validWIFUncompressed = '5HueCGU8rMjxEXxiPuD5BDku4MkFqeZyd4dZ1jvhTVqvbTLvyTJ';

--- a/src/core/validation/privateKey.ts
+++ b/src/core/validation/privateKey.ts
@@ -1,4 +1,4 @@
-import { AddressFormat } from '@/core/bitcoin/address';
+import { AddressFormat, DEFAULT_ADDRESS_FORMAT } from '@/core/bitcoin/address';
 
 /**
  * Private key format validation interface
@@ -53,7 +53,7 @@ export function validatePrivateKeyFormat(privateKey: string): PrivateKeyValidati
     return {
       isValid: true,
       format: 'hex',
-      suggestedAddressFormat: AddressFormat.P2TR, // Default for hex
+      suggestedAddressFormat: DEFAULT_ADDRESS_FORMAT,
     };
   }
 
@@ -86,7 +86,7 @@ function validateWIFFormat(wif: string): PrivateKeyValidationResult {
     return {
       isValid: true,
       format: 'wif-compressed',
-      suggestedAddressFormat: AddressFormat.P2SH_P2WPKH, // Compressed keys can use SegWit
+      suggestedAddressFormat: DEFAULT_ADDRESS_FORMAT,
     };
   }
 

--- a/src/pages/keychain/setup/import-mnemonic.tsx
+++ b/src/pages/keychain/setup/import-mnemonic.tsx
@@ -10,7 +10,7 @@ import { CheckboxInput } from "@/components/ui/inputs/checkbox-input";
 import { PasswordInput } from "@/components/ui/inputs/password-input";
 import { useHeader } from "@/contexts/header-context";
 import { useWallet } from "@/contexts/wallet-context";
-import { AddressFormat, detectAddressFormat, isCounterwalletFormat } from "@/core/bitcoin/address";
+import { AddressFormat, DEFAULT_ADDRESS_FORMAT, detectAddressFormat, isCounterwalletFormat } from "@/core/bitcoin/address";
 import { getPrivateKeyFromMnemonic } from "@/core/bitcoin/privateKey";
 import { isValidCounterwalletMnemonic } from "@/core/counterwallet";
 import { MIN_PASSWORD_LENGTH } from "@/core/encryption/encryption";
@@ -131,8 +131,8 @@ function ImportMnemonicPage() {
           try {
             addressFormat = await detectAddressFormat(mnemonic);
           } catch (detectError) {
-            console.warn("Address format detection failed, using P2TR default:", detectError);
-            addressFormat = AddressFormat.P2TR;
+            console.warn("Address format detection failed, using Native SegWit default:", detectError);
+            addressFormat = DEFAULT_ADDRESS_FORMAT;
           }
         }
 

--- a/src/pages/keychain/setup/import-private-key.tsx
+++ b/src/pages/keychain/setup/import-private-key.tsx
@@ -15,7 +15,7 @@ import { CheckboxInput } from "@/components/ui/inputs/checkbox-input";
 import { PasswordInput } from "@/components/ui/inputs/password-input";
 import { useHeader } from "@/contexts/header-context";
 import { useWallet } from "@/contexts/wallet-context";
-import { AddressFormat } from "@/core/bitcoin/address";
+import { AddressFormat, DEFAULT_ADDRESS_FORMAT } from "@/core/bitcoin/address";
 import { MIN_PASSWORD_LENGTH } from "@/core/encryption/encryption";
 import { validatePrivateKeyFormat } from "@/core/validation/privateKey";
 import { analytics } from "@/platform/fathom";
@@ -37,7 +37,7 @@ function ImportPrivateKeyPage() {
   const { setHeaderProps } = useHeader();
   const { createPrivateKeyWallet, verifyPassword } = useWallet();
 
-  const [addressFormat, setAddressFormat] = useState<AddressFormat>(AddressFormat.P2PKH);
+  const [addressFormat, setAddressFormat] = useState<AddressFormat>(DEFAULT_ADDRESS_FORMAT);
   const [privateKeyReady, setPrivateKeyReady] = useState(false);
   const [isConfirmed, setIsConfirmed] = useState(false);
   const [passwordReady, setPasswordReady] = useState(false);

--- a/src/platform/__tests__/walletManager.test.ts
+++ b/src/platform/__tests__/walletManager.test.ts
@@ -38,6 +38,9 @@ vi.mock('@/core/bitcoin/psbt', () => ({
   extractPsbtDetails: vi.fn(),
   completePsbtWithInputValues: vi.fn(),
 }));
+vi.mock('@/core/bitcoin/psbtPrevouts', () => ({
+  verifyPsbtPrevouts: vi.fn(async (psbt: string) => ({ hex: psbt, prevouts: [] })),
+}));
 vi.mock('@/core/counterwallet');
 vi.mock('@/core/wallet/rarePepeWallet', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@/core/wallet/rarePepeWallet')>()),

--- a/src/platform/__tests__/walletManagerHardwarePaths.test.ts
+++ b/src/platform/__tests__/walletManagerHardwarePaths.test.ts
@@ -1,0 +1,61 @@
+import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
+import { getPublicKey } from '@noble/secp256k1';
+import { p2wpkh, Transaction } from '@scure/btc-signer';
+import { describe, expect, it, vi } from 'vitest';
+import { AddressFormat } from '@/core/bitcoin/address';
+import { finalizePSBT, signPSBT } from '@/core/bitcoin/psbt';
+import { WalletManager } from '@/platform/walletManager';
+import type { Wallet } from '@/types/wallet';
+
+const { hardware } = vi.hoisted(() => ({
+  hardware: { init: vi.fn(), signPsbt: vi.fn() },
+}));
+vi.mock('@/core/hardware/trezorAdapter', () => ({ getTrezorAdapter: () => hardware }));
+vi.mock('@/platform/auth/sessionManager', async (original) => ({
+  ...(await original<typeof import('@/platform/auth/sessionManager')>()),
+  getUnlockedSecret: vi.fn(async () => JSON.stringify({ deviceType: 'trezor' })),
+}));
+
+describe('WalletManager hardware input derivation', () => {
+  it('passes each verified input owner to Trezor using the real hardened-path parser', async () => {
+    const keys = ['01'.padStart(64, '0'), '02'.padStart(64, '0')];
+    const owners = keys.map((key) => p2wpkh(getPublicKey(hexToBytes(key))));
+    const wallet: Wallet = {
+      id: 'hardware-paths', name: 'Hardware', type: 'hardware',
+      addressFormat: AddressFormat.P2WPKH, addressCount: 2,
+      addresses: owners.map((owner, index) => ({
+        address: owner.address, name: `Address ${index + 1}`,
+        path: `m/84'/0'/0'/0/${index === 0 ? 0 : 7}`,
+        pubKey: bytesToHex(getPublicKey(hexToBytes(keys[index]!))),
+      })),
+    };
+    const parent = new Transaction();
+    parent.addInput({ txid: '11'.repeat(32), index: 0 });
+    for (const owner of owners) parent.addOutput({ script: owner.script, amount: 50_000n });
+    const spending = new Transaction();
+    owners.forEach((_, index) => {
+      spending.addInput({ txid: parent.id, index, nonWitnessUtxo: parent.unsignedTx });
+    });
+    spending.addOutput({ script: owners[0]!.script, amount: 99_000n });
+    const psbtHex = bytesToHex(spending.toPSBT());
+    const signedPsbt = keys.reduce((psbt, key, index) =>
+      signPSBT(psbt, key, [index], AddressFormat.P2WPKH), psbtHex);
+    const signedTxHex = finalizePSBT(signedPsbt);
+    hardware.init.mockResolvedValue(undefined);
+    hardware.signPsbt.mockResolvedValue({ signedTxHex });
+    const manager = new WalletManager();
+    manager['wallets'] = [wallet];
+    manager['activeWalletId'] = wallet.id;
+
+    await expect(manager.signTransaction(bytesToHex(spending.unsignedTx), owners[0]!.address, {
+      psbtHex, inputValues: [50_000, 50_000],
+      lockScripts: owners.map((owner) => bytesToHex(owner.script)),
+    })).resolves.toBe(signedTxHex);
+    expect(hardware.signPsbt).toHaveBeenCalledWith(expect.objectContaining({
+      inputPaths: new Map([
+        [0, [0x80000054, 0x80000000, 0x80000000, 0, 0]],
+        [1, [0x80000054, 0x80000000, 0x80000000, 0, 7]],
+      ]),
+    }));
+  });
+});

--- a/src/platform/provider/signPsbtPhase.test.ts
+++ b/src/platform/provider/signPsbtPhase.test.ts
@@ -75,6 +75,7 @@ describe('dependent attach and listing signing', () => {
     expect(bytesToHex(resolvedListing.getInput(1)!.txid!)).toBe(finalAttachTxid);
     expect(bytesToHex(resolvedListing.getInput(0)!.txid!)).toBe('00'.repeat(32));
     expect(resolvedListing.getInput(1)!.partialSig).toHaveLength(1);
+    expect(resolvedListing.getInput(1)!.nonWitnessUtxo).toBeDefined();
   });
 
   it('refuses to rebind a different source outpoint', () => {

--- a/src/platform/provider/signPsbtPhase.ts
+++ b/src/platform/provider/signPsbtPhase.ts
@@ -36,6 +36,7 @@ export function rebindDependentListingPsbt(
   listingPsbtHex: string,
   expectedOutpoint: DependentListingOutpoint,
   finalAttachTxid: string,
+  finalAttachRawTx?: string,
 ): string {
   const transaction = parsePSBT(listingPsbtHex);
   if (transaction.inputsLength !== 2 || transaction.outputsLength !== 2) {
@@ -59,6 +60,9 @@ export function rebindDependentListingPsbt(
   }
   transaction.updateInput(1, {
     txid: hexToBytes(txidHex(finalAttachTxid, 'final attach txid')),
+    // Package children cannot fetch an unbroadcast parent. Carry the exact signed parent so the
+    // wallet can verify this input independently when the listing reaches its signing boundary.
+    ...(finalAttachRawTx ? { nonWitnessUtxo: hexToBytes(finalAttachRawTx) } : {}),
   }, true);
   return bytesToHex(transaction.toPSBT());
 }
@@ -84,13 +88,15 @@ export async function signAttachAndListingForDelivery<T extends { psbtHex: strin
   if (unsignedTransactionHex(signedAttach) !== unsignedTransactionHex(attach.psbtHex)) {
     throw new Error('attach signer changed the reviewed transaction');
   }
-  const finalAttachTxid = computeTxid(finalizePSBT(signedAttach));
+  const finalAttachRawTx = finalizePSBT(signedAttach);
+  const finalAttachTxid = computeTxid(finalAttachRawTx);
   if (!finalAttachTxid) throw new Error('wallet could not derive the signed attach transaction id');
 
   const reboundListing = rebindDependentListingPsbt(
     listing.psbtHex,
     expectedOutpoint,
     finalAttachTxid,
+    finalAttachRawTx,
   );
   const signedListing = await sign({ ...listing, psbtHex: reboundListing }, 1);
   if (unsignedTransactionHex(signedListing) !== unsignedTransactionHex(reboundListing)) {

--- a/src/platform/walletManager.ts
+++ b/src/platform/walletManager.ts
@@ -2,10 +2,11 @@ import { sha256 } from '@noble/hashes/sha2.js';
 import { bytesToHex, utf8ToBytes } from '@noble/hashes/utils.js';
 import { validateMnemonic } from '@scure/bip39';
 import { wordlist } from '@scure/bip39/wordlists/english.js';
-import { AddressFormat, getAddressFromMnemonic, getDerivationPathForAddressFormat, isCounterwalletFormat, normalizeAddressForComparison } from '@/core/bitcoin/address';
+import { AddressFormat, DEFAULT_ADDRESS_FORMAT, getAddressFromMnemonic, getDerivationPathForAddressFormat, isCounterwalletFormat, normalizeAddressForComparison } from '@/core/bitcoin/address';
 import { signMessage } from '@/core/bitcoin/messageSigner';
 import { decodeWIF, encodeWIF, getAddressFromPrivateKey, getPrivateKeyFromMnemonic, getPublicKeyFromPrivateKey, isWIF } from '@/core/bitcoin/privateKey';
-import { signPSBT as btcSignPSBT, completePsbtWithInputValues, extractPsbtDetails } from '@/core/bitcoin/psbt';
+import { signPSBT as btcSignPSBT, completePsbtWithInputValues } from '@/core/bitcoin/psbt';
+import { verifyPsbtPrevouts } from '@/core/bitcoin/psbtPrevouts';
 import { broadcastTransaction as btcBroadcastTransaction } from '@/core/bitcoin/transactionBroadcaster';
 import { signTransaction as btcSignTransaction } from '@/core/bitcoin/transactionSigner';
 import { isValidCounterwalletMnemonic } from '@/core/counterwallet';
@@ -17,6 +18,7 @@ import {
   deriveKeyAsync,
   encryptWithKey,
 } from '@/core/encryption/encryption';
+import { mapVerifiedInputPaths } from '@/core/hardware/inputPaths';
 import { type AppSettings, DEFAULT_SETTINGS, getAutoLockTimeoutMs, setSettingsProvider } from '@/core/settings';
 import {
   deriveAddressesFromSecret,
@@ -284,7 +286,7 @@ export class WalletManager {
     mnemonic: string,
     password: string,
     name?: string,
-    addressFormat: AddressFormat = AddressFormat.P2WPKH
+    addressFormat: AddressFormat = DEFAULT_ADDRESS_FORMAT
   ): Promise<Wallet> {
     if (this.wallets.length >= MAX_WALLETS) {
       throw new Error(`Maximum number of wallets (${MAX_WALLETS}) reached`);
@@ -354,7 +356,7 @@ export class WalletManager {
     privateKey: string,
     password: string,
     name?: string,
-    addressFormat: AddressFormat = AddressFormat.P2TR
+    addressFormat: AddressFormat = DEFAULT_ADDRESS_FORMAT
   ): Promise<Wallet> {
     if (this.wallets.length >= MAX_WALLETS) {
       throw new Error(`Maximum number of wallets (${MAX_WALLETS}) reached`);
@@ -1457,33 +1459,44 @@ export class WalletManager {
         throw new Error("Hardware wallet signing requires a PSBT. The transaction cannot be signed without PSBT data.");
       }
 
+      // Treat amounts/scripts shipped beside the PSBT as hints only. Resolve the raw parent
+      // transaction for every input, bind the outpoint to it, and use those independently
+      // verified values for both device display and signing.
+      const verified = await verifyPsbtPrevouts(psbtHex, {
+        resolveTrustedPrevout: getTrustedBroadcastPrevout,
+      });
+      const verifiedValues = verified.prevouts.map((prevout) => Number(prevout.amount));
+      const verifiedScripts = verified.prevouts.map((prevout) => bytesToHex(prevout.script));
+      if (
+        inputValues
+        && (
+          inputValues.length !== verifiedValues.length
+          || inputValues.some((value, index) => value !== verifiedValues[index])
+        )
+      ) {
+        throw new Error('Counterparty input values do not match the real previous outputs');
+      }
+      if (
+        lockScripts
+        && (
+          lockScripts.length !== verifiedScripts.length
+          || lockScripts.some((script, index) => script.toLowerCase() !== verifiedScripts[index])
+        )
+      ) {
+        throw new Error('Counterparty lock scripts do not match the real previous outputs');
+      }
+      const completedPsbtHex = completePsbtWithInputValues(
+        verified.hex,
+        verifiedValues,
+        verifiedScripts,
+      );
+
       const { trezor, DerivationPaths } = await this.getInitializedTrezor(wallet.id);
-
-      // Convert derivation path string to number array
-      const pathArray = DerivationPaths.stringToPath(targetAddress.path);
-
-      // Complete the PSBT with input values - required for hardware wallet signing
-      // The Counterparty API returns PSBTs without witnessUtxo data, providing
-      // inputs_values and lock_scripts separately. We need to combine them.
-      if (!inputValues || !lockScripts || inputValues.length === 0 || lockScripts.length === 0) {
-        throw new Error(
-          "Hardware wallet signing requires input values and lock scripts from the API. " +
-          "The transaction data appears incomplete. Please try again."
-        );
-      }
-      const completedPsbtHex = completePsbtWithInputValues(psbtHex, inputValues, lockScripts);
-
-      // Create input paths map - all inputs use the same path for single-address wallets
-      // For multi-input transactions, we'd need to map each input to its path
-      const inputPaths = new Map<number, number[]>();
-
-      // Parse PSBT to find how many inputs there are
-      const psbtDetails = extractPsbtDetails(completedPsbtHex);
-
-      // For now, assume all inputs are from our address (single-signer scenario)
-      for (let i = 0; i < psbtDetails.inputs.length; i++) {
-        inputPaths.set(i, pathArray);
-      }
+      const inputPaths = mapVerifiedInputPaths(
+        verified.prevouts,
+        wallet.addresses,
+        (path) => DerivationPaths.stringToPath(path),
+      );
 
       // Sign PSBT with hardware wallet - returns fully signed raw tx
       const result = await trezor.signPsbt({
@@ -1612,6 +1625,17 @@ export class WalletManager {
         "Use the built-in transaction composer or your hardware wallet's native dApp connector."
       );
     }
+
+    // The PSBT may contain witnessUtxo metadata supplied by an untrusted dApp. Validate every
+    // input against its actual parent transaction before selecting keys or producing signatures.
+    const requestedInputIndices = signInputs && Object.keys(signInputs).length > 0
+      ? Object.values(signInputs).flat()
+      : undefined;
+    const verified = await verifyPsbtPrevouts(psbtHex, {
+      resolveTrustedPrevout: getTrustedBroadcastPrevout,
+      ...(requestedInputIndices ? { inputIndices: requestedInputIndices } : {}),
+    });
+    psbtHex = verified.hex;
 
     // If signInputs is provided, sign only the specified inputs
     // Otherwise, sign all inputs we can (using the active address)


### PR DESCRIPTION
## Summary

- independently verify PSBT prevouts and Counterparty sidecar amounts/scripts before software or Trezor signing
- map each Trezor input to its verified owning derivation path and preserve unbroadcast package parents
- centralize bounded permissive raw-transaction parsing while keeping PSBT wrapper and Taproot checks enabled
- enforce PSBT/raw parsing resource ceilings and strict BIP370 transaction-modifiable semantics
- make Native SegWit the shared new-wallet/import fallback while explicitly detecting existing Taproot activity
- distinguish exact SEC serialization for address identity from EC-point equality for Counterparty recovery, and centralize the narrow legacy sighash adapter

## Verification

- npm run compile
- npm run lint
- npm run build
- npx vitest run src (4,993 passed, 62 skipped)
- targeted Playwright smoke tests for Native SegWit default, private-key import, and PSBT approval (3 passed)

## QA and integration

Fixed a hardware-signing regression found during QA: preserve the receiver used by the hardened derivation-path parser. The new regression exercises two verified input owners with the real parser and signed PSBT bytes. 506 existing focused tests passed; 53 relevant tests passed after the fix, along with TypeScript and targeted lint.

The final published head passed the full CI suite before merging.

Merged after all 40 checks passed. The merge tree `4d084f268879149a8fbdc7acaec83be69947a715` exactly matches the reviewed tree.
