### PR TITLE
Stop warning about batches where nothing is wrong

### DIFF
--- a/src/core/counterparty/marketplaceBatch.ts
+++ b/src/core/counterparty/marketplaceBatch.ts
@@ -261,7 +261,10 @@ export function analyzeMarketplaceBatch(
       { kind: 'text' as const, label: 'Broadcast', value: 'Not broadcast now.' },
       { kind: 'paragraph' as const, label: 'Signature invalidation', value: 'Spend each attached asset UTXO' },
     );
-    notice = 'Every listing independently guarantees its seller payment. Each flexible signature remains valid until its attached asset outpoint is spent.';
+    // No notice, for the reason stated above the facts: the durable-signature boundary is the
+    // `Signature invalidation` row, and the per-listing guarantee is what the payout rows say.
+    // Restating both in an amber box warned about a batch that had verified completely.
+    notice = '';
   }
 
   return {

--- a/src/core/counterparty/marketplaceBatch.ts
+++ b/src/core/counterparty/marketplaceBatch.ts
@@ -233,7 +233,11 @@ export function analyzeMarketplaceBatch(
         value: formatXcpRaw(attaches.map(intent => intent.protocolFee.quotedAmountRaw)),
       },
     );
-    notice = 'Every attach proves its source, clean funding, new UTXO, miner fee, and local Counterparty message. XCP fees remain block-dependent until confirmation.';
+    // No notice. Every clean attach is `caution` by design, which turns any notice here amber —
+    // and a recital of the checks that just passed reads as an alarm about a batch where nothing
+    // is wrong. The single-attach review says the same thing by carrying `notices: []`, and the
+    // quoted XCP fee is already a fact above.
+    notice = '';
   } else {
     const listings = intents as CreateListingIntentClaim[];
     const gross = exactSafeSum(listings.map(intent => intent.priceSats), 'listing prices');
@@ -266,7 +270,9 @@ export function analyzeMarketplaceBatch(
     title,
     ...(summary ? { bundleSummary: summary } : {}),
     facts,
-    notices: blockers.length > 0 ? [] : [{ severity: status === 'caution' ? 'warning' : 'info', message: notice }],
+    notices: blockers.length > 0 || !notice
+      ? []
+      : [{ severity: status === 'caution' ? 'warning' : 'info', message: notice }],
     blockers,
   };
 }


### PR DESCRIPTION
Two amber notices fired on marketplace batches that had verified completely, so a clean batch announced itself as a problem.

## Why they were amber

A clean attach is `caution` by design — every check passes, but the quoted XCP fee stays block-dependent until confirmation. `marketplaceBatch.ts` maps any notice on a `caution` review to `severity: 'warning'`, and `psbts/approve.tsx` renders those as warning items. So the box was amber purely because of the status, regardless of what it said.

What it said was the problem:

> Every attach proves its source, clean funding, new UTXO, miner fee, and local Counterparty message. XCP fees remain block-dependent until confirmation.

That is a recital of the five checks that had *just passed*. Nothing was wrong, and it read like something was.

## The precedent

The single-attach screen already refuses to do this. `psbt/approve.tsx` suppresses the same notice via `routineAttach`:

> Attach quotes are intrinsically block-dependent and already disclosed in the action card. A second click on a proved listing or inventory attach would turn that routine protocol fact into warning wallpaper.

The batch screen never got the same treatment. Dropping the notice at the source lets batch match single.

## Both notices

- **bulk-attach / prepare-assets** — removed. The quoted XCP fee is still a fact on the card.
- **create-listings** — removed. The comment directly above those facts already says where this belongs: *"Proved reviews speak through facts, not notices, so the durable-signature boundary has to live here."* `Signature invalidation: Spend each attached asset UTXO` is a fact row; the per-listing guarantee is what the payout rows say.

`prepare_bulk_fanout` resolves to `proved`, so its notice was already `info` and filtered out — untouched.

## Not changed

The `caution` status itself. Several tests pin it and it is a security posture, not a display choice. Only the notices are gone; `notices` is now empty for these kinds, which the existing render path already handles.

4,895 unit tests pass, `tsc` and Biome clean.