### PR TITLE
chore(release): bump version to 0.11.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xcp-wallet",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xcp-wallet",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "xcp-wallet",
   "description": "Counterparty Web3 Wallet",
   "private": true,
-  "version": "0.11.1",
+  "version": "0.11.2",
   "license": "MIT",
   "type": "module",
   "engines": {


### PR DESCRIPTION
Bumps the extension from 0.11.1 to 0.11.2 for the release containing search/pagination fixes (#403), exact-amount handling (#399), broadcast propagation and input reservations (#396), API request pacing (#398), and oracle-dispenser filtering (#401).

Only the three root version fields in package.json and package-lock.json change, using `npm version 0.11.2 --no-git-tag-version`. No dependency changes.

Validation: `npm run check:lockfile`, `npm run compile`, and `npm run zip` pass. The Chrome ZIP manifest reports MV3 and version 0.11.2; all 15 other packaged runtime files are byte-identical to the build that passed the seven browser regressions. The archive contains no test files or QA screenshots.
