### PR TITLE
Sign Counterparty bare multisig data outputs again

### DIFF
--- a/src/core/bitcoin/__tests__/transactionSigner.test.ts
+++ b/src/core/bitcoin/__tests__/transactionSigner.test.ts
@@ -21,7 +21,7 @@ const mockGetTrustedBroadcastPrevout = vi.fn();
 
 // Import necessary functions for test setup
 import { getPublicKey } from '@noble/secp256k1';
-import { p2sh, p2tr, p2wpkh, Transaction } from '@scure/btc-signer';
+import { OutScript, p2sh, p2tr, p2wpkh, Transaction } from '@scure/btc-signer';
 import { hash160 } from '@scure/btc-signer/utils.js';
 
 describe('Transaction Signer Utilities', () => {
@@ -747,6 +747,64 @@ describe('Transaction Signer Utilities', () => {
         inputValues,
         lockScripts
       )).rejects.toThrow(/doesn't match/);
+    });
+  });
+
+  describe('Counterparty bare multisig outputs', () => {
+    // Counterparty's multisig data encoding: a 1-of-3 bare multisig whose first key is the
+    // sender's and whose other two "keys" carry the payload. btc-signer's checkScript rejects
+    // this output shape ("non-wrapped ms"), which broke fairminter and other data-heavy
+    // composes after the check was re-enabled. allowUnknownOutputs does not cover it because
+    // bare multisig is a known script type.
+    // Counterparty nudges its payload keys onto the curve, so they decode as real pubkeys.
+    const payloadKey = (seed: string) => getPublicKey(hexToBytes(seed.repeat(32)), true);
+    const dataOutputScript = OutScript.encode({ type: 'ms', m: 1, pubkeys: [publicKey, payloadKey('03'), payloadKey('04')] });
+
+    const buildRawTx = () => {
+      const tx = new Transaction({ allowUnknownOutputs: true, disableScriptCheck: true });
+      tx.addInput({ txid: mockTxid, index: 0 });
+      tx.addOutput({ script: dataOutputScript, amount: 546n });
+      tx.addOutput({ script: hexToBytes('76a914' + pubKeyHashHex + '88ac'), amount: 90000n });
+      return bytesToHex(tx.unsignedTx);
+    };
+
+    it('signs a transaction that carries a bare multisig data output', async () => {
+      const signed = await signTransaction(buildRawTx(), mockWallet, mockTargetAddress, mockPrivateKey);
+
+      const parsed = Transaction.fromRaw(hexToBytes(signed), { allowUnknownOutputs: true, disableScriptCheck: true });
+      expect(parsed.outputsLength).toBe(2);
+      expect(bytesToHex(parsed.getOutput(0).script!)).toBe(bytesToHex(dataOutputScript));
+      expect(parsed.getOutput(0).amount).toBe(546n);
+      // The P2PKH input was finalized with a scriptSig, so signing itself went through.
+      expect(parsed.getInput(0).finalScriptSig?.length).toBeGreaterThan(0);
+    });
+
+    it('still rejects a bare multisig output that is not the Counterparty data encoding', async () => {
+      const tx = new Transaction({ allowUnknownOutputs: true, disableScriptCheck: true });
+      tx.addInput({ txid: mockTxid, index: 0 });
+      // 2-of-3 is a spendable multisig script, not the 1-of-3 data carrier core composes.
+      tx.addOutput({ script: OutScript.encode({ type: 'ms', m: 2, pubkeys: [publicKey, payloadKey('03'), payloadKey('04')] }), amount: 546n });
+
+      await expect(signTransaction(bytesToHex(tx.unsignedTx), mockWallet, mockTargetAddress, mockPrivateKey))
+        .rejects.toThrow(/Output 0 is not a script this wallet signs: checkScript: non-wrapped ms/);
+    });
+
+    it('still rejects a nested SegWit input whose redeemScript does not hash to the prevout', async () => {
+      const p2shWallet = { ...mockWallet, addressFormat: AddressFormat.P2SH_P2WPKH };
+      const otherKey = getPublicKey(hexToBytes('02'.repeat(32)), true);
+      const foreignNestedScript = bytesToHex(p2sh(p2wpkh(otherKey)).script);
+
+      await expect(signTransaction(
+        buildRawTx(), p2shWallet, mockTargetAddress, mockPrivateKey, true, [100000], [foreignNestedScript],
+      )).rejects.toThrow(/does not match its previous output/);
+    });
+
+    it('still rejects Taproot key material against a non-Taproot prevout', async () => {
+      const p2trWallet = { ...mockWallet, addressFormat: AddressFormat.P2TR };
+
+      await expect(signTransaction(
+        buildRawTx(), p2trWallet, mockTargetAddress, mockPrivateKey, true, [100000], ['0014' + pubKeyHashHex],
+      )).rejects.toThrow(/does not match its previous output/);
     });
   });
 });

