### PR TITLE
chore(release): bump version to 0.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xcp-wallet",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xcp-wallet",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -33,7 +33,7 @@
         "@testing-library/user-event": "14.6.7",
         "@trezor/connect": "9.7.3",
         "@trezor/trezor-user-env-link": "1.0.0",
-        "@types/chrome": "0.2.8",
+        "@types/chrome": "0.2.9",
         "@types/react": "19.2.18",
         "@types/react-dom": "19.2.7",
         "@wxt-dev/module-react": "1.2.2",
@@ -3917,9 +3917,9 @@
       }
     },
     "node_modules/@types/chrome": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.2.8.tgz",
-      "integrity": "sha512-dznDYMiJUyuc7b+78PxnWhaGOonmbX/OmcWu7NE42sg/yTLJMYnJ7Uah40SLPNFiCh8reqcthk7vOva2+MSvzw==",
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.2.9.tgz",
+      "integrity": "sha512-6rXrDPkkWv4D2Q23HqT+iED4voODU5CpOSc2VFgKyecSFItuEsIBvz9CY6jUQ3dd+Q7zo1bnCE9pKRMtkYut5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "xcp-wallet",
   "description": "Counterparty Web3 Wallet",
   "private": true,
-  "version": "0.10.1",
+  "version": "0.11.0",
   "license": "MIT",
   "type": "module",
   "engines": {
@@ -64,7 +64,7 @@
     "@testing-library/user-event": "14.6.7",
     "@trezor/connect": "9.7.3",
     "@trezor/trezor-user-env-link": "1.0.0",
-    "@types/chrome": "0.2.8",
+    "@types/chrome": "0.2.9",
     "@types/react": "19.2.18",
     "@types/react-dom": "19.2.7",
     "@wxt-dev/module-react": "1.2.2",


### PR DESCRIPTION
Bumps the extension to 0.11.0 for release and pins `@types/chrome` to 0.2.9, the only pinned dependency with a newer stable version. `@trezor/connect-webextension` stays on 9.7.3 because v10 has only alpha and beta tags.

Lockfile patched minimally and verified with `npm ci --dry-run`. Local `tsc --noEmit`, `biome check`, and `wxt zip` pass; the built manifest reports 0.11.0.