### PR TITLE
Count the mempool in the swap quote and in Auto slippage

### DIFF
--- a/src/core/counterparty/__tests__/pool.test.ts
+++ b/src/core/counterparty/__tests__/pool.test.ts
@@ -44,6 +44,20 @@ describe("counterparty pool utilities", () => {
     expect(getAutoSlippage(-3)).toBe("0.5");
   });
 
+  it("adds what the mempool would take to Auto slippage", () => {
+    // The pending orders' drop rides on top of the impact share.
+    expect(getAutoSlippage(1.23, 2)).toBe("3.3");
+    // The impact share keeps its 5% cap; the mempool share is let through past it.
+    expect(getAutoSlippage(42, 3)).toBe("8");
+    // ...up to the point where it stops being a market order.
+    expect(getAutoSlippage(1, 40)).toBe("20");
+    // Nothing pending, or nothing usable, leaves the original figure alone.
+    expect(getAutoSlippage(1.23, 0)).toBe("1.3");
+    expect(getAutoSlippage(1.23, null)).toBe("1.3");
+    expect(getAutoSlippage(1.23, Number.NaN)).toBe("1.3");
+    expect(getAutoSlippage(1.23, -4)).toBe("1.3");
+  });
+
   it("falls back to the standing default when there is no quote to read", () => {
     expect(getAutoSlippage(null)).toBe("1");
     expect(getAutoSlippage(undefined)).toBe("1");

--- a/src/core/counterparty/__tests__/poolQuote.test.ts
+++ b/src/core/counterparty/__tests__/poolQuote.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import {
+  cloneMarket,
+  computePoolOutput,
+  fillMarket,
+  quoteAfterMempool,
+  XCP_POOL_FEE_BPS,
+  type MarketState,
+} from "@/core/counterparty/poolQuote";
+
+/**
+ * The bigint port of Core's swap quote. The numbers below were checked
+ * against the live `/pools/{a}/{b}/quote` endpoint for real pairs (pool-only,
+ * book-only, and mixed fills all matched to the unit), so what these tests
+ * pin is the behaviour the widget leans on: replaying pending orders first
+ * lowers the quote, and only same-direction orders count.
+ */
+
+const pool = (reserveIn: bigint, reserveOut: bigint): MarketState => ({
+  pool: { reserveIn, reserveOut, feeBps: XCP_POOL_FEE_BPS },
+  book: [],
+});
+
+describe("computePoolOutput", () => {
+  it("is constant-product with the fee taken on the way in", () => {
+    // (in * 9950 * out) / (in_reserve * 10000 + in * 9950), floored.
+    expect(computePoolOutput(1_000_000_000_000n, 1_000_000_000_000n, 10_000_000_000n, 50)).toBe(
+      (10_000_000_000n * 9950n * 1_000_000_000_000n) /
+        (1_000_000_000_000n * 10_000n + 10_000_000_000n * 9950n),
+    );
+  });
+
+  it("answers zero for an empty pool or no input", () => {
+    expect(computePoolOutput(0n, 10n, 5n, 50)).toBe(0n);
+    expect(computePoolOutput(10n, 10n, 0n, 50)).toBe(0n);
+  });
+});
+
+describe("fillMarket", () => {
+  it("fills a pool-only pair from the pool and moves the reserves", () => {
+    const state = pool(1_000_000_000_000n, 1_000_000_000_000n);
+    const fill = fillMarket(state, 10_000_000_000n);
+    expect(fill.bookOutput).toBe(0n);
+    expect(fill.poolOutput).toBe(fill.output);
+    expect(fill.giveRemaining).toBe(0n);
+    expect(state.pool!.reserveOut).toBe(1_000_000_000_000n - fill.output);
+    expect(state.pool!.reserveIn).toBeGreaterThan(1_000_000_000_000n);
+  });
+
+  it("takes a resting order priced better than the pool before the pool", () => {
+    // Pool at 1:1; a maker giving 2 out per 1 in is twice as good.
+    const state: MarketState = {
+      ...pool(1_000_000_000_000n, 1_000_000_000_000n),
+      book: [
+        { giveQuantity: 2_000n, getQuantity: 1_000n, giveRemaining: 2_000n, getRemaining: 1_000n },
+      ],
+    };
+    const fill = fillMarket(state, 1_000n);
+    expect(fill.bookOutput).toBe(2_000n);
+    expect(fill.poolOutput).toBe(0n);
+    expect(state.book[0]!.giveRemaining).toBe(0n);
+  });
+
+  it("leaves the remainder unfilled on a book-only pair", () => {
+    const state: MarketState = {
+      pool: null,
+      book: [
+        { giveQuantity: 500n, getQuantity: 500n, giveRemaining: 500n, getRemaining: 500n },
+      ],
+    };
+    const fill = fillMarket(state, 800n);
+    expect(fill.output).toBe(500n);
+    expect(fill.giveRemaining).toBe(300n);
+  });
+
+  it("does not touch the state it was cloned from", () => {
+    const original = pool(1_000_000n, 1_000_000n);
+    fillMarket(cloneMarket(original), 10_000n);
+    expect(original.pool!.reserveIn).toBe(1_000_000n);
+  });
+});
+
+describe("quoteAfterMempool", () => {
+  it("quotes the same as the baseline when nothing is pending", () => {
+    const q = quoteAfterMempool(pool(1_000_000_000_000n, 1_000_000_000_000n), [], 10_000_000_000n);
+    expect(q.output).toBe(q.baseline);
+    expect(q.dropPercent).toBe(0);
+    expect(q.pendingCount).toBe(0);
+  });
+
+  it("quotes less once pending orders of the same direction go first", () => {
+    const state = pool(1_000_000_000_000n, 1_000_000_000_000n);
+    const one = quoteAfterMempool(state, [10_000_000_000n], 10_000_000_000n);
+    const two = quoteAfterMempool(state, [10_000_000_000n, 10_000_000_000n], 10_000_000_000n);
+    expect(one.output).toBeLessThan(one.baseline);
+    expect(two.output).toBeLessThan(one.output);
+    expect(one.dropPercent).toBeGreaterThan(0);
+    expect(two.dropPercent).toBeGreaterThan(one.dropPercent);
+    // One percent of the pool in moves the marginal price by about two
+    // percent (both reserves move), so a same-size trade ahead costs the
+    // next taker a little under two percent.
+    expect(one.dropPercent).toBeGreaterThan(1.8);
+    expect(one.dropPercent).toBeLessThan(2.1);
+  });
+
+  it("ignores zero pending quantities", () => {
+    const q = quoteAfterMempool(pool(1_000_000n, 1_000_000n), [0n], 1_000n);
+    expect(q.output).toBe(q.baseline);
+  });
+});

--- a/src/core/counterparty/__tests__/poolQuote.test.ts
+++ b/src/core/counterparty/__tests__/poolQuote.test.ts
@@ -3,9 +3,9 @@ import {
   cloneMarket,
   computePoolOutput,
   fillMarket,
+  type MarketState,
   quoteAfterMempool,
   XCP_POOL_FEE_BPS,
-  type MarketState,
 } from "@/core/counterparty/poolQuote";
 
 /**

--- a/src/core/counterparty/api.ts
+++ b/src/core/counterparty/api.ts
@@ -1387,3 +1387,54 @@ export async function fetchServerInfo(): Promise<ServerInfo> {
   }
   return data.result;
 }
+
+/** An order still in the node's mempool: the fields a quote replay needs. */
+export interface MempoolOpenOrder {
+  tx_hash: string;
+  source: string;
+  give_asset: string;
+  get_asset: string;
+  give_quantity: ApiQuantity;
+  get_quantity: ApiQuantity;
+}
+
+/**
+ * Orders broadcast but not yet confirmed, chain-wide.
+ *
+ * Read fresh every time: the point of asking is to price a trade against what
+ * lands in the next block, and a cached answer from a minute ago is exactly the
+ * one that misses the order which just went in ahead of it.
+ */
+export async function fetchMempoolOpenOrders(): Promise<MempoolOpenOrder[]> {
+  const data = await cpApiGet<PaginatedResponse<{ tx_hash: string; params: Omit<MempoolOpenOrder, 'tx_hash'> & { status?: string } }>>(
+    '/v2/mempool/events/OPEN_ORDER',
+    { verbose: false, limit: 500 },
+    { skipCache: true }
+  );
+  return (data.result ?? [])
+    .filter((event) => event.params.status === undefined || event.params.status === 'open')
+    .map((event) => ({ tx_hash: event.tx_hash, ...event.params }));
+}
+
+/** A resting order in raw units, as the non-verbose pair endpoint returns it. */
+export interface RawBookOrder {
+  give_asset: string;
+  get_asset: string;
+  give_quantity: ApiQuantity;
+  get_quantity: ApiQuantity;
+  give_remaining: ApiQuantity;
+  get_remaining: ApiQuantity;
+}
+
+/**
+ * The open orders on a pair, raw. Non-verbose on purpose: a quote replay wants
+ * the integer quantities consensus matches on, not display strings.
+ */
+export async function fetchOpenBookOrders(giveAsset: string, getAsset: string): Promise<RawBookOrder[]> {
+  const data = await cpApiGet<PaginatedResponse<RawBookOrder>>(
+    `/v2/orders/${encodePath(giveAsset)}/${encodePath(getAsset)}`,
+    { verbose: false, status: 'open', limit: 1000 },
+    { skipCache: true }
+  );
+  return data.result ?? [];
+}

--- a/src/core/counterparty/pool.ts
+++ b/src/core/counterparty/pool.ts
@@ -57,24 +57,38 @@ export function getPoolDisplayPair(assetA: string, assetB: string): string {
 /** Below the pool fee a swap mostly just fails; above 5% the tolerance stops protecting anything. */
 const MIN_AUTO_SLIPPAGE = "0.5";
 const MAX_AUTO_SLIPPAGE = "5";
+/** With the mempool counted, how far Auto may follow it. Past this the swap is not a market order
+ *  any more, and the tolerance needs a deliberate manual choice. */
+const MAX_AUTO_SLIPPAGE_WITH_MEMPOOL = "20";
 
 /**
  * Slippage tolerance Auto picks for a swap, as a percent string.
  *
- * A trade's own price impact is what another taker of the same size would move the price by, so
- * Auto tolerates roughly that and no more: rounded up to a tenth, floored at 0.5% (pool-fee
- * territory, below which a swap mostly just fails) and capped at 5%. With no quote yet there is
- * nothing to derive it from, so it falls back to the standing default.
+ * Two parts. A trade's own price impact is what another taker of the same size would move the
+ * price by, so Auto tolerates roughly that: rounded up to a tenth, floored at 0.5% (pool-fee
+ * territory, below which a swap mostly just fails) and capped at 5%. On top of that goes the drop
+ * the pending orders already in the mempool would cause if they confirm first (see
+ * useMempoolAheadQuote) — not a guess, so it is allowed through, up to the point where this stops
+ * being a market order. With no quote yet there is nothing to derive it from, so it falls back to
+ * the standing default.
  */
-export function getAutoSlippage(priceImpact: number | null | undefined): string {
+export function getAutoSlippage(
+  priceImpact: number | null | undefined,
+  mempoolDropPercent: number | null | undefined = 0
+): string {
   // price_impact arrives as a raw JSON number, so NaN and the infinities are all reachable.
   if (typeof priceImpact !== "number" || !isFiniteNumber(priceImpact)) {
     return DEFAULT_POOL_SLIPPAGE;
   }
+  const drop =
+    typeof mempoolDropPercent === "number" && isFiniteNumber(mempoolDropPercent) && mempoolDropPercent > 0
+      ? mempoolDropPercent
+      : 0;
   // Rounded through BigNumber rather than Math.ceil: the impact arrives as a float, and an impact
   // of exactly 2 can reach here as 2.0000000000000004, which raw arithmetic rounds up to 2.1.
-  const toTenth = divide(roundUp(multiply(priceImpact, 10)), 10);
-  return minimum(MAX_AUTO_SLIPPAGE, maximum(MIN_AUTO_SLIPPAGE, toTenth)).toString();
+  const impactShare = minimum(MAX_AUTO_SLIPPAGE, maximum(0, priceImpact));
+  const toTenth = divide(roundUp(multiply(impactShare.plus(drop), 10)), 10);
+  return minimum(MAX_AUTO_SLIPPAGE_WITH_MEMPOOL, maximum(MIN_AUTO_SLIPPAGE, toTenth)).toString();
 }
 
 /**
@@ -90,9 +104,10 @@ export function getAutoSlippage(priceImpact: number | null | undefined): string 
  */
 export function resolvePoolSlippage(
   setting: string | undefined,
-  priceImpact?: number | null
+  priceImpact?: number | null,
+  mempoolDropPercent?: number | null
 ): string {
-  if (!setting || setting === POOL_SLIPPAGE_AUTO) return getAutoSlippage(priceImpact);
+  if (!setting || setting === POOL_SLIPPAGE_AUTO) return getAutoSlippage(priceImpact, mempoolDropPercent);
   return setting;
 }
 

--- a/src/core/counterparty/poolQuote.ts
+++ b/src/core/counterparty/poolQuote.ts
@@ -1,0 +1,299 @@
+/**
+ * Counterparty's swap quote, ported so it can be run against a state the
+ * node does not have yet: the mempool's.
+ *
+ * Core's `/pools/{a}/{b}/quote` says of itself "reflects current state only;
+ * actual execution may differ if trades confirm before yours." That gap is
+ * exactly what slippage exists to cover, and it is a gap we can see — the
+ * pending orders on a pair are public. This module is the quote algorithm
+ * (`api/queries.py::get_pool_quote` and the integer helpers in
+ * `ledger/markets.py`) in bigint, so a page can replay the orders already
+ * ahead of a trade and quote what is left for it.
+ *
+ * Integer math throughout, mirroring execution's own floors, because a
+ * quote in doubles would quietly disagree with consensus at the boundaries
+ * that decide whether a market order fills or rests. Nothing here talks to
+ * the network; callers bring the pool, the book, and the pending orders.
+ *
+ * The routing rule, as Core documents it: fill from the pool while its
+ * marginal price beats the best resting order, take that order, repeat; the
+ * pool absorbs whatever the book cannot. `fix_pool_best_price_routing`
+ * (block 961,100) is assumed live, so the pool fills use the integer-exact
+ * search rather than the older continuous quadratic.
+ */
+
+const BPS = 10_000n;
+
+/** The fee a pool charges, in basis points — Core's ledger/markets.py. */
+export const XCP_POOL_FEE_BPS = 50;
+export const OTHER_POOL_FEE_BPS = 100;
+
+/** The side of the pool a taker sees: what they pay into, what they draw. */
+export interface PoolSide {
+  reserveIn: bigint;
+  reserveOut: bigint;
+  feeBps: number;
+}
+
+/**
+ * A resting order on the far side of the book: the maker GIVES what the
+ * taker wants and GETS what the taker pays. Original quantities carry the
+ * price; remaining quantities carry the depth.
+ */
+export interface BookOrder {
+  giveQuantity: bigint;
+  getQuantity: bigint;
+  giveRemaining: bigint;
+  getRemaining: bigint;
+}
+
+/** Everything one taker's fill can change. */
+export interface MarketState {
+  pool: PoolSide | null;
+  book: BookOrder[];
+}
+
+export interface Fill {
+  /** What the taker receives, pool and book together. */
+  output: bigint;
+  poolOutput: bigint;
+  bookOutput: bigint;
+  /** What neither the pool nor the book could take. */
+  giveRemaining: bigint;
+}
+
+const bigMax = (a: bigint, b: bigint) => (a > b ? a : b);
+const bigMin = (a: bigint, b: bigint) => (a < b ? a : b);
+
+/** Constant-product output for one input, fee taken on the way in. */
+export function computePoolOutput(
+  reserveIn: bigint,
+  reserveOut: bigint,
+  input: bigint,
+  feeBps: number,
+): bigint {
+  if (input <= 0n || reserveIn <= 0n || reserveOut <= 0n) return 0n;
+  const inputWithFee = input * (BPS - BigInt(feeBps));
+  return (inputWithFee * reserveOut) / (reserveIn * BPS + inputWithFee);
+}
+
+/** Smallest input whose floored output reaches `output`; `high` already does. */
+function minPoolInputForOutput(
+  reserveIn: bigint,
+  reserveOut: bigint,
+  output: bigint,
+  feeBps: number,
+  high: bigint,
+): bigint {
+  let low = 1n;
+  while (low < high) {
+    const mid = (low + high) / 2n;
+    if (computePoolOutput(reserveIn, reserveOut, mid, feeBps) >= output) high = mid;
+    else low = mid + 1n;
+  }
+  return low;
+}
+
+/**
+ * What the book charges for `output` units at a maker's price — Python's
+ * `round()` on an exact fraction, which is half-to-even.
+ */
+function bookInputForOutput(output: bigint, priceNum: bigint, priceDen: bigint): bigint {
+  const numerator = output * priceNum;
+  const quotient = numerator / priceDen;
+  const remainder = numerator - quotient * priceDen;
+  const twice = remainder * 2n;
+  if (twice < priceDen) return quotient;
+  if (twice > priceDen) return quotient + 1n;
+  return quotient % 2n === 0n ? quotient : quotient + 1n;
+}
+
+/**
+ * The most a taker should put through the pool before the next resting order
+ * is the better deal, capped at what they have left. Zero when the pool is
+ * already past that price.
+ */
+export function computePoolInputForTargetPrice(
+  reserveIn: bigint,
+  reserveOut: bigint,
+  priceNum: bigint,
+  priceDen: bigint,
+  feeBps: number,
+  maxInput: bigint,
+): bigint {
+  if (reserveIn <= 0n || reserveOut <= 0n) return 0n;
+  if (priceNum <= 0n || priceDen <= 0n) return 0n;
+  const feeFactor = BPS - BigInt(feeBps);
+  if (reserveIn * BPS * priceDen >= reserveOut * feeFactor * priceNum) return 0n;
+
+  // Largest input whose post-fill marginal price still beats the book.
+  let high = (reserveOut * feeFactor * priceNum) / (BPS * priceDen) - reserveIn;
+  high = bigMin(bigMax(high, 0n), maxInput);
+  let low = 0n;
+  while (low < high) {
+    const mid = (low + high + 1n) / 2n;
+    const output = computePoolOutput(reserveIn, reserveOut, mid, feeBps);
+    if ((reserveIn + mid) * BPS * priceDen <= (reserveOut - output) * feeFactor * priceNum) {
+      low = mid;
+    } else {
+      high = mid - 1n;
+    }
+  }
+
+  // Never pay the pool more than the book would charge for the same units.
+  let dx = low;
+  let output = computePoolOutput(reserveIn, reserveOut, dx, feeBps);
+  while (output > 0n) {
+    const minInput = minPoolInputForOutput(reserveIn, reserveOut, output, feeBps, dx);
+    if (minInput <= bookInputForOutput(output, priceNum, priceDen)) return minInput;
+    dx = minInput - 1n;
+    output = computePoolOutput(reserveIn, reserveOut, dx, feeBps);
+  }
+  return 0n;
+}
+
+/** The pool's take of an unlimited-price fill: trimmed to the cheapest input
+ *  that still yields the floored output, the rest refunded. */
+export function computePoolFill(
+  reserveIn: bigint,
+  reserveOut: bigint,
+  maxGive: bigint,
+  feeBps: number,
+): { fill: bigint; output: bigint } {
+  const output = computePoolOutput(reserveIn, reserveOut, maxGive, feeBps);
+  if (output <= 0n) return { fill: 0n, output: 0n };
+  return {
+    fill: minPoolInputForOutput(reserveIn, reserveOut, output, feeBps, maxGive),
+    output,
+  };
+}
+
+/** Cheapest maker first: the order Core walks the book in (`give_price:asc`). */
+function byPriceAscending(a: BookOrder, b: BookOrder): number {
+  const lhs = a.getQuantity * b.giveQuantity;
+  const rhs = b.getQuantity * a.giveQuantity;
+  return lhs < rhs ? -1 : lhs > rhs ? 1 : 0;
+}
+
+/** A private copy, so a simulation never edits what it was handed. */
+export function cloneMarket(state: MarketState): MarketState {
+  return {
+    pool: state.pool ? { ...state.pool } : null,
+    book: state.book.map((order) => ({ ...order })),
+  };
+}
+
+/**
+ * One taker, run through `state` — which is UPDATED in place: reserves move,
+ * resting orders shrink. That is the point; running the pending orders
+ * through first is what makes the next call a mempool-aware quote.
+ */
+export function fillMarket(state: MarketState, give: bigint): Fill {
+  const pool =
+    state.pool && state.pool.reserveIn > 0n && state.pool.reserveOut > 0n ? state.pool : null;
+  const feeBps = pool?.feeBps ?? 0;
+  let giveRemaining = give;
+  let poolOutput = 0n;
+  let bookOutput = 0n;
+
+  state.book.sort(byPriceAscending);
+  for (const order of state.book) {
+    if (giveRemaining <= 0n) break;
+    if (order.giveRemaining <= 0n) continue;
+
+    if (pool) {
+      const poolFill = bigMin(
+        computePoolInputForTargetPrice(
+          pool.reserveIn,
+          pool.reserveOut,
+          order.getQuantity,
+          order.giveQuantity,
+          feeBps,
+          giveRemaining,
+        ),
+        giveRemaining,
+      );
+      if (poolFill > 0n) {
+        const out = computePoolOutput(pool.reserveIn, pool.reserveOut, poolFill, feeBps);
+        if (out > 0n) {
+          poolOutput += out;
+          giveRemaining -= poolFill;
+          pool.reserveIn += poolFill;
+          pool.reserveOut -= out;
+        }
+      }
+    }
+    if (giveRemaining <= 0n) break;
+
+    let canTake = bigMin(giveRemaining, order.getRemaining);
+    if (canTake <= 0n) continue;
+    let fromOrder = (canTake * order.giveQuantity) / order.getQuantity;
+    if (fromOrder > order.giveRemaining) {
+      fromOrder = order.giveRemaining;
+      canTake = (fromOrder * order.getQuantity) / order.giveQuantity;
+    }
+    if (fromOrder > 0n && canTake > 0n) {
+      bookOutput += fromOrder;
+      giveRemaining -= canTake;
+      order.giveRemaining -= fromOrder;
+      order.getRemaining -= canTake;
+    }
+  }
+
+  if (giveRemaining > 0n && pool) {
+    const { fill, output } = computePoolFill(
+      pool.reserveIn,
+      pool.reserveOut,
+      giveRemaining,
+      feeBps,
+    );
+    if (output > 0n) {
+      poolOutput += output;
+      giveRemaining -= fill;
+      pool.reserveIn += fill;
+      pool.reserveOut -= output;
+    }
+  }
+
+  return { output: poolOutput + bookOutput, poolOutput, bookOutput, giveRemaining };
+}
+
+export interface MempoolQuote {
+  /** What the trade gets if every pending order ahead of it confirms first. */
+  output: bigint;
+  /** What the same model says it gets against the confirmed state — the
+   *  number to compare `output` to, so model drift cancels out. */
+  baseline: bigint;
+  /** Percentage `output` falls short of `baseline`; never negative. */
+  dropPercent: number;
+  pendingCount: number;
+}
+
+/**
+ * The quote for `give`, after the same-direction orders already in the
+ * mempool have had their turn.
+ *
+ * Same direction only, deliberately. An opposite-side order pending on the
+ * pair can only improve the taker's price, and its ordering within the block
+ * is no more knowable than anyone else's — so it is left out and the
+ * estimate errs toward caution. Confirmation order among the pending orders
+ * themselves does not matter to the result: each one moves the pool along
+ * the same curve, and the book is walked cheapest-first either way.
+ */
+export function quoteAfterMempool(
+  state: MarketState,
+  pendingGives: bigint[],
+  give: bigint,
+): MempoolQuote {
+  const baseline = fillMarket(cloneMarket(state), give).output;
+  const ahead = cloneMarket(state);
+  for (const pending of pendingGives) {
+    if (pending > 0n) fillMarket(ahead, pending);
+  }
+  const output = fillMarket(ahead, give).output;
+  const dropPercent =
+    baseline > 0n && output < baseline
+      ? Number(((baseline - output) * 1_000_000n) / baseline) / 10_000
+      : 0;
+  return { output, baseline, dropPercent, pendingCount: pendingGives.length };
+}

--- a/src/hooks/useMempoolAheadQuote.ts
+++ b/src/hooks/useMempoolAheadQuote.ts
@@ -5,10 +5,10 @@ import {
   type Pool,
 } from "@/core/counterparty/api";
 import {
+  type MempoolQuote,
   OTHER_POOL_FEE_BPS,
   quoteAfterMempool,
   XCP_POOL_FEE_BPS,
-  type MempoolQuote,
 } from "@/core/counterparty/poolQuote";
 import { toBigNumber } from "@/core/numeric";
 

--- a/src/hooks/useMempoolAheadQuote.ts
+++ b/src/hooks/useMempoolAheadQuote.ts
@@ -1,0 +1,130 @@
+import { useEffect, useState } from "react";
+import {
+  fetchMempoolOpenOrders,
+  fetchOpenBookOrders,
+  type Pool,
+} from "@/core/counterparty/api";
+import {
+  OTHER_POOL_FEE_BPS,
+  quoteAfterMempool,
+  XCP_POOL_FEE_BPS,
+  type MempoolQuote,
+} from "@/core/counterparty/poolQuote";
+import { toBigNumber } from "@/core/numeric";
+
+/** A raw quantity as bigint, whether it arrived as a digit string or a number. */
+const rawBig = (value: string | number): bigint => BigInt(toBigNumber(value).toFixed(0));
+
+export interface MempoolAheadState {
+  /** Null until both the pending orders and, if any, the book have been read. */
+  data: MempoolQuote | null;
+  isLoading: boolean;
+}
+
+/**
+ * The swap quote after the orders already in the mempool have had their turn.
+ *
+ * Core's `/quote` reflects the confirmed state only, and says so: "actual execution may differ if
+ * trades confirm before yours." Those trades are public — the node lists its own mempool — so the
+ * same-direction ones are replayed through Core's quote algorithm (poolQuote.ts) ahead of this
+ * trade, and what they leave is what Auto slippage has to cover. Priced off the confirmed quote
+ * alone, a swap missed its price whenever a pending order confirmed first, and rested for a block
+ * instead of filling: a network fee for nothing.
+ *
+ * Two reads, the second only when the first finds something. The mempool listing is one call; the
+ * resting book is fetched only while there are pending orders to replay through it. A book that
+ * fails to load counts as empty: the pool then absorbs every pending order, which overstates the
+ * drop, and overstating is the safe direction for a tolerance. A mempool read that fails yields
+ * null — the form falls back to the tolerance it always used.
+ */
+export function useMempoolAheadQuote({
+  giveAsset,
+  getAsset,
+  quantity,
+  pool,
+  feeBps,
+  enabled,
+}: {
+  giveAsset: string;
+  getAsset: string;
+  /** Raw base units of giveAsset, as a digit string. */
+  quantity: string;
+  /** The pair's pool, or null when there is none; undefined while it loads. */
+  pool: Pool | null | undefined;
+  /** The fee the quote reported; the protocol default for the pair when it did not. */
+  feeBps?: number;
+  enabled: boolean;
+}): MempoolAheadState {
+  const [state, setState] = useState<MempoolAheadState>({ data: null, isLoading: false });
+
+  const reserveA = pool?.reserve_a;
+  const reserveB = pool?.reserve_b;
+  const poolAssetA = pool?.asset_a;
+  const poolKnown = pool !== undefined;
+
+  useEffect(() => {
+    if (!enabled || !poolKnown || !/^\d+$/.test(quantity) || quantity === "0") {
+      setState({ data: null, isLoading: false });
+      return;
+    }
+
+    let cancelled = false;
+    setState((previous) => ({ data: previous.data, isLoading: true }));
+
+    const read = async () => {
+      const pendingAhead = (await fetchMempoolOpenOrders())
+        .filter((order) => order.give_asset === giveAsset && order.get_asset === getAsset)
+        .map((order) => rawBig(order.give_quantity))
+        .filter((give) => give > 0n);
+      if (cancelled) return;
+      if (pendingAhead.length === 0) {
+        setState({ data: null, isLoading: false });
+        return;
+      }
+
+      const book = await fetchOpenBookOrders(getAsset, giveAsset)
+        .then((orders) =>
+          orders
+            .filter((order) => order.give_asset === getAsset && order.get_asset === giveAsset)
+            .map((order) => ({
+              giveQuantity: rawBig(order.give_quantity),
+              getQuantity: rawBig(order.get_quantity),
+              giveRemaining: rawBig(order.give_remaining),
+              getRemaining: rawBig(order.get_remaining),
+            }))
+        )
+        .catch(() => []);
+      if (cancelled) return;
+
+      const hasPool =
+        reserveA !== undefined && reserveB !== undefined && reserveA > 0 && reserveB > 0;
+      const simPool = hasPool
+        ? {
+            reserveIn: rawBig(poolAssetA === giveAsset ? reserveA : reserveB),
+            reserveOut: rawBig(poolAssetA === giveAsset ? reserveB : reserveA),
+            feeBps:
+              feeBps ?? (giveAsset === "XCP" || getAsset === "XCP" ? XCP_POOL_FEE_BPS : OTHER_POOL_FEE_BPS),
+          }
+        : null;
+      if (!simPool && book.length === 0) {
+        setState({ data: null, isLoading: false });
+        return;
+      }
+
+      setState({
+        data: quoteAfterMempool({ pool: simPool, book }, pendingAhead, BigInt(quantity)),
+        isLoading: false,
+      });
+    };
+
+    read().catch(() => {
+      if (!cancelled) setState({ data: null, isLoading: false });
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled, poolKnown, quantity, giveAsset, getAsset, reserveA, reserveB, poolAssetA, feeBps]);
+
+  return state;
+}

--- a/src/hooks/useMempoolAheadQuote.ts
+++ b/src/hooks/useMempoolAheadQuote.ts
@@ -21,6 +21,12 @@ export interface MempoolAheadState {
   isLoading: boolean;
 }
 
+/** What one answer was computed for, so an answer to an older question is never shown. */
+interface Answer {
+  key: string;
+  data: MempoolQuote | null;
+}
+
 /**
  * The swap quote after the orders already in the mempool have had their turn.
  *
@@ -55,21 +61,26 @@ export function useMempoolAheadQuote({
   feeBps?: number;
   enabled: boolean;
 }): MempoolAheadState {
-  const [state, setState] = useState<MempoolAheadState>({ data: null, isLoading: false });
+  const [answer, setAnswer] = useState<Answer | null>(null);
 
   const reserveA = pool?.reserve_a;
   const reserveB = pool?.reserve_b;
   const poolAssetA = pool?.asset_a;
   const poolKnown = pool !== undefined;
+  const active = enabled && poolKnown && /^\d+$/.test(quantity) && quantity !== "0";
+  // Everything the answer depends on. The effect below only ever sets state after a network
+  // round trip, so the question being asked is derived here rather than mirrored into state.
+  const key = active
+    ? [giveAsset, getAsset, quantity, poolAssetA ?? "", reserveA ?? "", reserveB ?? "", feeBps ?? ""].join("|")
+    : "";
 
   useEffect(() => {
-    if (!enabled || !poolKnown || !/^\d+$/.test(quantity) || quantity === "0") {
-      setState({ data: null, isLoading: false });
-      return;
-    }
+    if (!active) return;
 
     let cancelled = false;
-    setState((previous) => ({ data: previous.data, isLoading: true }));
+    const settle = (data: MempoolQuote | null) => {
+      if (!cancelled) setAnswer({ key, data });
+    };
 
     const read = async () => {
       const pendingAhead = (await fetchMempoolOpenOrders())
@@ -78,7 +89,7 @@ export function useMempoolAheadQuote({
         .filter((give) => give > 0n);
       if (cancelled) return;
       if (pendingAhead.length === 0) {
-        setState({ data: null, isLoading: false });
+        settle(null);
         return;
       }
 
@@ -107,24 +118,21 @@ export function useMempoolAheadQuote({
           }
         : null;
       if (!simPool && book.length === 0) {
-        setState({ data: null, isLoading: false });
+        settle(null);
         return;
       }
 
-      setState({
-        data: quoteAfterMempool({ pool: simPool, book }, pendingAhead, BigInt(quantity)),
-        isLoading: false,
-      });
+      settle(quoteAfterMempool({ pool: simPool, book }, pendingAhead, BigInt(quantity)));
     };
 
-    read().catch(() => {
-      if (!cancelled) setState({ data: null, isLoading: false });
-    });
+    read().catch(() => settle(null));
 
     return () => {
       cancelled = true;
     };
-  }, [enabled, poolKnown, quantity, giveAsset, getAsset, reserveA, reserveB, poolAssetA, feeBps]);
+  }, [active, key, quantity, giveAsset, getAsset, reserveA, reserveB, poolAssetA, feeBps]);
 
-  return state;
+  if (!active) return { data: null, isLoading: false };
+  const current = answer !== null && answer.key === key;
+  return { data: current ? answer.data : null, isLoading: !current };
 }

--- a/src/pages/compose/swap/form.tsx
+++ b/src/pages/compose/swap/form.tsx
@@ -23,10 +23,13 @@ import {
   isGreaterThan,
   isLessThanOrEqualTo,
   isValidPositiveNumber,
+  roundDown,
   toBigNumber,
+  toSatoshis,
 } from "@/core/numeric";
 import { POOL_SLIPPAGE_AUTO } from "@/core/settings";
 import { useAssetDetails } from "@/hooks/useAssetDetails";
+import { useMempoolAheadQuote } from "@/hooks/useMempoolAheadQuote";
 import { usePool } from "@/hooks/usePool";
 import { usePoolSwapQuote } from "@/hooks/usePoolQuotes";
 import { SlippageInput } from "@/pages/compose/pool/slippage-input";
@@ -40,6 +43,8 @@ interface SwapFormProps {
 
 /** Everything the UI needs from a usable quote, in display units. */
 interface QuoteView {
+  /** What the trade gets if the pending orders ahead of it confirm first; null when none are. */
+  afterMempool: string | null;
   estimated: string;
   minReceived: string;
   price: string | null;
@@ -162,8 +167,22 @@ export function SwapForm({
     : null;
   const unfilled = outcome === "partial";
 
-  // Auto reads the tolerance off this quote's own price impact; a stored percent is used as-is.
-  const slippage = resolvePoolSlippage(slippageSetting, quote?.price_impact);
+  // What is already in line ahead of this swap. Core's quote reflects the confirmed state only;
+  // the pending same-direction orders are replayed ahead of this one so Auto can cover what they
+  // leave, and so the card can say how many there are.
+  const { data: ahead } = useMempoolAheadQuote({
+    giveAsset,
+    getAsset,
+    quantity: isGiveDivisible ? toSatoshis(amount || "0") : roundDown(amount || "0").toString(),
+    pool: isPoolLoading ? undefined : pool,
+    feeBps: typeof quote?.fee_bps === "number" ? quote.fee_bps : undefined,
+    enabled: canQuote,
+  });
+  const mempoolDrop = ahead?.dropPercent ?? 0;
+
+  // Auto reads the tolerance off this quote's own price impact plus what the mempool would take;
+  // a stored percent is used as-is.
+  const slippage = resolvePoolSlippage(slippageSetting, quote?.price_impact, mempoolDrop);
 
   // Null until the quote produces actual output; all values in display units.
   const quoteView = useMemo<QuoteView | null>(() => {
@@ -176,8 +195,16 @@ export function SwapForm({
       : null;
     const priceValid = priceRatio?.isFinite() && priceRatio.isGreaterThan(0);
 
+    // Core's quote, scaled by what the replay says the mempool leaves of it — scaled rather than
+    // used directly so any drift between the port and the node cancels out.
+    const afterMempoolSats =
+      ahead && ahead.baseline > 0n
+        ? ((BigInt(toBigNumber(estimatedSats).toFixed(0)) * ahead.output) / ahead.baseline).toString()
+        : null;
+
     return {
       estimated,
+      afterMempool: afterMempoolSats !== null ? toDisplayUnits(afterMempoolSats, isGetDivisible) : null,
       minReceived: toDisplayUnits(applyPoolSlippage(estimatedSats, slippage), isGetDivisible),
       // Computed in display units: the API's effective_price is a raw satoshi
       // ratio, which is wrong across mixed divisibility.
@@ -198,7 +225,15 @@ export function SwapForm({
         : null,
       route: routeLabel(quote),
     };
-  }, [quote, amount, slippage, isGetDivisible, isGiveDivisible]);
+  }, [quote, amount, slippage, isGetDivisible, isGiveDivisible, ahead]);
+
+  // The guarantee is above what the mempool leaves: as priced, this swap rests for a block and
+  // refunds instead of filling if the pending orders confirm first. Auto never lands here; a
+  // stored percent can.
+  const minBelowMempool =
+    quoteView?.afterMempool !== null
+    && quoteView?.afterMempool !== undefined
+    && isGreaterThan(quoteView.minReceived, quoteView.afterMempool);
 
   // ---- Submission ----
   const isSlippageValid =
@@ -350,8 +385,19 @@ export function SwapForm({
           <label htmlFor="swap-receive-estimate" className="text-sm font-medium text-gray-700 flex justify-between items-center">
             <span>Amount <span className="text-red-500">*</span></span>
             {signedImpact !== null && (
-              <span className={`text-xs font-normal ${impactClass}`}>
-                Impact: {signedImpact > 0 ? "+" : ""}{formatAmount({ value: signedImpact, maximumFractionDigits: 2 })}%
+              <span className="text-xs font-normal">
+                <span className={impactClass}>
+                  Impact: {signedImpact > 0 ? "+" : ""}{formatAmount({ value: signedImpact, maximumFractionDigits: 2 })}%
+                </span>
+                {ahead && (
+                  <span
+                    className={mempoolDrop >= 3 ? "text-amber-600" : "text-gray-500"}
+                    title={`${ahead.pendingCount} unconfirmed ${ahead.pendingCount === 1 ? "order" : "orders"} on this pair in the same direction. If they confirm first, this swap gets about ${formatAmount({ value: mempoolDrop, maximumFractionDigits: 1 })}% less than the quote. Auto slippage allows for it.`}
+                  >
+                    {" · "}{ahead.pendingCount} ahead in mempool
+                    {mempoolDrop > 0 && ` (−${formatAmount({ value: mempoolDrop, maximumFractionDigits: 1 })}%)`}
+                  </span>
+                )}
               </span>
             )}
           </label>
@@ -396,10 +442,22 @@ export function SwapForm({
           <div className={showDetails ? "border-t border-gray-200 p-3 space-y-3 text-sm text-gray-600" : "hidden"}>
             {quoteView && (
               <>
+                {quoteView.afterMempool !== null && (
+                  <DetailRow
+                    label="After mempool"
+                    value={`≈ ${formatAmount({ value: quoteView.afterMempool, maximumFractionDigits: 8 })} ${getAsset}`}
+                  />
+                )}
                 <DetailRow
                   label="Minimum received"
                   value={`${formatAmount({ value: quoteView.minReceived, maximumFractionDigits: 8 })} ${getAsset}`}
                 />
+                {minBelowMempool && (
+                  <div className="rounded border border-amber-200 bg-amber-50 p-2 text-xs text-amber-700">
+                    Above what the pending orders would leave. If they confirm first, this swap rests for a
+                    block and refunds instead of filling — raise the slippage or use Auto.
+                  </div>
+                )}
                 {quoteView.poolFee && (
                   <DetailRow
                     label={`Pool fee (${(quoteView.poolFee.bps / 100).toFixed(2)}%)`}


### PR DESCRIPTION
## Summary
- Port Core's swap quote algorithm (`get_pool_quote` + the integer helpers in `ledger/markets.py`) to bigint in `core/counterparty/poolQuote.ts`. Verified to the unit against the live `/quote` endpoint on twelve mainnet pools at three sizes each, covering pool-only, book-only and mixed fills.
- New `useMempoolAheadQuote` hook: reads the node's pending `OPEN_ORDER` events, and only when some are on the pair in the same direction, the resting book; replays them ahead of the swap and reports the drop.
- `getAutoSlippage` / `resolvePoolSlippage` take that drop: Auto = min(impact, 5%) + mempool drop, floored at 0.5%, capped at 20%.
- Swap form shows "N ahead in mempool (−x.x%)" beside the impact, an "After mempool" detail row, and a warning when a stored tolerance's minimum is above what the mempool would leave.

## Why
A market swap priced off the confirmed quote missed its price whenever a pending order confirmed first, and rested for a block instead of filling. The pending orders are public, so the tolerance can account for them.

## Test plan
- [x] `vitest src/core/counterparty/__tests__/poolQuote.test.ts src/core/counterparty/__tests__/pool.test.ts`
- [ ] Open the swap form on a pair with a pending order in the mempool; confirm the impact label shows the count and Auto slippage rises by the shown drop.