### PR TITLE
Prove platform fees in exact offer approvals

### DIFF
--- a/APPROVAL-DESIGN.md
+++ b/APPROVAL-DESIGN.md
@@ -12,7 +12,7 @@ The original audit below reviewed 25 ordinary raw-transaction gallery images, se
 
 | Group | Examples | Assessment and direction |
 | --- | --- | --- |
-| Strongest | `send-divisible-bech32`, `checkout-buy-proved`, `listing-attach-caution` | Clear action or amount, understandable supporting facts, and a recognizable progression toward approval. Use these as references for information hierarchy, while retaining each action's actual conditions. |
+| Strongest | `send-divisible-bech32`, `checkout-buy-proved`, `listing-attach` | Clear action or amount, understandable supporting facts, and a recognizable progression toward approval. Use these as references for information hierarchy, while retaining each action's actual conditions. |
 | Strongest composition | Order give/receive cards | Two related amounts read as a trade instead of an opaque sentence. Preserve this composition. The slippage callout is a separate issue and does not make the give/receive structure wrong. |
 | Middle | MPMA, dispenser, issuance, paired prepare | Useful information is present, but grouping, field treatment, and density need a common grammar. MPMA must keep every recipient and quantity available. Paired prepare must keep the signing identities clear. |
 | Middle | CPFP | Lead with the user's net proceeds and place the fee explanation beneath them. Do not imply that gross returned value is the amount the user gains. |

