### PR TITLE
Pace Counterparty reads and obey the node's 429

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -468,17 +468,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@bcoe/v8-coverage": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
-      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@biomejs/biome": {
       "version": "2.5.12",
       "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.12.tgz",
@@ -4380,31 +4369,6 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/@vitest/istanbul-lib-coverage": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@vitest/istanbul-lib-coverage/-/istanbul-lib-coverage-1.0.1.tgz",
-      "integrity": "sha512-k3DJZ8LhMBK9NS4SclF1ASD3OgXEWDorbIcPTRDK0/Zae6fRvu+fJRxtFdLfHsa9Y24beCdPnoNZ4LviTNstfA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/@vitest/istanbul-lib-report": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@vitest/istanbul-lib-report/-/istanbul-lib-report-1.0.1.tgz",
-      "integrity": "sha512-1EOLRfsTMnyAr3+kEAsP4o9dhaDlGPpD7H5iLBBeq//YpNB1VIahkPhB+eRp9N2Dkfw8oySROjE3yf9XDeaIkQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@vitest/istanbul-lib-coverage": "1.0.1"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
     "node_modules/@vitest/mocker": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-5.0.0.tgz",
@@ -4670,27 +4634,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/ast-v8-to-istanbul": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.5.tgz",
-      "integrity": "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.31",
-        "estree-walker": "^3.0.3",
-        "js-tokens": "^10.0.0"
-      }
-    },
-    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
-      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/async-mutex": {
       "version": "0.5.0",
@@ -7079,6 +7022,7 @@
       "integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.29.7",
         "@babel/types": "^7.29.7",
@@ -8425,17 +8369,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
-      }
-    },
-    "node_modules/tinyrainbow": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
-      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/to-buffer": {

--- a/src/core/api/client.ts
+++ b/src/core/api/client.ts
@@ -38,6 +38,8 @@ export interface ApiError extends Error {
     data: unknown;
     status: number;
   };
+  /** Seconds the server asked us to wait, from a 429's Retry-After header. */
+  retryAfter?: number;
 }
 
 /**
@@ -46,12 +48,13 @@ export interface ApiError extends Error {
 function createApiError(
   message: string,
   code: ApiError['code'],
-  options?: { status?: number; response?: { data: unknown; status: number } }
+  options?: { status?: number; response?: { data: unknown; status: number }; retryAfter?: number }
 ): ApiError {
   const error = new Error(message) as ApiError;
   error.code = code;
   error.status = options?.status;
   error.response = options?.response;
+  error.retryAfter = options?.retryAfter;
   return error;
 }
 
@@ -192,23 +195,24 @@ async function fetchWithTimeout<T>(
 
     // Check for HTTP errors
     if (!response.ok) {
+      const retryAfterHeader = response.headers.get('Retry-After');
+      const retryAfter = retryAfterHeader ? parseInt(retryAfterHeader, 10) : undefined;
       // Emit API status for rate limiting or server errors
       const statusType = getStatusTypeFromCode(response.status);
       if (statusType) {
-        const retryAfter = response.headers.get('Retry-After');
         emitApiStatus({
           type: statusType,
           statusCode: response.status,
           message: response.status === 429
             ? 'API rate limited. Requests may be slow.'
             : `API error (${response.status}). Some features may be unavailable.`,
-          retryAfter: retryAfter ? parseInt(retryAfter, 10) : undefined,
+          retryAfter,
         });
       }
       throw createApiError(
         `Request failed with status ${response.status}`,
         'HTTP_ERROR',
-        { status: response.status, response: { data, status: response.status } }
+        { status: response.status, response: { data, status: response.status }, retryAfter }
       );
     }
 

--- a/src/core/api/client.ts
+++ b/src/core/api/client.ts
@@ -38,7 +38,7 @@ export interface ApiError extends Error {
     data: unknown;
     status: number;
   };
-  /** Seconds the server asked us to wait, from a 429's Retry-After header. */
+  /** Seconds to wait from Retry-After delay-seconds or its HTTP-date deadline. */
   retryAfter?: number;
 }
 
@@ -142,6 +142,21 @@ function buildUrl(url: string, params?: Record<string, string | number | boolean
   }
 }
 
+/** Retry-After permits integer delay-seconds or an HTTP-date, not a numeric prefix. */
+function parseRetryAfter(value: string | null, now: number): number | undefined {
+  if (value === null) return undefined;
+  const header = value.trim();
+  if (/^\d+$/.test(header)) {
+    const seconds = Number(header);
+    return Number.isFinite(seconds) ? seconds : undefined;
+  }
+  // All HTTP-date forms begin with a weekday. Avoid Date.parse accepting
+  // malformed numeric delays such as "1.5" as a calendar date.
+  if (!/^(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)/i.test(header)) return undefined;
+  const deadline = Date.parse(header);
+  return Number.isFinite(deadline) ? Math.max(0, (deadline - now) / 1000) : undefined;
+}
+
 /**
  * Create a timeout-aware fetch with AbortController
  */
