### PR TITLE
Size consolidation outputs from their real scripts

### DIFF
--- a/src/core/bitcoin/__tests__/consolidateBatch.test.ts
+++ b/src/core/bitcoin/__tests__/consolidateBatch.test.ts
@@ -31,6 +31,9 @@ import {
 const TEST_PRIVATE_KEY = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
 const TEST_ADDRESS = '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa';
 const FEE_ADDRESS = '1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2';
+// BIP86 test vector: first receive address of the "abandon … about" account 0.
+const TAPROOT_FEE_ADDRESS = 'bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr';
+const TAPROOT_FEE_SCRIPT_HEX = '5120a60869f0dbcf1dc659c9cecbaf8050135ea9e8cdc487053f1dc6880949dc684c';
 
 const privateKeyBytes = hexToBytes(TEST_PRIVATE_KEY);
 const compressedPubkey = getPublicKey(privateKeyBytes, true);
@@ -311,6 +314,29 @@ describe('consolidateBareMultisigBatch', () => {
       expect(wire.outputs).toHaveLength(2);
       expect(wire.outputs[0]!.amount).toBe(BigInt(result.outputAmount));
       expect(bytesToHex(wire.outputs[1]!.script)).toBe(p2pkhScriptHex(FEE_ADDRESS));
+      expect(wire.outputs[1]!.amount).toBe(BigInt(result.serviceFee));
+    });
+
+    it('should size a Taproot service fee output at its real 43 bytes', async () => {
+      const batchData = createBatchData({
+        utxoCount: 5,
+        amountPerUtxo: 200_000,
+        feePercent: 5,
+        exemptionThreshold: 100_000,
+        feeAddress: TAPROOT_FEE_ADDRESS,
+      });
+
+      const result = await consolidateBareMultisigBatch(TEST_PRIVATE_KEY, TEST_ADDRESS, batchData, 10);
+
+      // P2PKH destination (34) plus P2TR fee output (43):
+      // (5 * 115 + 10 + 1 + 34 + 43) * 10 = 6630 network fee.
+      expect(result.networkFee).toBe(6630);
+      expect(result.serviceFee).toBe(49_668);
+      expect(result.outputAmount).toBe(1_000_000 - 6630 - 49_668);
+
+      const wire = parseWireTx(hexToBytes(result.signedTxHex));
+      expect(wire.outputs).toHaveLength(2);
+      expect(bytesToHex(wire.outputs[1]!.script)).toBe(TAPROOT_FEE_SCRIPT_HEX);
       expect(wire.outputs[1]!.amount).toBe(BigInt(result.serviceFee));
     });
 

--- a/src/core/bitcoin/consolidateBatch.ts
+++ b/src/core/bitcoin/consolidateBatch.ts
@@ -5,7 +5,7 @@
 
 import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
 import { getPublicKey } from '@noble/secp256k1';
-import { Transaction } from '@scure/btc-signer';
+import { Address, OutScript, Transaction } from '@scure/btc-signer';
 import type { ConsolidationData, ConsolidationUTXO } from '@/core/bitcoin/consolidationApi';
 import { assertSignableBareMultisig, signAndFinalizeBareMultisig } from '@/core/bitcoin/multisigSigner';
 import { parseConsensusTransaction } from '@/core/bitcoin/rawTransaction';
@@ -18,10 +18,20 @@ const DUST_LIMIT_SATS = 546n;
 
 // Empirical consolidation transaction sizes: ~115 bytes per bare multisig
 // input (36 outpoint + 1 scriptSig varint + ~74 scriptSig + 4 sequence),
-// 10 bytes base overhead, ~34 bytes per P2PKH output.
+// 10 bytes base overhead. Outputs are sized from their actual script.
 const BYTES_PER_INPUT = 115;
 const BASE_OVERHEAD = 10;
-const BYTES_PER_OUTPUT = 34;
+
+/**
+ * Exact serialized size of an output paying this address: 8-byte value, a
+ * 1-byte script length, then the script itself — 34 for P2PKH, 31 for
+ * P2WPKH, 43 for P2TR. The service fee address became Taproot when the
+ * recovery service moved to an xpub; sizing every output as P2PKH
+ * under-counted it by 9 bytes, which came straight off the feerate.
+ */
+function outputBytes(address: string): number {
+  return 9 + OutScript.encode(Address().decode(address)).length;
+}
 
 export interface ConsolidationResult {
   signedTxHex: string;
@@ -139,12 +149,13 @@ export async function consolidateBareMultisigBatch(
     }
 
     const inputCountVarintSize = utxos.length >= 253 ? 3 : 1;
-    const estimateNetworkFee = (outputCount: number): bigint => BigInt(roundUp(multiply(
-      utxos.length * BYTES_PER_INPUT + BASE_OVERHEAD + inputCountVarintSize + outputCount * BYTES_PER_OUTPUT,
+    const estimateNetworkFee = (outputAddresses: string[]): bigint => BigInt(roundUp(multiply(
+      utxos.length * BYTES_PER_INPUT + BASE_OVERHEAD + inputCountVarintSize
+        + outputAddresses.reduce((sum, address) => sum + outputBytes(address), 0),
       feeRateSatPerVByte
     )).toFixed());
 
-    let networkFeeSats = estimateNetworkFee(1);
+    let networkFeeSats = estimateNetworkFee([destination]);
     let serviceFeeSats = 0n;
     let serviceFeeAddress: string | undefined;
 
@@ -152,7 +163,7 @@ export async function consolidateBareMultisigBatch(
       if (!batchData.fee_config.fee_address) {
         throw new Error('Recovery fee configuration is unavailable. Please try again later.');
       }
-      const feeWithServiceOutput = estimateNetworkFee(2);
+      const feeWithServiceOutput = estimateNetworkFee([destination, batchData.fee_config.fee_address]);
       const afterNetworkFee = totalInputSats - feeWithServiceOutput;
       if (afterNetworkFee > BigInt(batchData.fee_config.exemption_threshold)) {
         const candidate = (afterNetworkFee * BigInt(batchData.fee_config.fee_percent)) / 100n;


### PR DESCRIPTION
XCP/explorer#17 moves the recovery service fee from a static P2PKH list to addresses derived from a BIP86 xpub, so the fee output is now Taproot. `consolidateBatch.ts` sized every output as a 34-byte P2PKH; a bc1p output is 43 bytes, so the estimate under-counted by 9 bytes and the shortfall came off the requested feerate (about 0.02% on a full 420-input batch — not dangerous, but not exact either).

Outputs are now sized from the script the address encodes to (`OutScript.encode(Address().decode(addr))`), which also makes a bech32 destination address exact instead of over-paid.

No API or UI change; the extension already paid bc1p addresses correctly, this only fixes the estimate. `consolidateBatch.test.ts`: 23 pass, including a new Taproot fee-output case; biome clean.