### PR TITLE
Keep a paired grant across the active Legacy/SegWit switch

### DIFF
--- a/PROVIDER.md
+++ b/PROVIDER.md
@@ -81,7 +81,9 @@ await xcpwallet.request({
 ```
 
 The additional checkbox is opt-in and remains scoped to the connected site, wallet, and
-address index until disconnect. It only permits address disclosure and signing requests;
+address index until disconnect. The grant covers both halves of that index: a site that
+connected on the Legacy account keeps its paired access after the user switches the active
+account to the SegWit sibling, and vice versa. It only permits address disclosure and signing requests;
 every transaction still requires approval. Connection and paired-address grants are rechecked
 immediately before signing, so disconnecting the site invalidates an open request.
 

--- a/src/core/settings.ts
+++ b/src/core/settings.ts
@@ -95,6 +95,8 @@ export interface AppSettings {
     pairedAddresses?: boolean;
     walletId?: string;
     address?: string;
+    /** The Legacy/SegWit sibling of `address`; the grant covers both halves of the pair. */
+    pairedAddress?: string;
   }>;
 
   /** Allow unconfirmed transaction inputs */

--- a/src/core/wallet/keychainCrypto.ts
+++ b/src/core/wallet/keychainCrypto.ts
@@ -52,7 +52,8 @@ function parseSettings(value: unknown): AppSettings {
       if (!isRecord(capability) ||
           (capability.pairedAddresses !== undefined && typeof capability.pairedAddresses !== 'boolean') ||
           (capability.walletId !== undefined && typeof capability.walletId !== 'string') ||
-          (capability.address !== undefined && typeof capability.address !== 'string')) return invalidKeychain();
+          (capability.address !== undefined && typeof capability.address !== 'string') ||
+          (capability.pairedAddress !== undefined && typeof capability.pairedAddress !== 'string')) return invalidKeychain();
     }
   }
   return structuredClone(settings);

--- a/src/platform/provider/__tests__/pairedGrant.test.ts
+++ b/src/platform/provider/__tests__/pairedGrant.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { pairedGrantCovers } from '../pairedGrant';
+
+const LEGACY = '19QWXpMXeLkoEKEJv2xo9rn8wkPCyxACSX';
+const SEGWIT = 'bc1qsvqsa9arwz30g2z0w09twzn8gz3380h36yxacs';
+const grant = { pairedAddresses: true, walletId: 'wallet-1', address: LEGACY, pairedAddress: SEGWIT };
+
+describe('pairedGrantCovers', () => {
+  it('covers the address that was active at approval', () => {
+    expect(pairedGrantCovers(grant, 'wallet-1', LEGACY)).toBe(true);
+  });
+
+  it('covers the sibling after the user switches the active account', () => {
+    expect(pairedGrantCovers(grant, 'wallet-1', SEGWIT)).toBe(true);
+  });
+
+  it('compares SegWit addresses case-insensitively', () => {
+    expect(pairedGrantCovers(grant, 'wallet-1', SEGWIT.toUpperCase())).toBe(true);
+  });
+
+  it('never covers another derivation index or wallet', () => {
+    expect(pairedGrantCovers(grant, 'wallet-1', 'bc1qother')).toBe(false);
+    expect(pairedGrantCovers(grant, 'wallet-2', LEGACY)).toBe(false);
+  });
+
+  it('keeps an older grant without a recorded sibling scoped to its one address', () => {
+    const legacyOnly = { pairedAddresses: true, walletId: 'wallet-1', address: LEGACY };
+    expect(pairedGrantCovers(legacyOnly, 'wallet-1', LEGACY)).toBe(true);
+    expect(pairedGrantCovers(legacyOnly, 'wallet-1', SEGWIT)).toBe(false);
+  });
+
+  it('is false without the paired capability', () => {
+    expect(pairedGrantCovers({ ...grant, pairedAddresses: false }, 'wallet-1', LEGACY)).toBe(false);
+    expect(pairedGrantCovers(undefined, 'wallet-1', LEGACY)).toBe(false);
+  });
+});

--- a/src/platform/provider/pairedGrant.ts
+++ b/src/platform/provider/pairedGrant.ts
@@ -1,0 +1,28 @@
+import { normalizeAddressForComparison } from '@/core/bitcoin/address';
+
+/** The persisted shape of a site's paired-address grant (`settings.providerCapabilities[origin]`). */
+export interface PairedGrant {
+  pairedAddresses?: boolean;
+  walletId?: string;
+  /** The address that was active when the user approved the grant. */
+  address?: string;
+  /** Its Legacy/SegWit sibling at the same derivation index, recorded at approval time. */
+  pairedAddress?: string;
+}
+
+/**
+ * A paired grant covers one derivation index, not one address. The user approves both halves on
+ * the connect screen, so the grant must keep working whichever half is active afterwards: a site
+ * that connected on the Legacy account must not lose its source address, or refuse a signature
+ * it already showed, because the user switched to the SegWit sibling in the extension.
+ *
+ * Grants written before the sibling was recorded carry only `address`; they keep matching that
+ * half exactly and are upgraded the next time the site connects.
+ */
+export function pairedGrantCovers(grant: PairedGrant | undefined, walletId: string, address: string): boolean {
+  if (grant?.pairedAddresses !== true || grant.walletId !== walletId) return false;
+  const wanted = normalizeAddressForComparison(address);
+  return [grant.address, grant.pairedAddress].some(
+    candidate => typeof candidate === 'string' && normalizeAddressForComparison(candidate) === wanted,
+  );
+}

--- a/src/platform/provider/signDelivery.ts
+++ b/src/platform/provider/signDelivery.ts
@@ -1,6 +1,7 @@
 import { normalizeAddressForComparison } from '@/core/bitcoin/address';
 import { PROVIDER_ERROR_CODES, ProviderError } from '@/core/rpcErrors';
 import { assertSessionGeneration } from '@/platform/auth/sessionManager';
+import { pairedGrantCovers } from '@/platform/provider/pairedGrant';
 import { getIdentityMismatchError } from '@/platform/provider/requestIdentity';
 import { type ProviderSigningRequest, SIGN_FLOW_TTL_MS } from '@/platform/provider/signFlow';
 import type { AuthorizedRequest } from '@/platform/storage/requestStorage';
@@ -55,8 +56,7 @@ export async function assertSignDeliveryAuthorized(
       throw new ProviderError(PROVIDER_ERROR_CODES.UNAUTHORIZED, 'This site is no longer connected. Reconnect it before signing.');
     }
     const capability = settings.providerCapabilities?.[request.origin];
-    if (pairedAddresses && (capability?.pairedAddresses !== true
-      || capability.walletId !== request.walletId || capability.address !== request.address)) {
+    if (pairedAddresses && !pairedGrantCovers(capability, request.walletId, request.address)) {
       throw new ProviderError(PROVIDER_ERROR_CODES.UNAUTHORIZED, 'Paired address access was revoked');
     }
     const currentWallet = walletManager.getActiveWallet();

--- a/src/platform/walletManager.ts
+++ b/src/platform/walletManager.ts
@@ -963,7 +963,7 @@ export class WalletManager {
   }
 
   /** Persist a connection and its optional paired-address grant in one keychain write. */
-  public addConnectedWebsite(origin: string, pairedIdentity?: { walletId: string; address: string }): Promise<void> {
+  public addConnectedWebsite(origin: string, pairedIdentity?: { walletId: string; address: string; pairedAddress?: string }): Promise<void> {
     return this.mutateVault(async () => {
       const settings = this.getSettings();
       const providerCapabilities = { ...settings.providerCapabilities };
@@ -993,7 +993,7 @@ export class WalletManager {
   }
 
   /** A revoked connection cannot be recreated by an in-flight capability approval. */
-  public setPairedAddressPermission(origin: string, identity: { walletId: string; address: string } | null): Promise<void> {
+  public setPairedAddressPermission(origin: string, identity: { walletId: string; address: string; pairedAddress?: string } | null): Promise<void> {
     return this.mutateVault(async () => {
       const settings = this.getSettings();
       if (identity && !settings.connectedWebsites.includes(origin)) {

--- a/src/services/__tests__/connectionService.test.ts
+++ b/src/services/__tests__/connectionService.test.ts
@@ -39,6 +39,10 @@ vi.mock('@/services/walletService', () => ({
   getWalletService: vi.fn(() => ({
     isKeychainUnlocked: vi.fn().mockResolvedValue(true),
     getActiveAddress: vi.fn().mockResolvedValue({ address: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa' }),
+    getPairedAddresses: vi.fn().mockResolvedValue({
+      legacy: { address: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa', pubKey: '02', format: 'p2pkh', type: 'p2pkh' },
+      segwit: { address: 'bc1qsibling', pubKey: '02', format: 'p2wpkh', type: 'p2wpkh' },
+    }),
     // Connected-website access delegates to the walletManager mock so existing
     // getSettings/updateSettings drivers and assertions keep working.
     getSettings: () => walletManager.getSettings(),
@@ -445,6 +449,48 @@ describe('ConnectionService', () => {
       // Connection should succeed since there's no address validation
       expect(result).toEqual(['1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa']);
     }, 10000); // Increase timeout
+  });
+
+  describe('paired grant covers the whole derivation pair', () => {
+    it('records the sibling with the grant and honours either half afterwards', async () => {
+      let settings: any = { connectedWebsites: ['https://paired.com'] };
+      mockGetSettings.mockImplementation(() => settings);
+      mockUpdateSettings.mockImplementation(async (updates) => {
+        settings = { ...settings, ...updates };
+      });
+      mockApprovalService.requestApproval.mockResolvedValueOnce({
+        approved: true,
+        updatedParams: { pairedAddresses: true },
+      });
+      vi.spyOn(connectionService, 'hasPermission').mockResolvedValue(true);
+
+      await connectionService.requestPairedAddressPermission(
+        'https://paired.com',
+        '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa',
+        'wallet-123'
+      );
+
+      expect(settings.providerCapabilities['https://paired.com']).toEqual({
+        pairedAddresses: true,
+        walletId: 'wallet-123',
+        address: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa',
+        pairedAddress: 'bc1qsibling',
+      });
+      // The user switches the extension to the SegWit sibling: the grant still applies.
+      await expect(connectionService.hasPairedAddressPermission(
+        'https://paired.com', 'wallet-123', 'bc1qsibling'
+      )).resolves.toBe(true);
+      await expect(connectionService.hasPairedAddressPermission(
+        'https://paired.com', 'wallet-123', '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa'
+      )).resolves.toBe(true);
+      // Another index or wallet never inherits it.
+      await expect(connectionService.hasPairedAddressPermission(
+        'https://paired.com', 'wallet-123', 'bc1qelsewhere'
+      )).resolves.toBe(false);
+      await expect(connectionService.hasPairedAddressPermission(
+        'https://paired.com', 'wallet-999', 'bc1qsibling'
+      )).resolves.toBe(false);
+    });
   });
 
   describe('requestPairedAddressPermission', () => {

--- a/src/services/connectionService.ts
+++ b/src/services/connectionService.ts
@@ -9,9 +9,11 @@
  * - Connection security analysis
  */
 
+import { normalizeAddressForComparison } from '@/core/bitcoin/address';
 import { generateRequestId } from '@/core/id';
 import { PROVIDER_ERROR_CODES, ProviderError } from '@/core/rpcErrors';
 import { analytics } from '@/platform/fathom';
+import { pairedGrantCovers } from '@/platform/provider/pairedGrant';
 import { connectionRateLimiter } from '@/platform/provider/rateLimiter';
 import { createWriteLock } from '@/platform/storage/mutex';
 import { type ApprovalResult, getApprovalService } from '@/services/approvalService';
@@ -166,11 +168,10 @@ export class ConnectionService extends BaseService {
     }
   }
 
+  /** True when the site's paired grant covers this wallet and either half of the granted pair. */
   async hasPairedAddressPermission(origin: string, walletId: string, address: string): Promise<boolean> {
     const capability = (await getWalletService().getSettings()).providerCapabilities?.[origin];
-    return capability?.pairedAddresses === true
-      && capability.walletId === walletId
-      && capability.address === address;
+    return pairedGrantCovers(capability, walletId, address);
   }
 
   /**
@@ -197,7 +198,9 @@ export class ConnectionService extends BaseService {
     const { origin, address, walletId, pairedAddresses } = grant;
 
     await analytics.track('connection_established');
-    await getWalletService().addConnectedWebsite(origin, pairedAddresses ? { walletId, address } : undefined);
+    await getWalletService().addConnectedWebsite(origin, pairedAddresses
+      ? await this.pairedIdentity(walletId, address)
+      : undefined);
 
     this.state.connectionCache.set(origin, {
       origin,
@@ -222,7 +225,29 @@ export class ConnectionService extends BaseService {
     walletId: string,
     address: string
   ): Promise<void> {
-    await getWalletService().setPairedAddressPermission(origin, { walletId, address });
+    await getWalletService().setPairedAddressPermission(origin, await this.pairedIdentity(walletId, address));
+  }
+
+  /**
+   * The other half of the active derivation index, recorded with the grant so it keeps covering
+   * the pair after the user switches which half is active. Undefined when the wallet cannot derive
+   * a pair (non-mnemonic, locked, unpaired format); the grant then covers its one address only.
+   */
+  private async pairedIdentity(
+    walletId: string,
+    address: string,
+  ): Promise<{ walletId: string; address: string; pairedAddress?: string }> {
+    try {
+      const pair = await getWalletService().getPairedAddresses();
+      const wanted = normalizeAddressForComparison(address);
+      const halves = [pair.legacy.address, pair.segwit.address];
+      // Only an address that is itself one half of the pair has a sibling to record.
+      if (!halves.some(candidate => normalizeAddressForComparison(candidate) === wanted)) return { walletId, address };
+      const sibling = halves.find(candidate => normalizeAddressForComparison(candidate) !== wanted);
+      return sibling === undefined ? { walletId, address } : { walletId, address, pairedAddress: sibling };
+    } catch {
+      return { walletId, address };
+    }
   }
 
   private async clearPairedAddressPermission(origin: string): Promise<void> {

--- a/src/services/walletService.ts
+++ b/src/services/walletService.ts
@@ -25,10 +25,10 @@ interface WalletService {
   refreshWallets: () => Promise<void>;
   getSettings: () => Promise<import('@/core/settings').AppSettings>;
   updateSettings: (updates: Partial<import('@/core/settings').AppSettings>) => Promise<void>;
-  addConnectedWebsite: (origin: string, pairedIdentity?: { walletId: string; address: string }) => Promise<void>;
+  addConnectedWebsite: (origin: string, pairedIdentity?: { walletId: string; address: string; pairedAddress?: string }) => Promise<void>;
   removeConnectedWebsite: (origin: string) => Promise<void>;
   clearConnectedWebsites: () => Promise<void>;
-  setPairedAddressPermission: (origin: string, identity: { walletId: string; address: string } | null) => Promise<void>;
+  setPairedAddressPermission: (origin: string, identity: { walletId: string; address: string; pairedAddress?: string } | null) => Promise<void>;
   getWallets: () => Promise<Wallet[]>;
   getActiveWallet: () => Promise<Wallet | undefined>;
   getActiveAddress: () => Promise<Address | undefined>;


### PR DESCRIPTION
The paired-address grant was checked as `capability.address === activeAddress`, and the stored address is whichever half was active when the user approved. Switch the extension from the Legacy account to its SegWit sibling and `hasPairedAddressPermission` returns false: `xcp_getAddresses` stops reporting the pair, a connected site loses its legacy source, and sign delivery refuses a request it already displayed.

**Fix.** The grant now records the sibling at approval time (`pairedAddress`), and a shared `pairedGrantCovers()` accepts either half of the derivation index in `ConnectionService.hasPairedAddressPermission` and in the synchronous `assertSignDeliveryAuthorized` guard. Older grants without a recorded sibling keep matching their one address and are upgraded on the next connect. Another derivation index or wallet never inherits the grant.

**Verified.** New `pairedGrant.test.ts`; `connectionService.test.ts` gains a test that the grant stores the sibling and honours both halves; keychain validation covers the new field. `tsc --noEmit` clean, biome clean on touched files, `vitest run src/services src/platform/provider src/core/wallet` 482 passing.

Found while wiring the marketplace's legacy-source attach flow, where the site connects on `19Q...` and works as the granted `bc1q` sibling.