@@ -195,8 +210,7 @@ async function fetchWithTimeout<T>(
 
     // Check for HTTP errors
     if (!response.ok) {
-      const retryAfterHeader = response.headers.get('Retry-After');
-      const retryAfter = retryAfterHeader ? parseInt(retryAfterHeader, 10) : undefined;
+      const retryAfter = parseRetryAfter(response.headers.get('Retry-After'), Date.now());
       // Emit API status for rate limiting or server errors
       const statusType = getStatusTypeFromCode(response.status);
       if (statusType) {

--- a/src/core/balances/invalidate.ts
+++ b/src/core/balances/invalidate.ts
@@ -15,7 +15,7 @@
  */
 
 import { clearBalanceCache } from '@/core/bitcoin/balance';
-import { clearApiCacheMatching, resetRequestPace } from '@/core/counterparty/api';
+import { clearApiCacheMatching } from '@/core/counterparty/api';
 
 /**
  * Drop every cached balance for an address, so the next read goes to the network.
@@ -29,6 +29,5 @@ export function invalidateAddressBalances(address: string): void {
   if (!address) return;
   clearApiCacheMatching(address);
   clearBalanceCache(address);
-  // The same gesture also ends any cooldown a 429 imposed: the user is asking to try again now.
-  resetRequestPace();
+  // A refresh invalidates data, not the server's rate-limit deadline.
 }

--- a/src/core/balances/invalidate.ts
+++ b/src/core/balances/invalidate.ts
@@ -15,7 +15,7 @@
  */
 
 import { clearBalanceCache } from '@/core/bitcoin/balance';
-import { clearApiCacheMatching } from '@/core/counterparty/api';
+import { clearApiCacheMatching, resetRequestPace } from '@/core/counterparty/api';
 
 /**
  * Drop every cached balance for an address, so the next read goes to the network.
@@ -29,4 +29,6 @@ export function invalidateAddressBalances(address: string): void {
   if (!address) return;
   clearApiCacheMatching(address);
   clearBalanceCache(address);
+  // The same gesture also ends any cooldown a 429 imposed: the user is asking to try again now.
+  resetRequestPace();
 }

--- a/src/core/counterparty/__tests__/requestCoalescing.test.ts
+++ b/src/core/counterparty/__tests__/requestCoalescing.test.ts
@@ -128,6 +128,26 @@ describe('collapsing identical reads that are in flight together', () => {
 });
 
 describe('invalidation reaches requests that are still in the air', () => {
+  it.each(['all', 'matching'] as const)('keeps the post-mutation cached balance when an invalidated response finishes last (%s)', async scope => {
+    const address = '1AddressAAAAAAAAAAAAAAAAAAAAAAAAAA';
+    const before = deferred<ReturnType<typeof page>>();
+    const current = [{ asset: 'XCP', quantity: 2, quantity_normalized: '0.00000002' }];
+    mockedApiClient.get.mockReturnValueOnce(before.promise as never);
+    mockedApiClient.get.mockResolvedValue(page(current) as never);
+
+    const oldRead = fetchTokenBalances(address);
+    await flush();
+    if (scope === 'all') clearApiCache();
+    else clearApiCacheMatching(address);
+
+    await expect(fetchTokenBalances(address)).resolves.toEqual(current);
+    before.settle(page([{ asset: 'XCP', quantity: 1, quantity_normalized: '0.00000001' }]));
+    await expect(oldRead).resolves.toMatchObject([{ quantity: 1 }]);
+
+    await expect(fetchTokenBalances(address)).resolves.toEqual(current);
+    expect(mockedApiClient.get).toHaveBeenCalledTimes(2);
+  });
+
   it('does not hand a post-mutation caller an answer that predates the mutation', async () => {
     const before = deferred<ReturnType<typeof page>>();
     mockedApiClient.get.mockReturnValueOnce(before.promise as never);

--- a/src/core/counterparty/__tests__/requestCoalescing.test.ts
+++ b/src/core/counterparty/__tests__/requestCoalescing.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { apiClient } from '@/core/api/client';
+import {
+  clearApiCache,
+  clearApiCacheMatching,
+  fetchMempoolLedgerEvents,
+  fetchTokenBalances,
+} from '../api';
+
+/**
+ * One question asked many times at once should be one request.
+ *
+ * The response cache can only collapse a repeat after the first answer is
+ * back. It does nothing for the case that actually produces a 429 storm: a
+ * screen mounting and asking the same thing several times in the same tick.
+ * Every one of those misses the empty cache and every one goes to the node.
+ *
+ * That is the shape of the refusals that started this work — roughly seventy
+ * 429s for a single `/v2/addresses/mempool` URL, one address, one event
+ * filter. Not many questions, one question many times.
+ */
+
+vi.mock('@/core/api/client');
+vi.mock('@/core/counterparty/capabilities', () => ({
+  requireCounterpartyFeature: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('@/core/settings', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/core/settings')>()),
+  getActiveSettings: vi.fn().mockReturnValue({
+    counterpartyApiBase: 'https://api.counterparty.io',
+  }),
+}));
+
+const mockedApiClient = vi.mocked(apiClient, true);
+
+/** A response that does not resolve until the test says so. */
+function deferred<T>() {
+  let settle!: (value: T) => void;
+  let fail!: (reason: unknown) => void;
+  const promise = new Promise<T>((resolve, reject) => {
+    settle = resolve;
+    fail = reject;
+  });
+  return { promise, settle, fail };
+}
+
+/** Let every settled promise run its continuations. cpApiGet awaits the API
+ *  base before it reaches the client, so one tick is not enough. */
+const flush = async () => {
+  for (let i = 0; i < 50; i += 1) await Promise.resolve();
+};
+
+const page = (result: unknown[]) => ({
+  data: { result, result_count: result.length },
+  status: 200,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  clearApiCache();
+});
+
+describe('collapsing identical reads that are in flight together', () => {
+  it('asks the node once when a screen asks the same question ten times', async () => {
+    const gate = deferred<ReturnType<typeof page>>();
+    mockedApiClient.get.mockReturnValue(gate.promise as never);
+
+    const callers = Array.from({ length: 10 }, () =>
+      fetchMempoolLedgerEvents(['1AddressAAAAAAAAAAAAAAAAAAAAAAAAAA']),
+    );
+    // Let every caller reach the client before anything resolves.
+    await flush();
+
+    expect(mockedApiClient.get).toHaveBeenCalledTimes(1);
+
+    gate.settle(page([{ tx_hash: 'a', event: 'CREDIT' }]));
+    const results = await Promise.all(callers);
+
+    // Every caller gets the answer, not just the one that happened to be first.
+    expect(results).toHaveLength(10);
+    for (const r of results) expect(r.result).toHaveLength(1);
+  });
+
+  it('keeps different questions apart', async () => {
+    mockedApiClient.get.mockResolvedValue(page([]) as never);
+
+    await Promise.all([
+      fetchMempoolLedgerEvents(['1AddressAAAAAAAAAAAAAAAAAAAAAAAAAA']),
+      fetchMempoolLedgerEvents(['1AddressBBBBBBBBBBBBBBBBBBBBBBBBBB']),
+    ]);
+
+    expect(mockedApiClient.get).toHaveBeenCalledTimes(2);
+  });
+
+  it('shares work rather than storing it: a failure is not remembered', async () => {
+    const first = deferred<ReturnType<typeof page>>();
+    mockedApiClient.get.mockReturnValueOnce(first.promise as never);
+    mockedApiClient.get.mockResolvedValue(page([]) as never);
+
+    const failing = fetchMempoolLedgerEvents(['1AddressAAAAAAAAAAAAAAAAAAAAAAAAAA']);
+    // Registered before the rejection so it is never an unhandled one.
+    const rejects = expect(failing).rejects.toThrow();
+    await flush();
+    first.fail(new Error('socket closed'));
+    await rejects;
+
+    // The next caller asks again rather than inheriting the failure.
+    await fetchMempoolLedgerEvents(['1AddressAAAAAAAAAAAAAAAAAAAAAAAAAA']);
+    expect(mockedApiClient.get).toHaveBeenCalledTimes(2);
+  });
+
+  it('collapses a skipCache read into the request already on its way', async () => {
+    // Skipping the cache means "not a stored answer from a minute ago", not
+    // "open a second socket beside the identical request already in the air".
+    const gate = deferred<ReturnType<typeof page>>();
+    mockedApiClient.get.mockReturnValue(gate.promise as never);
+
+    const callers = [
+      fetchTokenBalances('1AddressAAAAAAAAAAAAAAAAAAAAAAAAAA'),
+      fetchTokenBalances('1AddressAAAAAAAAAAAAAAAAAAAAAAAAAA'),
+    ];
+    await flush();
+
+    expect(mockedApiClient.get).toHaveBeenCalledTimes(1);
+    gate.settle(page([]));
+    await Promise.all(callers);
+  });
+});
+
+describe('invalidation reaches requests that are still in the air', () => {
+  it('does not hand a post-mutation caller an answer that predates the mutation', async () => {
+    const before = deferred<ReturnType<typeof page>>();
+    mockedApiClient.get.mockReturnValueOnce(before.promise as never);
+    mockedApiClient.get.mockResolvedValue(page([{ tx_hash: 'after', event: 'CREDIT' }]) as never);
+
+    const inFlight = fetchMempoolLedgerEvents(['1AddressAAAAAAAAAAAAAAAAAAAAAAAAAA']);
+    await flush();
+    expect(mockedApiClient.get).toHaveBeenCalledTimes(1);
+
+    // A send broadcasts here. The read already on its way was sent before it,
+    // so its answer cannot contain it.
+    clearApiCache();
+
+    const afterMutation = fetchMempoolLedgerEvents(['1AddressAAAAAAAAAAAAAAAAAAAAAAAAAA']);
+    await flush();
+    expect(mockedApiClient.get).toHaveBeenCalledTimes(2);
+
+    before.settle(page([]));
+    // The original caller still gets its own answer; nothing was cancelled.
+    await expect(inFlight).resolves.toBeDefined();
+    await expect(afterMutation).resolves.toBeDefined();
+  });
+
+  it('narrows to the address being invalidated', async () => {
+    mockedApiClient.get.mockResolvedValue(page([]) as never);
+    const A = '1AddressAAAAAAAAAAAAAAAAAAAAAAAAAA';
+    const B = '1AddressBBBBBBBBBBBBBBBBBBBBBBBBBB';
+
+    await fetchMempoolLedgerEvents([A]);
+    await fetchMempoolLedgerEvents([B]);
+    expect(mockedApiClient.get).toHaveBeenCalledTimes(2);
+
+    // Both answers are stored, so neither is asked again.
+    await fetchMempoolLedgerEvents([A]);
+    await fetchMempoolLedgerEvents([B]);
+    expect(mockedApiClient.get).toHaveBeenCalledTimes(2);
+
+    clearApiCacheMatching(A);
+
+    // Only A was invalidated, so only A goes back to the node.
+    await fetchMempoolLedgerEvents([A]);
+    await fetchMempoolLedgerEvents([B]);
+    expect(mockedApiClient.get).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/core/counterparty/__tests__/requestCoalescing.test.ts
+++ b/src/core/counterparty/__tests__/requestCoalescing.test.ts
@@ -1,8 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { apiClient } from '@/core/api/client';
+import { CounterpartyApiError } from '@/core/errors';
 import {
   clearApiCache,
   clearApiCacheMatching,
+  fetchAssetDetails,
   fetchMempoolLedgerEvents,
   fetchTokenBalances,
 } from '../api';
@@ -61,6 +63,28 @@ beforeEach(() => {
 });
 
 describe('collapsing identical reads that are in flight together', () => {
+  it('preserves the API error contract for every caller sharing a missing-asset lookup', async () => {
+    const pending = deferred<ReturnType<typeof page>>();
+    mockedApiClient.get.mockReturnValueOnce(pending.promise as never);
+    const results = Promise.allSettled([
+      fetchAssetDetails('NEWASSET'),
+      fetchAssetDetails('NEWASSET'),
+    ]);
+    await flush();
+    expect(mockedApiClient.get).toHaveBeenCalledTimes(1);
+    pending.fail(Object.assign(new Error('Request failed with status 404'), {
+      status: 404,
+      response: { status: 404, data: { error: 'Asset not found' } },
+    }));
+    for (const result of await results) {
+      expect(result.status).toBe('rejected');
+      if (result.status === 'rejected') {
+        expect(result.reason).toBeInstanceOf(CounterpartyApiError);
+        expect(result.reason).toMatchObject({ statusCode: 404, message: 'Asset not found' });
+      }
+    }
+  });
+
   it('asks the node once when a screen asks the same question ten times', async () => {
     const gate = deferred<ReturnType<typeof page>>();
     mockedApiClient.get.mockReturnValue(gate.promise as never);

--- a/src/core/counterparty/__tests__/requestGate.test.ts
+++ b/src/core/counterparty/__tests__/requestGate.test.ts
@@ -59,7 +59,7 @@ describe('RequestGate', () => {
 
   it('waits out Retry-After after a refusal, then sends the refused request again', async () => {
     const clock = fakeClock();
-    const gate = new RequestGate({ now: clock.now, sleep: clock.sleep, random: () => 1 });
+    const gate = new RequestGate({ now: clock.now, sleep: clock.sleep, random: () => 0 });
     let calls = 0;
     const request = async () => {
       calls += 1;
@@ -83,7 +83,7 @@ describe('RequestGate', () => {
 
   it('holds every other request during the cooldown too', async () => {
     const clock = fakeClock();
-    const gate = new RequestGate({ now: clock.now, sleep: clock.sleep, random: () => 1 });
+    const gate = new RequestGate({ now: clock.now, sleep: clock.sleep, random: () => 0 });
     let refusedOnce = false;
     const first = gate.run(async () => {
       if (!refusedOnce) {
@@ -109,7 +109,7 @@ describe('RequestGate', () => {
 
   it('backs off longer while refusals continue, and gives up after the retries', async () => {
     const clock = fakeClock();
-    const gate = new RequestGate({ defaultCooldownMs: 1_000, maxRetries: 2, now: clock.now, sleep: clock.sleep });
+    const gate = new RequestGate({ defaultCooldownMs: 1_000, maxRetries: 2, now: clock.now, sleep: clock.sleep, random: () => 0 });
     let calls = 0;
     const alwaysRefused = gate.run(async () => {
       calls += 1;
@@ -128,17 +128,19 @@ describe('RequestGate', () => {
     await expect(alwaysRefused).rejects.toThrow('429');
   });
 
-  it('never holds longer than the ceiling, whatever the node asked for', async () => {
+  it('never caps a server deadline at the default-backoff ceiling', async () => {
     const clock = fakeClock();
-    const gate = new RequestGate({ maxCooldownMs: 10_000, now: clock.now, sleep: clock.sleep });
+    const gate = new RequestGate({ maxCooldownMs: 10_000, now: clock.now, sleep: clock.sleep, random: () => 0 });
     let calls = 0;
     const result = gate.run(async () => {
       calls += 1;
-      if (calls === 1) throw new Error('429 3600000');
+      if (calls === 1) throw new Error('429 60000');
       return 'ok';
     }, refused);
     await flush();
-    await clock.advance(10_000);
+    await clock.advance(59_999);
+    expect(calls).toBe(1);
+    await clock.advance(1);
     expect(calls).toBe(2);
     await expect(result).resolves.toBe('ok');
   });
@@ -147,6 +149,31 @@ describe('RequestGate', () => {
     const gate = new RequestGate();
     await expect(gate.run(async () => { throw new Error('500'); }, refused)).rejects.toThrow('500');
     expect(gate.coolingDown).toBe(false);
+  });
+
+  it('splits a long timer without shortening the server deadline', async () => {
+    const clock = fakeClock();
+    const sleeps: number[] = [];
+    const gate = new RequestGate({
+      now: clock.now,
+      sleep: ms => { sleeps.push(ms); return clock.sleep(ms); },
+      random: () => 0,
+    });
+    let calls = 0;
+    const delay = 2_147_483_647 + 60_000;
+    const result = gate.run(async () => {
+      if (++calls === 1) throw new Error(`429 ${delay}`);
+      return 'ok';
+    }, refused);
+    await flush();
+    expect(sleeps).toEqual([2_147_483_647]);
+    await clock.advance(2_147_483_647);
+    expect(calls).toBe(1);
+    expect(sleeps).toEqual([2_147_483_647, 60_000]);
+    await clock.advance(59_999);
+    expect(calls).toBe(1);
+    await clock.advance(1);
+    await expect(result).resolves.toBe('ok');
   });
 
   it('spreads a cooldown so a refused wave does not return as a wave', async () => {
@@ -166,8 +193,8 @@ describe('RequestGate', () => {
 
       // Stepped rather than a while on `calls`: the counter changes inside the
       // request, which the loop body cannot see it doing.
-      let waited = 8_000;
-      for (let step = 100; step <= 8_000; step += 100) {
+      let waited = 12_000;
+      for (let step = 100; step <= 12_000; step += 100) {
         await clock.advance(100);
         if (calls >= 2) {
           waited = step;
@@ -178,13 +205,8 @@ describe('RequestGate', () => {
       waits.push(waited);
     }
 
-    // Never longer than the node asked for, never less than half of it, and
-    // genuinely different across rolls.
-    for (const w of waits) {
-      expect(w).toBeLessThanOrEqual(8_000);
-      expect(w).toBeGreaterThanOrEqual(4_000);
-    }
-    expect(new Set(waits).size).toBeGreaterThan(1);
+    // Every roll waits the full server delay; jitter only adds time after it.
+    expect(waits).toEqual([8_000, 10_000, 12_000]);
   });
 
   it('defaults to the concurrency the node actually rewards', async () => {

--- a/src/core/counterparty/__tests__/requestGate.test.ts
+++ b/src/core/counterparty/__tests__/requestGate.test.ts
@@ -59,7 +59,7 @@ describe('RequestGate', () => {
 
   it('waits out Retry-After after a refusal, then sends the refused request again', async () => {
     const clock = fakeClock();
-    const gate = new RequestGate({ now: clock.now, sleep: clock.sleep });
+    const gate = new RequestGate({ now: clock.now, sleep: clock.sleep, random: () => 1 });
     let calls = 0;
     const request = async () => {
       calls += 1;
@@ -83,7 +83,7 @@ describe('RequestGate', () => {
 
   it('holds every other request during the cooldown too', async () => {
     const clock = fakeClock();
-    const gate = new RequestGate({ now: clock.now, sleep: clock.sleep });
+    const gate = new RequestGate({ now: clock.now, sleep: clock.sleep, random: () => 1 });
     let refusedOnce = false;
     const first = gate.run(async () => {
       if (!refusedOnce) {
@@ -147,5 +147,71 @@ describe('RequestGate', () => {
     const gate = new RequestGate();
     await expect(gate.run(async () => { throw new Error('500'); }, refused)).rejects.toThrow('500');
     expect(gate.coolingDown).toBe(false);
+  });
+
+  it('spreads a cooldown so a refused wave does not return as a wave', async () => {
+    // Everything queued was refused at the same instant. Without jitter every
+    // one of them wakes at the same instant too, and re-earns the refusal.
+    const waits: number[] = [];
+    for (const roll of [0, 0.5, 1]) {
+      const clock = fakeClock();
+      const gate = new RequestGate({ now: clock.now, sleep: clock.sleep, random: () => roll });
+      let calls = 0;
+      const result = gate.run(async () => {
+        calls += 1;
+        if (calls === 1) throw new Error('429 8000');
+        return 'ok';
+      }, refused);
+      await flush();
+
+      // Stepped rather than a while on `calls`: the counter changes inside the
+      // request, which the loop body cannot see it doing.
+      let waited = 8_000;
+      for (let step = 100; step <= 8_000; step += 100) {
+        await clock.advance(100);
+        if (calls >= 2) {
+          waited = step;
+          break;
+        }
+      }
+      await expect(result).resolves.toBe('ok');
+      waits.push(waited);
+    }
+
+    // Never longer than the node asked for, never less than half of it, and
+    // genuinely different across rolls.
+    for (const w of waits) {
+      expect(w).toBeLessThanOrEqual(8_000);
+      expect(w).toBeGreaterThanOrEqual(4_000);
+    }
+    expect(new Set(waits).size).toBeGreaterThan(1);
+  });
+
+  it('defaults to the concurrency the node actually rewards', async () => {
+    // Measured: one in flight returns ~2.5 useful responses a second, two ~2.0,
+    // four or more returns nothing but 429s. A third parallel request is not a
+    // tuning preference, it is spending budget for no throughput.
+    const clock = fakeClock();
+    const gate = new RequestGate({ now: clock.now, sleep: clock.sleep });
+    const started: number[] = [];
+    const finish: Array<() => void> = [];
+    const request = (id: number) => () =>
+      new Promise<number>((resolve) => {
+        started.push(id);
+        finish.push(() => resolve(id));
+      });
+
+    const results = Promise.all([1, 2, 3, 4].map((id) => gate.run(request(id), refused)));
+    await flush();
+    expect(started).toEqual([1, 2]);
+
+    finish[0]!();
+    finish[1]!();
+    await flush();
+    expect(started).toEqual([1, 2, 3, 4]);
+
+    finish[2]!();
+    finish[3]!();
+    await expect(results).resolves.toEqual([1, 2, 3, 4]);
   });
 });

--- a/src/core/counterparty/__tests__/requestGate.test.ts
+++ b/src/core/counterparty/__tests__/requestGate.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+import { type RateLimitRefusal, RequestGate } from '@/core/counterparty/requestGate';
+
+/** A clock the test advances, and a sleep that parks until the clock reaches its due time. */
+function fakeClock() {
+  let time = 0;
+  const timers: Array<{ due: number; wake: () => void }> = [];
+  return {
+    now: () => time,
+    sleep: (ms: number) => new Promise<void>((wake) => timers.push({ due: time + ms, wake })),
+    async advance(ms: number) {
+      time += ms;
+      for (const timer of timers.splice(0)) {
+        if (timer.due <= time) timer.wake();
+        else timers.push(timer);
+      }
+      await flush();
+    },
+  };
+}
+
+/** Let every settled promise run its continuations. */
+const flush = async () => {
+  for (let i = 0; i < 20; i += 1) await Promise.resolve();
+};
+
+const refused = (error: unknown): RateLimitRefusal | null =>
+  error instanceof Error && error.message.startsWith('429') ? { retryAfterMs: Number(error.message.slice(4)) || undefined } : null;
+
+describe('RequestGate', () => {
+  it('lets only a few requests run at once and releases the rest in order', async () => {
+    const clock = fakeClock();
+    const gate = new RequestGate({ maxInFlight: 3, now: clock.now, sleep: clock.sleep });
+    const started: number[] = [];
+    const finish: Array<() => void> = [];
+    const request = (id: number) => () =>
+      new Promise<number>((resolve) => {
+        started.push(id);
+        finish.push(() => resolve(id));
+      });
+
+    const results = Promise.all([1, 2, 3, 4, 5].map((id) => gate.run(request(id), refused)));
+    await flush();
+    expect(started).toEqual([1, 2, 3]);
+
+    finish[0]!();
+    await flush();
+    expect(started).toEqual([1, 2, 3, 4]);
+
+    finish[1]!();
+    finish[2]!();
+    await flush();
+    expect(started).toEqual([1, 2, 3, 4, 5]);
+
+    finish[3]!();
+    finish[4]!();
+    await expect(results).resolves.toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('waits out Retry-After after a refusal, then sends the refused request again', async () => {
+    const clock = fakeClock();
+    const gate = new RequestGate({ now: clock.now, sleep: clock.sleep });
+    let calls = 0;
+    const request = async () => {
+      calls += 1;
+      if (calls === 1) throw new Error('429 5000');
+      return 'ok';
+    };
+
+    const result = gate.run(request, refused);
+    await flush();
+    expect(calls).toBe(1);
+    expect(gate.coolingDown).toBe(true);
+
+    await clock.advance(4_999);
+    expect(calls).toBe(1);
+
+    await clock.advance(1);
+    expect(calls).toBe(2);
+    await expect(result).resolves.toBe('ok');
+    expect(gate.coolingDown).toBe(false);
+  });
+
+  it('holds every other request during the cooldown too', async () => {
+    const clock = fakeClock();
+    const gate = new RequestGate({ now: clock.now, sleep: clock.sleep });
+    let refusedOnce = false;
+    const first = gate.run(async () => {
+      if (!refusedOnce) {
+        refusedOnce = true;
+        throw new Error('429 3000');
+      }
+      return 'first';
+    }, refused);
+    await flush();
+
+    let secondSent = false;
+    const second = gate.run(async () => {
+      secondSent = true;
+      return 'second';
+    }, refused);
+    await flush();
+    expect(secondSent).toBe(false);
+
+    await clock.advance(3_000);
+    expect(secondSent).toBe(true);
+    await expect(Promise.all([first, second])).resolves.toEqual(['first', 'second']);
+  });
+
+  it('backs off longer while refusals continue, and gives up after the retries', async () => {
+    const clock = fakeClock();
+    const gate = new RequestGate({ defaultCooldownMs: 1_000, maxRetries: 2, now: clock.now, sleep: clock.sleep });
+    let calls = 0;
+    const alwaysRefused = gate.run(async () => {
+      calls += 1;
+      throw new Error('429');
+    }, refused);
+    alwaysRefused.catch(() => undefined);
+
+    await flush();
+    expect(calls).toBe(1);
+    await clock.advance(1_000); // first cooldown: the default
+    expect(calls).toBe(2);
+    await clock.advance(1_000);
+    expect(calls).toBe(2); // second cooldown doubled
+    await clock.advance(1_000);
+    expect(calls).toBe(3);
+    await expect(alwaysRefused).rejects.toThrow('429');
+  });
+
+  it('never holds longer than the ceiling, whatever the node asked for', async () => {
+    const clock = fakeClock();
+    const gate = new RequestGate({ maxCooldownMs: 10_000, now: clock.now, sleep: clock.sleep });
+    let calls = 0;
+    const result = gate.run(async () => {
+      calls += 1;
+      if (calls === 1) throw new Error('429 3600000');
+      return 'ok';
+    }, refused);
+    await flush();
+    await clock.advance(10_000);
+    expect(calls).toBe(2);
+    await expect(result).resolves.toBe('ok');
+  });
+
+  it('passes every other error straight through', async () => {
+    const gate = new RequestGate();
+    await expect(gate.run(async () => { throw new Error('500'); }, refused)).rejects.toThrow('500');
+    expect(gate.coolingDown).toBe(false);
+  });
+});

--- a/src/core/counterparty/__tests__/retryAfter.test.ts
+++ b/src/core/counterparty/__tests__/retryAfter.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/core/bitcoin/balance', () => ({ clearBalanceCache: vi.fn() }));
+vi.mock('@/core/settings', () => ({
+  getActiveSettings: () => ({ counterpartyApiBase: 'https://api.counterparty.io' }),
+}));
+
+const address = '1AddressAAAAAAAAAAAAAAAAAAAAAAAAAA';
+const start = Date.UTC(2026, 8, 7, 12);
+
+describe('Retry-After through the API client and shared request gate', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useFakeTimers();
+    vi.setSystemTime(start);
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it.each(['60', new Date(start + 60_000).toUTCString()])('preserves the full server deadline across a balance refresh: %s', async retryAfter => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response('{"error":"rate limited"}', {
+        status: 429,
+        headers: { 'Content-Type': 'application/json', 'Retry-After': retryAfter },
+      }))
+      .mockImplementation(async () => new Response('{"result":[],"result_count":0}', {
+        headers: { 'Content-Type': 'application/json' },
+      }));
+    vi.stubGlobal('fetch', fetchMock);
+    const { fetchTokenBalances } = await import('../api');
+    const { invalidateAddressBalances } = await import('@/core/balances/invalidate');
+
+    const first = fetchTokenBalances(address);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    invalidateAddressBalances(address);
+    const refreshed = fetchTokenBalances(address);
+    await vi.advanceTimersByTimeAsync(59_999);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(Promise.all([first, refreshed])).resolves.toEqual([[], []]);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(Date.now()).toBe(start + 60_000);
+  });
+
+  it.each(['1.5', '-1', '60seconds', 'not a date'])('leaves malformed Retry-After values unavailable for the default backoff: %s', async retryAfter => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('{}', {
+      status: 429,
+      headers: { 'Content-Type': 'application/json', 'Retry-After': retryAfter },
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+    const { apiClient } = await import('@/core/api/client');
+    await expect(apiClient.get('https://api.counterparty.io/v2/', { retries: 0 }))
+      .rejects.toMatchObject({ status: 429, retryAfter: undefined });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(['0', new Date(start - 60_000).toUTCString()])('treats an already elapsed deadline as zero: %s', async retryAfter => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('{}', {
+      status: 429,
+      headers: { 'Content-Type': 'application/json', 'Retry-After': retryAfter },
+    })));
+    const { apiClient } = await import('@/core/api/client');
+    await expect(apiClient.get('https://api.counterparty.io/v2/', { retries: 0 }))
+      .rejects.toMatchObject({ status: 429, retryAfter: 0 });
+  });
+});

--- a/src/core/counterparty/api.ts
+++ b/src/core/counterparty/api.ts
@@ -8,6 +8,7 @@
  */
 
 import { apiClient } from '@/core/api/client';
+import { type RateLimitRefusal, RequestGate } from '@/core/counterparty/requestGate';
 import { CounterpartyApiError } from '@/core/errors';
 import { asBaseUnits, asDisplayUnits, type BaseUnits, type DisplayUnits, toBigNumber } from '@/core/numeric';
 import { getActiveSettings } from '@/core/settings';
@@ -29,6 +30,32 @@ interface CacheEntry<T> {
 }
 
 const cache = new Map<string, CacheEntry<unknown>>();
+
+// =============================================================================
+// PACE
+// =============================================================================
+
+/**
+ * Every Counterparty read goes through one gate, so a screen that asks ten questions at once is
+ * answered a few at a time, and a node that says 429 is obeyed by everyone until its Retry-After
+ * passes. See `requestGate.ts` for why.
+ */
+const requestGate = new RequestGate();
+
+/** A 429 from the API client, with the wait the node asked for when it said. */
+function rateLimitRefusal(error: unknown): RateLimitRefusal | null {
+  if (!error || typeof error !== 'object') return null;
+  const { status, retryAfter } = error as { status?: unknown; retryAfter?: unknown };
+  if (status !== 429) return null;
+  return {
+    retryAfterMs: typeof retryAfter === 'number' && Number.isFinite(retryAfter) ? retryAfter * 1000 : undefined,
+  };
+}
+
+/** Forget any cooldown the node imposed: a user pressing refresh means "try again now". */
+export function resetRequestPace(): void {
+  requestGate.reset();
+}
 
 /**
  * Generate a cache key from URL and params.
@@ -549,7 +576,10 @@ async function cpApiGet<T = unknown>(
   }
 
   try {
-    const response = await apiClient.get<T | { error: string }>(url, { params: filteredParams });
+    const response = await requestGate.run(
+      () => apiClient.get<T | { error: string }>(url, { params: filteredParams }),
+      rateLimitRefusal
+    );
 
     if (response.data && typeof response.data === 'object' && 'error' in response.data) {
       throw new CounterpartyApiError(

--- a/src/core/counterparty/api.ts
+++ b/src/core/counterparty/api.ts
@@ -109,11 +109,43 @@ function setInCache<T>(key: string, data: T): void {
 }
 
 /**
+ * The reads that have been sent and not yet answered, by cache key.
+ *
+ * The response cache above can only collapse a repeat once the first answer is
+ * back. It does nothing for the case that actually produces a 429 storm: a
+ * screen mounting and asking the same question several times in the same tick.
+ * Every one of those misses the empty cache and every one goes to the node.
+ *
+ * That is not hypothetical here. The refusals that started this work were
+ * seventy-odd 429s for a single URL — `/v2/addresses/mempool` for one address
+ * with one event filter — which is one question asked many times at once, not
+ * many questions. `fetchMempoolLedgerEvents` even documents the intent:
+ * "several parts of a screen ask this at once ... collapsing those into one
+ * call matters more than a few seconds of freshness." The cache could not
+ * deliver that. This does.
+ *
+ * The entry is dropped as soon as the request settles, so this shares work
+ * rather than storing it: a caller never receives an answer older than one it
+ * would have fetched itself, and a failure is never remembered. How long an
+ * answer stays good remains the response cache's business.
+ *
+ * `skipCache` callers join too, and should. Asking to skip the cache means
+ * "not a stored answer from up to a minute ago", not "open a second socket
+ * alongside the identical request already in the air".
+ */
+const inFlight = new Map<string, Promise<unknown>>();
+
+/**
  * Clear the API cache. Call after mutations (send, create order, etc.)
  * to ensure fresh data on next read.
  */
 export function clearApiCache(): void {
   cache.clear();
+  // A read already on its way was sent before the mutation, so its answer will
+  // not contain it. Dropping the entry does not cancel that request — its own
+  // caller still gets it — but it stops anyone who asks next from joining an
+  // answer that predates the thing they are refreshing to see.
+  inFlight.clear();
 }
 
 /**
@@ -123,6 +155,12 @@ export function clearApiCacheMatching(pattern: string): void {
   for (const key of cache.keys()) {
     if (key.includes(pattern)) {
       cache.delete(key);
+    }
+  }
+  // Same reasoning as clearApiCache, narrowed to the keys being invalidated.
+  for (const key of inFlight.keys()) {
+    if (key.includes(pattern)) {
+      inFlight.delete(key);
     }
   }
 }
@@ -575,7 +613,12 @@ async function cpApiGet<T = unknown>(
     }
   }
 
-  try {
+  // Join a request for the same thing that is already on its way, rather than
+  // opening a second one beside it.
+  const running = inFlight.get(cacheKey) as Promise<T> | undefined;
+  if (running) return running;
+
+  const started = (async () => {
     const response = await requestGate.run(
       () => apiClient.get<T | { error: string }>(url, { params: filteredParams }),
       rateLimitRefusal
@@ -593,6 +636,12 @@ async function cpApiGet<T = unknown>(
     setInCache(cacheKey, response.data as T);
 
     return response.data as T;
+  })();
+
+  inFlight.set(cacheKey, started);
+
+  try {
+    return await started;
   } catch (error: unknown) {
     if (error instanceof CounterpartyApiError) throw error;
 
@@ -609,6 +658,10 @@ async function cpApiGet<T = unknown>(
     throw new CounterpartyApiError(message, path, {
       cause: error instanceof Error ? error : undefined,
     });
+  } finally {
+    // Only clear our own entry: a later caller may already have started the
+    // next request under the same key.
+    if (inFlight.get(cacheKey) === started) inFlight.delete(cacheKey);
   }
 }
 

--- a/src/core/counterparty/api.ts
+++ b/src/core/counterparty/api.ts
@@ -52,11 +52,6 @@ function rateLimitRefusal(error: unknown): RateLimitRefusal | null {
   };
 }
 
-/** Forget any cooldown the node imposed: a user pressing refresh means "try again now". */
-export function resetRequestPace(): void {
-  requestGate.reset();
-}
-
 /**
  * Generate a cache key from URL and params.
  * Params are sorted for consistent keys regardless of object property order.
@@ -632,16 +627,17 @@ async function cpApiGet<T = unknown>(
       );
     }
 
-    // Cache successful response
-    setInCache(cacheKey, response.data as T);
-
     return response.data as T;
   })();
 
   inFlight.set(cacheKey, started);
 
   try {
-    return await started;
+    const data = await started;
+    // Invalidation revokes ownership of this key. An older response may still
+    // reach its original caller, but cannot repopulate or overwrite the cache.
+    if (inFlight.get(cacheKey) === started) setInCache(cacheKey, data);
+    return data;
   } catch (error: unknown) {
     if (error instanceof CounterpartyApiError) throw error;
 

--- a/src/core/counterparty/api.ts
+++ b/src/core/counterparty/api.ts
@@ -628,17 +628,9 @@ async function cpApiGet<T = unknown>(
     }
 
     return response.data as T;
-  })();
-
-  inFlight.set(cacheKey, started);
-
-  try {
-    const data = await started;
-    // Invalidation revokes ownership of this key. An older response may still
-    // reach its original caller, but cannot repopulate or overwrite the cache.
-    if (inFlight.get(cacheKey) === started) setInCache(cacheKey, data);
-    return data;
-  } catch (error: unknown) {
+  })().catch((error: unknown) => {
+    // Normalize inside the shared promise so joined callers receive the same
+    // error type and status (including the 404 used by new-asset issuance).
     if (error instanceof CounterpartyApiError) throw error;
 
     // Handle errors with response data
@@ -654,6 +646,16 @@ async function cpApiGet<T = unknown>(
     throw new CounterpartyApiError(message, path, {
       cause: error instanceof Error ? error : undefined,
     });
+  });
+
+  inFlight.set(cacheKey, started);
+
+  try {
+    const data = await started;
+    // Invalidation revokes ownership of this key. An older response may still
+    // reach its original caller, but cannot repopulate or overwrite the cache.
+    if (inFlight.get(cacheKey) === started) setInCache(cacheKey, data);
+    return data;
   } finally {
     // Only clear our own entry: a later caller may already have started the
     // next request under the same key.

--- a/src/core/counterparty/requestGate.ts
+++ b/src/core/counterparty/requestGate.ts
@@ -26,6 +26,13 @@ export interface RateLimitRefusal {
 export interface RequestGateOptions {
   /** Requests allowed in flight at once. */
   maxInFlight?: number;
+  /**
+   * Fraction of a cooldown that is randomised away, 0 to 1. Defaults to 0.5,
+   * so a wait lands somewhere in the second half of what was asked for.
+   */
+  jitter?: number;
+  /** Injectable for tests; defaults to Math.random. */
+  random?: () => number;
   /** The wait after a refusal that carried no Retry-After; doubles per consecutive refusal. */
   defaultCooldownMs?: number;
   /** The longest the gate will ever hold requests, whatever the node asked for. */
@@ -41,6 +48,8 @@ export class RequestGate {
   private readonly defaultCooldownMs: number;
   private readonly maxCooldownMs: number;
   private readonly maxRetries: number;
+  private readonly jitter: number;
+  private readonly random: () => number;
   private readonly now: () => number;
   private readonly sleep: (ms: number) => Promise<void>;
 
@@ -50,7 +59,15 @@ export class RequestGate {
   private refusalsInARow = 0;
 
   constructor(options: RequestGateOptions = {}) {
-    this.maxInFlight = options.maxInFlight ?? 3;
+    // Measured against api.counterparty.io by sustaining load and counting what
+    // came back: one request in flight returns ~2.5 useful responses a second,
+    // two returns ~2.0, and four or more returns nothing at all — every reply
+    // is a 429. Useful throughput does not rise with concurrency there, it
+    // collapses, so a third parallel request buys the wallet no speed and
+    // costs it the budget the next screen needs.
+    this.maxInFlight = options.maxInFlight ?? 2;
+    this.jitter = Math.min(Math.max(options.jitter ?? 0.5, 0), 1);
+    this.random = options.random ?? Math.random;
     this.defaultCooldownMs = options.defaultCooldownMs ?? 2_000;
     this.maxCooldownMs = options.maxCooldownMs ?? 30_000;
     this.maxRetries = options.maxRetries ?? 2;
@@ -99,7 +116,13 @@ export class RequestGate {
     const backoff = this.defaultCooldownMs * 2 ** (this.refusalsInARow - 1);
     const asked = refusal.retryAfterMs;
     const wait = asked !== undefined && Number.isFinite(asked) && asked >= 0 ? asked : backoff;
-    this.holdUntil = Math.max(this.holdUntil, this.now() + Math.min(wait, this.maxCooldownMs));
+    const capped = Math.min(wait, this.maxCooldownMs);
+    // Everything the wallet had queued was refused at the same moment, so
+    // without this they all return at the same moment and earn the refusal
+    // again. Jitter only ever shortens the wait, and never below half of it,
+    // so the node's Retry-After is still substantially honoured.
+    const spread = capped * (1 - this.jitter + this.jitter * this.random());
+    this.holdUntil = Math.max(this.holdUntil, this.now() + spread);
   }
 
   private async waitForCooldown(): Promise<void> {

--- a/src/core/counterparty/requestGate.ts
+++ b/src/core/counterparty/requestGate.ts
@@ -1,0 +1,131 @@
+/**
+ * The pace the wallet asks a Counterparty node at.
+ *
+ * The public node meters requests per client. A home-screen visit is ten reads
+ * at once (the mempool, the UTXO check, owned assets, one per pinned asset, the
+ * first balances page), and flipping between addresses repeats the burst. The
+ * node answers with 429 and every list goes empty, because nothing slowed down
+ * and nothing tried again. Two rules keep the wallet inside the budget, and both
+ * live here so no screen has to think about it:
+ *
+ * - at most a few requests in flight at once; the rest wait their turn in order;
+ * - when the node says stop, everyone waits out its Retry-After (or a default
+ *   that grows while refusals continue) before anyone sends again, and the
+ *   request that was refused is sent again after the wait.
+ *
+ * Pure: no fetch, no API shapes. The caller hands in the function that performs
+ * one request and a predicate that recognises a rate-limit refusal, so this can
+ * be tested with a clock and a counter.
+ */
+
+/** A refusal the node explained: how long it asked us to wait, when it said. */
+export interface RateLimitRefusal {
+  retryAfterMs?: number;
+}
+
+export interface RequestGateOptions {
+  /** Requests allowed in flight at once. */
+  maxInFlight?: number;
+  /** The wait after a refusal that carried no Retry-After; doubles per consecutive refusal. */
+  defaultCooldownMs?: number;
+  /** The longest the gate will ever hold requests, whatever the node asked for. */
+  maxCooldownMs?: number;
+  /** How many times one request is sent again after being refused. */
+  maxRetries?: number;
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export class RequestGate {
+  private readonly maxInFlight: number;
+  private readonly defaultCooldownMs: number;
+  private readonly maxCooldownMs: number;
+  private readonly maxRetries: number;
+  private readonly now: () => number;
+  private readonly sleep: (ms: number) => Promise<void>;
+
+  private inFlight = 0;
+  private readonly waiting: Array<() => void> = [];
+  private holdUntil = 0;
+  private refusalsInARow = 0;
+
+  constructor(options: RequestGateOptions = {}) {
+    this.maxInFlight = options.maxInFlight ?? 3;
+    this.defaultCooldownMs = options.defaultCooldownMs ?? 2_000;
+    this.maxCooldownMs = options.maxCooldownMs ?? 30_000;
+    this.maxRetries = options.maxRetries ?? 2;
+    this.now = options.now ?? (() => Date.now());
+    this.sleep = options.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
+  }
+
+  /**
+   * Perform one request under the gate: take a slot, wait out any cooldown,
+   * send, and on a refusal note the cooldown and send again after it.
+   */
+  async run<T>(request: () => Promise<T>, refusal: (error: unknown) => RateLimitRefusal | null): Promise<T> {
+    for (let attempt = 0; ; attempt += 1) {
+      // The slot is taken before the cooldown wait, so a burst that arrives during a cooldown
+      // is still released a few at a time once it ends, never all at once.
+      await this.acquire();
+      try {
+        await this.waitForCooldown();
+        const result = await request();
+        this.refusalsInARow = 0;
+        return result;
+      } catch (error) {
+        const refused = refusal(error);
+        if (!refused) throw error;
+        this.noteRefusal(refused);
+        if (attempt >= this.maxRetries) throw error;
+      } finally {
+        this.release();
+      }
+    }
+  }
+
+  /** Whether the node has asked us to wait and the wait is not over. */
+  get coolingDown(): boolean {
+    return this.holdUntil > this.now();
+  }
+
+  /** Forget refusals and any cooldown: for tests, and for a user who insists on trying now. */
+  reset(): void {
+    this.holdUntil = 0;
+    this.refusalsInARow = 0;
+  }
+
+  private noteRefusal(refusal: RateLimitRefusal): void {
+    this.refusalsInARow += 1;
+    const backoff = this.defaultCooldownMs * 2 ** (this.refusalsInARow - 1);
+    const asked = refusal.retryAfterMs;
+    const wait = asked !== undefined && Number.isFinite(asked) && asked >= 0 ? asked : backoff;
+    this.holdUntil = Math.max(this.holdUntil, this.now() + Math.min(wait, this.maxCooldownMs));
+  }
+
+  private async waitForCooldown(): Promise<void> {
+    for (;;) {
+      const remaining = this.holdUntil - this.now();
+      if (remaining <= 0) return;
+      await this.sleep(remaining);
+    }
+  }
+
+  private acquire(): Promise<void> {
+    if (this.inFlight < this.maxInFlight) {
+      this.inFlight += 1;
+      return Promise.resolve();
+    }
+    return new Promise((resolve) => {
+      this.waiting.push(() => {
+        this.inFlight += 1;
+        resolve();
+      });
+    });
+  }
+
+  private release(): void {
+    this.inFlight -= 1;
+    const next = this.waiting.shift();
+    if (next) next();
+  }
+}

--- a/src/core/counterparty/requestGate.ts
+++ b/src/core/counterparty/requestGate.ts
@@ -27,15 +27,15 @@ export interface RequestGateOptions {
   /** Requests allowed in flight at once. */
   maxInFlight?: number;
   /**
-   * Fraction of a cooldown that is randomised away, 0 to 1. Defaults to 0.5,
-   * so a wait lands somewhere in the second half of what was asked for.
+   * Additional fraction of a cooldown to randomise, 0 to 1. Defaults to 0.5.
+   * Jitter only adds time after the full server deadline.
    */
   jitter?: number;
   /** Injectable for tests; defaults to Math.random. */
   random?: () => number;
   /** The wait after a refusal that carried no Retry-After; doubles per consecutive refusal. */
   defaultCooldownMs?: number;
-  /** The longest the gate will ever hold requests, whatever the node asked for. */
+  /** Ceiling for generated backoff before jitter; never caps a server deadline. */
   maxCooldownMs?: number;
   /** How many times one request is sent again after being refused. */
   maxRetries?: number;
@@ -105,23 +105,17 @@ export class RequestGate {
     return this.holdUntil > this.now();
   }
 
-  /** Forget refusals and any cooldown: for tests, and for a user who insists on trying now. */
-  reset(): void {
-    this.holdUntil = 0;
-    this.refusalsInARow = 0;
-  }
-
   private noteRefusal(refusal: RateLimitRefusal): void {
     this.refusalsInARow += 1;
     const backoff = this.defaultCooldownMs * 2 ** (this.refusalsInARow - 1);
     const asked = refusal.retryAfterMs;
-    const wait = asked !== undefined && Number.isFinite(asked) && asked >= 0 ? asked : backoff;
-    const capped = Math.min(wait, this.maxCooldownMs);
+    const wait = asked !== undefined && Number.isFinite(asked) && asked >= 0
+      ? asked
+      : Math.min(backoff, this.maxCooldownMs);
     // Everything the wallet had queued was refused at the same moment, so
     // without this they all return at the same moment and earn the refusal
-    // again. Jitter only ever shortens the wait, and never below half of it,
-    // so the node's Retry-After is still substantially honoured.
-    const spread = capped * (1 - this.jitter + this.jitter * this.random());
+    // again. Jitter only adds time: Retry-After is a minimum server deadline.
+    const spread = wait * (1 + this.jitter * this.random());
     this.holdUntil = Math.max(this.holdUntil, this.now() + spread);
   }
 
@@ -129,7 +123,9 @@ export class RequestGate {
     for (;;) {
       const remaining = this.holdUntil - this.now();
       if (remaining <= 0) return;
-      await this.sleep(remaining);
+      // Long server deadlines must not overflow the platform's signed 32-bit
+      // timer delay. Sleeping in chunks preserves the complete deadline.
+      await this.sleep(Math.min(remaining, 2_147_483_647));
     }
   }
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -39,6 +39,11 @@ export default function HomePage(): ReactElement {
   const location = useLocation();
   const [searchParams, setSearchParams] = useSearchParams();
   const activeTab = (searchParams.get("tab") as "Assets" | "Balances" | "UTXOs") || "Balances";
+  // A list mounts the first time its tab is looked at and stays mounted after. Hidden tabs cost
+  // no requests on arrival — three lists loading at once was a third of the burst that gets the
+  // public node's 429 — and switching back costs none either.
+  const [visitedTabs, setVisitedTabs] = useState<ReadonlySet<string>>(() => new Set([activeTab]));
+  if (!visitedTabs.has(activeTab)) setVisitedTabs(new Set(visitedTabs).add(activeTab));
   const [copiedToClipboard, setCopiedToClipboard] = useState(false);
   const [hasUtxos, setHasUtxos] = useState(false);
   const [utxoCheckDone, setUtxoCheckDone] = useState(false);
@@ -276,13 +281,17 @@ export default function HomePage(): ReactElement {
         <div className="p-4 pb-0 flex-shrink-0">
           {content}
         </div>
-        <div className="flex-grow overflow-y-auto no-scrollbar px-4 pb-4" style={{ display: activeTab === "Balances" ? "block" : "none" }}>
-          <BalanceList refreshNonce={refreshNonces.Balances} onRefreshed={stopRefreshing} />
-        </div>
-        <div className="flex-grow overflow-y-auto no-scrollbar px-4 pb-4" style={{ display: activeTab === "Assets" ? "block" : "none" }}>
-          <AssetList refreshNonce={refreshNonces.Assets} onRefreshed={stopRefreshing} />
-        </div>
-        {hasUtxos && (
+        {visitedTabs.has("Balances") && (
+          <div className="flex-grow overflow-y-auto no-scrollbar px-4 pb-4" style={{ display: activeTab === "Balances" ? "block" : "none" }}>
+            <BalanceList refreshNonce={refreshNonces.Balances} onRefreshed={stopRefreshing} />
+          </div>
+        )}
+        {visitedTabs.has("Assets") && (
+          <div className="flex-grow overflow-y-auto no-scrollbar px-4 pb-4" style={{ display: activeTab === "Assets" ? "block" : "none" }}>
+            <AssetList refreshNonce={refreshNonces.Assets} onRefreshed={stopRefreshing} />
+          </div>
+        )}
+        {hasUtxos && visitedTabs.has("UTXOs") && (
           <div className="flex-grow overflow-y-auto no-scrollbar px-4 pb-4" style={{ display: activeTab === "UTXOs" ? "block" : "none" }}>
             <UtxoList refreshNonce={refreshNonces.UTXOs} onRefreshed={stopRefreshing} />
           </div>


### PR DESCRIPTION
Public Counterparty nodes reject bursts of duplicate wallet reads with 429 responses. The wallet now shares identical requests already in flight, limits Counterparty read concurrency to two, and retries refused reads only after the server's complete cooldown.

- Identical reads share one request until it settles. Failures are not cached.
- Cache invalidation revokes ownership of pending reads. Their original callers still receive their responses, but a response sent before a mutation cannot repopulate the cache or overwrite newer balances.
- Retry-After supports both delay-seconds and HTTP-date values. Jitter adds time after the full server deadline; the default-backoff ceiling never shortens that deadline. Long timer waits are split without shortening the wait.
- Manual balance refresh clears cached data while preserving the shared rate-limit cooldown. The refused request and subsequent reads continue through the same gate.
- Missing or malformed Retry-After values use bounded exponential backoff. Existing request retry limits and non-rate-limit error handling remain in place.

Validation at the updated head:

- 1,391 tests passed across Counterparty, balances, and API-client suites; 51 existing skips.
- Deterministic regressions cover old response A finishing after refreshed response B, both full and matching cache invalidation, the complete 60-second deadline through the real API client and gate, HTTP-date parsing, balance refresh during cooldown, positive-only jitter, malformed headers, elapsed deadlines, and long timer waits.
- TypeScript, repository lint, and the production Chrome extension build passed. Lint retained the existing 498 warning/error budget entries; build retained the existing large-chunk warning.

The tests use fake network responses and clocks. This update does not claim a new live-node load measurement; request count, 429 frequency, recovery time, and balance freshness remain the bounded release smoke measurements.

QA correction: normalize failures inside the shared request promise so every joined caller receives CounterpartyApiError and its HTTP status. A concurrent missing-asset lookup previously gave the second caller an unwrapped API error, breaking the exact-amount issuance path's 404 handling. The new regression fails before the correction; all 90 focused request/API tests, TypeScript, and lint pass after it.

