### PR TITLE
Register in window.btc_providers

### DIFF
--- a/e2e/tests/provider.spec.ts
+++ b/e2e/tests/provider.spec.ts
@@ -41,6 +41,7 @@ function createTestServer(): Promise<{ server: http.Server; url: string }> {
                 hasOn: typeof provider.on === 'function',
                 hasRemoveListener: typeof provider.removeListener === 'function',
                 hasIsConnected: typeof provider.isConnected === 'function'
+                ,registered: Array.isArray(window.btc_providers) && window.btc_providers.some(p => p.id === 'XcpWalletProvider')
               };
             };
 

--- a/src/entrypoints/injected.ts
+++ b/src/entrypoints/injected.ts
@@ -22,6 +22,9 @@ interface PendingRequest {
 
 const REQUEST_TIMEOUT_MS = 60_000;
 
+/** The 48px logo, inlined: an injected script has no extension URL a page may load. */
+const XCP_WALLET_ICON = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAPnSURBVGhD7ZhJaBRBFIanJzF6UBGdRFHBm6KoRBA9qIgGJTloElFccMnFiDcPxhVNohET3MGTMS6IJl6yXFSECIKCZyUuKO5e0gF3ULOM/99VM5nuqerumUi81Ac/773q7ur3uruWmYjBYDAYDAZD9ljS+tKTX5YHMxKKOw1urJjd/l36oUB/o6Xrhfn0or9fIgwmsADcrAjmPMSbDrDNwwjoEXqqiHW3fxNNauz88jwrEm+EuwLqdRrdRKHfUBWKaHNaAvAtQCbfDumeWCqd6K0MRfyQsQskn4vkm+GuFS2+sLgNKKJVhHpYsRIkvxyGTyFM8qQIH1grrhsr4yR2QWkmyRO+1Rb0VS5CPcoCcOEyGD75MU5DePhpnBGuwEk+bt2AGzb5BIkiykSoJq0AmXwHlGnyCWxpmXwOkr8Od51oyRhOHjf9inCNAZw4H6YTSvsMJByk74XrPKEZwk1y0eqLVk743Bq3JyL5ASf59eKQklcQZxzOblOg8ZCKP1AJxsQ9EQ7ifQPFkC75N9ASdDIHtjBixWfB7uIBSROObZfJR5H8NbT5JV+DvGfCFuK6ubALoSc8oIBvolS4brwFqOZ58hriE3jMALY/1t0xAHsO4UZoN17mDh5LSZ7tOmpwbW3M7uhjX2yA5dsogXRFqKbw0AVU4wYvpO8C7S3QqZjd1m9PWs3kr6J5kziq5AjOr5W+C7R/gtkronAoZyEFX6TV0j15lWX1R6/A3SxalBxFktXS1/FV2lCELUD3ZpJEe3OY/BYRKalD8oel70fgvVIJW4B3tnGB2esyzFYRKWHyh6QfxHRpQ+EtQLe1qEOSylkA7ZdgKkSk5FgieZw7DmqGGnsKSrk5dIF2rkFnRZSGMjfvOrAHpkFEaXC+roQeQDkQiz8AbYN0HEfyPMdJHoar+1LGgNuUgxD3PZyJ5kFNEM9TcRJ9VUk/ibcALiZ3oNlOg5rEVpdFcDHTUY8b7qeDfrlAcXVfzDiFPikySloVb6GV6O+lCAdJey242VSY25BfEUE04Gb76KA/Loy3oEWMs4DJF6M/5TSeNohx4kcYLihdTkPmnEgkL1kAZZv8O4gLqDJ5opyFUop46jSEh98px1EqYWc6L9xzMfnnIlSj7RwXfoDh3ihsEadxTdogAxnN6xI+eX42z0SoRzdtJsE3PA2mDuJAVO1HcqH7uFm9CN3gev5GuCsiF5x5HkJc5RMPkvn8hLhXCkyeBBYwVHwKaEOSa6SfNdl+n/8CfqJDZjgK0L1lfnpDZjgK0P3HE/q/Hz+GYwxwz7MT4mTAgct78ifiBYwB/sozGAwGg8Fg+D9EIn8BnbIl6I1ut4oAAAAASUVORK5CYII=';
+
 // Methods that open a popup for user approval — no injected-side timeout.
 // The background's own timeout (10 min) is the safety net.
 const INTERACTIVE_METHODS = new Set([
@@ -224,6 +227,21 @@ export default defineUnlistedScript(() => {
     writable: false,
     configurable: false,
     enumerable: true
+  });
+
+  // The page-global registry Bitcoin wallets share (the sats-connect convention),
+  // so a dapp discovering wallets by id finds this one next to the others.
+  const registry = window as Window & { btc_providers?: unknown[] };
+  if (!Array.isArray(registry.btc_providers)) registry.btc_providers = [];
+  registry.btc_providers.push({
+    id: 'XcpWalletProvider',
+    name: 'XCP Wallet',
+    icon: XCP_WALLET_ICON,
+    methods: [
+      'xcp_requestAccounts', 'xcp_accounts', 'xcp_disconnect', 'xcp_getAddresses',
+      'xcp_signMessage', 'xcp_signTransaction', 'xcp_signPsbt', 'xcp_signPsbts',
+      'xcp_signBitcoinPsbt', 'xcp_broadcastTransaction', 'xcp_getNetwork', 'xcp_chainId',
+    ],
   });
 
   // Announce provider is available


### PR DESCRIPTION
Registers the wallet in `window.btc_providers`, the page-global registry Bitcoin wallets share (the sats-connect convention), with id `XcpWalletProvider`, the inlined 48px logo, and the method list. `window.xcpwallet` and the announce events are unchanged, so nothing existing moves.

Why: `@xcp/wallet-sdk`'s discovery lists wallets from this registry behind an allowlist (XCP Wallet first, Horizon second, nothing else offered). Horizon already registers; with this, discovery is one path and the SDK's XCP descriptor (v0.4.0+) recognises this build through the registry as well as through the injected object.

The provider e2e asserts the registry entry alongside the existing surface checks. For 0.11.0; no release here.