### PR TITLE
Hide oracle dispensers from extension listings

### DIFF
--- a/src/components/domain/dispenser/dispenser-input.tsx
+++ b/src/components/domain/dispenser/dispenser-input.tsx
@@ -3,6 +3,7 @@ import { type ReactElement, useEffect, useState } from "react";
 import { DispenserList, type DispenserOption } from "@/components/ui/lists/dispenser-list";
 import { fetchAddressDispensers } from "@/core/counterparty/api";
 import type { DispenseOptions } from "@/core/counterparty/compose";
+import { isFixedRateDispenser } from "@/core/counterparty/oraclePolicy";
 import { isValidBitcoinAddress } from "@/core/validation/bitcoin";
 
 // ============================================================================
@@ -84,7 +85,8 @@ export function DispenserInput({
           verbose: true
         });
 
-        if (!response.result || response.result.length === 0) {
+        const fixedRateDispensers = (response.result ?? []).filter(isFixedRateDispenser);
+        if (fixedRateDispensers.length === 0) {
           const errorMsg = "No open dispenser found at this address.";
           setError(errorMsg);
           if (onError) onError(errorMsg);
@@ -92,7 +94,7 @@ export function DispenserInput({
         }
 
         // Process and normalize dispensers
-        const processedDispensers = (response.result as any[])
+        const processedDispensers = (fixedRateDispensers as any[])
           .map(dispenser => {
             const isDivisible = dispenser.asset_info?.divisible ?? false;
             const divisor = isDivisible ? SATOSHIS_PER_BTC : 1;

--- a/src/core/counterparty/api.ts
+++ b/src/core/counterparty/api.ts
@@ -385,6 +385,7 @@ export interface Dispenser {
   tx_hash: string;
   source: string;
   asset: string;
+  oracle_address?: string | null;
   status: number;
   give_remaining: ApiQuantity;
   give_remaining_normalized: DisplayUnits;

--- a/src/core/counterparty/dispenseOutcome.ts
+++ b/src/core/counterparty/dispenseOutcome.ts
@@ -84,7 +84,7 @@ export async function resolveDispensersAt(
   for (const d of ordered) {
     const name = d.asset_info?.asset_longname || d.asset;
 
-    if ((d as { oracle_address?: string | null }).oracle_address) {
+    if (d.oracle_address) {
       payouts.push({ asset: name, oraclePriced: true, partiallyFilled: false });
       continue;
     }

--- a/src/core/counterparty/oraclePolicy.ts
+++ b/src/core/counterparty/oraclePolicy.ts
@@ -11,6 +11,13 @@
 
 import type { SecurityWarning } from '@/core/counterparty/transactionSafety';
 
+/** Hide oracle listings before calculating prices or offering a dispenser for selection.
+ * Keep API responses unfiltered so signing checks can still detect oracle payouts.
+ */
+export function isFixedRateDispenser(dispenser: { oracle_address?: string | null }): boolean {
+  return !dispenser.oracle_address;
+}
+
 /** Refuse a dispense that would trigger an oracle-priced dispenser. */
 export function oracleDispenseWarning(oracleAssets: string[]): SecurityWarning | null {
   if (oracleAssets.length === 0) return null;

--- a/src/hooks/__tests__/useMarketData.test.ts
+++ b/src/hooks/__tests__/useMarketData.test.ts
@@ -1,0 +1,64 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as api from '@/core/counterparty/api';
+import { useMarketData } from '@/hooks/useMarketData';
+
+vi.mock('@/core/counterparty/api');
+
+function dispenser(tx_hash: string, oracle_address?: string | null) {
+  return { tx_hash, oracle_address, asset: 'XCP' } as api.DispenserDetails;
+}
+const fixed = dispenser('fixed', null);
+const oracle = dispenser('oracle', '1F6zwfr9VePPFJYFfQt9FWmMmJ1iVn1ziJ');
+const options = {
+  activeAddress: 'wallet', activeTab: 0, viewMode: 'explore' as const,
+  searchQuery: '', inView: false,
+};
+const response = (result: api.DispenserDetails[]) => ({ result, result_count: result.length });
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(api.fetchAllDispensers).mockResolvedValue(response([oracle, fixed]));
+  vi.mocked(api.fetchAddressDispensers).mockResolvedValue(response([oracle, fixed]));
+  vi.mocked(api.fetchAssetDispensers).mockResolvedValue(response([oracle, fixed]));
+  vi.mocked(api.fetchAllOrders).mockResolvedValue({ result: [], result_count: 0 });
+  vi.mocked(api.fetchOrders).mockResolvedValue({ result: [], result_count: 0 });
+});
+
+describe('dispenser visibility', () => {
+  it('excludes oracle listings from explore, manage, and asset search', async () => {
+    const { result } = renderHook(() => useMarketData(options));
+    await waitFor(() => expect(result.current.dispensers.data).toEqual([fixed]));
+    expect(result.current.userDispensers.data).toEqual([fixed]);
+    expect(result.current.filteredUserDispensers).toEqual([fixed]);
+    await act(async () => { await result.current.handleDispenserSearch('XCP'); });
+    expect(result.current.dispenserResults).toEqual([fixed]);
+  });
+
+  it.each(['explore', 'manage'] as const)('gets past an oracle-only first page in %s', async (viewMode) => {
+    const fetcher = viewMode === 'explore' ? api.fetchAllDispensers : api.fetchAddressDispensers;
+    vi.mocked(fetcher)
+      .mockResolvedValueOnce(response(Array.from({ length: 20 }, (_, i) => dispenser(`oracle-${i}`, 'feed'))))
+      .mockResolvedValueOnce(response([fixed]));
+    const { result } = renderHook(() => useMarketData({ ...options, viewMode }));
+    await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(2));
+    await waitFor(() => {
+      const page = viewMode === 'explore' ? result.current.dispensers : result.current.userDispensers;
+      expect(page.data).toEqual([fixed]);
+      expect(page.hasMore).toBe(false);
+    });
+    expect(vi.mocked(fetcher).mock.calls[1]?.at(-1)).toMatchObject({ offset: 20 });
+  });
+
+  it('uses raw row counts when loading another mixed page', async () => {
+    vi.mocked(api.fetchAllDispensers)
+      .mockResolvedValueOnce(response([fixed, ...Array.from({ length: 19 }, (_, i) => dispenser(`oracle-${i}`, 'feed'))]))
+      .mockResolvedValueOnce(response([oracle, dispenser('second', '')]));
+    const { result } = renderHook(() => useMarketData(options));
+    await waitFor(() => expect(result.current.dispensers.data).toEqual([fixed]));
+    expect(result.current.dispensers.hasMore).toBe(true);
+    act(() => result.current.dispensers.loadMore());
+    await waitFor(() => expect(result.current.dispensers.data.map(d => d.tx_hash)).toEqual(['fixed', 'second']));
+    expect(api.fetchAllDispensers).toHaveBeenLastCalledWith({ offset: 20, limit: 20, status: 'open' });
+  });
+});

--- a/src/hooks/useMarketData.ts
+++ b/src/hooks/useMarketData.ts
@@ -10,6 +10,7 @@ import {
   type Order,
   type OrderDetails,
 } from "@/core/counterparty/api";
+import { isFixedRateDispenser } from "@/core/counterparty/oraclePolicy";
 import { normalizeAssetQuery } from "@/core/format";
 import { usePaginatedFetch } from "@/hooks/usePaginatedFetch";
 
@@ -128,16 +129,38 @@ export function useMarketData({
     maxItems: MAX_ITEMS,
   });
 
+  // Filter only the displayed data; pagination must count the original API rows.
+  const visibleDispensers = useMemo(
+    () => dispensers.data.filter(isFixedRateDispenser),
+    [dispensers.data]
+  );
+  const visibleUserDispensers = useMemo(
+    () => userDispensers.data.filter(isFixedRateDispenser),
+    [userDispensers.data]
+  );
+
+  // An oracle-only page has no cards (and thus no scroll sentinel). Continue to
+  // the next page so it cannot hide fixed-rate listings further down the results.
+  useEffect(() => {
+    if (activeTab !== 0 || (viewMode === "explore" && searchQuery.trim())) return;
+    const page = viewMode === "explore" ? dispensers : userDispensers;
+    const visible = viewMode === "explore" ? visibleDispensers : visibleUserDispensers;
+    if (page.data.length > 0 && visible.length === 0 && page.hasMore
+      && !page.isLoading && !page.isFetchingMore && !page.error) {
+      page.loadMore();
+    }
+  }, [activeTab, searchQuery, viewMode, dispensers, userDispensers, visibleDispensers, visibleUserDispensers]);
+
   // Memoized filtered data for manage mode
   const filteredUserDispensers = useMemo(() => {
-    if (!searchQuery.trim()) return userDispensers.data;
+    if (!searchQuery.trim()) return visibleUserDispensers;
     const query = searchQuery.toLowerCase();
-    return userDispensers.data.filter((d) => {
+    return visibleUserDispensers.filter((d) => {
       const asset = d.asset.toLowerCase();
       const longname = d.asset_info?.asset_longname?.toLowerCase() || "";
       return asset.includes(query) || longname.includes(query);
     });
-  }, [userDispensers.data, searchQuery]);
+  }, [visibleUserDispensers, searchQuery]);
 
   const filteredUserOrders = useMemo(() => {
     if (!searchQuery.trim()) return userOrders.data;
@@ -164,7 +187,7 @@ export function useMarketData({
     setDispenserSearchError(null);
     try {
       const res = await fetchAssetDispensers(normalizeAssetQuery(query), { status: "open", limit: PAGE_SIZE });
-      setDispenserResults(res.result);
+      setDispenserResults(res.result.filter(isFixedRateDispenser));
     } catch (err) {
       console.error("Failed to search dispensers:", err);
       setDispenserResults([]);
@@ -234,9 +257,9 @@ export function useMarketData({
   }, [inView, activeTab, viewMode, dispensers, orders, userDispensers, userOrders]);
 
   return {
-    dispensers,
+    dispensers: { ...dispensers, data: visibleDispensers },
     orders,
-    userDispensers,
+    userDispensers: { ...userDispensers, data: visibleUserDispensers },
     userOrders,
     filteredUserDispensers,
     filteredUserOrders,

--- a/src/pages/compose/dispenser/close-by-hash/form.tsx
+++ b/src/pages/compose/dispenser/close-by-hash/form.tsx
@@ -7,6 +7,7 @@ import { HashInput } from "@/components/ui/inputs/hash-input";
 import { useComposer } from "@/contexts/composer-context-object";
 import { fetchDispenserByHash } from "@/core/counterparty/api";
 import type { DispenserOptions } from "@/core/counterparty/compose";
+import { isFixedRateDispenser } from "@/core/counterparty/oraclePolicy";
 
 interface DispenserCloseByHashFormProps {
   formAction: (formData: FormData) => void;
@@ -61,7 +62,7 @@ export function DispenserCloseByHashForm({
     
     try {
       const dispenser = await fetchDispenserByHash(hashToLookup);
-      if (dispenser && dispenser.status === 0) { // STATUS_OPEN
+      if (dispenser && dispenser.status === 0 && isFixedRateDispenser(dispenser)) { // STATUS_OPEN
         setSelectedDispenser(dispenser);
       } else {
         setSelectedDispenser(null);

--- a/src/pages/compose/dispenser/close/form.tsx
+++ b/src/pages/compose/dispenser/close/form.tsx
@@ -17,6 +17,7 @@ import { useComposer } from "@/contexts/composer-context-object";
 import type { DispenserDetails } from "@/core/counterparty/api";
 import { fetchAddressDispensers } from "@/core/counterparty/api";
 import type { DispenserOptions } from "@/core/counterparty/compose";
+import { isFixedRateDispenser } from "@/core/counterparty/oraclePolicy";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 
 /**
@@ -77,7 +78,7 @@ export function DispenserCloseForm({
           status: "open",
           verbose: true,
         });
-        setDispensers(response.result);
+        setDispensers(response.result.filter(isFixedRateDispenser));
       } catch (err) {
         console.error("Failed to load dispensers:", err);
       } finally {

--- a/src/pages/compose/dispenser/dispense/__tests__/form.test.tsx
+++ b/src/pages/compose/dispenser/dispense/__tests__/form.test.tsx
@@ -168,6 +168,33 @@ describe('DispenseForm', () => {
     });
   });
 
+  it('hides oracle dispensers and selects the fixed-rate option', async () => {
+    mockFetchAddressDispensers.mockResolvedValue({
+      result: [
+        createMockDispenser({ asset: 'XCP', oracle_address: 'feed', satoshirate: asBaseUnits(888) }),
+        createMockDispenser({ tx_hash: 'fixed', oracle_address: null }),
+      ],
+      result_count: 2,
+    });
+    renderWithProvider();
+    await userEvent.type(screen.getByLabelText(/Dispenser Address/i), '1CounterpartyXXXXXXXXXXXXXXXUWLpVr');
+    await waitFor(() => expect(screen.getByText('PEPECASH')).toBeInTheDocument());
+    expect(screen.queryByText('XCP')).not.toBeInTheDocument();
+    expect(document.querySelector('input[name="satoshirate"]')).toHaveValue('5000');
+  });
+
+  it('offers no purchase when the address only has oracle dispensers', async () => {
+    mockFetchAddressDispensers.mockResolvedValue({
+      result: [createMockDispenser({ asset: 'XCP', oracle_address: 'feed' })],
+      result_count: 1,
+    });
+    renderWithProvider();
+    await userEvent.type(screen.getByLabelText(/Dispenser Address/i), '1CounterpartyXXXXXXXXXXXXXXXUWLpVr');
+    await waitFor(() => expect(screen.getAllByText(/No open dispenser found at this address/i).length).toBeGreaterThan(0));
+    expect(screen.queryByText('XCP')).not.toBeInTheDocument();
+    expect(document.querySelector('input[name="satoshirate"]')).toBeNull();
+  });
+
   it('should not fetch dispensers for invalid addresses', async () => {
     renderWithProvider();
     

--- a/src/pages/market/dispensers/[asset].tsx
+++ b/src/pages/market/dispensers/[asset].tsx
@@ -19,6 +19,7 @@ import {
   fetchAssetDispensers,
   fetchAssetDispenses,
 } from "@/core/counterparty/api";
+import { isFixedRateDispenser } from "@/core/counterparty/oraclePolicy";
 import { formatAmount } from "@/core/format";
 import { type BigNumber, divide, multiply, roundDown, toBigNumber, toNumber } from "@/core/numeric";
 import { formatPrice, getNextPriceUnit, getRawPrice } from "@/core/priceFormat";
@@ -150,7 +151,7 @@ export default function AssetDispensersPage(): ReactElement {
       if (infoRes) setAssetInfo(infoRes);
 
       // Sort by price (lowest first) for better UX
-      const sortedDispensers = [...dispensersRes.result].sort(
+      const sortedDispensers = dispensersRes.result.filter(isFixedRateDispenser).sort(
         byPricePerUnit
       );
       setDispensers(sortedDispensers);
@@ -224,7 +225,7 @@ export default function AssetDispensersPage(): ReactElement {
         if (res.result.length > 0) {
           setDispensers((prev) => {
             // Append, dedupe, and re-sort by price
-            const merged = [...prev, ...res.result];
+            const merged = [...prev, ...res.result.filter(isFixedRateDispenser)];
             const deduped = merged.filter(
               (d, i, arr) => arr.findIndex((x) => x.tx_hash === d.tx_hash) === i
             );

--- a/src/pages/market/dispensers/__tests__/asset.test.tsx
+++ b/src/pages/market/dispensers/__tests__/asset.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as api from '@/core/counterparty/api';
+import { asBaseUnits, asDisplayUnits } from '@/core/numeric';
+import AssetDispensersPage from '../[asset]';
+
+const mocks = vi.hoisted(() => ({
+  inView: false, setHeaderProps: vi.fn(), navigate: vi.fn(),
+  settings: { fiat: 'usd', priceUnit: 'sats' }, updateSettings: vi.fn(),
+  copy: vi.fn(), isCopied: () => false, ref: vi.fn(),
+}));
+vi.mock('@/core/counterparty/api');
+vi.mock('react-router', () => ({ useNavigate: () => mocks.navigate, useParams: () => ({ asset: 'XCP' }) }));
+vi.mock('@/contexts/header-context', () => ({ useHeader: () => ({ setHeaderProps: mocks.setHeaderProps }) }));
+vi.mock('@/contexts/settings-context', () => ({ useSettings: () => mocks }));
+vi.mock('@/hooks/useMarketPrices', () => ({ useMarketPrices: () => ({ btc: null }) }));
+vi.mock('@/hooks/useInView', () => ({ useInView: () => ({ ref: mocks.ref, inView: mocks.inView }) }));
+vi.mock('@/hooks/useCopyToClipboard', () => ({ useCopyToClipboard: () => mocks }));
+vi.mock('@/components/domain/dispenser/asset-dispenser-card', () => ({
+  AssetDispenserCard: ({ dispenser, formattedPrice }: { dispenser: api.DispenserDetails; formattedPrice: string }) =>
+    <div data-testid="listing">{dispenser.tx_hash}: {formattedPrice}</div>,
+}));
+
+function dispenser(tx_hash: string, oracle_address: string | null = null): api.DispenserDetails {
+  return {
+    tx_hash, oracle_address, source: '1F6zwfr9VePPFJYFfQt9FWmMmJ1iVn1ziJ', asset: 'XCP', status: 0,
+    give_quantity: asBaseUnits(100_000_000), give_quantity_normalized: asDisplayUnits('1'),
+    give_remaining: asBaseUnits(200_000_000), give_remaining_normalized: asDisplayUnits('2'),
+    satoshirate: asBaseUnits(oracle_address ? 888 : 8880),
+    satoshirate_normalized: asDisplayUnits('0.00008880'),
+    escrow_quantity: asBaseUnits(200_000_000), escrow_quantity_normalized: asDisplayUnits('2'),
+    block_index: 800000, block_time: 1700000000, price: asBaseUnits(8880), satoshi_price: 8880,
+  };
+}
+const response = (result: api.DispenserDetails[]) => ({ result, result_count: result.length });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.inView = false;
+  vi.mocked(api.fetchAssetDetails).mockResolvedValue(null);
+  vi.mocked(api.fetchAssetDispenses).mockResolvedValue({ result: [], result_count: 0 });
+});
+
+describe('Get XCP oracle filtering', () => {
+  it('removes oracle listings before calculating floor and average prices', async () => {
+    vi.mocked(api.fetchAssetDispensers).mockResolvedValue(response([dispenser('oracle', 'feed'), dispenser('fixed')]));
+    render(<AssetDispensersPage />);
+    await waitFor(() => expect(screen.getAllByTestId('listing')).toHaveLength(1));
+    expect(screen.getByTestId('listing')).toHaveTextContent('fixed: 8,880 sats');
+    expect(screen.getAllByText('8,880 sats')).toHaveLength(2); // Floor and average
+    expect(screen.queryByText('888 sats')).not.toBeInTheDocument();
+  });
+
+  it('continues past a full oracle-only page without using the filtered length as the offset', async () => {
+    vi.mocked(api.fetchAssetDispensers)
+      .mockResolvedValueOnce(response(Array.from({ length: 20 }, (_, i) => dispenser(`oracle-${i}`, 'feed'))))
+      .mockResolvedValueOnce(response([dispenser('another-oracle', 'feed'), dispenser('fixed')]));
+    const { rerender } = render(<AssetDispensersPage />);
+    await screen.findByText('No open XCP dispensers found');
+    mocks.inView = true;
+    rerender(<AssetDispensersPage />);
+    await waitFor(() => expect(screen.getAllByTestId('listing')).toHaveLength(1));
+    expect(screen.getByTestId('listing')).toHaveTextContent('fixed: 8,880 sats');
+    expect(api.fetchAssetDispensers).toHaveBeenLastCalledWith('XCP', { limit: 20, offset: 20, status: 'open' });
+  });
+});


### PR DESCRIPTION
Oracle-priced dispensers appeared in Get XCP and other extension lists with their raw rates presented as fixed satoshi prices, including the reported 888-sat XCP listing. Hide these listings before displaying prices, calculating floor/average values, or offering dispenser selection.

Apply the shared filter to asset listings, market browsing/search, management lists, purchase selection, and close-form lookups. Keep raw API responses available to the existing signing safety checks. Pagination still counts raw rows and advances past oracle-only first pages in market browsing.

Validation: 33 focused tests pass, covering listing visibility, price summaries, purchase selection, pagination, close forms, and oracle signing policy. TypeScript, lint, and the Chrome production build pass. The build reports a bundle-size warning.
