### PR TITLE
chore(release): bump version to 0.11.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xcp-wallet",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xcp-wallet",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "xcp-wallet",
   "description": "Counterparty Web3 Wallet",
   "private": true,
-  "version": "0.11.0",
+  "version": "0.11.1",
   "license": "MIT",
   "type": "module",
   "engines": {


### PR DESCRIPTION
Bumps the extension to 0.11.1 for a point release carrying #394 (Counterparty bare multisig data outputs sign again) and #393 (marketplace intents say utxoOwner, utxoAddress, utxoValueSats). No dependency changes.

Lockfile patched on the two root version lines only and verified with `npm ci --dry-run`. Local `wxt build` passes and the built manifest reports 0.11.1.