--- a/e2e/tests/approval-gallery.spec.ts
+++ b/e2e/tests/approval-gallery.spec.ts
@@ -438,7 +438,7 @@ walletTest('captures every provider approval screen', async ({ context, page, ex
       // for a multi-destination send that panel is the only place the payees appear at all.
       // Exact match: warning copy also mentions 'the transaction details', which makes a loose
       // locator ambiguous on any screen that carries one.
-      const details = approval.getByText(/^Transaction Details$/);
+      const details = approval.getByText(/^Transaction$/);
       await expect(details).toBeVisible({ timeout: 30_000 });
       await details.click();
       await expect(approval.getByText(/^Outputs \(/)).toBeVisible({ timeout: 10_000 });
@@ -498,7 +498,7 @@ walletTest('captures every provider approval screen', async ({ context, page, ex
 
       // Expanded, for the same reason as above: the recipients list and the checks line live in
       // this panel, and they are precisely what was missing from this screen.
-      const psbtDetails = approval.getByText(/^Transaction Details$/);
+      const psbtDetails = approval.getByText(/^Transaction$/);
       await expect(psbtDetails).toBeVisible({ timeout: 30_000 });
       await psbtDetails.click();
 

--- a/e2e/tests/marketplace-gallery.spec.ts
+++ b/e2e/tests/marketplace-gallery.spec.ts
@@ -832,12 +832,13 @@ function buildScenarios(wallet: string, pairedLegacy: string, walletId: string):
       const buyerAddr = accepting ? BUYER_EXT : wallet;
       const sellerAddr = accepting ? wallet : SELLER_A;
       const inputs: BuiltInput[] = [
-        { txid: BID_TXID, vout: 4, address: buyerAddr, value: 250_000, signed: accepting },
+        { txid: BID_TXID, vout: 4, address: buyerAddr, value: 256_250, signed: accepting },
         { txid: ASSET_TXID, vout: 7, address: sellerAddr, value: 546 },
       ];
       const outputs: BuiltOutput[] = [
         { scriptHex: opReturnScript(detachPayload(buyerAddr), BID_TXID), value: 0 },
         { scriptHex: scriptFor(sellerAddr), value: 250_046 },
+        { scriptHex: scriptFor(PLATFORM), value: 6_250 },
       ];
       const { psbtHex, txid } = buildPsbt(inputs, outputs);
       const intent = {
@@ -858,6 +859,7 @@ function buildScenarios(wallet: string, pairedLegacy: string, walletId: string):
         carrierValueSats: 546,
         sellerProceedsSats: 250_046,
         networkFeeSats: 500,
+        platformFeeSats: 6_250,
         expectedTxid: txid,
         delivery: { mode: 'detached', address: buyerAddr },
         marketplaceExpiresAt: FUTURE + 3_600,
@@ -873,6 +875,7 @@ function buildScenarios(wallet: string, pairedLegacy: string, walletId: string):
     const authorize = offer(false);
     scenarios.push({
       name: 'offer-authorize-caution',
+      expectedText: ['Platform fee', '6,250 sats', 'Paid by the buyer', '256,250 sats'],
       route: '/requests/psbt/approve',
       expectFooter: 'Review',
       record: seedRecord('mk-authorize', {
@@ -891,6 +894,7 @@ function buildScenarios(wallet: string, pairedLegacy: string, walletId: string):
     const accept = offer(true);
     scenarios.push({
       name: 'offer-accept-proved',
+      expectedText: ['Platform fee', '6,250 sats', 'Paid by the buyer', '250,046 sats'],
       route: '/requests/psbt/approve',
       expectFooter: 'Accept offer',
       record: seedRecord('mk-accept', {
@@ -913,6 +917,7 @@ function buildScenarios(wallet: string, pairedLegacy: string, walletId: string):
     );
     scenarios.push({
       name: 'bundle-accept-cpfp-proved',
+      expectedText: ['Platform fee', '6,250 sats', 'Paid by the buyer', '249,046 sats'],
       route: '/requests/psbts/approve',
       expectFooter: 'Accept offer',
       record: seedRecord('mk-bundle', {

--- a/e2e/tests/marketplace-gallery.spec.ts
+++ b/e2e/tests/marketplace-gallery.spec.ts
@@ -279,6 +279,8 @@ interface Scenario {
     | 'Attach and list';
   /** Important semantic disclosures that must survive visual refactors. */
   expectedText?: string[];
+  /** Principal decision facts must be visible without expanding any details. */
+  initialText?: string[];
   /** False-positive warnings that would make an ordinary marketplace request look unsafe. */
   absentText?: string[];
 }
@@ -827,16 +829,17 @@ function buildScenarios(wallet: string, pairedLegacy: string, walletId: string):
   }
 
   // --- exact offers: buyer authorization (caution) and seller acceptance (proved) -----------
-  {
+  for (const attached of [false, true]) {
+    const suffix = attached ? '-attached' : '';
     const offer = (accepting: boolean) => {
       const buyerAddr = accepting ? BUYER_EXT : wallet;
       const sellerAddr = accepting ? wallet : SELLER_A;
       const inputs: BuiltInput[] = [
-        { txid: BID_TXID, vout: 4, address: buyerAddr, value: 256_250, signed: accepting },
+        { txid: BID_TXID, vout: 4, address: buyerAddr, value: 256_250 + (attached ? 330 : 0), signed: accepting },
         { txid: ASSET_TXID, vout: 7, address: sellerAddr, value: 546 },
       ];
       const outputs: BuiltOutput[] = [
-        { scriptHex: opReturnScript(detachPayload(buyerAddr), BID_TXID), value: 0 },
+        { scriptHex: attached ? scriptFor(buyerAddr) : opReturnScript(detachPayload(buyerAddr), BID_TXID), value: attached ? 330 : 0 },
         { scriptHex: scriptFor(sellerAddr), value: 250_046 },
         { scriptHex: scriptFor(PLATFORM), value: 6_250 },
       ];
@@ -861,7 +864,9 @@ function buildScenarios(wallet: string, pairedLegacy: string, walletId: string):
         networkFeeSats: 500,
         platformFeeSats: 6_250,
         expectedTxid: txid,
-        delivery: { mode: 'detached', address: buyerAddr },
+        delivery: attached
+          ? { mode: 'attached', address: buyerAddr, carrierValueSats: 330 }
+          : { mode: 'detached', address: buyerAddr },
         marketplaceExpiresAt: FUTURE + 3_600,
         bitcoinExpiresAt: null,
         bitcoinInvalidation: {
@@ -874,7 +879,9 @@ function buildScenarios(wallet: string, pairedLegacy: string, walletId: string):
 
     const authorize = offer(false);
     scenarios.push({
-      name: 'offer-authorize-caution',
+      name: `offer-authorize-caution${suffix}`,
+      initialText: ['Offer to buy', 'You pay if accepted', '256,250 sats', 'Platform fee', 'Paid by the buyer'],
+      absentText: ['Returned to wallet'],
       expectedText: ['Platform fee', '6,250 sats', 'Paid by the buyer', '256,250 sats'],
       route: '/requests/psbt/approve',
       expectFooter: 'Review',
@@ -893,7 +900,9 @@ function buildScenarios(wallet: string, pairedLegacy: string, walletId: string):
 
     const accept = offer(true);
     scenarios.push({
-      name: 'offer-accept-proved',
+      name: `offer-accept-proved${suffix}`,
+      initialText: ['You receive', '250,046 sats', 'Deducted from seller proceeds'],
+      absentText: ['Returned to wallet', 'Cancellation', 'Withdraw by spending your funding UTXO'],
       expectedText: ['Platform fee', '6,250 sats', 'Paid by the buyer', '250,046 sats'],
       route: '/requests/psbt/approve',
       expectFooter: 'Accept offer',
@@ -916,7 +925,9 @@ function buildScenarios(wallet: string, pairedLegacy: string, walletId: string):
       [{ scriptHex: scriptFor(wallet), value: 249_046 }],
     );
     scenarios.push({
-      name: 'bundle-accept-cpfp-proved',
+      name: `bundle-accept-cpfp-proved${suffix}`,
+      initialText: ['You receive', '249,046 sats', 'Paid by the buyer', 'Accept offer for 1 RAREPEPE'],
+      absentText: ['Returned to wallet'],
       expectedText: ['Platform fee', '6,250 sats', 'Paid by the buyer', '249,046 sats'],
       route: '/requests/psbts/approve',
       expectFooter: 'Accept offer',
@@ -1124,6 +1135,9 @@ walletTest('captures every marketplace and provider-safety approval screen', asy
         stateMismatches.push(`${scenario.name}: footer reads "${footerLabel}", expected "${scenario.expectFooter}"`);
       }
 
+      for (const initialText of scenario.initialText ?? []) {
+        await expect(approval.getByText(initialText, { exact: true }).first()).toBeVisible();
+      }
       await captureApprovalSizes(approval, OUT_DIR, scenario.name);
 
       // Capture the paired signer disclosure at the top of the approval before opening lower

--- a/e2e/tests/marketplace-gallery.spec.ts
+++ b/e2e/tests/marketplace-gallery.spec.ts
@@ -320,7 +320,7 @@ function buildScenarios(wallet: string, pairedLegacy: string, walletId: string):
     ];
     const { psbtHex, txid } = buildPsbt([funding], outputs);
     scenarios.push({
-      name: 'listing-attach-caution',
+      name: 'listing-attach',
       route: '/requests/psbt/approve',
       expectFooter: 'Sign transaction',
       record: seedRecord('mk-attach', {
@@ -879,12 +879,12 @@ function buildScenarios(wallet: string, pairedLegacy: string, walletId: string):
 
     const authorize = offer(false);
     scenarios.push({
-      name: `offer-authorize-caution${suffix}`,
+      name: `offer-authorize${suffix}`,
       initialText: ['Offer to buy', 'You pay if accepted', '256,250 sats', 'Platform fee', 'Paid by the buyer'],
-      absentText: ['Returned to wallet'],
-      expectedText: ['Platform fee', '6,250 sats', 'Paid by the buyer', '256,250 sats'],
+      absentText: ['Returned to wallet', 'The seller can complete this sale at any time', 'What to review'],
+      expectedText: ['Platform fee', '6,250 sats', 'Paid by the buyer', '256,250 sats', 'Withdraw by spending your funding UTXO'],
       route: '/requests/psbt/approve',
-      expectFooter: 'Review',
+      expectFooter: 'Authorize offer',
       record: seedRecord('mk-authorize', {
         requestKey: 'xcp_signPsbt:mk-authorize',
         kind: 'sign-psbt',
@@ -902,8 +902,9 @@ function buildScenarios(wallet: string, pairedLegacy: string, walletId: string):
     scenarios.push({
       name: `offer-accept-proved${suffix}`,
       initialText: ['You receive', '250,046 sats', 'Deducted from seller proceeds'],
-      absentText: ['Returned to wallet', 'Cancellation', 'Withdraw by spending your funding UTXO'],
-      expectedText: ['Platform fee', '6,250 sats', 'Paid by the buyer', '250,046 sats'],
+      // The seller does not pay the platform fee, so their screen never names it.
+      absentText: ['Returned to wallet', 'Cancellation', 'Withdraw by spending your funding UTXO', 'Platform fee', 'Fee recipient'],
+      expectedText: ['250,046 sats', 'Offer price', '250,000 sats'],
       route: '/requests/psbt/approve',
       expectFooter: 'Accept offer',
       record: seedRecord('mk-accept', {
@@ -926,9 +927,9 @@ function buildScenarios(wallet: string, pairedLegacy: string, walletId: string):
     );
     scenarios.push({
       name: `bundle-accept-cpfp-proved${suffix}`,
-      initialText: ['You receive', '249,046 sats', 'Paid by the buyer', 'Accept offer for 1 RAREPEPE'],
-      absentText: ['Returned to wallet'],
-      expectedText: ['Platform fee', '6,250 sats', 'Paid by the buyer', '249,046 sats'],
+      initialText: ['You receive', '249,046 sats', 'Accept offer for 1 RAREPEPE'],
+      absentText: ['Returned to wallet', 'Platform fee', 'Paid by the buyer'],
+      expectedText: ['249,046 sats', 'Added child fee', '1,000 sats'],
       route: '/requests/psbts/approve',
       expectFooter: 'Accept offer',
       record: seedRecord('mk-bundle', {
@@ -1127,7 +1128,7 @@ walletTest('captures every marketplace and provider-safety approval screen', asy
       );
 
       const footer = approval.getByRole('button', {
-        name: /^(sign transaction|buy collectibles|accept offer|prepare funds|send bitcoin|review|blocked|awaiting verification|authorize listing|authorize reprice|prepare asset|attach and list)$/i,
+        name: /^(sign transaction|buy collectibles|accept offer|prepare funds|send bitcoin|review|blocked|awaiting verification|authorize listing|authorize reprice|authorize offer|prepare asset|attach and list)$/i,
       });
       await expect(footer).toBeVisible({ timeout: 60_000 });
       const footerLabel = (await footer.textContent())?.trim() ?? '';
@@ -1155,7 +1156,7 @@ walletTest('captures every marketplace and provider-safety approval screen', asy
       }
 
       // Open the lower-level transaction surfaces for the companion detail capture.
-      for (const title of [/^Transaction Details$/, /^Linked Transaction Details$/, /^Compare payment details$/, /^Payout and fee details$/, /^Why signing is unavailable$/, /^What to review$/]) {
+      for (const title of [/^Transaction$/, /^Transactions$/, /^Compare payment details$/, /^Payout and fee details$/, /^Why signing is unavailable$/, /^What to review$/]) {
         const toggle = approval.getByText(title);
         if (await toggle.count()) await toggle.first().click();
       }

--- a/e2e/utils/approval-layout.ts
+++ b/e2e/utils/approval-layout.ts
@@ -26,7 +26,7 @@ export async function captureApprovalSizes(page: Page, directory: string, name: 
     if (name === 'checkout-buy-proved') {
       await expect(content.getByText('You pay', { exact: true }).locator('..')).toBeInViewport({ ratio: 1 });
     }
-    const outcome = name.startsWith('offer-authorize-') ? 'You pay if accepted'
+    const outcome = /^offer-authorize(-|$)/.test(name) ? 'You pay if accepted'
       : /^(offer-accept-|bundle-accept-cpfp-)/.test(name) ? 'You receive' : null;
     if (outcome) {
       await expect(content.getByText(outcome, { exact: true }).first().locator('..'),

--- a/e2e/utils/approval-layout.ts
+++ b/e2e/utils/approval-layout.ts
@@ -26,6 +26,12 @@ export async function captureApprovalSizes(page: Page, directory: string, name: 
     if (name === 'checkout-buy-proved') {
       await expect(content.getByText('You pay', { exact: true }).locator('..')).toBeInViewport({ ratio: 1 });
     }
+    const outcome = name.startsWith('offer-authorize-') ? 'You pay if accepted'
+      : /^(offer-accept-|bundle-accept-cpfp-)/.test(name) ? 'You receive' : null;
+    if (outcome) {
+      await expect(content.getByText(outcome, { exact: true }).first().locator('..'),
+        `${name}: the signer outcome must be above the fold`).toBeInViewport({ ratio: 1 });
+    }
     await page.screenshot({ path: path.join(directory, `${name}-initial-${width}.png`) });
   }
   if (['listing-create-proved', 'bitcoin-pay-proved', 'bitcoin-pay-mismatch-blocked', 'bundle-accept-cpfp-proved', 'connect-proved', 'message-proved'].includes(name)) {

--- a/src/components/domain/approval/approval-summary-card.test.tsx
+++ b/src/components/domain/approval/approval-summary-card.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import '@testing-library/jest-dom/vitest';
+import type { MarketplaceApprovalReview } from '@/core/counterparty/marketplaceIntent';
 import { ApprovalSummaryCard } from './approval-summary-card';
 import type { MoneyMovement } from './money-movement';
 
@@ -11,6 +12,79 @@ const movement = (over: Partial<MoneyMovement> = {}): MoneyMovement => ({
 const base = { movement: movement(), hasHighFee: false, protocolFeeXcp: null } as const;
 
 describe('ApprovalSummaryCard', () => {
+  const review = (over: Partial<MarketplaceApprovalReview> = {}): MarketplaceApprovalReview => ({
+    status: 'proved', family: 'accept_exact_offer', title: 'Accept offer',
+    facts: [], notices: [], blockers: [],
+    paymentSummary: [
+      { kind: 'amount', label: 'You receive', value: '250,046 sats', emphasis: 'primary' },
+      { kind: 'amount', label: 'Network fee', value: '500 sats', description: 'Deducted from seller proceeds' },
+    ],
+    ...over,
+  });
+
+  it('shows seller proceeds, not change or the buyer-paid external output', () => {
+    render(<ApprovalSummaryCard {...base} txAction={{ label: 'Accept offer', description: '1 RAREPEPE' }} marketplaceReview={review()} />);
+    expect(screen.getByText('You receive')).toBeInTheDocument();
+    expect(screen.getByText('250,046 sats')).toBeInTheDocument();
+    expect(screen.getByText('Deducted from seller proceeds')).toBeInTheDocument();
+    expect(screen.queryByText('Returned to wallet')).not.toBeInTheDocument();
+    expect(screen.queryByText('Change')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('bc1qexternaldest')).not.toBeInTheDocument();
+  });
+
+  it('shows the buyer conditional cost, not a generic send', () => {
+    render(<ApprovalSummaryCard {...base} txAction={{ label: 'Offer to buy', description: '1 RAREPEPE' }} marketplaceReview={review({
+      status: 'caution', family: 'authorize_exact_offer',
+      paymentSummary: [
+        { kind: 'amount', label: 'You pay if accepted', value: '256,250 sats', emphasis: 'primary' },
+        { kind: 'amount', label: 'Platform fee', value: '6,250 sats', description: 'Paid by the buyer' },
+      ],
+    })} />);
+    expect(screen.getByText('You pay if accepted')).toBeInTheDocument();
+    expect(screen.getByText('256,250 sats')).toBeInTheDocument();
+    expect(screen.getByText('Paid by the buyer')).toBeInTheDocument();
+    expect(screen.queryByText('You send')).not.toBeInTheDocument();
+    expect(screen.queryByText('Returned to wallet')).not.toBeInTheDocument();
+  });
+
+  it('keeps an attached purchase output separate from actual change', () => {
+    render(<ApprovalSummaryCard {...base} txAction={{ label: 'Buy collectibles', description: '1 collectible' }} marketplaceReview={review({
+      family: 'buy_listings', paymentSummary: [
+        { kind: 'amount', label: 'You pay', value: '106,000 sats', emphasis: 'primary' },
+        { kind: 'amount', label: 'Sats kept with your asset', value: '330 sats' },
+        { kind: 'amount', label: 'Change', value: '293,670 sats' },
+      ],
+    })} />);
+    expect(screen.getByText('Sats kept with your asset')).toBeInTheDocument();
+    expect(screen.getByText('330 sats')).toBeInTheDocument();
+    expect(screen.getByText('Change')).toBeInTheDocument();
+    expect(screen.getByText('293,670 sats')).toBeInTheDocument();
+    expect(screen.queryByText('Returned to wallet')).not.toBeInTheDocument();
+  });
+
+  it('shows a conditional listing payout even though this PSBT is not funded', () => {
+    render(<ApprovalSummaryCard {...base} hideMovement txAction={{ label: 'List for sale', description: '1 RAREPEPE' }} marketplaceReview={review({
+      family: 'create_listing', paymentSummary: [
+        { kind: 'amount', label: 'Your payout if sold', value: '250,546 sats', emphasis: 'primary' },
+      ],
+    })} />);
+    expect(screen.getByText('Your payout if sold')).toBeInTheDocument();
+    expect(screen.getByText('250,546 sats')).toBeInTheDocument();
+    expect(screen.queryByText('Network fee')).not.toBeInTheDocument();
+  });
+
+  it.each(['blocked', 'retry'] as const)('does not trust payment labels from a %s review', (status) => {
+    render(<ApprovalSummaryCard {...base} txAction={null} marketplaceReview={review({ status })} />);
+    expect(screen.queryByText('250,046 sats')).not.toBeInTheDocument();
+    expect(screen.getByText('You send')).toBeInTheDocument();
+    expect(screen.getByTitle('bc1qexternaldest')).toBeInTheDocument();
+  });
+
+  it('does not drop a high-fee warning when replacing generic movement', () => {
+    render(<ApprovalSummaryCard {...base} hasHighFee txAction={null} marketplaceReview={review()} />);
+    expect(screen.getByText(/unusually high network fee/i)).toBeInTheDocument();
+  });
+
   it('puts the verified checkout total before supporting payment rows', () => {
     render(<ApprovalSummaryCard {...base}
       txAction={{ label: 'Buy collectibles', description: '2 collectibles' }} principal

--- a/src/components/domain/approval/approval-summary-card.tsx
+++ b/src/components/domain/approval/approval-summary-card.tsx
@@ -5,6 +5,7 @@ import { MoneyMovementView } from '@/components/domain/approval/money-movement-v
 import { type OrderAction, OrderCard } from '@/components/domain/approval/order-card';
 import type { PsbtFlexibilityKind } from '@/components/domain/approval/psbt-flexibility';
 import type { ProtocolField } from '@/core/counterparty/describe';
+import type { MarketplaceApprovalReview } from '@/core/counterparty/marketplaceIntent';
 import { formatAmount } from '@/core/format';
 import { fromSatoshis } from '@/core/numeric';
 
@@ -44,6 +45,8 @@ interface ApprovalSummaryCardProps {
   principal?: boolean;
   /** Verified principal consequences that must precede supporting BTC movement. */
   primaryFacts?: ProtocolField[];
+  /** Background-proved role-specific economics, never website-provided display labels. */
+  marketplaceReview?: MarketplaceApprovalReview;
   /**
    * A DEX order, which gets a card of its own instead of the label-and-sentence treatment: a trade
    * is two amounts that only mean something as a pair. Takes precedence over txAction.
@@ -93,6 +96,7 @@ export function ApprovalSummaryCard({
   txAction,
   principal = false,
   primaryFacts = [],
+  marketplaceReview,
   order,
   movement,
   flexibility,
@@ -103,6 +107,9 @@ export function ApprovalSummaryCard({
   protocolFeeXcp,
 }: ApprovalSummaryCardProps) {
   const protocolFee = formatProtocolFee(protocolFeeXcp);
+  const paymentSummary = marketplaceReview?.status === 'proved' || marketplaceReview?.status === 'caution'
+    ? marketplaceReview.paymentSummary : undefined;
+  const hasPaymentSummary = Boolean(paymentSummary?.length);
   return (
     <div className="bg-white rounded-lg shadow-sm p-4">
       {order ? <OrderCard order={order} /> : txAction && (
@@ -125,12 +132,16 @@ export function ApprovalSummaryCard({
           })()}
         </div>
       )}
-      {primaryFacts.length > 0 && (
+      {hasPaymentSummary && <ApprovalFacts fields={paymentSummary!} />}
+      {hasPaymentSummary && hasHighFee && !deferCautions && (
+        <p className="mt-2 text-sm text-warning-600 text-center">Unusually high network fee. Double-check before signing.</p>
+      )}
+      {!hasPaymentSummary && primaryFacts.length > 0 && (
         <div className="mb-3 border-b border-gray-100 pb-3">
           <ApprovalFacts fields={primaryFacts} />
         </div>
       )}
-      {!hideMovement && (
+      {!hasPaymentSummary && !hideMovement && (
         <MoneyMovementView
           movement={movement}
           flexibility={flexibility}

--- a/src/components/domain/approval/approval-transaction-details.test.tsx
+++ b/src/components/domain/approval/approval-transaction-details.test.tsx
@@ -29,7 +29,7 @@ describe('ApprovalTransactionDetails', () => {
         }}
       />,
     );
-    fireEvent.click(screen.getByRole('button', { name: 'Transaction Details' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Transaction' }));
 
     expect(screen.getByText('0.00050000 BTC')).toBeInTheDocument();
     expect(screen.getAllByText('RAREPEPE')).toHaveLength(1);
@@ -49,7 +49,7 @@ describe('ApprovalTransactionDetails', () => {
         }]}
       />,
     );
-    fireEvent.click(screen.getByRole('button', { name: 'Transaction Details' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Transaction' }));
 
     expect(screen.getByText('Asset status unavailable')).toBeInTheDocument();
   });

--- a/src/components/domain/approval/approval-transaction-details.tsx
+++ b/src/components/domain/approval/approval-transaction-details.tsx
@@ -40,7 +40,7 @@ export function ApprovalTransactionDetails({
   const attachedByInput = new Map(attachedAssets.map((entry) => [entry.inputIndex, entry]));
 
   return (
-    <Collapsible compact variant="card" title="Transaction Details">
+    <Collapsible compact variant="card" title="Transaction">
       {txid && (
         <div>
           <h4 className="mb-2 text-xs font-medium uppercase text-gray-500">TX Hash</h4>

--- a/src/components/domain/approval/bundle-review-card.test.tsx
+++ b/src/components/domain/approval/bundle-review-card.test.tsx
@@ -1,25 +1,32 @@
 import '@testing-library/jest-dom/vitest';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { BundleReviewCard } from './bundle-review-card';
 
 describe('BundleReviewCard', () => {
-  it('shows final seller proceeds and preserves who pays the platform fee', () => {
+  it('shows final seller proceeds without repeating summary amounts in the disclosure', () => {
     render(<BundleReviewCard review={{
       status: 'proved', family: 'accept_exact_offer_with_cpfp', title: 'Accept offer',
-      facts: [], notices: [], blockers: [],
+      facts: [
+        { kind: 'amount', label: 'Network fees', value: '1,500 sats' },
+        { kind: 'amount', label: 'Added child fee', value: '1,000 sats' },
+      ],
+      notices: [], blockers: [],
       bundleSummary: {
         outcome: { kind: 'amount', label: 'You receive', value: '249,046 sats', emphasis: 'primary' },
         action: 'Sell 1 RAREPEPE',
         amounts: [
-          { label: 'Platform fee', value: '6,250 sats', description: 'Paid by the buyer' },
-          { label: 'Network fees', value: '1,500 sats' },
+          { label: 'Network fees', value: '1,500 sats', description: 'Deducted from your proceeds' },
         ],
       },
     }} />);
     expect(screen.getByText('You receive')).toBeInTheDocument();
     expect(screen.getByText('249,046 sats')).toBeInTheDocument();
-    expect(screen.getByText('Paid by the buyer')).toBeVisible();
+    expect(screen.getByText('Deducted from your proceeds')).toBeVisible();
+    // The disclosure adds facts; it does not repeat an amount already shown above it.
+    fireEvent.click(screen.getByRole('button', { name: 'Payout and fee details' }));
+    expect(screen.getAllByText('Network fees')).toHaveLength(1);
+    expect(screen.getByText('Added child fee')).toBeInTheDocument();
     expect(screen.queryByText('Returned to wallet')).not.toBeInTheDocument();
     expect(screen.queryByText('Change')).not.toBeInTheDocument();
   });

--- a/src/components/domain/approval/bundle-review-card.test.tsx
+++ b/src/components/domain/approval/bundle-review-card.test.tsx
@@ -1,0 +1,26 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { BundleReviewCard } from './bundle-review-card';
+
+describe('BundleReviewCard', () => {
+  it('shows final seller proceeds and preserves who pays the platform fee', () => {
+    render(<BundleReviewCard review={{
+      status: 'proved', family: 'accept_exact_offer_with_cpfp', title: 'Accept offer',
+      facts: [], notices: [], blockers: [],
+      bundleSummary: {
+        outcome: { kind: 'amount', label: 'You receive', value: '249,046 sats', emphasis: 'primary' },
+        action: 'Sell 1 RAREPEPE',
+        amounts: [
+          { label: 'Platform fee', value: '6,250 sats', description: 'Paid by the buyer' },
+          { label: 'Network fees', value: '1,500 sats' },
+        ],
+      },
+    }} />);
+    expect(screen.getByText('You receive')).toBeInTheDocument();
+    expect(screen.getByText('249,046 sats')).toBeInTheDocument();
+    expect(screen.getByText('Paid by the buyer')).toBeVisible();
+    expect(screen.queryByText('Returned to wallet')).not.toBeInTheDocument();
+    expect(screen.queryByText('Change')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/domain/approval/bundle-review-card.tsx
+++ b/src/components/domain/approval/bundle-review-card.tsx
@@ -31,7 +31,8 @@ export function BundleReviewCard({ review }: { review: MarketplaceBundleReview }
       </dl>
       {summary.timing && <p className="mt-3 text-xs leading-4 text-gray-600">{summary.timing}</p>}
       <Collapsible className="mt-3 border-t border-gray-100 pt-3" title="Payout and fee details">
-        <ApprovalFacts fields={review.facts.filter(field => field.emphasis !== 'primary')} />
+        <ApprovalFacts fields={review.facts.filter(field =>
+          field.emphasis !== 'primary' && !summary.amounts.some(amount => amount.label === field.label))} />
       </Collapsible>
     </div>
   );

--- a/src/components/domain/approval/bundle-review-card.tsx
+++ b/src/components/domain/approval/bundle-review-card.tsx
@@ -25,6 +25,7 @@ export function BundleReviewCard({ review }: { review: MarketplaceBundleReview }
           <div key={field.label} className="flex min-w-0 flex-wrap items-baseline justify-between gap-x-3 gap-y-0.5">
             <dt className="text-gray-600">{field.label}</dt>
             <dd className="ml-auto min-w-0 text-right font-medium tabular-nums text-gray-900 [overflow-wrap:anywhere]">{field.value}</dd>
+            {field.description && <dd className="w-full text-xs leading-normal text-gray-600">{field.description}</dd>}
           </div>
         ))}
       </dl>

--- a/src/components/domain/approval/counterparty-details-card.tsx
+++ b/src/components/domain/approval/counterparty-details-card.tsx
@@ -28,7 +28,7 @@ export function CounterpartyDetailsCard({
 
   return (
     <div className="bg-white rounded-lg shadow-sm p-4">
-      <h3 className="text-xs font-medium text-gray-500 uppercase mb-2">Counterparty Details</h3>
+      <h3 className="text-xs font-medium text-gray-500 uppercase mb-2">Counterparty</h3>
       <ApprovalFacts fields={fields} />
       {recipients.length > 0 && (
         <div className={fields.length > 0 ? 'mt-3' : ''}>

--- a/src/components/domain/approval/money-movement-view.test.tsx
+++ b/src/components/domain/approval/money-movement-view.test.tsx
@@ -21,14 +21,14 @@ describe('MoneyMovementView', () => {
     expect(screen.getByText(/0\.00060000/)).toBeInTheDocument(); // headline net, distinct from the 0.00070000 row
   });
 
-  it('lists an external destination, wallet return, and fee', () => {
+  it('lists an external destination and fee, and leaves routine change to the transaction section', () => {
     render(
       <MoneyMovementView
         movement={movement({ net: -95000, external: [{ address: 'bc1qexternaldestinationaddr', value: 90000 }], backToYou: 5000, fee: 5000 })}
       />
     );
     expect(screen.getByText(/^bc1q/)).toBeInTheDocument(); // the external destination (truncated)
-    expect(screen.getByText('Returned to wallet')).toBeInTheDocument();
+    expect(screen.queryByText('Returned to wallet')).not.toBeInTheDocument();
     expect(screen.getByText('Network fee')).toBeInTheDocument();
   });
 

--- a/src/components/domain/approval/money-movement-view.tsx
+++ b/src/components/domain/approval/money-movement-view.tsx
@@ -39,7 +39,7 @@ export function MoneyMovementView({
   unfunded,
   showHeadline = true,
 }: MoneyMovementViewProps) {
-  const { net, external, backToYou, atRisk, fee, incomplete } = movement;
+  const { net, external, atRisk, fee, incomplete } = movement;
   const sending = net < 0;
 
   return (
@@ -92,14 +92,9 @@ export function MoneyMovementView({
             {unfunded ? 'Set by the other party' : incomplete ? 'Unavailable' : `${btc(fee)} BTC`}
           </span>
         </div>
-        {backToYou > 0 && (
-          <div className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
-            {/* This can include more than a conventional change output, such as a paired-address
-                asset destination, so name the ownership fact without misclassifying the outputs. */}
-            <span className="text-gray-500">Returned to wallet</span>
-            <span className="text-gray-500 font-medium tabular-nums">{btc(backToYou)} BTC</span>
-          </div>
-        )}
+        {/* Outputs that come back to this wallet are not listed: change is routine, and every
+            such output is still itemized under Transaction. Only the at-risk portion above is
+            a decision fact. */}
         {hasHighFee && !deferCautions && (
           <p className="text-warning-600 text-center">Unusually high — double-check before signing.</p>
         )}

--- a/src/components/ui/collapsible.test.tsx
+++ b/src/components/ui/collapsible.test.tsx
@@ -24,10 +24,10 @@ describe('Collapsible', () => {
 
   it('supports the card variant (white surface + title header)', () => {
     const { container } = render(
-      <Collapsible variant="card" title="Transaction Details"><p>rows</p></Collapsible>
+      <Collapsible variant="card" title="Transaction"><p>rows</p></Collapsible>
     );
     expect(container.firstChild).toHaveClass('bg-white');
-    expect(screen.getByRole('button', { name: /transaction details/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^transaction$/i })).toBeInTheDocument();
   });
 
   it('forwards a custom className to the wrapper', () => {

--- a/src/core/counterparty/__tests__/marketplaceBundle.test.ts
+++ b/src/core/counterparty/__tests__/marketplaceBundle.test.ts
@@ -28,6 +28,7 @@ const parentIntent = {
   carrierValueSats: 546,
   sellerProceedsSats: 250_046,
   networkFeeSats: 500,
+  platformFeeSats: 6_250,
   expectedTxid: PARENT_TXID,
   delivery: { mode: 'detached', address: BUYER },
   marketplaceExpiresAt: 2_000_003_600,
@@ -121,6 +122,34 @@ describe('exact acceptance plus CPFP atomic proof', () => {
     expect(review.facts).toContainEqual({ kind: 'amount', label: 'Added child fee', value: '1,000 sats' });
     expect(review.facts).toContainEqual({ kind: 'amount', label: 'Your proceeds after fee bump', value: '249,046 sats', emphasis: 'primary' });
     expect(review.notices[0]?.message).toMatch(/before either signature/i);
+    const platformFee = {
+      kind: 'amount', label: 'Platform fee', value: '6,250 sats', description: 'Paid by the buyer',
+    };
+    expect(review.facts).toContainEqual(platformFee);
+    expect(review.bundleSummary?.amounts).toContainEqual(platformFee);
+    expect(review.bundleSummary?.amounts).toContainEqual({
+      kind: 'amount', label: 'Network fees', value: '1,500 sats',
+    });
+  });
+
+  it('does not describe attached delivery as a detach in the bundle', () => {
+    const request = base();
+    request.parentIntent.delivery = { mode: 'attached', address: BUYER, carrierValueSats: 330 };
+    const review = analyzeAcceptanceCpfpBundle(request);
+    expect(review.status).toBe('proved');
+    expect(review.facts).toContainEqual({
+      kind: 'address', label: 'Delivery', value: BUYER,
+      description: 'Asset stays attached to a 330-sat UTXO at this address',
+    });
+  });
+
+  it('does not invent a platform fee for a fee-free parent', () => {
+    const request = base();
+    request.parentIntent.platformFeeSats = 0;
+    const review = analyzeAcceptanceCpfpBundle(request);
+    expect(review.status).toBe('proved');
+    expect(review.bundleSummary?.amounts.some(field => field.label === 'Platform fee')).toBe(false);
+    expect(review.facts.some(field => field.label === 'Platform fee')).toBe(false);
   });
 
   it.each([
@@ -141,6 +170,12 @@ describe('exact acceptance plus CPFP atomic proof', () => {
     }],
     ['parent txid', {
       childInputs: [{ ...base().childInputs[0]!, txid: '13'.repeat(32) }],
+    }],
+    ['spending the platform output instead of seller proceeds', {
+      childInputs: [{ ...base().childInputs[0]!, vout: 2 }],
+    }],
+    ['charging the buyer platform fee again as a package fee', {
+      childIntent: { ...base().childIntent, packageFeeSats: 7_750 },
     }],
     ['parent value', {
       childInputs: [{ ...base().childInputs[0]!, value: 250_045 }],

--- a/src/core/counterparty/__tests__/marketplaceBundle.test.ts
+++ b/src/core/counterparty/__tests__/marketplaceBundle.test.ts
@@ -125,11 +125,9 @@ describe('exact acceptance plus CPFP atomic proof', () => {
     expect(review.bundleSummary?.outcome).toEqual({ kind: 'amount', label: 'You receive', value: '249,046 sats', emphasis: 'primary' });
     expect(review.bundleSummary?.action).toBe('Accept offer for 1 RAREPEPE');
     expect(review.notices[0]?.message).toMatch(/before either signature/i);
-    const platformFee = {
-      kind: 'amount', label: 'Platform fee', value: '6,250 sats', description: 'Paid by the buyer',
-    };
-    expect(review.facts).toContainEqual(platformFee);
-    expect(review.bundleSummary?.amounts).toContainEqual(platformFee);
+    // The seller does not pay the platform fee, so neither the summary nor the facts list it.
+    expect(review.facts.some(field => field.label === 'Platform fee')).toBe(false);
+    expect(review.bundleSummary?.amounts.some(field => field.label === 'Platform fee')).toBe(false);
     expect(review.bundleSummary?.amounts).toContainEqual({
       kind: 'amount', label: 'Network fees', value: '1,500 sats',
     });

--- a/src/core/counterparty/__tests__/marketplaceBundle.test.ts
+++ b/src/core/counterparty/__tests__/marketplaceBundle.test.ts
@@ -73,6 +73,7 @@ const base = () => {
       status: 'proved' as const,
       family: 'accept_exact_offer' as const,
       title: 'Accept exact offer',
+      summary: { label: 'Accept offer', description: '1 RAREPEPE' },
       facts: [],
       notices: [],
       blockers: [],
@@ -121,6 +122,8 @@ describe('exact acceptance plus CPFP atomic proof', () => {
     });
     expect(review.facts).toContainEqual({ kind: 'amount', label: 'Added child fee', value: '1,000 sats' });
     expect(review.facts).toContainEqual({ kind: 'amount', label: 'Your proceeds after fee bump', value: '249,046 sats', emphasis: 'primary' });
+    expect(review.bundleSummary?.outcome).toEqual({ kind: 'amount', label: 'You receive', value: '249,046 sats', emphasis: 'primary' });
+    expect(review.bundleSummary?.action).toBe('Accept offer for 1 RAREPEPE');
     expect(review.notices[0]?.message).toMatch(/before either signature/i);
     const platformFee = {
       kind: 'amount', label: 'Platform fee', value: '6,250 sats', description: 'Paid by the buyer',

--- a/src/core/counterparty/__tests__/marketplaceIntent.test.ts
+++ b/src/core/counterparty/__tests__/marketplaceIntent.test.ts
@@ -273,6 +273,7 @@ const authorizeExactIntent: AuthorizeExactOfferIntentClaim = {
   carrierValueSats: 546,
   sellerProceedsSats: 250_046,
   networkFeeSats: 500,
+  platformFeeSats: 0,
   expectedTxid: EXACT_TXID,
   delivery: { mode: 'detached', address: BUYER },
   marketplaceExpiresAt: 2_000_003_600,
@@ -340,6 +341,17 @@ const attachedExactBase = (accepting = false) => ({
   hasCounterpartyPayload: false,
   localCounterpartyMessage: undefined,
 });
+
+const feeExactBase = (accepting = false, attached = false, feeSats = 6_250) => {
+  const request = attached ? attachedExactBase(accepting) : exactBase(accepting);
+  return {
+    ...request,
+    intent: { ...request.intent, platformFeeSats: feeSats },
+    inputs: request.inputs.map(entry => entry.index === 0
+      ? { ...entry, value: entry.value + feeSats } : entry),
+    outputs: [...request.outputs, { index: 2, type: 'p2tr', address: PLATFORM, value: feeSats }],
+  };
+};
 
 const fanoutIntent: PrepareBulkFanoutIntentClaim = {
   standard: 'counterparty-marketplace',
@@ -942,6 +954,77 @@ describe('buy-listings proof', () => {
 });
 
 describe('exact-offer authorization and unilateral acceptance proof', () => {
+  it('defaults only omitted pre-fee claims to zero, without allowing an undeclared fee output', () => {
+    const { platformFeeSats: _fee, ...legacy } = authorizeExactIntent;
+    expect(parseMarketplaceIntent(legacy)).toEqual(authorizeExactIntent);
+    const request = feeExactBase();
+    expect(analyzeMarketplaceIntent({
+      ...request, intent: parseMarketplaceIntent(legacy),
+    }).status).toBe('blocked');
+  });
+
+  it.each([-1, 0.5, Number.MAX_SAFE_INTEGER + 1, NaN, Infinity, '6250', null])(
+    'rejects an invalid platform fee %s at the request boundary', platformFeeSats => {
+      expect(() => parseMarketplaceIntent({ ...authorizeExactIntent, platformFeeSats })).toThrow(/platformFeeSats/);
+    },
+  );
+
+  for (const accepting of [false, true]) {
+    for (const attached of [false, true]) {
+      describe(`${accepting ? 'seller acceptance' : 'buyer authorization'}, ${attached ? 'attached' : 'detached'}`, () => {
+        it.each([1_000, 6_250, 6_251])('proves and displays a buyer-funded %i-sat fee separately from miner fees', feeSats => {
+          const request = feeExactBase(accepting, attached, feeSats);
+          const parsed = parseMarketplaceIntent(request.intent);
+          expect(parsed).toEqual(request.intent);
+          const review = analyzeMarketplaceIntent({ ...request, intent: parsed });
+          expect(review).toMatchObject({ status: accepting ? 'proved' : 'caution', blockers: [] });
+          expect(review.facts).toContainEqual({
+            kind: 'amount', label: 'Platform fee', value: `${feeSats.toLocaleString()} sats`, description: 'Paid by the buyer',
+          });
+          expect(review.facts).toContainEqual({ kind: 'address', label: 'Fee recipient', value: PLATFORM });
+          expect(review.facts).toContainEqual({ kind: 'amount', label: 'Seller receives', value: '250,046 sats' });
+          expect(review.facts).toContainEqual({
+            kind: 'amount', label: 'Network fee', value: '500 sats', description: 'Deducted from seller proceeds',
+          });
+          if (!accepting) {
+            expect(review.facts).toContainEqual(expect.objectContaining({
+              label: 'Buyer funding', value: `${(250_000 + feeSats + (attached ? 330 : 0)).toLocaleString()} sats`,
+            }));
+          }
+        });
+
+        const mutations: Array<[string, (request: ReturnType<typeof feeExactBase>) => void]> = [
+          ['wrong fee amount', request => { request.outputs[2]!.value -= 1; }],
+          ['missing fee output', request => { request.outputs.pop(); }],
+          ['extra output', request => { request.outputs.push({ ...request.outputs[2]!, index: 3 }); }],
+          ['reordered payments', request => {
+            [request.outputs[1], request.outputs[2]] = [request.outputs[2]!, request.outputs[1]!];
+          }],
+          ['burned fee', request => { request.outputs[2]!.type = 'op_return'; }],
+          ['unknown fee recipient', request => { request.outputs[2]!.address = undefined; }],
+          ['fee returned to bidder', request => { request.outputs[2]!.address = BUYER; }],
+          ['fee sent to seller', request => { request.outputs[2]!.address = SELLER; }],
+          ['unfunded fee', request => { request.inputs[0]!.value -= request.intent.platformFeeSats; }],
+          ['understated fee claim', request => { request.intent.platformFeeSats -= 1; }],
+          ['fee charged twice to seller', request => {
+            request.outputs[1]!.value -= request.intent.platformFeeSats;
+            request.intent.sellerProceedsSats -= request.intent.platformFeeSats;
+          }],
+          ['weakened sighash', request => { request.signedInputs[0]!.sighashType = 0x81; }],
+          ['different transaction', request => { request.transactionId = TXID_TWO; }],
+          ['unsafe funding sum', request => { request.intent.platformFeeSats = Number.MAX_SAFE_INTEGER; }],
+        ];
+        it.each(mutations)('blocks %s', (_name, mutate) => {
+          const request = feeExactBase(accepting, attached);
+          mutate(request);
+          const review = analyzeMarketplaceIntent(request);
+          expect(review.status).toBe('blocked');
+          expect(review.blockers.length).toBeGreaterThan(0);
+        });
+      });
+    }
+  }
+
   it('proves the buyer authorization while clearly labeling shared-slot authority', () => {
     const review = analyzeMarketplaceIntent(exactBase());
 

--- a/src/core/counterparty/__tests__/marketplaceIntent.test.ts
+++ b/src/core/counterparty/__tests__/marketplaceIntent.test.ts
@@ -997,10 +997,15 @@ describe('exact-offer authorization and unilateral acceptance proof', () => {
           expect(parsed).toEqual(request.intent);
           const review = analyzeMarketplaceIntent({ ...request, intent: parsed });
           expect(review).toMatchObject({ status: accepting ? 'proved' : 'caution', blockers: [] });
-          expect(review.facts).toContainEqual({
-            kind: 'amount', label: 'Platform fee', value: `${feeSats.toLocaleString()} sats`, description: 'Paid by the buyer',
-          });
-          expect(review.facts).toContainEqual({ kind: 'address', label: 'Fee recipient', value: PLATFORM });
+          // The buyer sees the fee they pay and where it goes; the seller's screen omits both.
+          expect(review.facts.some(field => field.label === 'Platform fee')).toBe(!accepting);
+          expect(review.facts.some(field => field.label === 'Fee recipient')).toBe(!accepting);
+          if (!accepting) {
+            expect(review.facts).toContainEqual({
+              kind: 'amount', label: 'Platform fee', value: `${feeSats.toLocaleString()} sats`, description: 'Paid by the buyer',
+            });
+            expect(review.facts).toContainEqual({ kind: 'address', label: 'Fee recipient', value: PLATFORM });
+          }
           expect(review.facts).toContainEqual({
             kind: 'amount', label: accepting ? 'You receive' : 'Seller receives', value: '250,046 sats',
             ...(accepting ? { emphasis: 'primary' } : {}),
@@ -1066,6 +1071,7 @@ describe('exact-offer authorization and unilateral acceptance proof', () => {
       blockers: [],
     });
     expect(review.facts).toContainEqual({ kind: 'amount', label: 'Offer price', value: '250,000 sats' });
+    expect(review.notices[0]?.severity).toBe('info');
     expect(review.notices[0]?.message).toMatch(/without another approval/i);
     expect(review.notices[0]?.message).toMatch(/first confirmed spend wins/i);
   });

--- a/src/core/counterparty/__tests__/marketplaceIntent.test.ts
+++ b/src/core/counterparty/__tests__/marketplaceIntent.test.ts
@@ -695,6 +695,7 @@ describe('create-listing proof', () => {
     expect(review.blockers).toEqual([]);
     expect(review.title).toContain('RAREPEPE');
     expect(review.summary).toEqual({ label: 'List for sale', description: '1 RAREPEPE' });
+    expect(review.paymentSummary?.[0]).toMatchObject({ label: 'Your payout if sold', value: '250,546 sats', emphasis: 'primary' });
     expect(review.facts).toContainEqual({ kind: 'amount', label: 'Sale price', value: '250,000 sats' });
     expect(review.facts).toContainEqual({
       kind: 'amount', label: 'Your payout if sold',
@@ -845,17 +846,33 @@ describe('buy-listings proof', () => {
     expect(review.summary).toEqual({ label: 'Buy collectibles', description: '2 collectibles' });
     expect(review.facts[0]).toEqual({ kind: 'amount', label: 'You pay', value: '306,000 sats', emphasis: 'primary' });
     expect(review.facts).toContainEqual({ kind: 'address', label: 'Delivery', value: BUYER, description: 'Assets detach to this address' });
+    expect(review.paymentSummary).toContainEqual({ kind: 'amount', label: 'Change', value: '94,000 sats' });
+    expect(review.paymentSummary?.some(field => field.label === 'Sats kept with your asset')).toBe(false);
   });
 
   it('proves one attached purchase and its buyer-owned carrier', () => {
     const review = analyzeMarketplaceIntent(attachedBuyBase());
 
     expect(review).toMatchObject({ status: 'proved', family: 'buy_listings', blockers: [] });
+    expect(review.paymentSummary?.[0]).toMatchObject({ label: 'You pay', value: '106,000 sats' });
+    expect(review.paymentSummary).toContainEqual({ kind: 'amount', label: 'Change', value: '293,670 sats' });
+    expect(review.paymentSummary).toContainEqual(expect.objectContaining({ label: 'Sats kept with your asset', value: '330 sats' }));
+    expect(review.paymentSummary?.some(field => field.value === '294,000 sats')).toBe(false);
     expect(review.facts).toContainEqual({ kind: 'amount', label: 'You receive', value: '1 RAREPEPE' });
     expect(review.facts).toContainEqual({
       kind: 'address', label: 'Delivery', value: BUYER,
       description: 'Asset stays attached to a 330-sat UTXO at this address',
     });
+  });
+
+  it.each([false, true])('does not invent change for an exact-funded purchase (attached=%s)', (attached) => {
+    const request = attached ? attachedBuyBase() : buyBase();
+    const change = request.outputs.pop()!;
+    request.inputs[0]!.value -= change.value;
+    const review = analyzeMarketplaceIntent(request);
+    expect(review.status).toBe('proved');
+    expect(review.paymentSummary?.some(field => field.label === 'Change')).toBe(false);
+    expect(review.paymentSummary?.some(field => field.label === 'Sats kept with your asset')).toBe(attached);
   });
 
   it('names the ledger-normalized divisible amount in the attached purchase summary', () => {
@@ -928,6 +945,7 @@ describe('buy-listings proof', () => {
     }],
   ])('blocks a mutation of %s', (_label, override) => {
     const review = analyzeMarketplaceIntent({ ...buyBase(), ...override });
+    expect(review.paymentSummary).toBeUndefined();
     expect(review.status).toBe('blocked');
     expect(review.summary).toBeUndefined();
     expect(review.blockers.length).toBeGreaterThan(0);
@@ -947,6 +965,7 @@ describe('buy-listings proof', () => {
     ['transaction id', { transactionId: undefined }],
   ])('requires a retry when %s cannot be proved', (_label, override) => {
     const review = analyzeMarketplaceIntent({ ...buyBase(), ...override });
+    expect(review.paymentSummary).toBeUndefined();
     expect(review.status).toBe('retry');
     expect(review.summary).toBeUndefined();
     expect(review.blockers.length).toBeGreaterThan(0);
@@ -982,7 +1001,19 @@ describe('exact-offer authorization and unilateral acceptance proof', () => {
             kind: 'amount', label: 'Platform fee', value: `${feeSats.toLocaleString()} sats`, description: 'Paid by the buyer',
           });
           expect(review.facts).toContainEqual({ kind: 'address', label: 'Fee recipient', value: PLATFORM });
-          expect(review.facts).toContainEqual({ kind: 'amount', label: 'Seller receives', value: '250,046 sats' });
+          expect(review.facts).toContainEqual({
+            kind: 'amount', label: accepting ? 'You receive' : 'Seller receives', value: '250,046 sats',
+            ...(accepting ? { emphasis: 'primary' } : {}),
+          });
+          expect(review.paymentSummary?.[0]).toEqual({
+            kind: 'amount', label: accepting ? 'You receive' : 'You pay if accepted', emphasis: 'primary',
+            value: accepting ? '250,046 sats' : `${(250_000 + feeSats).toLocaleString()} sats`,
+          });
+          expect(review.paymentSummary?.some(field => field.label === 'Change')).toBe(false);
+          expect(review.paymentSummary?.some(field => field.label === 'Platform fee')).toBe(!accepting);
+          expect(review.paymentSummary?.some(field => field.label === 'Network fee')).toBe(accepting);
+          expect(review.paymentSummary?.some(field => field.label === 'Sats kept with your asset')).toBe(!accepting && attached);
+          expect(review.facts.some(field => field.label === 'Cancellation')).toBe(!accepting);
           expect(review.facts).toContainEqual({
             kind: 'amount', label: 'Network fee', value: '500 sats', description: 'Deducted from seller proceeds',
           });
@@ -1019,6 +1050,7 @@ describe('exact-offer authorization and unilateral acceptance proof', () => {
           mutate(request);
           const review = analyzeMarketplaceIntent(request);
           expect(review.status).toBe('blocked');
+          expect(review.paymentSummary).toBeUndefined();
           expect(review.blockers.length).toBeGreaterThan(0);
         });
       });
@@ -1036,6 +1068,12 @@ describe('exact-offer authorization and unilateral acceptance proof', () => {
     expect(review.facts).toContainEqual({ kind: 'amount', label: 'Offer price', value: '250,000 sats' });
     expect(review.notices[0]?.message).toMatch(/without another approval/i);
     expect(review.notices[0]?.message).toMatch(/first confirmed spend wins/i);
+  });
+
+  it('does not label a zero-fee offer as a Bitcoin payment made immediately', () => {
+    const review = analyzeMarketplaceIntent(exactBase());
+    expect(review.paymentSummary?.[0]).toMatchObject({ label: 'You pay if accepted', value: '250,000 sats' });
+    expect(review.paymentSummary?.some(field => field.label === 'Platform fee')).toBe(false);
   });
 
   it('proves attached delivery for both buyer authorization and seller acceptance', () => {

--- a/src/core/counterparty/__tests__/signRequestAnalysis.test.ts
+++ b/src/core/counterparty/__tests__/signRequestAnalysis.test.ts
@@ -142,6 +142,7 @@ const EXACT_AUTHORIZATION_INTENT = parseMarketplaceIntent({
   carrierValueSats: 546,
   sellerProceedsSats: 250_046,
   networkFeeSats: 500,
+  platformFeeSats: 6_250,
   expectedTxid: EXACT_TXID,
   delivery: { mode: 'detached', address: SIGNER },
   marketplaceExpiresAt: 2_000_003_600,
@@ -451,7 +452,7 @@ describe('the marketplace intent proof', () => {
         txid: EXACT_FUNDING_TXID,
         vout: 1,
         address: SIGNER,
-        value: 250_000,
+        value: 256_250,
         hasSignatures: accepting,
       },
       {
@@ -466,6 +467,7 @@ describe('the marketplace intent proof', () => {
     outputs: [
       { index: 0, value: 0, type: 'op_return' },
       { index: 1, value: 250_046, type: 'witness_v0_keyhash', address: VAULT },
+      { index: 2, value: 6_250, type: 'witness_v0_keyhash', address: 'bc1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq9e75rs' },
     ],
     signerAddresses: [accepting ? VAULT : SIGNER],
     signedInputIndices: [accepting ? 1 : 0],
@@ -493,7 +495,7 @@ describe('the marketplace intent proof', () => {
         txid: EXACT_FUNDING_TXID,
         vout: 1,
         address: SIGNER,
-        value: 250_330,
+        value: 256_580,
         hasSignatures: accepting,
       },
       {
@@ -508,6 +510,7 @@ describe('the marketplace intent proof', () => {
     outputs: [
       { index: 0, value: 330, type: 'witness_v0_keyhash', address: SIGNER },
       { index: 1, value: 250_046, type: 'witness_v0_keyhash', address: VAULT },
+      { index: 2, value: 6_250, type: 'witness_v0_keyhash', address: 'bc1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq9e75rs' },
     ],
     ...overrides,
   });
@@ -652,6 +655,21 @@ describe('the marketplace intent proof', () => {
     expect(analysis.safety.warnings).not.toContainEqual(expect.objectContaining({
       code: 'external_btc_output',
     }));
+    expect(analysis.marketplaceReview?.facts).toContainEqual(expect.objectContaining({
+      label: 'Platform fee', value: '6,250 sats', description: 'Paid by the buyer',
+    }));
+  });
+
+  it('keeps the signing gate closed when a fee-bearing offer hides its fee claim', async () => {
+    vi.mocked(verifyProviderTransaction).mockReturnValue({
+      localUnpack: { success: true, messageType: 'detach', data: { destination: SIGNER } },
+    } as never);
+    const analysis = await exact(false, {
+      marketplaceIntent: parseMarketplaceIntent({ ...EXACT_AUTHORIZATION_INTENT, platformFeeSats: 0 }),
+    });
+    expect(analysis.safety.blocked).toBe(true);
+    expect(analysis.marketplaceReview?.status).toBe('blocked');
+    expect(analysis.safety.warnings[0]?.title).toBe('Blocked: Marketplace Intent Mismatch');
   });
 
   it.each([

--- a/src/core/counterparty/__tests__/signRequestAnalysis.test.ts
+++ b/src/core/counterparty/__tests__/signRequestAnalysis.test.ts
@@ -655,9 +655,14 @@ describe('the marketplace intent proof', () => {
     expect(analysis.safety.warnings).not.toContainEqual(expect.objectContaining({
       code: 'external_btc_output',
     }));
-    expect(analysis.marketplaceReview?.facts).toContainEqual(expect.objectContaining({
-      label: 'Platform fee', value: '6,250 sats', description: 'Paid by the buyer',
-    }));
+    // Only the buyer, who pays the platform fee, sees it named; the seller's screen omits it.
+    if (accepting) {
+      expect(analysis.marketplaceReview?.facts.some(field => field.label === 'Platform fee')).toBe(false);
+    } else {
+      expect(analysis.marketplaceReview?.facts).toContainEqual(expect.objectContaining({
+        label: 'Platform fee', value: '6,250 sats', description: 'Paid by the buyer',
+      }));
+    }
   });
 
   it('keeps the signing gate closed when a fee-bearing offer hides its fee claim', async () => {

--- a/src/core/counterparty/marketplaceBundle.ts
+++ b/src/core/counterparty/marketplaceBundle.ts
@@ -324,7 +324,10 @@ export function analyzeAcceptanceCpfpBundle(
         amounts: [
           { kind: 'amount' as const, label: 'Offer price', value: `${parentIntent.priceSats.toLocaleString()} sats` },
           { kind: 'amount' as const, label: 'UTXO returned', value: `${parentIntent.carrierValueSats.toLocaleString()} sats` },
-          // The exact-offer proof has only miner fees. Do not invent a platform fee category.
+          ...(parentIntent.platformFeeSats > 0 ? [{
+            kind: 'amount' as const, label: 'Platform fee',
+            value: `${parentIntent.platformFeeSats.toLocaleString()} sats`, description: 'Paid by the buyer',
+          }] : []),
           { kind: 'amount' as const, label: 'Network fees', value: `${childIntent.packageFeeSats.toLocaleString()} sats` },
         ],
         timing: 'Both network fees are already deducted from your final proceeds.',
@@ -337,6 +340,10 @@ export function analyzeAcceptanceCpfpBundle(
         emphasis: 'primary',
       },
       { kind: 'amount' as const, label: 'Offer price', value: `${parentIntent.priceSats.toLocaleString()} sats` },
+      ...(parentIntent.platformFeeSats > 0 ? [{
+        kind: 'amount' as const, label: 'Platform fee',
+        value: `${parentIntent.platformFeeSats.toLocaleString()} sats`, description: 'Paid by the buyer',
+      }] : []),
       { kind: 'amount' as const, label: 'Your UTXO sats returned', value: `${parentIntent.carrierValueSats.toLocaleString()} sats` },
       {
         kind: 'amount' as const, label: 'Parent seller proceeds',
@@ -346,7 +353,12 @@ export function analyzeAcceptanceCpfpBundle(
       { kind: 'amount' as const, label: 'Added child fee', value: `${childIntent.childNetworkFeeSats.toLocaleString()} sats` },
       { kind: 'amount' as const, label: 'Package fee', value: `${childIntent.packageFeeSats.toLocaleString()} sats` },
       { kind: 'amount' as const, label: 'Quoted package rate', value: `${childIntent.packageFeeRate.toFixed(2)} sat/vB` },
-      { kind: 'address' as const, label: 'Delivery', value: parentIntent.delivery.address, description: 'Asset detaches to this address' },
+      {
+        kind: 'address' as const, label: 'Delivery', value: parentIntent.delivery.address,
+        description: parentIntent.delivery.mode === 'attached'
+          ? `Asset stays attached to a ${parentIntent.delivery.carrierValueSats.toLocaleString()}-sat UTXO at this address`
+          : 'Asset detaches to this address',
+      },
     ],
     notices: allProblems.length > 0
       ? []

--- a/src/core/counterparty/marketplaceBundle.ts
+++ b/src/core/counterparty/marketplaceBundle.ts
@@ -317,13 +317,13 @@ export function analyzeAcceptanceCpfpBundle(
     ...(status === 'proved' ? {
       bundleSummary: {
         outcome: {
-          kind: 'amount' as const, label: 'Final proceeds',
+          kind: 'amount' as const, label: 'You receive',
           value: `${childIntent.finalSellerProceedsSats.toLocaleString()} sats`, emphasis: 'primary' as const,
         },
-        action: `Accept offer for ${claim.asset}`,
+        action: `Accept offer for ${parentReview.summary?.description ?? claim.asset}`,
         amounts: [
           { kind: 'amount' as const, label: 'Offer price', value: `${parentIntent.priceSats.toLocaleString()} sats` },
-          { kind: 'amount' as const, label: 'UTXO returned', value: `${parentIntent.carrierValueSats.toLocaleString()} sats` },
+          { kind: 'amount' as const, label: 'Your UTXO sats returned', value: `${parentIntent.carrierValueSats.toLocaleString()} sats` },
           ...(parentIntent.platformFeeSats > 0 ? [{
             kind: 'amount' as const, label: 'Platform fee',
             value: `${parentIntent.platformFeeSats.toLocaleString()} sats`, description: 'Paid by the buyer',

--- a/src/core/counterparty/marketplaceBundle.ts
+++ b/src/core/counterparty/marketplaceBundle.ts
@@ -324,10 +324,6 @@ export function analyzeAcceptanceCpfpBundle(
         amounts: [
           { kind: 'amount' as const, label: 'Offer price', value: `${parentIntent.priceSats.toLocaleString()} sats` },
           { kind: 'amount' as const, label: 'Your UTXO sats returned', value: `${parentIntent.carrierValueSats.toLocaleString()} sats` },
-          ...(parentIntent.platformFeeSats > 0 ? [{
-            kind: 'amount' as const, label: 'Platform fee',
-            value: `${parentIntent.platformFeeSats.toLocaleString()} sats`, description: 'Paid by the buyer',
-          }] : []),
           { kind: 'amount' as const, label: 'Network fees', value: `${childIntent.packageFeeSats.toLocaleString()} sats` },
         ],
         timing: 'Both network fees are already deducted from your final proceeds.',
@@ -340,10 +336,7 @@ export function analyzeAcceptanceCpfpBundle(
         emphasis: 'primary',
       },
       { kind: 'amount' as const, label: 'Offer price', value: `${parentIntent.priceSats.toLocaleString()} sats` },
-      ...(parentIntent.platformFeeSats > 0 ? [{
-        kind: 'amount' as const, label: 'Platform fee',
-        value: `${parentIntent.platformFeeSats.toLocaleString()} sats`, description: 'Paid by the buyer',
-      }] : []),
+      // The buyer-paid platform fee is not the seller's cost and is not listed here.
       { kind: 'amount' as const, label: 'Your UTXO sats returned', value: `${parentIntent.carrierValueSats.toLocaleString()} sats` },
       {
         kind: 'amount' as const, label: 'Parent seller proceeds',
@@ -351,7 +344,7 @@ export function analyzeAcceptanceCpfpBundle(
       },
       { kind: 'amount' as const, label: 'Parent fee', value: `${childIntent.parentNetworkFeeSats.toLocaleString()} sats` },
       { kind: 'amount' as const, label: 'Added child fee', value: `${childIntent.childNetworkFeeSats.toLocaleString()} sats` },
-      { kind: 'amount' as const, label: 'Package fee', value: `${childIntent.packageFeeSats.toLocaleString()} sats` },
+      // The package total is the "Network fees" amount in the summary above; not repeated here.
       { kind: 'amount' as const, label: 'Quoted package rate', value: `${childIntent.packageFeeRate.toFixed(2)} sat/vB` },
       {
         kind: 'address' as const, label: 'Delivery', value: parentIntent.delivery.address,

--- a/src/core/counterparty/marketplaceIntent.ts
+++ b/src/core/counterparty/marketplaceIntent.ts
@@ -134,6 +134,8 @@ interface ExactOfferIntentBase<Action extends 'authorize_exact_offer' | 'accept_
   carrierValueSats: number;
   sellerProceedsSats: number;
   networkFeeSats: number;
+  /** Buyer-funded external fee. Omitted pre-fee v1 requests parse as zero. */
+  platformFeeSats: number;
   expectedTxid: string;
   delivery: MarketplaceSettlementDelivery;
   marketplaceExpiresAt: number;
@@ -583,6 +585,9 @@ const parseExactOfferIntent = <
       positive: true,
     })!,
     networkFeeSats: nonNegativeSafeInteger(value.networkFeeSats, 'networkFeeSats'),
+    platformFeeSats: value.platformFeeSats === undefined
+      ? 0
+      : nonNegativeSafeInteger(value.platformFeeSats, 'platformFeeSats'),
     expectedTxid,
     delivery,
     marketplaceExpiresAt: safeInteger(value.marketplaceExpiresAt, 'marketplaceExpiresAt', {
@@ -1352,6 +1357,9 @@ function analyzeExactOfferIntent(
     : 0;
   const requestedInputIndex = authorizing ? 0 : 1;
   const requestedSigner = authorizing ? intent.bidder : intent.seller;
+  const buyerFundingSats = safeSum([
+    intent.priceSats, deliveryCarrierSats, intent.platformFeeSats,
+  ]);
 
   if (!sameAddress(intent.delivery.address, intent.bidder)) {
     blockers.push('the delivery address differs from the bidder');
@@ -1392,8 +1400,24 @@ function analyzeExactOfferIntent(
     }
   }
 
-  if (inputs.length !== 2 || outputs.length !== 2) {
-    blockers.push(`expected exactly 2 inputs and 2 outputs, got ${inputs.length}/${outputs.length}`);
+  const expectedOutputs = intent.platformFeeSats > 0 ? 3 : 2;
+  if (inputs.length !== 2 || outputs.length !== expectedOutputs) {
+    blockers.push(`expected exactly 2 inputs and ${expectedOutputs} outputs, got ${inputs.length}/${outputs.length}`);
+  }
+  if (intent.platformFeeSats > 0) {
+    const platformOutput = outputs[2];
+    // Match the declared amount to a distinct, decoded payment output. The site chooses
+    // its fee recipient; this proves the payment, not the recipient's business identity.
+    if (
+      !platformOutput
+      || platformOutput.type === 'op_return'
+      || !platformOutput.address
+      || sameAddress(platformOutput.address, intent.bidder)
+      || sameAddress(platformOutput.address, intent.seller)
+      || platformOutput.value !== intent.platformFeeSats
+    ) {
+      blockers.push('output 2 is not the claimed external platform fee');
+    }
   }
   const inputOutpoints = inputs.map(transactionInput =>
     `${transactionInput.txid.toLowerCase()}:${transactionInput.vout}`);
@@ -1438,10 +1462,10 @@ function analyzeExactOfferIntent(
     if (bidderInput.value === undefined) {
       retry.push('buyer funding input 0 has no authenticated value');
     } else if (
-      bidderInput.value
-      !== intent.priceSats + deliveryCarrierSats
+      buyerFundingSats === null
+      || bidderInput.value !== buyerFundingSats
     ) {
-      blockers.push('buyer funding input 0 does not equal the offer price and selected delivery carrier');
+      blockers.push('buyer funding input 0 does not equal the offer price plus platform fee and selected delivery UTXO value');
     }
   }
 
@@ -1539,7 +1563,24 @@ function analyzeExactOfferIntent(
       ` for ${provedQuantity ? `${provedQuantity} ` : ''}${claim.asset}`,
     facts: [
       { kind: 'amount' as const, label: 'Offer price', value: `${intent.priceSats.toLocaleString()} sats` },
+      ...(intent.platformFeeSats > 0 ? [
+        {
+          kind: 'amount' as const, label: 'Platform fee',
+          value: `${intent.platformFeeSats.toLocaleString()} sats`, description: 'Paid by the buyer',
+        },
+        ...(outputs[2]?.address ? [{
+          kind: 'address' as const, label: 'Fee recipient', value: outputs[2].address,
+        }] : []),
+      ] : []),
+      ...(authorizing && buyerFundingSats !== null ? [{
+        kind: 'amount' as const, label: 'Buyer funding', value: `${buyerFundingSats.toLocaleString()} sats`,
+        description: 'Offer price, platform fee, and any attached delivery UTXO',
+      }] : []),
       { kind: 'amount' as const, label: 'Seller receives', value: `${intent.sellerProceedsSats.toLocaleString()} sats` },
+      {
+        kind: 'amount' as const, label: 'Network fee', value: `${intent.networkFeeSats.toLocaleString()} sats`,
+        description: 'Deducted from seller proceeds',
+      },
       {
         kind: 'address' as const, label: 'Delivery', value: intent.delivery.address,
         description: attachedDelivery

--- a/src/core/counterparty/marketplaceIntent.ts
+++ b/src/core/counterparty/marketplaceIntent.ts
@@ -801,7 +801,7 @@ function analyzeCreateListingIntent({
       `${(intent.priceSats / 100_000_000).toFixed(8)} BTC`,
     facts: [
       payout, salePrice, utxoReturn,
-      { kind: 'amount' as const, label: 'Quantity', value: `${provedQuantity ?? claim.quantityRaw} ${claim.asset}` },
+      // The headline already names the proved quantity and asset.
       { kind: 'paragraph' as const, label: 'Delivery', value: 'Buyer chooses attached or detached delivery' },
       // The signature commits only the seller-payment output; state who controls the rest.
       { kind: 'paragraph' as const, label: 'Buyer controls', value: 'Funding, fees, and delivery destination' },
@@ -1607,12 +1607,11 @@ function analyzeExactOfferIntent(
       ` for ${provedQuantity ? `${provedQuantity} ` : ''}${claim.asset}`,
     facts: [
       ...paymentSummary,
-      ...(intent.platformFeeSats > 0 ? [
-        ...(!authorizing ? [platformFee] : []),
-        ...(outputs[2]?.address ? [{
-          kind: 'address' as const, label: 'Fee recipient', value: outputs[2].address,
-        }] : []),
-      ] : []),
+      // The platform fee is the buyer's cost. The seller does not pay it, so their screen does
+      // not list it; the fee output itself remains itemized in the raw transaction section.
+      ...(authorizing && intent.platformFeeSats > 0 && outputs[2]?.address ? [{
+        kind: 'address' as const, label: 'Fee recipient', value: outputs[2].address,
+      }] : []),
       ...(authorizing && buyerFundingSats !== null ? [{
         kind: 'amount' as const, label: 'Buyer funding', value: `${buyerFundingSats.toLocaleString()} sats`,
         description: 'Offer price, platform fee, and any attached delivery UTXO',
@@ -1631,7 +1630,8 @@ function analyzeExactOfferIntent(
     notices: allProblems.length > 0
       ? []
       : [{
-          severity: authorizing ? 'warning' : 'info',
+          // Both are statements of what the signature is for, not exceptions to act on.
+          severity: 'info',
           message: authorizing
             ? 'After signing, this seller can complete this exact trade without another approval. Other exact offers backed by the same funding UTXO are alternatives: the first confirmed spend wins and invalidates its siblings.'
             : 'Your signature completes this exact sale without a buyer callback. If the buyer already spent the shared funding UTXO, broadcast fails and your asset remains yours.',

--- a/src/core/counterparty/marketplaceIntent.ts
+++ b/src/core/counterparty/marketplaceIntent.ts
@@ -183,6 +183,9 @@ export type MarketplaceIntentClaimV1 =
 export interface MarketplaceApprovalReview {
   /** Optional concise action summary, separate from the full transaction description. */
   summary?: { label: string; description: string };
+  /** Role-specific payment facts, emitted only after the transaction's economics prove.
+   * These replace the generic all-parties BTC movement on the decision screen. */
+  paymentSummary?: ProtocolField[];
   status: 'proved' | 'caution' | 'retry' | 'blocked';
   family:
     | 'attach_for_listing'
@@ -775,9 +778,18 @@ function analyzeCreateListingIntent({
 
   const allProblems = [...retry, ...blockers];
   const status = blockers.length > 0 ? 'blocked' : retry.length > 0 ? 'retry' : 'proved';
+  const payout: ProtocolField = {
+    kind: 'amount', label: 'Your payout if sold',
+    value: `${intent.guaranteedSellerPaymentSats.toLocaleString()} sats`, emphasis: 'primary',
+  };
+  const salePrice: ProtocolField = { kind: 'amount', label: 'Sale price', value: `${intent.priceSats.toLocaleString()} sats` };
+  const utxoReturn: ProtocolField = {
+    kind: 'amount', label: 'Your UTXO sats returned', value: `${intent.carrierValueSats.toLocaleString()} sats`, layout: 'stacked',
+  };
   return {
     status,
     family: 'create_listing',
+    ...(status === 'proved' ? { paymentSummary: [payout, salePrice, utxoReturn] } : {}),
     ...(status === 'proved' && provedQuantity !== null ? {
       summary: {
         label: intent.listingContext?.mode === 'reprice' ? 'Reprice listing' : 'List for sale',
@@ -788,16 +800,7 @@ function analyzeCreateListingIntent({
       `${intent.listingContext?.mode === 'reprice' ? 'to' : 'for'} ` +
       `${(intent.priceSats / 100_000_000).toFixed(8)} BTC`,
     facts: [
-      { kind: 'amount' as const, label: 'Sale price', value: `${intent.priceSats.toLocaleString()} sats` },
-      {
-        kind: 'amount' as const, label: 'Your UTXO sats returned',
-        value: `${intent.carrierValueSats.toLocaleString()} sats`, layout: 'stacked',
-      },
-      {
-        kind: 'amount' as const, label: 'Your payout if sold',
-        value: `${intent.guaranteedSellerPaymentSats.toLocaleString()} sats`,
-        emphasis: 'primary',
-      },
+      payout, salePrice, utxoReturn,
       { kind: 'amount' as const, label: 'Quantity', value: `${provedQuantity ?? claim.quantityRaw} ${claim.asset}` },
       { kind: 'paragraph' as const, label: 'Delivery', value: 'Buyer chooses attached or detached delivery' },
       // The signature commits only the seller-payment output; state who controls the rest.
@@ -1280,10 +1283,22 @@ function analyzeBuyListingsIntent(
   // An attached checkout has no decoded Counterparty message to supply asset summary rows.
   // Name the independently checked ledger amount on the decision screen, never raw base units.
   const receivedAsset = attachedDelivery && status === 'proved' ? balances.get(1)?.assets[0] : undefined;
+  const paymentSummary: ProtocolField[] = [
+    { kind: 'amount', label: 'You pay', value: `${intent.totalSats.toLocaleString()} sats`, emphasis: 'primary' },
+    { kind: 'amount', label: 'Seller subtotal', value: `${intent.subtotalSats.toLocaleString()} sats` },
+    { kind: 'amount', label: 'Platform fee', value: `${intent.platformFeeSats.toLocaleString()} sats` },
+    { kind: 'amount', label: 'Network fee', value: `${intent.networkFeeSats.toLocaleString()} sats` },
+    ...(deliveryCarrierSats > 0 ? [{
+      kind: 'amount' as const, label: 'Sats kept with your asset', value: `${deliveryCarrierSats.toLocaleString()} sats`,
+      description: 'Still yours, separate from the purchase cost and change',
+    }] : []),
+    ...(changeOutput ? [{ kind: 'amount' as const, label: 'Change', value: `${changeOutput.value.toLocaleString()} sats` }] : []),
+  ];
   return {
     status,
     family: 'buy_listings',
     ...(status === 'proved' ? {
+      paymentSummary,
       summary: {
         label: 'Buy collectibles',
         description: `${itemCount} collectible${itemCount === 1 ? '' : 's'}`,
@@ -1291,7 +1306,7 @@ function analyzeBuyListingsIntent(
     } : {}),
     title: `Buy ${itemCount} collectible${itemCount === 1 ? '' : 's'} for ${(intent.totalSats / 100_000_000).toFixed(8)} BTC`,
     facts: [
-      { kind: 'amount' as const, label: 'You pay', value: `${intent.totalSats.toLocaleString()} sats`, emphasis: 'primary' },
+      ...paymentSummary,
       ...(receivedAsset
         ? [{ kind: 'amount' as const, label: 'You receive', value: `${receivedAsset.quantity_normalized} ${receivedAsset.asset}` }]
         : []),
@@ -1303,9 +1318,6 @@ function analyzeBuyListingsIntent(
           ? `${itemCount}`
           : `${itemCount} (${distinctAssets} assets)`,
       },
-      // No network-fee row: the money-movement summary beside these facts already states it.
-      { kind: 'amount' as const, label: 'Seller subtotal', value: `${intent.subtotalSats.toLocaleString()} sats` },
-      { kind: 'amount' as const, label: 'Platform fee', value: `${intent.platformFeeSats.toLocaleString()} sats` },
       {
         kind: 'address' as const, label: 'Delivery', value: intent.delivery.address,
         description: attachedDelivery
@@ -1556,18 +1568,47 @@ function analyzeExactOfferIntent(
         ? 'caution'
         : 'proved';
   const fundingOutpoint = intent.bitcoinInvalidation.outpoint;
+  const offerPrice: ProtocolField = { kind: 'amount', label: 'Offer price', value: `${intent.priceSats.toLocaleString()} sats` };
+  const platformFee: ProtocolField = {
+    kind: 'amount', label: 'Platform fee', value: `${intent.platformFeeSats.toLocaleString()} sats`, description: 'Paid by the buyer',
+  };
+  const networkFee: ProtocolField = {
+    kind: 'amount', label: 'Network fee', value: `${intent.networkFeeSats.toLocaleString()} sats`, description: 'Deducted from seller proceeds',
+  };
+  const sellerReceives: ProtocolField = {
+    kind: 'amount', label: authorizing ? 'Seller receives' : 'You receive', value: `${intent.sellerProceedsSats.toLocaleString()} sats`,
+    ...(!authorizing ? { emphasis: 'primary' as const } : {}),
+  };
+  const buyerCost = safeSum([intent.priceSats, intent.platformFeeSats]);
+  const paymentSummary: ProtocolField[] = authorizing ? [
+    { kind: 'amount', label: 'You pay if accepted', value: buyerCost === null ? 'Unavailable' : `${buyerCost.toLocaleString()} sats`, emphasis: 'primary' },
+    offerPrice,
+    ...(intent.platformFeeSats > 0 ? [platformFee] : []),
+    ...(deliveryCarrierSats > 0 ? [{
+      kind: 'amount' as const, label: 'Sats kept with your asset', value: `${deliveryCarrierSats.toLocaleString()} sats`,
+      description: 'Still yours, separate from the offer cost',
+    }] : []),
+  ] : [
+    sellerReceives, offerPrice,
+    { kind: 'amount', label: 'Your UTXO sats returned', value: `${intent.carrierValueSats.toLocaleString()} sats` },
+    networkFee,
+  ];
   return {
     status,
     family: intent.action,
+    ...(allProblems.length === 0 ? {
+      paymentSummary,
+      summary: {
+        label: authorizing ? 'Offer to buy' : 'Accept offer',
+        description: `${provedQuantity} ${claim.asset}`,
+      },
+    } : {}),
     title: `${authorizing ? 'Authorize' : 'Accept'} ${(intent.priceSats / 100_000_000).toFixed(8)} BTC` +
       ` for ${provedQuantity ? `${provedQuantity} ` : ''}${claim.asset}`,
     facts: [
-      { kind: 'amount' as const, label: 'Offer price', value: `${intent.priceSats.toLocaleString()} sats` },
+      ...paymentSummary,
       ...(intent.platformFeeSats > 0 ? [
-        {
-          kind: 'amount' as const, label: 'Platform fee',
-          value: `${intent.platformFeeSats.toLocaleString()} sats`, description: 'Paid by the buyer',
-        },
+        ...(!authorizing ? [platformFee] : []),
         ...(outputs[2]?.address ? [{
           kind: 'address' as const, label: 'Fee recipient', value: outputs[2].address,
         }] : []),
@@ -1576,20 +1617,16 @@ function analyzeExactOfferIntent(
         kind: 'amount' as const, label: 'Buyer funding', value: `${buyerFundingSats.toLocaleString()} sats`,
         description: 'Offer price, platform fee, and any attached delivery UTXO',
       }] : []),
-      { kind: 'amount' as const, label: 'Seller receives', value: `${intent.sellerProceedsSats.toLocaleString()} sats` },
-      {
-        kind: 'amount' as const, label: 'Network fee', value: `${intent.networkFeeSats.toLocaleString()} sats`,
-        description: 'Deducted from seller proceeds',
-      },
+      ...(authorizing ? [sellerReceives, networkFee] : []),
       {
         kind: 'address' as const, label: 'Delivery', value: intent.delivery.address,
         description: attachedDelivery
           ? `Asset stays attached to a ${deliveryCarrierSats.toLocaleString()}-sat UTXO at this address`
           : 'Asset detaches to this address',
       },
-      { kind: 'outpoint' as const, label: 'Funding UTXO', value: `${fundingOutpoint.txid}:${fundingOutpoint.vout}` },
+      { kind: 'outpoint' as const, label: authorizing ? 'Funding UTXO' : 'Buyer funding UTXO', value: `${fundingOutpoint.txid}:${fundingOutpoint.vout}` },
       { kind: 'text' as const, label: 'Marketplace expiry', value: formatExpiry(intent.marketplaceExpiresAt) },
-      { kind: 'paragraph' as const, label: 'Cancellation', value: 'Anytime — spend the funding UTXO' },
+      ...(authorizing ? [{ kind: 'paragraph' as const, label: 'Cancellation', value: 'Withdraw by spending your funding UTXO' }] : []),
     ],
     notices: allProblems.length > 0
       ? []

--- a/src/pages/requests/psbt/approve.tsx
+++ b/src/pages/requests/psbt/approve.tsx
@@ -158,11 +158,6 @@ export default function ApprovePsbtPage() {
     !psbtDetails.unfunded && exceedsSaneFeeRate(psbtDetails.fee, estimatedVsize, fastestFee);
   const hasHighFee = psbtDetails.fee > 10000000 || feeRateAbsurd; // > 0.1 BTC, or an absurd rate
 
-  // Distinguish seller vs buyer in atomic swap PSBTs:
-  // - Seller: the REQUEST asks the user to sign with ANYONECANPAY (0x80 bit set)
-  // - Buyer: the PSBT contains an ANYONECANPAY input (seller's signature) but
-  //   the user is signing with SIGHASH_ALL — they are completing the swap
-
   const verificationPassed = verification?.passed;
   const verificationWarning = verification?.warning;
   const isStrictMode = settings?.strictTransactionVerification !== false;
@@ -404,12 +399,14 @@ export default function ApprovePsbtPage() {
       ? marketplaceReview!.summary ?? { label: "", description: marketplaceReview!.title }
       : null;
   const marketplaceFacts = semanticMarketplaceReview ? marketplaceReview!.facts : [];
-  const primaryFacts = marketplaceReview?.family === "buy_listings"
+  const paymentLabels = new Set(semanticMarketplaceReview
+    ? marketplaceReview!.paymentSummary?.map(field => field.label) : []);
+  const primaryFacts = paymentLabels.size === 0 && marketplaceReview?.family === "buy_listings"
     ? marketplaceFacts.filter(field => field.emphasis === "primary")
     : [];
   const protocolFields = txAction && "protocol" in txAction ? txAction.protocol : [];
   const detailFields = [
-    ...marketplaceFacts.filter(field => !primaryFacts.includes(field)),
+    ...marketplaceFacts.filter(field => !primaryFacts.includes(field) && !paymentLabels.has(field.label)),
     // The quoted marketplace XCP fee supersedes the generic XCP-fee row on an attach.
     ...protocolFields.filter(
       (field) =>
@@ -541,6 +538,7 @@ export default function ApprovePsbtPage() {
           txAction={marketplaceHeadline ?? txAction}
           principal={Boolean(semanticMarketplaceReview && marketplaceReview?.summary)}
           primaryFacts={primaryFacts}
+          marketplaceReview={marketplaceReview}
           order={order}
           movement={movement}
           flexibility={semanticMarketplaceReview ? undefined : flexibilityReview?.kind}

--- a/src/pages/requests/psbt/approve.tsx
+++ b/src/pages/requests/psbt/approve.tsx
@@ -293,27 +293,20 @@ export default function ApprovePsbtPage() {
     movement.atRisk > 0 ? attention.filter((item) => item.key !== "anyonecanpay") : attention;
   // Attach quotes are intrinsically block-dependent and already disclosed in the action card. A
   // second click on a proved listing or inventory attach would turn that routine protocol fact
-  // into warning wallpaper.
-  const marketplaceRequiresAttention = marketplaceReview?.status === "caution" && !routineAttach;
+  // into warning wallpaper. An exact offer is likewise what it says: the buyer is making an
+  // offer that the seller may accept until it expires, and the cancellation fact names the way
+  // out, so it earns neither a warning nor a second step.
+  const marketplaceRequiresAttention =
+    marketplaceReview?.status === "caution" &&
+    !routineAttach &&
+    marketplaceReview.family !== "authorize_exact_offer";
   // Plain-language consequences per family: what signing does, and how to undo it. The analyzer's
   // notices state the same facts in protocol terms; this screen is where a person decides.
   // create_listing is absent here on purpose: a fully proved listing is 'proved', never
   // 'caution', so its consequences live in the review facts on the one screen.
   const marketplaceAttention: WarningItem[] = !marketplaceRequiresAttention
     ? []
-    : marketplaceReview.family === "authorize_exact_offer"
-      ? [
-          {
-            key: "marketplace-offer",
-            severity: "warning" as const,
-            title: "The seller can complete this sale at any time",
-            description:
-              "Signing lets the seller finish this exact trade without asking you again — the " +
-              "first confirmed spend of your funding wins. To withdraw the offer, spend your " +
-              "funding UTXO.",
-          },
-        ]
-      : marketplaceReview.notices.map((notice, index) => ({
+    : marketplaceReview.notices.map((notice, index) => ({
           key: `marketplace-${index}`,
           severity: notice.severity,
           title: "This authorization remains usable after signing",
@@ -349,9 +342,7 @@ export default function ApprovePsbtPage() {
     counterpartyMessage?.messageType === "destroy" && txAction
       ? txAction.description
       : marketplaceRequiresAttention
-        ? marketplaceReview.family === "authorize_exact_offer"
-          ? "Before you authorize"
-          : "Review before signing"
+        ? "Review before signing"
         : approvalAttentionItems.some((item) => item.severity === "danger")
           ? "Review transaction risk"
           : "Review before signing";
@@ -381,14 +372,9 @@ export default function ApprovePsbtPage() {
       title: "Transaction details did not verify", description: verificationWarning,
     }] : []),
   ];
-  const visibleCautions: WarningItem[] = [
-    ...approvalAttentionItems,
-    ...(routineAttach && marketplaceReview?.status === "caution" ? [{
-      key: "attach-quote", severity: "warning" as const,
-      title: "XCP fee is finalized at confirmation",
-      description: "The displayed XCP fee is a quote. Counterparty determines the fee in the block that confirms this transaction.",
-    }] : []),
-  ];
+  // The attach XCP fee is a quote until confirmation; the fact row already says so, and a yellow
+  // notice restating a routine protocol property is not something the signer can act on.
+  const visibleCautions: WarningItem[] = [...approvalAttentionItems];
 
   // The marketplace review is the screen's one voice: proved/caution states take over the
   // headline and merge their facts into the Counterparty details instead of stacking a second
@@ -457,7 +443,9 @@ export default function ApprovePsbtPage() {
                       ? "Buy collectibles"
                       : marketplaceReview?.family === "accept_exact_offer"
                         ? "Accept offer"
-                        : "Sign transaction"
+                        : marketplaceReview?.family === "authorize_exact_offer"
+                          ? "Authorize offer"
+                          : "Sign transaction"
           }
         />
       }

--- a/src/pages/requests/psbts/approve.tsx
+++ b/src/pages/requests/psbts/approve.tsx
@@ -155,7 +155,7 @@ export default function ApprovePsbtsPage() {
         </Button>
       )}
       <BundleReviewCard review={decodedInfo.review} />
-      <Collapsible compact variant="card" title="Linked Transaction Details">
+      <Collapsible compact variant="card" title="Transactions">
         <div className="space-y-3 text-xs">
           {decodedInfo.items.map((item, index) => (
             <div

--- a/src/services/__tests__/providerService.test.ts
+++ b/src/services/__tests__/providerService.test.ts
@@ -187,6 +187,7 @@ const MARKETPLACE_EXACT_INTENT = {
   carrierValueSats: 546,
   sellerProceedsSats: 250_046,
   networkFeeSats: 500,
+  platformFeeSats: 6_250,
   expectedTxid: 'cd'.repeat(32),
   delivery: { mode: 'detached', address: '1FvyAqqELFiQyaEWdhFbWF8MZapKPZS8J7' },
   marketplaceExpiresAt: 2_000_003_600,


### PR DESCRIPTION
## Why

#368, #379, and #382 are merged, but the exact-offer proof still expects two outputs and buyer funding without a platform fee. Marketplace now builds three outputs and funds price plus fee. Eight existing cross-repo approval checks failed against clean extension main (4863da59); signatures themselves verified.

## Change

- Parse and preserve `platformFeeSats`. An omitted pre-fee v1 field means zero and still permits only two outputs. Invalid numeric values are rejected.
- For a positive fee, require exactly two inputs and three outputs: delivery, seller proceeds, external platform payment. Prove the fee amount, buyer funding, seller proceeds and actual miner fee independently.
- Display the buyer-paid platform fee and decoded recipient separately from seller-paid miner fees. Retain exact-target, SIGHASH_ALL, asset lookup and signer checks. No site allowlist or new signing bypass.
- Preserve seller-only CPFP spending of output 1. Show platform and package fees separately, and describe attached delivery accurately in the bundle.

The wallet proves the declared payment, not the recipient's business identity or a site's fee schedule. Marketplace owns its 2.5% / minimum policy; the wallet does not hard-code it. No provider response, address-pairing, signer, or version-number change.

## Verification

- `npm run compile`, `npm run lint`, `npm run build`: passed. Lint remains within existing repository budgets; existing chunk-size warning remains.
- 379 focused tests across intent parsing, semantic proof, signing policy, provider persistence, bundle/batch and approval components: passed.
- Mutation cases cover missing/extra/reordered fee outputs, wrong amounts, fee redirection to a participant, underfunding, double charging, unsafe sums, wrong sighashes and wrong transaction IDs.
- Rendered approval gallery: buyer authorization, seller acceptance and acceptance+CPFP passed; fee text asserted. Reviewed 380px screenshots, with 350px captures also generated.
- Marketplace cross-repo suite expanded to 78 passing checks using this checkout. Both delivery modes, all SegWit/Taproot buyer/seller combinations, fee-output mutations after signing, parent/child finalization and real wallet signing are covered. This also exercises the actual request parsers.

Full unit/E2E matrix runs in this PR's CI. These are isolated test wallets and fabricated UTXOs, not mainnet trades. Marketplace will pin this revision in its compatibility CI. A compatible extension release is still required before public users receive the fix.

## Role-specific presentation (second commit)

The signing rules above were right, but the decision card still led with the generic all-parties BTC movement. A seller accepting an offer saw sale proceeds under "Returned to wallet" as if they were change, and the buyer-funded platform fee appeared on the seller's screen without attribution.

- Each proved or caution marketplace review now emits a `paymentSummary` that replaces the generic movement on the summary card. Buyer authorizing: "You pay if accepted". Seller accepting: "You receive", with the network fee shown as deducted from proceeds. Buy listings: "You pay" with actual change kept separate from sats held with an attached asset. Listing and reprice: "Your payout if sold". Acceptance with CPFP: "You receive" and the action names the proved quantity.
- The cancellation instruction about spending the funding UTXO is shown only to the buyer.
- Blocked and retry reviews carry no `paymentSummary`, so the card falls back to the generic movement and never trusts labels from an unproved request.
- The gallery asserts the signer outcome is visible above the fold before any details are expanded, and covers attached and detached delivery for offer scenarios.

Verified locally: `compile`, `lint`, 884 unit tests across counterparty, approval components, request pages, hooks, provider and services, plus both gallery specs rendered and reviewed at 350px and 380px.


## Copy review (third commit)

Screen-by-screen review of both galleries with Dan. Routine facts stop being yellow notices, and each signer sees only their own costs:

- Headings are "Counterparty" and "Transaction". The generic card drops "Returned to wallet"; change is routine and still itemized under Transaction.
- No "XCP fee is finalized at confirmation" notice; the fact row carries it.
- Authorizing an exact offer is a single step with an "Authorize offer" footer. The analyzer notice is informational and the Cancellation fact names the way out.
- A seller accepting an offer does not see the buyer-paid platform fee or its recipient; the buyer does. The fee output stays in the raw Transaction section.
- The CPFP disclosure no longer repeats summary amounts; Create listing drops the Quantity row that duplicated the headline.