--- a/src/core/bitcoin/transactionSigner.ts
+++ b/src/core/bitcoin/transactionSigner.ts
@@ -1,14 +1,69 @@
 import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
 import { getPublicKey } from '@noble/secp256k1';
-import { p2wpkh, SigHash, Transaction } from '@scure/btc-signer';
+import { OutScript, p2tr, p2wpkh, SigHash, Transaction } from '@scure/btc-signer';
+import { checkScript } from '@scure/btc-signer/payment.js';
 import { AddressFormat } from '@/core/bitcoin/address';
 import { parseConsensusTransaction, parseTransactionForSigning } from '@/core/bitcoin/rawTransaction';
 import { assertTransactionMatchesReviewed } from '@/core/bitcoin/transactionIntegrity';
 import { noTrustedPrevout, type TrustedPrevoutResolver } from '@/core/bitcoin/trustedPrevout';
 import { hybridSignTransaction } from '@/core/bitcoin/uncompressedSigner';
 import { fetchPreviousRawTransaction, fetchUTXOs, getUtxoByTxid } from '@/core/bitcoin/utxo';
+import { isBareMultisigDataOutput } from '@/core/counterparty/unpack/multisig';
 import { SigningError, UtxoError, ValidationError } from '@/core/errors';
 import type { Address, Wallet } from '@/types/wallet';
