### PR TITLE
Allow inscription reveals above the legacy script-size cap

### DIFF
--- a/src/core/bitcoin/__tests__/psbtInscriptionSize.test.ts
+++ b/src/core/bitcoin/__tests__/psbtInscriptionSize.test.ts
@@ -1,0 +1,72 @@
+import { sha256 } from '@noble/hashes/sha2.js';
+import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
+import { getPublicKey } from '@noble/secp256k1';
+import { Address, p2tr, SigHash, Transaction, taprootNumsKey } from '@scure/btc-signer';
+import { describe, expect, it } from 'vitest';
+import { AddressFormat } from '../address';
+import { extractPsbtDetails, parsePSBT, signPSBT } from '../psbt';
+
+const PRIVATE_KEY = '01'.repeat(32);
+const owner = p2tr(getPublicKey(hexToBytes(PRIVATE_KEY)).slice(1, 33));
+const decodedOwner = Address().decode(owner.address!);
+if (decodedOwner.type !== 'tr') throw new Error('Expected Taproot fixture');
+const ownerOutputKey = decodedOwner.pubkey;
+
+function reveal(bodyBytes: number, wrongCommitment = false) {
+  const script: number[] = [0x00, 0x63, 0x03, 0x6f, 0x72, 0x64, 0x00];
+  // Body pushes stay within the 520-byte element limit; only total script size grows.
+  for (let remaining = bodyBytes; remaining > 0;) {
+    const length = Math.min(remaining, 520);
+    if (length < 76) script.push(length);
+    else if (length < 256) script.push(0x4c, length);
+    else script.push(0x4d, length & 0xff, length >> 8);
+    script.push(...new Uint8Array(length).fill(7));
+    remaining -= length;
+  }
+  script.push(0x68, 0x20, ...ownerOutputKey, 0xac);
+  const leaf = new Uint8Array(script);
+  const commit = p2tr(taprootNumsKey(), { script: leaf, leafVersion: 0xc0 }, undefined, true);
+  const tx = new Transaction({ allowUnknownInputs: true, allowUnknownOutputs: true,
+    disableScriptCheck: wrongCommitment });
+  tx.addInput({ txid: '11'.repeat(32), index: 0,
+    witnessUtxo: { script: wrongCommitment ? owner.script : commit.script, amount: 100_000n },
+    tapLeafScript: commit.tapLeafScript, sighashType: SigHash.ALL });
+  tx.addOutputAddress(owner.address!, 546n);
+  return { hex: bytesToHex(tx.toPSBT()), leaf };
+}
+
+describe('PSBT inscription script sizes', () => {
+  it('parses and signs a 10 KiB inscription body through to its final witness', () => {
+    const fixture = reveal(10_240);
+    expect(fixture.leaf.length).toBeGreaterThan(10_000);
+    expect(extractPsbtDetails(fixture.hex).inputs[0]!.tapLeafScripts)
+      .toEqual([bytesToHex(fixture.leaf)]);
+    const signed = signPSBT(fixture.hex, PRIVATE_KEY, [0], AddressFormat.P2TR);
+    const tx = Transaction.fromPSBT(hexToBytes(signed), { allowUnknownInputs: true,
+      allowUnknownOutputs: true, disableScriptCheck: true });
+    tx.finalize();
+    expect(tx.getInput(0).finalScriptWitness).toHaveLength(3);
+    expect(tx.getInput(0).finalScriptWitness![1]).toEqual(fixture.leaf);
+    expect(tx.extract().length).toBeGreaterThan(10_240);
+  });
+
+  it('still rejects a large leaf whose commitment does not match the prevout', () => {
+    expect(() => parsePSBT(reveal(10_240, true).hex))
+      .toThrow(/Taproot commitment does not match previous output/);
+  });
+
+  it('bounds Taproot script allocation even though BIP342 removes the legacy cap', () => {
+    expect(() => parsePSBT(reveal(400_000).hex)).toThrow(/oversized Taproot script/);
+  });
+
+  it('keeps the legacy witness-script size limit', () => {
+    const witnessScript = new Uint8Array(10_001).fill(0x61);
+    const script = new Uint8Array([0x00, 0x20, ...sha256(witnessScript)]);
+    const tx = new Transaction({ allowUnknownInputs: true, disableScriptCheck: true });
+    tx.addInput({ txid: '22'.repeat(32), index: 0,
+      witnessUtxo: { script, amount: 100_000n }, witnessScript });
+    tx.addOutputAddress(owner.address!, 90_000n);
+    expect(() => parsePSBT(bytesToHex(tx.toPSBT())))
+      .toThrow(/oversized script|witnessScript exceeds 10,000 bytes/);
+  });
+});

