### PR TITLE
Propagate accepted broadcasts and reserve spent inputs immediately

### DIFF
--- a/src/core/bitcoin/__tests__/broadcastErrors.test.ts
+++ b/src/core/bitcoin/__tests__/broadcastErrors.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { isStaleInputsError } from '@/core/bitcoin/broadcastErrors';
+import { isAlreadyKnownError, isStaleInputsError } from '@/core/bitcoin/broadcastErrors';
 
 describe('isStaleInputsError', () => {
   it('recognises the node rejection that means the batch list is out of date', () => {
@@ -27,5 +27,30 @@ describe('isStaleInputsError', () => {
     expect(isStaleInputsError('Request failed with status 500')).toBe(false);
     expect(isStaleInputsError('dust output')).toBe(false);
     expect(isStaleInputsError('')).toBe(false);
+  });
+});
+
+describe('isAlreadyKnownError', () => {
+  it('recognises the Counterparty node answering a repeat of a send that already landed', () => {
+    expect(isAlreadyKnownError('Error broadcasting transaction: txn-already-in-mempool')).toBe(true);
+  });
+
+  it('recognises a public relay that already has the transaction in a block', () => {
+    expect(
+      isAlreadyKnownError(
+        'sendrawtransaction RPC error: {"code":-27,"message":"Transaction already in block chain"}',
+      ),
+    ).toBe(true);
+  });
+
+  it('recognises the peer-level duplicate answers', () => {
+    expect(isAlreadyKnownError('txn-already-known')).toBe(true);
+    expect(isAlreadyKnownError('already have transaction')).toBe(true);
+  });
+
+  it('does not mistake a spent-input rejection for a duplicate', () => {
+    expect(isAlreadyKnownError('bad-txns-inputs-missingorspent')).toBe(false);
+    expect(isAlreadyKnownError('txn-mempool-conflict')).toBe(false);
+    expect(isAlreadyKnownError('min relay fee not met')).toBe(false);
   });
 });

--- a/src/core/bitcoin/__tests__/transactionBroadcaster.settlement.test.ts
+++ b/src/core/bitcoin/__tests__/transactionBroadcaster.settlement.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { apiClient } from '@/core/api/client';
+import { clearSpentUtxoCache, isUtxoRecentlySpent } from '@/core/bitcoin/spentUtxoCache';
+import { broadcastTransaction, computeTxid, extractInputsFromRawTx } from '@/core/bitcoin/transactionBroadcaster';
+import * as bitcoinUtxo from '@/core/bitcoin/utxo';
+import * as counterpartyApi from '@/core/counterparty/api';
+import { selectUtxosForTransaction } from '@/core/counterparty/utxoSelection';
+import { DEFAULT_SETTINGS, getActiveSettings } from '@/core/settings';
+
+vi.mock('@/core/settings', async importOriginal => ({
+  ...(await importOriginal<typeof import('@/core/settings')>()),
+  getActiveSettings: vi.fn(),
+}));
+vi.mock('@/core/api/client', () => ({
+  apiClient: { post: vi.fn() },
+  API_TIMEOUTS: { BROADCAST: 45_000 },
+  isApiError: (error: unknown) => error instanceof Error && 'response' in error,
+}));
+
+const inputTxid = '000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f';
+const wireInputTxid = '1f1e1d1c1b1a191817161514131211100f0e0d0c0b0a09080706050403020100';
+// A wire fixture with one non-symmetric input outpoint, vout 3, and a zero-value OP_RETURN.
+// It is only parsed locally; mocked endpoints accept it and nothing is sent to a real node.
+const rawTx = `0200000001${wireInputTxid}0300000000ffffffff010000000000000000036a010000000000`;
+const echoedTxid = 'ff'.repeat(32);
+const accepted = (node: boolean) => ({
+  status: 200, statusText: 'OK', headers: {}, data: node ? { result: echoedTxid } : echoedTxid,
+});
+const alreadyKnown = () => Object.assign(new Error('HTTP 503'), {
+  response: { status: 503, data: { error: 'txn-already-in-mempool' } },
+});
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((done, fail) => { resolve = done; reject = fail; });
+  return { promise, resolve, reject };
+}
+
+describe('broadcast acceptance settles actual spent outpoints before propagation', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.resetAllMocks();
+    clearSpentUtxoCache();
+    vi.mocked(getActiveSettings).mockReturnValue({ ...DEFAULT_SETTINGS, transactionDryRun: false });
+  });
+
+  it('extracts the display-order outpoint from a non-symmetric wire input', () => {
+    expect(extractInputsFromRawTx(rawTx)).toEqual([{ txid: inputTxid, vout: 3 }]);
+  });
+
+  it.each([
+    { viaRelay: false, known: false },
+    { viaRelay: false, known: true },
+    { viaRelay: true, known: false },
+    { viaRelay: true, known: true },
+  ])('reserves on acceptance (public relay=$viaRelay, already known=$known) while fan-out is pending', async ({ viaRelay, known }) => {
+    const fanoutStarted = deferred<void>();
+    const blockstream = deferred<never>();
+    const mempool = deferred<never>();
+    const post = vi.mocked(apiClient.post);
+    if (viaRelay) post.mockRejectedValueOnce(new Error('Counterparty unavailable'));
+    if (known) post.mockRejectedValueOnce(alreadyKnown());
+    else post.mockResolvedValueOnce(accepted(!viaRelay));
+    if (!viaRelay) post.mockImplementationOnce(() => blockstream.promise);
+    post.mockImplementationOnce(() => {
+      fanoutStarted.resolve();
+      return mempool.promise;
+    });
+    // A stale upstream index still lists the spent input as its largest funding candidate.
+    vi.spyOn(bitcoinUtxo, 'fetchUTXOs').mockResolvedValue([3, 2].map(vout => ({
+      txid: inputTxid, vout, value: vout === 3 ? 50_000 : 20_000,
+      status: { confirmed: true, block_height: 1, block_hash: 'fixture', block_time: 0 },
+    })));
+    vi.spyOn(counterpartyApi, 'fetchTokenBalances').mockResolvedValue([]);
+
+    let completed = false;
+    const response = broadcastTransaction(rawTx).then(result => { completed = true; return result; });
+    await fanoutStarted.promise;
+    try {
+      expect(completed).toBe(false);
+      // The actual spent cache used by UTXO filtering must match the real outpoint, not its reverse.
+      expect(isUtxoRecentlySpent(inputTxid, 3)).toBe(true);
+      expect(isUtxoRecentlySpent(wireInputTxid, 3)).toBe(false);
+      expect(isUtxoRecentlySpent(inputTxid, 2)).toBe(false);
+      const funding = await selectUtxosForTransaction('bc1qfixture');
+      expect(funding.inputsSet).toBe(`${inputTxid}:2`);
+      expect(funding.totalValue).toBe(20_000);
+      expect(completed).toBe(false);
+      expect(post).toHaveBeenLastCalledWith(
+        'https://mempool.space/api/tx', rawTx,
+        { headers: { 'Content-Type': 'text/plain' }, timeout: 10_000, retries: 0 },
+      );
+    } finally {
+      if (!viaRelay) blockstream.reject(new Error('Public relay unavailable'));
+      mempool.reject(new Error('Public relay timeout'));
+    }
+    await expect(response).resolves.toEqual({ txid: computeTxid(rawTx) });
+    expect(isUtxoRecentlySpent(inputTxid, 3)).toBe(true);
+    expect(post).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not reserve a rejected transaction', async () => {
+    vi.mocked(apiClient.post).mockRejectedValue(new Error('min relay fee not met'));
+    await expect(broadcastTransaction(rawTx)).rejects.toThrow('min relay fee not met');
+    expect(isUtxoRecentlySpent(inputTxid, 3)).toBe(false);
+  });
+
+  it('propagates a local settlement exception before starting relay fan-out', async () => {
+    const localFailure = new Error('Local cache unavailable');
+    vi.spyOn(counterpartyApi, 'clearApiCache').mockImplementation(() => { throw localFailure; });
+    vi.mocked(apiClient.post).mockResolvedValueOnce(accepted(true));
+    await expect(broadcastTransaction(rawTx)).rejects.toBe(localFailure);
+    expect(apiClient.post).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/core/bitcoin/__tests__/transactionBroadcaster.test.ts
+++ b/src/core/bitcoin/__tests__/transactionBroadcaster.test.ts
@@ -111,311 +111,170 @@ describe('Transaction Broadcaster Utilities', () => {
   });
 
   describe('broadcastTransaction with real endpoints', () => {
-    it('should broadcast successfully using counterparty endpoint', async () => {
-      mockApiClient.post.mockResolvedValue({
-        status: 200,
-        data: { result: mockTxid }
+    const accepted = (data: unknown) => ({ status: 200, data });
+    const apiRejection = (data: unknown, status = 503) =>
+      Object.assign(new Error(typeof data === 'string' ? data : 'HTTP error'), {
+        code: 'HTTP_ERROR',
+        status,
+        response: { data, status },
       });
+    const urlsCalled = () => mockApiClient.post.mock.calls.map((call: unknown[]) => String(call[0]));
 
-      const result = await broadcastTransaction(mockSignedTxHex);
-      
-      expect(result.txid).toBe(computeTxid(mockSignedTxHex));
-      expect(mockApiClient.post).toHaveBeenCalledWith(
-        expect.stringContaining('api.counterparty.io'),
-        null,
-        { headers: { 'Content-Type': 'application/json' } }
-      );
-    });
-
-    it('should broadcast successfully using blockcypher endpoint', async () => {
+    it('accepts through the Counterparty node and then feeds both public relays', async () => {
       mockApiClient.post
-        .mockRejectedValueOnce(new Error('Counterparty failed'))
-        .mockResolvedValueOnce({
-          status: 201,
-          data: { 
-            tx: { 
-              hash: mockTxid,
-              fees: 2500
-            }
-          }
-        });
+        .mockResolvedValueOnce(accepted({ result: mockTxid }))
+        .mockResolvedValueOnce(accepted(mockTxid))
+        .mockResolvedValueOnce(accepted(mockTxid));
 
       const result = await broadcastTransaction(mockSignedTxHex);
-      
-      expect(result.txid).toBe(computeTxid(mockSignedTxHex));
-      expect(result.fees).toBe(2500);
-      expect(mockApiClient.post).toHaveBeenCalledWith(
-        'https://api.blockcypher.com/v1/btc/main/txs/push',
-        { tx: mockSignedTxHex },
-        { headers: { 'Content-Type': 'application/json' } }
-      );
-    });
 
-    it('should broadcast successfully using blockstream endpoint', async () => {
-      mockApiClient.post
-        .mockRejectedValueOnce(new Error('Counterparty failed'))
-        .mockRejectedValueOnce(new Error('Blockcypher failed'))
-        .mockResolvedValueOnce({
-          status: 200,
-          data: mockTxid
-        });
-
-      const result = await broadcastTransaction(mockSignedTxHex);
-      
       expect(result.txid).toBe(computeTxid(mockSignedTxHex));
-      expect(mockApiClient.post).toHaveBeenCalledWith(
+      expect(urlsCalled()).toEqual([
+        expect.stringContaining('/v2/bitcoin/transactions?signedhex='),
         'https://blockstream.info/api/tx',
-        mockSignedTxHex,
-        { headers: { 'Content-Type': 'text/plain' } }
-      );
-    });
-
-    it('should broadcast successfully using mempool endpoint', async () => {
-      mockApiClient.post
-        .mockRejectedValueOnce(new Error('Counterparty failed'))
-        .mockRejectedValueOnce(new Error('Blockcypher failed'))
-        .mockRejectedValueOnce(new Error('Blockstream failed'))
-        .mockResolvedValueOnce({
-          status: 200,
-          data: ` ${mockTxid} ` // With whitespace to test trimming
-        });
-
-      const result = await broadcastTransaction(mockSignedTxHex);
-      
-      expect(result.txid).toBe(computeTxid(mockSignedTxHex));
-      expect(mockApiClient.post).toHaveBeenCalledWith(
         'https://mempool.space/api/tx',
-        mockSignedTxHex,
-        { headers: { 'Content-Type': 'text/plain' } }
-      );
+      ]);
     });
 
-    it('should throw error when all endpoints fail', async () => {
-      mockApiClient.post.mockRejectedValue(new Error('Network error'));
-
-      await expect(broadcastTransaction(mockSignedTxHex)).rejects.toThrow(
-        'Network error'
-      );
-    });
-
-    it('should handle HTTP error status codes', async () => {
+    it('sends each broadcast exactly once, with the broadcast timeout and no client-side retry', async () => {
       mockApiClient.post
-        .mockResolvedValueOnce({
-          status: 400,
-          data: { error: 'Bad request' }
-        })
-        .mockResolvedValueOnce({
-          status: 200,
-          data: { tx: { hash: mockTxid } }
-        });
-
-      const result = await broadcastTransaction(mockSignedTxHex);
-      expect(result.txid).toBe(computeTxid(mockSignedTxHex));
-    });
-
-    it('should handle responses without valid txid', async () => {
-      mockApiClient.post
-        .mockResolvedValueOnce({
-          status: 200,
-          data: { result: null } // No valid txid
-        })
-        .mockResolvedValueOnce({
-          status: 200,
-          data: { tx: { hash: mockTxid } }
-        });
-
-      const result = await broadcastTransaction(mockSignedTxHex);
-      expect(result.txid).toBe(computeTxid(mockSignedTxHex));
-    });
-
-    it('should handle empty response data', async () => {
-      mockApiClient.post
-        .mockResolvedValueOnce({
-          status: 200,
-          data: null
-        })
-        .mockResolvedValueOnce({
-          status: 200,
-          data: { tx: { hash: mockTxid } }  // blockcypher format
-        });
-
-      const result = await broadcastTransaction(mockSignedTxHex);
-      expect(result.txid).toBe(computeTxid(mockSignedTxHex));
-    });
-
-    it('should properly encode URL parameters for counterparty', async () => {
-      const specialCharHex = 'abc+def/123=456';
-      mockApiClient.post.mockResolvedValue({
-        status: 200,
-        data: { result: mockTxid }
-      });
-
-      await broadcastTransaction(specialCharHex);
-      
-      const expectedUrl = expect.stringContaining('signedhex=abc%2Bdef%2F123%3D456');
-      expect(mockApiClient.post).toHaveBeenCalledWith(
-        expectedUrl,
-        null,
-        { headers: { 'Content-Type': 'application/json' } }
-      );
-    });
-
-    it('should handle network timeout errors', async () => {
-      mockApiClient.post
-        .mockRejectedValueOnce({ code: 'ECONNABORTED', message: 'timeout' })
-        .mockResolvedValueOnce({
-          status: 200,
-          data: { tx: { hash: mockTxid } }  // blockcypher format
-        });
-
-      const result = await broadcastTransaction(mockSignedTxHex);
-      expect(result.txid).toBe(computeTxid(mockSignedTxHex));
-    });
-
-    it('should handle malformed JSON responses', async () => {
-      mockApiClient.post
-        .mockRejectedValueOnce(new Error('JSON parse error'))
-        .mockResolvedValueOnce({
-          status: 200,
-          data: { tx: { hash: mockTxid } }
-        });
-
-      const result = await broadcastTransaction(mockSignedTxHex);
-      expect(result.txid).toBe(computeTxid(mockSignedTxHex));
-    });
-
-    it('should handle response format differences correctly', async () => {
-      // Test counterparty format
-      mockApiClient.post.mockResolvedValueOnce({
-        status: 200,
-        data: { result: mockTxid }
-      });
-
-      let result = await broadcastTransaction(mockSignedTxHex);
-      expect(result.txid).toBe(computeTxid(mockSignedTxHex));
-      expect(result.fees).toBeUndefined();
-
-      // Reset and test blockcypher format
-      vi.clearAllMocks();
-      mockApiClient.post
-        .mockRejectedValueOnce(new Error('First failed'))
-        .mockResolvedValueOnce({
-          status: 200,
-          data: { 
-            tx: { 
-              hash: mockTxid,
-              fees: 1500
-            }
-          }
-        });
-
-      result = await broadcastTransaction(mockSignedTxHex);
-      expect(result.txid).toBe(computeTxid(mockSignedTxHex));
-      expect(result.fees).toBe(1500);
-    });
-
-    it('should handle custom counterparty API base URL', async () => {
-      // Clear the default mock and set a new one before the test
-      mockGetSettings.mockClear();
-      mockGetSettings.mockReturnValue({
-        ...DEFAULT_SETTINGS,
-        counterpartyApiBase: 'https://custom.api.com', // Custom API for this test
-      });
-
-      mockApiClient.post.mockResolvedValue({
-        status: 200,
-        data: { result: mockTxid }
-      });
+        .mockResolvedValueOnce(accepted({ result: mockTxid }))
+        .mockResolvedValue(accepted(mockTxid));
 
       await broadcastTransaction(mockSignedTxHex);
-      
-      expect(mockApiClient.post).toHaveBeenCalledWith(
-        expect.stringContaining('custom.api.com'),
+
+      expect(mockApiClient.post).toHaveBeenNthCalledWith(
+        1,
+        expect.stringContaining('api.counterparty.io'),
         null,
-        { headers: { 'Content-Type': 'application/json' } }
+        { headers: { 'Content-Type': 'application/json' }, timeout: 45000, retries: 0 },
+      );
+      expect(mockApiClient.post).toHaveBeenNthCalledWith(
+        2,
+        'https://blockstream.info/api/tx',
+        mockSignedTxHex,
+        { headers: { 'Content-Type': 'text/plain' }, timeout: 10000, retries: 0 },
       );
     });
 
-    it('should handle very long transaction hex', async () => {
-      const longHex = 'a'.repeat(10000);
-      mockApiClient.post.mockResolvedValue({
-        status: 200,
-        data: { result: mockTxid }
-      });
+    it('treats a node that already holds the transaction as a successful broadcast', async () => {
+      // The Counterparty node accepted a first send whose response was lost; Core wraps the
+      // node's answer to the repeat as a retryable 503.
+      mockApiClient.post
+        .mockRejectedValueOnce(apiRejection({ error: 'Error broadcasting transaction: txn-already-in-mempool' }))
+        .mockResolvedValue(accepted(mockTxid));
 
-      const result = await broadcastTransaction(longHex);
-      // Unparseable hex: no local txid computable, so fall back to the endpoint's.
-      expect(result.txid).toBe(mockTxid);
+      const result = await broadcastTransaction(mockSignedTxHex);
+
+      expect(result.txid).toBe(computeTxid(mockSignedTxHex));
+      expect(urlsCalled()).toHaveLength(3);
     });
 
-    it('should handle successful response with status code edge cases', async () => {
-      // Test status 201 (Created)
-      mockApiClient.post.mockResolvedValueOnce({
-        status: 201,
-        data: { result: mockTxid }
-      });
+    it('recognises a relay that already saw the transaction in a block', async () => {
+      mockApiClient.post
+        .mockRejectedValueOnce(new Error('Counterparty failed'))
+        .mockRejectedValueOnce(apiRejection(
+          'sendrawtransaction RPC error: {"code":-27,"message":"Transaction already in block chain"}',
+          400,
+        ))
+        .mockResolvedValue(accepted(mockTxid));
 
       const result = await broadcastTransaction(mockSignedTxHex);
       expect(result.txid).toBe(computeTxid(mockSignedTxHex));
-
-      // Test status 202 (Accepted)
-      vi.clearAllMocks();
-      // Re-setup the settings mock after clearing
-      mockGetSettings.mockReturnValue(DEFAULT_SETTINGS);
-      // Test blockstream format for 202
-      mockApiClient.post
-        .mockRejectedValueOnce(new Error('First failed'))  // counterparty fails
-        .mockRejectedValueOnce(new Error('Second failed'))  // blockcypher fails
-        .mockResolvedValueOnce({
-          status: 202,
-          data: mockTxid  // blockstream returns plain string
-        });
-
-      const result2 = await broadcastTransaction(mockSignedTxHex);
-      expect(result2.txid).toBe(computeTxid(mockSignedTxHex));
-    });
-  });
-
-  describe('error handling', () => {
-    it('should preserve last error message when all endpoints fail', async () => {
-      const specificError = 'Transaction already exists';
-      mockApiClient.post
-        .mockRejectedValueOnce(new Error('First error'))
-        .mockRejectedValueOnce(new Error('Second error'))
-        .mockRejectedValueOnce(new Error('Third error'))
-        .mockRejectedValueOnce(new Error(specificError));
-
-      await expect(broadcastTransaction(mockSignedTxHex)).rejects.toThrow(specificError);
     });
 
-    it('should handle unknown endpoint format gracefully', async () => {
-      // This test simulates an internal error in formatResponse
-      mockApiClient.post.mockResolvedValue({
-        status: 200,
-        data: { result: mockTxid }
-      });
-
-      // Mock a scenario where formatResponse would throw
-      const originalConsoleError = console.error;
-      console.error = vi.fn();
+    it('falls through to a public relay when the Counterparty node is down, and still feeds the other', async () => {
+      mockApiClient.post
+        .mockRejectedValueOnce(new Error('Counterparty failed'))
+        .mockResolvedValueOnce(accepted(mockTxid))
+        .mockResolvedValueOnce(accepted(mockTxid));
 
       const result = await broadcastTransaction(mockSignedTxHex);
-      expect(result.txid).toBe(computeTxid(mockSignedTxHex));
 
-      console.error = originalConsoleError;
+      expect(result.txid).toBe(computeTxid(mockSignedTxHex));
+      expect(urlsCalled()).toEqual([
+        expect.stringContaining('api.counterparty.io'),
+        'https://blockstream.info/api/tx',
+        'https://mempool.space/api/tx',
+      ]);
     });
 
-    it('should handle axios request config errors', async () => {
-      mockApiClient.post.mockRejectedValue({
-        config: {},
-        request: {},
-        response: {
-          status: 500,
-          data: 'Internal server error'
-        }
+    it('does not let a failing relay fan-out change a successful outcome', async () => {
+      mockApiClient.post
+        .mockResolvedValueOnce(accepted({ result: mockTxid }))
+        .mockRejectedValueOnce(new Error('blockstream down'))
+        .mockRejectedValueOnce(apiRejection('Transaction rate limit', 429));
+
+      await expect(broadcastTransaction(mockSignedTxHex)).resolves.toEqual({
+        txid: computeTxid(mockSignedTxHex),
       });
+    });
+
+    it('never pushes to BlockCypher', async () => {
+      mockApiClient.post.mockRejectedValue(new Error('Network error'));
 
       await expect(broadcastTransaction(mockSignedTxHex)).rejects.toThrow();
+      expect(urlsCalled().some((url: string) => url.includes('blockcypher'))).toBe(false);
+    });
+
+    it('throws the first endpoint rejection when every endpoint refuses', async () => {
+      mockApiClient.post
+        .mockRejectedValueOnce(apiRejection({ error: 'Error broadcasting transaction: min relay fee not met' }))
+        .mockRejectedValueOnce(apiRejection('min relay fee not met', 400))
+        .mockRejectedValueOnce(apiRejection('min relay fee not met', 400));
+
+      await expect(broadcastTransaction(mockSignedTxHex)).rejects.toThrow(
+        'Error broadcasting transaction: min relay fee not met',
+      );
+    });
+
+    it('throws a plain network error when no endpoint answered at all', async () => {
+      mockApiClient.post.mockRejectedValue(new Error('Network error'));
+
+      await expect(broadcastTransaction(mockSignedTxHex)).rejects.toThrow('Network error');
+      expect(mockApiClient.post).toHaveBeenCalledTimes(3);
+    });
+
+    it('treats a non-2xx response as a refusal and moves on', async () => {
+      mockApiClient.post
+        .mockResolvedValueOnce({ status: 400, data: { error: 'Bad request' } })
+        .mockResolvedValue(accepted(mockTxid));
+
+      const result = await broadcastTransaction(mockSignedTxHex);
+      expect(result.txid).toBe(computeTxid(mockSignedTxHex));
+    });
+
+    it('treats an acceptance without a txid echo as a refusal', async () => {
+      mockApiClient.post
+        .mockResolvedValueOnce(accepted({ result: null }))
+        .mockResolvedValueOnce(accepted(''))
+        .mockResolvedValueOnce(accepted(mockTxid));
+
+      const result = await broadcastTransaction(mockSignedTxHex);
+      expect(result.txid).toBe(computeTxid(mockSignedTxHex));
+      expect(urlsCalled()).toHaveLength(3);
+    });
+
+    it('properly encodes the hex into the Counterparty URL', async () => {
+      const hexWithSpecialChars = mockSignedTxHex + '&test=value';
+      mockApiClient.post.mockResolvedValue(accepted({ result: mockTxid }));
+
+      await broadcastTransaction(hexWithSpecialChars);
+
+      expect(mockApiClient.post).toHaveBeenNthCalledWith(
+        1,
+        expect.stringContaining(encodeURIComponent(hexWithSpecialChars)),
+        null,
+        expect.any(Object),
+      );
+    });
+
+    it('reports the locally computed txid rather than the endpoint echo', async () => {
+      mockApiClient.post.mockResolvedValue(accepted({ result: 'not-the-real-id' }));
+
+      const result = await broadcastTransaction(mockSignedTxHex);
+      expect(result.txid).toBe(computeTxid(mockSignedTxHex));
+      expect(result.txid).not.toBe('not-the-real-id');
     });
   });
 });

--- a/src/core/bitcoin/broadcastErrors.ts
+++ b/src/core/bitcoin/broadcastErrors.ts
@@ -8,3 +8,16 @@ const STALE_INPUTS_PATTERN = /missingorspent|bad-txns-inputs|txn-mempool-conflic
 export function isStaleInputsError(message: string): boolean {
   return STALE_INPUTS_PATTERN.test(message);
 }
+
+/**
+ * Bitcoin Core's answers when the node already holds the transaction, in its mempool or in a
+ * block. Reaching one means an earlier attempt landed — an accept the client timed out on, or a
+ * peer that relayed it first — so it is success, and the one thing it must never trigger is
+ * another send of the same bytes.
+ */
+const ALREADY_KNOWN_PATTERN =
+  /txn-already-in-mempool|txn-already-known|already in block ?chain|already known|already have transaction/i;
+
+export function isAlreadyKnownError(message: string): boolean {
+  return ALREADY_KNOWN_PATTERN.test(message);
+}

--- a/src/core/bitcoin/transactionBroadcaster.ts
+++ b/src/core/bitcoin/transactionBroadcaster.ts
@@ -148,8 +148,8 @@ export function extractInputsFromRawTx(signedTxHex: string): { txid: string; vou
     for (let i = 0; i < tx.inputsLength; i++) {
       const input = tx.getInput(i);
       if (input.txid) {
-        // txid bytes are in internal (reversed) order; reverse for standard display format
-        const txid = bytesToHex(Uint8Array.from(input.txid).reverse());
+        // btc-signer has already converted the wire outpoint to display order.
+        const txid = bytesToHex(input.txid);
         inputs.push({ txid, vout: input.index ?? 0 });
       }
     }
@@ -203,6 +203,11 @@ export async function broadcastTransaction(signedTxHex: string): Promise<Transac
       continue;
     }
 
+    // Acceptance is the spent-input boundary. Reserve locally before another request can
+    // select the inputs while public propagation is still pending. Keep settlement outside
+    // attempt's rejection handling: a local failure is not a reason to resend accepted bytes.
+    settleLocalState(signedTxHex);
+
     // Accepted somewhere. Feed the public relays not yet asked, so the transaction sits in the
     // mempools explorers and miners actually read, not only in the one node that answered first.
     // Their verdicts do not change the outcome: a relay that already has it, or is down, is noise.
@@ -212,7 +217,6 @@ export async function broadcastTransaction(signedTxHex: string): Promise<Transac
         .map(relay => attempt(relay, signedTxHex, RELAY_FANOUT_TIMEOUT_MS)),
     );
 
-    settleLocalState(signedTxHex);
     const txid = localTxid ?? result.txid;
     if (!txid) throw new Error('Transaction was accepted but its id could not be determined');
     return { txid };

--- a/src/core/bitcoin/transactionBroadcaster.ts
+++ b/src/core/bitcoin/transactionBroadcaster.ts
@@ -1,6 +1,7 @@
 import { bytesToHex } from '@noble/hashes/utils.js';
-import { type ApiResponse, apiClient, isApiError, withRetry } from '@/core/api/client';
+import { API_TIMEOUTS, type ApiResponse, apiClient, isApiError } from '@/core/api/client';
 import { clearBalanceCache } from '@/core/bitcoin/balance';
+import { isAlreadyKnownError } from '@/core/bitcoin/broadcastErrors';
 import { parseTransactionForSigning } from '@/core/bitcoin/rawTransaction';
 import { recordSpentUtxos } from '@/core/bitcoin/spentUtxoCache';
 import { clearBitcoinCaches } from '@/core/bitcoin/utxo';
@@ -12,31 +13,34 @@ export interface TransactionResponse {
   fees?: number;
 }
 
-/** Data payload types for different broadcast endpoints */
-type BroadcastPayload = { tx: string } | string | null;
-
 interface BroadcastEndpoint {
-  name: string;
-  getUrl: (signedTxHex: string) => string | Promise<string>;
-  getData: (signedTxHex: string) => BroadcastPayload;
+  name: 'counterparty' | 'blockstream' | 'mempool';
+  getUrl: (signedTxHex: string) => string;
+  /** The raw hex as a text body, or nothing when the hex rides in the URL. */
+  getData: (signedTxHex: string) => string | null;
   headers: Record<string, string>;
 }
 
+/**
+ * The node the wallet trusts for Counterparty state goes first, but its mempool is not the
+ * network. A node that accepts a transaction and relays it nowhere leaves the user with a pending
+ * entry no explorer can see, which is exactly what stranded a 38-asset MPMA send. So acceptance
+ * anywhere is success, and the public relays are always fed afterwards as propagation insurance.
+ * Both relays take the raw hex as a text body and answer with permissive CORS, so no host
+ * permission is needed.
+ *
+ * BlockCypher is gone: its unauthenticated push endpoint rate-limits after a handful of calls,
+ * and a 429 is never retried, so as a fallback it only delayed the next one.
+ */
 const broadcastEndpoints: BroadcastEndpoint[] = [
   {
     name: 'counterparty',
-    getUrl: async (signedTxHex: string) => {
+    getUrl: (signedTxHex: string) => {
       const settings = getActiveSettings();
       const encoded = encodeURIComponent(signedTxHex);
       return `${settings.counterpartyApiBase}/v2/bitcoin/transactions?signedhex=${encoded}`;
     },
     getData: () => null,
-    headers: { 'Content-Type': 'application/json' },
-  },
-  {
-    name: 'blockcypher',
-    getUrl: () => 'https://api.blockcypher.com/v1/btc/main/txs/push',
-    getData: (signedTxHex: string) => ({ tx: signedTxHex }),
     headers: { 'Content-Type': 'application/json' },
   },
   {
@@ -53,32 +57,71 @@ const broadcastEndpoints: BroadcastEndpoint[] = [
   },
 ];
 
-const formatResponse = (endpoint: BroadcastEndpoint, response: ApiResponse): TransactionResponse | null => {
+/** A slow relay must not hold up the wallet's answer once the transaction is accepted. */
+const RELAY_FANOUT_TIMEOUT_MS = 10_000;
+
+/** The txid an endpoint echoes back on acceptance; the wallet reports its own computed id. */
+const echoedTxid = (endpoint: BroadcastEndpoint, response: ApiResponse): string | null => {
   try {
-    const data = response.data as Record<string, unknown>;
     if (endpoint.name === 'counterparty') {
-      const txid = data?.result as string | undefined;
-      return txid ? { txid } : null;
+      const data = response.data as Record<string, unknown> | undefined;
+      const txid = data?.result;
+      return typeof txid === 'string' && txid ? txid : null;
     }
-    if (endpoint.name === 'blockcypher') {
-      const tx = data?.tx as { hash?: string; fees?: number } | undefined;
-      return tx?.hash ? { txid: tx.hash, fees: tx.fees } : null;
-    }
-    if (endpoint.name === 'blockstream' || endpoint.name === 'mempool') {
-      const txid = typeof response.data === 'string' ? response.data.trim() : null;
-      return txid ? { txid } : null;
-    }
-    return null;
-  } catch (_error) {
+    const txid = typeof response.data === 'string' ? response.data.trim() : null;
+    return txid ? txid : null;
+  } catch {
     return null;
   }
 };
 
+/** The most specific message an endpoint gave for turning the transaction down. */
+function rejectionMessage(source: unknown): string | null {
+  const data = isApiError(source)
+    ? source.response?.data
+    : source && typeof source === 'object' && 'data' in source
+      ? (source as { data: unknown }).data
+      : undefined;
+  if (typeof data === 'string' && data.trim()) return data.trim();
+  if (data && typeof data === 'object') {
+    const record = data as Record<string, unknown>;
+    for (const key of ['error', 'message', 'result']) {
+      if (typeof record[key] === 'string' && record[key]) return record[key] as string;
+    }
+  }
+  return source instanceof Error && source.message ? source.message : null;
+}
+
+type Attempt =
+  | { accepted: true; txid: string | null }
+  | { accepted: false; message: string | null };
+
 /**
- * Parse a signed transaction hex to extract its inputs (txid + vout pairs).
- * Used to record spent UTXOs after broadcast. Fails gracefully — returns
- * empty array if parsing fails so broadcast is never blocked.
+ * One send to one endpoint, exactly once. A broadcast POST is not safe to repeat blindly: the
+ * first attempt may have landed while its response was lost, and the node's answer to a repeat
+ * is a rejection that reads as failure. The fan-out below is the only retry, and it is a fan-out
+ * to other nodes, not a repeat against the same one.
  */
+async function attempt(endpoint: BroadcastEndpoint, signedTxHex: string, timeout: number): Promise<Attempt> {
+  try {
+    const response = await apiClient.post(
+      endpoint.getUrl(signedTxHex),
+      endpoint.getData(signedTxHex),
+      { headers: endpoint.headers, timeout, retries: 0 },
+    );
+    if (response && response.status >= 200 && response.status < 300) {
+      const txid = echoedTxid(endpoint, response);
+      if (txid) return { accepted: true, txid };
+    }
+    return { accepted: false, message: rejectionMessage(response) };
+  } catch (error) {
+    const message = rejectionMessage(error);
+    // The node already holds these bytes: an earlier send landed. That is success.
+    if (message && isAlreadyKnownError(message)) return { accepted: true, txid: null };
+    return { accepted: false, message };
+  }
+}
+
 /**
  * Compute a signed transaction's txid locally, so the value we report is the
  * real transaction id rather than whatever a broadcast endpoint echoes back.
@@ -93,6 +136,11 @@ export function computeTxid(signedTxHex: string): string | null {
   }
 }
 
+/**
+ * Parse a signed transaction hex to extract its inputs (txid + vout pairs).
+ * Used to record spent UTXOs after broadcast. Fails gracefully — returns
+ * empty array if parsing fails so broadcast is never blocked.
+ */
 export function extractInputsFromRawTx(signedTxHex: string): { txid: string; vout: number }[] {
   try {
     const tx = parseTransactionForSigning(signedTxHex);
@@ -120,80 +168,55 @@ const generateMockTxid = (signedTxHex: string): string => {
   return `${MOCK_TXID_PREFIX}${truncatedHex}_${timestamp}`;
 };
 
+function settleLocalState(signedTxHex: string): void {
+  // Clear all caches after successful transaction
+  clearApiCache();
+  clearBitcoinCaches();
+  clearBalanceCache();
+  recordSpentUtxos(extractInputsFromRawTx(signedTxHex));
+}
+
 export async function broadcastTransaction(signedTxHex: string): Promise<TransactionResponse> {
   const settings = getActiveSettings();
-  
+
   if (settings.transactionDryRun) {
     await new Promise(resolve => setTimeout(resolve, 500));
-    
     if (signedTxHex.includes(FORCE_ERROR_HEX)) {
       throw new Error('Simulated broadcast error for testing');
     }
-
-    // Clear all caches after successful transaction
-    clearApiCache();
-    clearBitcoinCaches();
-    clearBalanceCache();
-    recordSpentUtxos(extractInputsFromRawTx(signedTxHex));
-
+    settleLocalState(signedTxHex);
     return {
       txid: generateMockTxid(signedTxHex),
       fees: 1000
     };
   }
 
-  let lastError: Error | null = null;
-  let errorMessage: string | null = null;
-  
-  for (const endpoint of broadcastEndpoints) {
-    try {
-      const url = await endpoint.getUrl(signedTxHex);
-      // Use broadcast-specific timeout (45 seconds) with retry logic
-      const response = await withRetry(
-        () => apiClient.post(
-          url,
-          endpoint.getData(signedTxHex),
-          { headers: endpoint.headers }
-        ),
-        2 // Only retry twice for broadcasts
-      );
-      if (response && response.status >= 200 && response.status < 300) {
-        const formatted = formatResponse(endpoint, response);
-        if (formatted && formatted.txid) {
-          // Clear all caches after successful transaction
-          clearApiCache();
-          clearBitcoinCaches();
-          clearBalanceCache();
-          recordSpentUtxos(extractInputsFromRawTx(signedTxHex));
-          // Report the locally-derived txid, not the endpoint's echo.
-          return { ...formatted, txid: computeTxid(signedTxHex) ?? formatted.txid };
-        }
-      }
-    } catch (error) {
-      lastError = error instanceof Error ? error : new Error(String(error));
+  const localTxid = computeTxid(signedTxHex);
+  const rejections: string[] = [];
+  const tried = new Set<BroadcastEndpoint>();
 
-      // Extract the actual error message from the API response
-      if (isApiError(error) && error.response?.data) {
-        const data = error.response.data;
-        if (typeof data === 'string') {
-          errorMessage = data;
-        } else if (typeof data === 'object' && data !== null) {
-          const dataObj = data as Record<string, unknown>;
-          if (typeof dataObj.error === 'string') {
-            errorMessage = dataObj.error;
-          } else if (typeof dataObj.message === 'string') {
-            errorMessage = dataObj.message;
-          } else if (typeof dataObj.result === 'string') {
-            errorMessage = dataObj.result;
-          }
-        }
-      }
+  for (const endpoint of broadcastEndpoints) {
+    tried.add(endpoint);
+    const result = await attempt(endpoint, signedTxHex, API_TIMEOUTS.BROADCAST);
+    if (!result.accepted) {
+      if (result.message) rejections.push(result.message);
+      continue;
     }
+
+    // Accepted somewhere. Feed the public relays not yet asked, so the transaction sits in the
+    // mempools explorers and miners actually read, not only in the one node that answered first.
+    // Their verdicts do not change the outcome: a relay that already has it, or is down, is noise.
+    await Promise.allSettled(
+      broadcastEndpoints
+        .filter(relay => !tried.has(relay) && relay.name !== 'counterparty')
+        .map(relay => attempt(relay, signedTxHex, RELAY_FANOUT_TIMEOUT_MS)),
+    );
+
+    settleLocalState(signedTxHex);
+    const txid = localTxid ?? result.txid;
+    if (!txid) throw new Error('Transaction was accepted but its id could not be determined');
+    return { txid };
   }
-  
-  // Throw the actual API error if we have one, otherwise the last error
-  if (errorMessage) {
-    throw new Error(errorMessage);
-  }
-  throw new Error(lastError?.message || 'Failed to broadcast transaction on all endpoints');
+
+  throw new Error(rejections[0] ?? 'Failed to broadcast transaction on all endpoints');
 }


### PR DESCRIPTION
An accepting Counterparty node can leave a transaction absent from public relays. The wallet now sends each endpoint once, recognizes already-known transactions as accepted, and propagates accepted bytes to the remaining public relays with a 10-second bound. Relay failures do not change an accepted result, and the reported transaction ID is computed locally.

Acceptance also immediately clears local caches and records the spent inputs, before waiting for propagation. This closes the window in which a subsequent funding selection could reuse accepted inputs while relays were still pending. Input transaction IDs now retain btc-signer's display order; reversing them previously recorded different outpoints in the spent cache. Local settlement exceptions remain explicit and are not reclassified as endpoint rejection or used to retry accepted bytes.

The Counterparty request uses the explicit broadcast timeout and disables client retries. The unauthenticated BlockCypher fallback is removed; propagation goes to Blockstream and mempool.space.

Validation: 64 focused broadcaster, error-classifier, spent-cache and UTXO-selection tests pass, along with TypeScript, the repository lint gate and the Chrome production build. New deferred-relay fixtures prove that the actual funding selector excludes a non-symmetric spent outpoint while other relays are pending, and that normal/already-known acceptance remains reserved when those relays fail. Rejected transactions remain unreserved. Six regression cases failed against the prior PR head before the correction. All network responses were mocked; no live transaction was broadcast.