+
+/**
+ * The output validation btc-signer performs when disableScriptCheck is off, applied per output,
+ * except for Counterparty's multisig encoding.
+ *
+ * btc-signer rejects every bare multisig output ("non-wrapped ms"), and allowUnknownOutputs does
+ * not cover it because bare multisig is a known script type. Counterparty's `multisig` encoding
+ * carries message data in exactly that shape, so the library option is off on the rebuilt
+ * transaction and the rule is re-applied here to every output that is not a recognized
+ * Counterparty data output. The recognizer is the one the review policy already trusts.
+ */
+function assertOutputScriptShape(index: number, script: Uint8Array | undefined): void {
+  if (!script || isBareMultisigDataOutput(bytesToHex(script))) return;
+  try {
+    checkScript(script);
+  } catch (err) {
+    throw new ValidationError(
+      'INVALID_TRANSACTION',
+      `Output ${index} is not a script this wallet signs: ${err instanceof Error ? err.message : 'unknown error'}`,
+    );
+  }
+}
+
+/**
+ * The input validation btc-signer performs when disableScriptCheck is off, applied per input.
+ *
+ * Inputs are always this wallet's own standard outputs, so the library's rules apply to them
+ * unchanged: a nested SegWit redeemScript must hash to the prevout, and Taproot key material must
+ * belong to a P2TR prevout that commits to it.
+ */
+function assertInputScriptShape(
+  index: number,
+  input: { redeemScript?: Uint8Array; witnessScript?: Uint8Array; tapInternalKey?: Uint8Array },
+  prevoutScript: Uint8Array | undefined,
+): void {
+  if (!prevoutScript) return;
+  try {
+    checkScript(prevoutScript, input.redeemScript, input.witnessScript);
+    const isTaprootPrevout = OutScript.decode(prevoutScript).type === 'tr';
+    if (input.tapInternalKey) {
+      if (!isTaprootPrevout) throw new Error('Taproot metadata without P2TR previous output');
+      const expected = p2tr(input.tapInternalKey).script;
+      if (bytesToHex(expected) !== bytesToHex(prevoutScript)) {
+        throw new Error('P2TR previous output does not commit to tapInternalKey');
+      }
+    }
+  } catch (err) {
+    throw new ValidationError(
+      'INVALID_TRANSACTION',
+      `Input ${index} does not match its previous output: ${err instanceof Error ? err.message : 'unknown error'}`,
+    );
+  }
+}
 
 /**
  * Transaction input data for signing.
@@ -117,8 +172,11 @@ export async function signTransaction(
       allowUnknownInputs: true,
       allowUnknownOutputs: true,
       allowLegacyWitnessUtxo: true,
-      // Standard inputs stay on btc-signer's validated path. Counterparty's unusual bare-multisig
-      // data appears in outputs, which is covered narrowly by allowUnknownOutputs.
+      // The library check is all-or-nothing per transaction and rejects Counterparty's bare
+      // multisig data outputs. It is off here and re-applied per input and per output by
+      // assertInputScriptShape and assertOutputScriptShape, which exempt only recognized
+      // Counterparty data outputs.
+      disableScriptCheck: true,
       lowR: true,
     });
 
@@ -263,11 +321,13 @@ export async function signTransaction(
         }
       }
 
+      assertInputScriptShape(i, inputData, inputData.witnessUtxo?.script ?? prevOutputScripts[i]);
       tx.addInput(inputData);
     }
 
     for (let i = 0; i < parsedTx.outputsLength; i++) {
       const output = parsedTx.getOutput(i);
+      assertOutputScriptShape(i, output.script);
       tx.addOutput({
         script: output.script,
         amount: output.amount,


### PR DESCRIPTION
Signing a Counterparty transaction that carries data in bare multisig outputs fails with `checkScript: non-wrapped ms`. Seen from xcp.fun on a "Create fairminter" request, and it affects the in-wallet compose path the same way.

**Cause.** #381 removed `disableScriptCheck` from the transaction `signTransaction` rebuilds, on the note that `allowUnknownOutputs` covers Counterparty's bare multisig outputs. It does not: bare multisig is a known script type to btc-signer, so `normalizeOutput` runs `checkScript` and rejects the output outright. Probed directly against btc-signer 2.4.1: `addOutput` and `fromRaw` reject the shape, `fromPSBT` accepts it, so the PSBT helpers are unaffected and the hardware path never dropped the option.

**Fix.** The library check is all-or-nothing per transaction, so it stays off on the rebuilt transaction and its rules are re-applied explicitly in `transactionSigner.ts`: `assertInputScriptShape` keeps the per-input rules unchanged (nested SegWit redeemScript must hash to the prevout, Taproot key material must belong to a P2TR prevout that commits to it), and `assertOutputScriptShape` applies `checkScript` to every output except one `isBareMultisigDataOutput` recognizes as Counterparty's 1-of-3 data carrier. That is the same predicate the review's output policy already trusts, so the exemption is gated on the encoding actually present in the bytes rather than on anything the caller claims.

**Verified.** Four tests added to `transactionSigner.test.ts`: signing a 1-of-3 Counterparty data output (reproduces the exact `non-wrapped ms` error on unfixed code), rejecting a 2-of-3 bare multisig that is not the data encoding, and rejecting a mismatched nested SegWit redeemScript and Taproot key material against the wrong prevout. `tsc --noEmit` clean, biome clean on touched files, `vitest run src/core/bitcoin src/core/counterparty src/services/__tests__/providerSigningService.test.ts` 2043 passing, lint within budget.