--- a/src/core/bitcoin/psbt.ts
+++ b/src/core/bitcoin/psbt.ts
@@ -19,6 +19,10 @@ export const MAX_PSBT_OUTPUTS = 1_000;
 const MAX_PSBT_BASE64_LENGTH = Math.ceil(MAX_PSBT_BYTES / 3) * 4 + 4;
 const MAX_TAPLEAVES_PER_INPUT = 128;
 const MAX_PSBT_SCRIPT_BYTES = 10_000;
+// BIP342 removes the legacy script-size cap. Bound Taproot leaf parsing by the
+// standard transaction weight ceiling; the total PSBT byte limit also applies.
+// This is a resource bound, not a check of the completed transaction's weight.
+const MAX_PSBT_TAPSCRIPT_BYTES = 400_000;
 
 function assertPsbtEncodedSize(length: number, encoding: 'hex' | 'base64'): void {
   const tooLarge = encoding === 'hex'
@@ -278,10 +282,13 @@ function assertPsbtComplexity(transaction: Transaction): void {
     const scripts = [
       input.redeemScript,
       input.witnessScript,
-      ...(input.tapLeafScript?.map(([, script]) => script) ?? []),
     ];
     if (scripts.some((script) => (script?.length ?? 0) > MAX_PSBT_SCRIPT_BYTES)) {
       throw new Error(`PSBT input ${index} contains an oversized script`);
+    }
+    // PSBT tapLeafScript values append one leaf-version byte to the script.
+    if (input.tapLeafScript?.some(([, script]) => script.length > MAX_PSBT_TAPSCRIPT_BYTES + 1)) {
+      throw new Error(`PSBT input ${index} contains an oversized Taproot script`);
     }
   }
 }

--- a/src/core/counterparty/transactionSafety.ts
+++ b/src/core/counterparty/transactionSafety.ts
@@ -305,7 +305,7 @@ export function analyzeTransactionSafety(
       message:
         `This funds an inscription: ${btcAmount} BTC goes to ${options.verifiedCommit.address.slice(0, 12)}…, ` +
         'an address derived from the inscription itself and spendable only by your key. ' +
-        'The follow-up reveal transaction publishes the content and returns the remainder.',
+        'The follow-up reveal transaction publishes the content. Review its destination and fees separately.',
     });
   }
 


### PR DESCRIPTION
A valid inscription reveal with a 10 KiB image is rejected as an oversized script. The PSBT resource guard applies the legacy 10,000-byte cap to Taproot leaves, so a site can fund a commit and then be unable to sign its reveal.

Keep the legacy redeem/witness-script cap and give Taproot scripts a separate 400,000-byte resource bound, excluding the PSBT leaf-version byte. The overall 2 MB PSBT limit, leaf count, commitment validation, and approval checks remain enforced. [BIP342 removes the legacy script cap](https://github.com/bitcoin/bips/blob/master/bip-0342.mediawiki#resource-limits); the new bound uses [Bitcoin Core's standard transaction weight ceiling](https://github.com/bitcoin/bitcoin/blob/master/src/policy/policy.h) as a parsing budget, not a substitute for final transaction validation.

The commit explanation now asks the user to review the reveal's destination and fees rather than promising a refund: Launchpad intentionally burns its inscription output.

Validation: 120 focused PSBT, inscription, and signing-analysis tests pass; TypeScript, lint, and Chrome production build pass. New regressions cover signing/finalizing a 10 KiB inscription, mismatched Taproot commitments, excessive Taproot scripts, and the unchanged legacy limit. An offline Chromium smoke using Launchpad's real React wallet context, SDK, and transaction builders completes both signatures with the companion context-forwarding fix; broadcasts were mocked and no funds were spent.
