### PR TITLE
Post the compose when its parameters outgrow a URL

### DIFF
--- a/e2e/inputs/file-upload-input.spec.ts
+++ b/e2e/inputs/file-upload-input.spec.ts
@@ -96,7 +96,7 @@ walletTest.describe('FileUploadInput Component', () => {
       const inscribeEnabled = await enableInscribeMode(page);
       walletTest.skip(!inscribeEnabled, 'Inscribe mode not available');
 
-      const maxSizeText = page.locator('text=/Max file size.*400KB/');
+      const maxSizeText = page.locator('text=/Max file size.*240KB/');
       await expect(maxSizeText).toBeVisible({ timeout: 3000 });
     });
 
@@ -272,14 +272,14 @@ walletTest.describe('FileUploadInput Component', () => {
   });
 
   walletTest.describe('File Size Validation', () => {
-    walletTest('shows error for file over 400KB', async ({ page }) => {
+    walletTest('shows error for file over 240KB', async ({ page }) => {
       const inscribeEnabled = await enableInscribeMode(page);
       walletTest.skip(!inscribeEnabled, 'Inscribe mode not available');
 
       const hiddenInput = getHiddenInput(page);
 
-      // Create a file larger than 400KB (401KB)
-      const largeContent = 'A'.repeat(401 * 1024);
+      // Create a file larger than 240KB (241KB)
+      const largeContent = 'A'.repeat(241 * 1024);
       const buffer = Buffer.from(largeContent);
 
       await hiddenInput.setInputFiles({
@@ -293,13 +293,13 @@ walletTest.describe('FileUploadInput Component', () => {
       await expect(errorText).toBeVisible({ timeout: 3000 });
     });
 
-    walletTest('accepts file under 400KB', async ({ page }) => {
+    walletTest('accepts file under 240KB', async ({ page }) => {
       const inscribeEnabled = await enableInscribeMode(page);
       walletTest.skip(!inscribeEnabled, 'Inscribe mode not available');
 
       const hiddenInput = getHiddenInput(page);
 
-      // Create a file under 400KB (100KB)
+      // Create a file under 240KB (100KB)
       const content = 'A'.repeat(100 * 1024);
       const buffer = Buffer.from(content);
 
@@ -310,7 +310,7 @@ walletTest.describe('FileUploadInput Component', () => {
       });
 
       // Check for file size error - should NOT appear
-      const sizeError = page.locator('text=/exceed|too large|400/i');
+      const sizeError = page.locator('text=/exceed|too large|must be less than/i');
       await expect(sizeError).not.toBeVisible({ timeout: 2000 });
     });
   });

--- a/e2e/pages/compose/broadcast/index.spec.ts
+++ b/e2e/pages/compose/broadcast/index.spec.ts
@@ -195,8 +195,8 @@ walletTest.describe('Broadcast Inscription (File Upload)', () => {
     await toggleButton.click();
     await page.waitForLoadState('networkidle');
 
-    // Create a file larger than 400KB limit
-    const largeContent = 'x'.repeat(450 * 1024);
+    // Create a file larger than the 240KB limit
+    const largeContent = 'x'.repeat(300 * 1024);
 
     const chooseFileButton = page.locator('text=/Choose File/i').first();
     await expect(chooseFileButton).toBeVisible({ timeout: 5000 });
@@ -212,6 +212,6 @@ walletTest.describe('Broadcast Inscription (File Upload)', () => {
     });
 
     // Should show error about file size
-    await expect(page.locator('text=/File size must be less than 400KB/i')).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('text=/File size must be less than 240KB/i')).toBeVisible({ timeout: 5000 });
   });
 });

--- a/src/core/counterparty/__tests__/compose.largeRequest.test.ts
+++ b/src/core/counterparty/__tests__/compose.largeRequest.test.ts
@@ -1,0 +1,159 @@
+/**
+ * A compose whose parameters outgrow a URL.
+ *
+ * Everything a compose names travels in the query string, and an inscription carries its file
+ * there too — hex-encoded, so the file costs twice its size. Past 32,768 bytes the node's front
+ * door rejects the request before the application sees it, and the rejection carries no CORS
+ * headers, so the browser blocks the response and `fetch` rejects. The wallet read that as
+ * "Network error. Please check your internet connection." and a user went looking at their router
+ * over a 150KB image.
+ *
+ * These tests pin the switch to a POST body, and that the switch is confined to the requests that
+ * need it: an ordinary send must still be the GET it has always been.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as apiClientUtils from '@/core/api/client';
+import { getActiveSettings } from '@/core/settings';
+import { composeIssuance, composeMPMA, composeSend, MAX_INSCRIPTION_FILE_BYTES } from '../compose';
+import {
+  createMockComposeResponse,
+  mockAddress,
+  mockApiBase,
+  mockDestAddress,
+  mockSatPerVbyte,
+  mockSettings,
+  testQuantities,
+} from './helpers/composeTestHelpers';
+
+vi.mock('@/core/api/client');
+vi.mock('@/core/counterparty/capabilities', () => ({
+  requireCounterpartyFeature: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('@/core/settings', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/core/settings')>();
+  return { ...actual, getActiveSettings: vi.fn().mockReturnValue(actual.DEFAULT_SETTINGS) };
+});
+
+// The txid is spelled out rather than imported as `mockInputTxid`: this factory is hoisted above
+// the imports and cannot read them. It must stay in step with composeTestHelpers, or the input
+// policy check has nothing to match and stops testing anything.
+vi.mock('@/core/counterparty/utxoSelection', () => ({
+  selectUtxosForTransaction: vi.fn().mockResolvedValue({
+    utxos: [{ txid: 'aa'.repeat(32), vout: 0, value: 100000, status: { confirmed: true } }],
+    inputsSet: `${'aa'.repeat(32)}:0`,
+    totalValue: 100000,
+    excludedWithAssets: 0,
+  }),
+}));
+
+const mockedApiClient = vi.mocked(apiClientUtils.apiClient, true);
+const mockedGetSettings = vi.mocked(getActiveSettings);
+
+/** Hex for a file of `bytes` bytes, the way `encodeInscriptionContent` produces it for binary. */
+const inscriptionHex = (bytes: number) => 'ab'.repeat(bytes);
+
+const issuanceWithFile = (bytes: number) =>
+  composeIssuance({
+    sourceAddress: mockAddress,
+    asset: 'A9999999999999999999',
+    quantity: testQuantities.SMALL,
+    divisible: false,
+    lock: false,
+    reset: false,
+    description: inscriptionHex(bytes),
+    inscription: 'true',
+    mime_type: 'image/jpeg',
+    sat_per_vbyte: mockSatPerVbyte,
+    encoding: 'taproot',
+  });
+
+describe('Compose requests too large for a URL', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedGetSettings.mockReturnValue(mockSettings as any);
+    mockedApiClient.get.mockResolvedValue(createMockComposeResponse());
+    mockedApiClient.post.mockResolvedValue(createMockComposeResponse());
+  });
+
+  it('sends an ordinary compose as a GET', async () => {
+    await composeSend({
+      sourceAddress: mockAddress,
+      destination: mockDestAddress,
+      asset: 'XCP',
+      quantity: testQuantities.MEDIUM,
+      sat_per_vbyte: mockSatPerVbyte,
+    });
+
+    expect(mockedApiClient.get).toHaveBeenCalledTimes(1);
+    expect(mockedApiClient.post).not.toHaveBeenCalled();
+  });
+
+  it('keeps a small inscription on the GET path', async () => {
+    await issuanceWithFile(2 * 1024);
+
+    expect(mockedApiClient.get).toHaveBeenCalledTimes(1);
+    expect(mockedApiClient.post).not.toHaveBeenCalled();
+  });
+
+  it('posts a form body once the URL would overflow, and sends no query string with it', async () => {
+    await issuanceWithFile(64 * 1024);
+
+    expect(mockedApiClient.get).not.toHaveBeenCalled();
+    expect(mockedApiClient.post).toHaveBeenCalledTimes(1);
+
+    const [url, body, config] = mockedApiClient.post.mock.calls[0]!;
+    expect(url).toBe(`${mockApiBase}/v2/addresses/${mockAddress}/compose/issuance`);
+    expect(url).not.toContain('?');
+    expect(config?.headers?.['Content-Type']).toBe('application/x-www-form-urlencoded');
+
+    // The body must carry everything the query string did, the file included.
+    const sent = new URLSearchParams(body as string);
+    expect(sent.get('description')).toBe(inscriptionHex(64 * 1024));
+    expect(sent.get('inscription')).toBe('true');
+    expect(sent.get('mime_type')).toBe('image/jpeg');
+    expect(sent.get('encoding')).toBe('taproot');
+    expect(sent.get('sat_per_vbyte')).toBe(String(mockSatPerVbyte));
+    expect(sent.get('verbose')).toBe('true');
+    expect(sent.get('inputs_set')).toBe(`${'aa'.repeat(32)}:0`);
+  });
+
+  it('carries MPMA repeated array keys through the body unchanged', async () => {
+    // `memos` is the one parameter core reads as a list of repeated plain keys — the others are
+    // comma-joined scalars. A body has to preserve that shape, or an MPMA long enough to cross
+    // the threshold would silently compose as a different send.
+    const memo = 'm'.repeat(20 * 1024);
+    await composeMPMA({
+      sourceAddress: mockAddress,
+      assets: ['XCP', 'PEPECASH'],
+      destinations: [mockDestAddress, mockDestAddress],
+      quantities: ['1000', '2000'],
+      memos: [memo, memo],
+      memos_are_hex: [false, false],
+      sat_per_vbyte: mockSatPerVbyte,
+    });
+
+    expect(mockedApiClient.get).not.toHaveBeenCalled();
+    const [, body] = mockedApiClient.post.mock.calls[0]!;
+    const sent = new URLSearchParams(body as string);
+    expect(sent.getAll('memos')).toEqual([memo, memo]);
+    expect(sent.get('assets')).toBe('XCP,PEPECASH');
+    expect(sent.get('destinations')).toBe(`${mockDestAddress},${mockDestAddress}`);
+    expect(sent.get('memos_are_hex')).toBe('false');
+  });
+
+  it('refuses a file past what a body can hold, without asking the node', async () => {
+    await expect(issuanceWithFile(MAX_INSCRIPTION_FILE_BYTES + 64 * 1024)).rejects.toThrow(
+      /too large for the Counterparty API/
+    );
+
+    expect(mockedApiClient.get).not.toHaveBeenCalled();
+    expect(mockedApiClient.post).not.toHaveBeenCalled();
+  });
+
+  it('still composes a file at the advertised maximum', async () => {
+    await issuanceWithFile(MAX_INSCRIPTION_FILE_BYTES);
+
+    expect(mockedApiClient.post).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/core/counterparty/compose.ts
+++ b/src/core/counterparty/compose.ts
@@ -482,6 +482,80 @@ async function executeWithUtxoFallback(
   }
 }
 
+/**
+ * The node's front door refuses a request line past 32,768 bytes, and its refusal carries no CORS
+ * headers. The browser therefore blocks the response and `fetch` rejects as a failed request, so
+ * the wallet reported "Network error. Please check your internet connection." for what was really
+ * an oversized URL — the message sent a user checking their router over a 150KB image. Measured
+ * against api.counterparty.io:4000: a 32,053-byte URL reached the application, 33,053 came back
+ * 503 from the proxy with no `server` header, and past ~65,000 it is a bare 431.
+ *
+ * The margin under 32,768 covers what `url.length` does not — the request line's method and
+ * version, and HTTP/2's encoded header block.
+ */
+const MAX_COMPOSE_URL_BYTES = 30_000;
+
+/**
+ * waitress refuses a form body past 512,000 bytes, answering 500 rather than a size error.
+ * Measured the same way: a 491,610-byte body composed, 512,090 did not.
+ */
+const MAX_COMPOSE_BODY_BYTES = 500_000;
+
+/**
+ * The largest file an inscription can carry, for the upload forms to refuse before the user waits
+ * on a compose that cannot finish. Derived from the transport rather than asserted next to it —
+ * the forms claimed 400KB while anything past ~15KB failed on the wire.
+ *
+ * Binary content travels hex-encoded (`encodeInscriptionContent`), so a file costs twice its size
+ * in the request, and the remaining parameters need a few hundred bytes more. Textual content is
+ * sent verbatim and percent-encoded instead, which can cost more than double for non-ASCII;
+ * `sendComposeRequest` measures the request that will actually be sent and is the check that
+ * cannot be fooled by encoding.
+ */
+export const MAX_INSCRIPTION_FILE_BYTES = 240 * 1024;
+
+/**
+ * Send a compose request, as a POST once the query outgrows what a URL may carry.
+ *
+ * GET stays the default and is what every ordinary compose still sends: it is cacheable, and it is
+ * legible in a network log. Only an inscription approaches the limit, because it carries its file
+ * in the query string. Core reads the same parameters from a form-encoded body — repeated keys
+ * included, so the MPMA array form survives the switch — and a body is not subject to the request
+ * line's limit. `application/x-www-form-urlencoded` is a CORS-safelisted content type, so the POST
+ * costs no preflight round trip.
+ */
+async function sendComposeRequest(
+  apiUrl: string,
+  query: string,
+  endpoint: string
+): Promise<ApiResponse> {
+  const url = `${apiUrl}?${query}`;
+  const fitsInUrl = url.length <= MAX_COMPOSE_URL_BYTES;
+
+  // Said here, where the size is known, rather than left to the node: past the body limit it
+  // answers 500 "Internal server error", which the error layer shows as a generic API failure.
+  if (!fitsInUrl && query.length > MAX_COMPOSE_BODY_BYTES) {
+    throw new CounterpartyApiError(
+      'This inscription is too large for the Counterparty API to compose. Use a smaller file.',
+      endpoint,
+      {}
+    );
+  }
+
+  const response = fitsInUrl
+    ? await apiClient.get<ApiResponse | { error: string }>(url, {
+        headers: { 'Content-Type': 'application/json' },
+      })
+    : await apiClient.post<ApiResponse | { error: string }>(apiUrl, query, {
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      });
+
+  if ('error' in response.data) {
+    throw new CounterpartyApiError(response.data.error, endpoint, {});
+  }
+  return response.data as ApiResponse;
+}
+
 // ============================================================================
 // Compose Functions
 // ============================================================================
@@ -522,16 +596,7 @@ export async function composeTransaction<T extends Record<string, unknown>>(
       ...(multisigPubkey && { multisig_pubkey: multisigPubkey }),
     }));
 
-    const response = await apiClient.get<ApiResponse | { error: string }>(
-      `${apiUrl}?${params.toString()}`,
-      { headers: { 'Content-Type': 'application/json' } }
-    );
-
-    if ('error' in response.data) {
-      throw new CounterpartyApiError(response.data.error, endpoint, {});
-    }
-
-    const composed = response.data as ApiResponse;
+    const composed = await sendComposeRequest(apiUrl, params.toString(), endpoint);
     // Checked here, where the set actually sent is in scope: the fallbacks below send different
     // ones, and the last sends none at all.
     const inputCheck = checkInputPolicy({
@@ -582,25 +647,19 @@ async function composeTransactionWithArrays<T extends Record<string, unknown>>(
     }));
 
     // Array params must be repeated plain keys: core's `query_params()` builds lists from
-    // repeated keys and treats a PHP-style `memos[]` as a different, ignored parameter.
-    let url = `${apiUrl}?${params.toString()}`;
+    // repeated keys and treats a PHP-style `memos[]` as a different, ignored parameter. A
+    // form-encoded body carries repeated keys the same way, which is what lets the POST fallback
+    // in `sendComposeRequest` serve this path too.
+    let query = params.toString();
     for (const [key, values] of Object.entries(arrayParams)) {
       if (Array.isArray(values)) {
         for (const value of values) {
-          url += `&${key}=${encodeURIComponent(String(value ?? ''))}`;
+          query += `&${key}=${encodeURIComponent(String(value ?? ''))}`;
         }
       }
     }
 
-    const response = await apiClient.get<ApiResponse | { error: string }>(url, {
-      headers: { 'Content-Type': 'application/json' },
-    });
-
-    if ('error' in response.data) {
-      throw new CounterpartyApiError(response.data.error, endpoint, {});
-    }
-
-    const composed = response.data as ApiResponse;
+    const composed = await sendComposeRequest(apiUrl, query, endpoint);
     // Checked here, where the set actually sent is in scope: the fallbacks below send different
     // ones, and the last sends none at all.
     const inputCheck = checkInputPolicy({
@@ -646,20 +705,10 @@ export async function composeUtxoTransaction<T extends Record<string, unknown>>(
     ...(encoding && { encoding }),
   }));
 
-  const url = `${apiUrl}?${params.toString()}`;
-
   try {
-    // Use apiClient for automatic timeout (60s for /compose) and retry logic
-    const response = await apiClient.get<ApiResponse | { error: string }>(url, {
-      headers: { 'Content-Type': 'application/json' },
-    });
-
-    // Check if the API returned an error response
-    if ('error' in response.data) {
-      throw new CounterpartyApiError(response.data.error, endpoint, {});
-    }
-
-    return response.data as ApiResponse;
+    // Routed through sendComposeRequest for the apiClient timeout (60s for /compose) and retry
+    // logic, and for the POST fallback when the query outgrows a URL.
+    return await sendComposeRequest(apiUrl, params.toString(), endpoint);
   } catch (error: unknown) {
     if (error instanceof CounterpartyApiError) throw error;
 

--- a/src/pages/compose/broadcast/form.tsx
+++ b/src/pages/compose/broadcast/form.tsx
@@ -8,8 +8,11 @@ import { SettingSwitch } from "@/components/ui/inputs/setting-switch";
 import { TextField } from "@/components/ui/inputs/text-field";
 import { useComposer } from "@/contexts/composer-context-object";
 import { isSegwitFormat } from '@/core/bitcoin/address';
-import type { BroadcastOptions } from "@/core/counterparty/compose";
+import { type BroadcastOptions, MAX_INSCRIPTION_FILE_BYTES } from "@/core/counterparty/compose";
 import { encodeInscriptionContent } from '@/core/counterparty/inscriptionEnvelope';
+
+/** Maximum file size for inscriptions in KB; see the compose layer for where it comes from. */
+const INSCRIPTION_MAX_SIZE_KB = MAX_INSCRIPTION_FILE_BYTES / 1024;
 
 /**
  * Props for the BroadcastForm component, aligned with Composer's formAction.
@@ -54,8 +57,8 @@ export function BroadcastForm({
   // Handlers
   const handleFileChange = (file: File | null) => {
     setFileError(null);
-    if (file && file.size > 400 * 1024) {
-      setFileError("File size must be less than 400KB");
+    if (file && file.size > MAX_INSCRIPTION_FILE_BYTES) {
+      setFileError(`File size must be less than ${INSCRIPTION_MAX_SIZE_KB}KB`);
       return;
     }
     setSelectedFile(file);
@@ -122,7 +125,7 @@ export function BroadcastForm({
               onFileChange={handleFileChange}
               error={fileError}
               disabled={false}
-              maxSizeKB={400}
+              maxSizeKB={INSCRIPTION_MAX_SIZE_KB}
               helpText="Upload a file to inscribe as the broadcast message. The file content will be stored permanently on-chain. To broadcast text, upload a .txt file."
               showHelpText={showHelpText}
             />

--- a/src/pages/compose/issuance/form.tsx
+++ b/src/pages/compose/issuance/form.tsx
@@ -12,14 +12,23 @@ import { SettingSwitch } from "@/components/ui/inputs/setting-switch";
 import { TextAreaInput } from "@/components/ui/inputs/textarea-input";
 import { useComposer } from "@/contexts/composer-context-object";
 import { isSegwitFormat } from '@/core/bitcoin/address';
-import type { IssuanceOptions } from "@/core/counterparty/compose";
+import { type IssuanceOptions, MAX_INSCRIPTION_FILE_BYTES } from "@/core/counterparty/compose";
 import { encodeInscriptionContent } from '@/core/counterparty/inscriptionEnvelope';
 import { asDisplayUnits } from '@/core/numeric';
 import { maxSupplyForDivisibility } from "@/core/validation/amount";
 import { useAssetDetails } from "@/hooks/useAssetDetails";
 
-/** Maximum file size for inscriptions in KB */
-const INSCRIPTION_MAX_SIZE_KB = 400;
+/**
+ * Maximum file size for inscriptions in KB.
+ *
+ * Read from the compose layer rather than stated here: the two disagreed, and the form won the
+ * argument in the worst way. It advertised 400KB while a compose carried the file in the request
+ * URL, where anything past ~15KB was refused by the node's front door — with no CORS headers, so
+ * the browser reported it as a failed fetch and the wallet said "Network error. Please check your
+ * internet connection." Compose now posts a body when the URL would overflow; this is what that
+ * body can actually hold.
+ */
+const INSCRIPTION_MAX_SIZE_KB = MAX_INSCRIPTION_FILE_BYTES / 1024;
 
 /**
  * Props for the IssuanceForm component, aligned with Composer's formAction.
@@ -87,7 +96,7 @@ export function IssuanceForm({
   // Handlers
   const handleFileChange = (file: File | null) => {
     setFileError(null);
-    if (file && file.size > INSCRIPTION_MAX_SIZE_KB * 1024) {
+    if (file && file.size > MAX_INSCRIPTION_FILE_BYTES) {
       setFileError(`File size must be less than ${INSCRIPTION_MAX_SIZE_KB}KB`);
       return;
     }

--- a/src/pages/compose/issuance/update-description/form.tsx
+++ b/src/pages/compose/issuance/update-description/form.tsx
@@ -9,9 +9,12 @@ import { SettingSwitch } from "@/components/ui/inputs/setting-switch";
 import { Spinner } from "@/components/ui/spinner";
 import { useComposer } from "@/contexts/composer-context-object";
 import { isSegwitFormat } from '@/core/bitcoin/address';
-import type { IssuanceOptions } from "@/core/counterparty/compose";
+import { type IssuanceOptions, MAX_INSCRIPTION_FILE_BYTES } from "@/core/counterparty/compose";
 import { asDisplayUnits } from '@/core/numeric';
 import { useAssetInfo } from "@/hooks/useAssetInfo";
+
+/** Maximum file size for inscriptions in KB; see the compose layer for where it comes from. */
+const INSCRIPTION_MAX_SIZE_KB = MAX_INSCRIPTION_FILE_BYTES / 1024;
 
 /**
  * Props for the UpdateDescriptionForm component, aligned with Composer's formAction.
@@ -45,8 +48,8 @@ export function UpdateDescriptionForm({
   // Handle file selection
   const handleFileChange = (file: File | null) => {
     setFileError(null);
-    if (file && file.size > 400 * 1024) {
-      setFileError("File size must be less than 400KB");
+    if (file && file.size > MAX_INSCRIPTION_FILE_BYTES) {
+      setFileError(`File size must be less than ${INSCRIPTION_MAX_SIZE_KB}KB`);
       setSelectedFile(null);
       return;
     }
@@ -123,6 +126,7 @@ export function UpdateDescriptionForm({
                 onFileChange={handleFileChange}
                 disabled={pending}
                 error={fileError}
+                maxSizeKB={INSCRIPTION_MAX_SIZE_KB}
                 showHelpText={showHelpText}
               />
               {selectedFile && (


### PR DESCRIPTION
Inscribing a ~150KB photo from the wallet failed with **"Network error. Please check your internet connection."** The internet was fine.

## What was actually happening

Every compose is a `GET` with its parameters in the query string (`compose.ts`), and an inscription carries its file there too — hex-encoded (`encodeInscriptionContent`), so a 150KB image becomes **307,200 characters of URL**.

The node's front door stops well short of that. Measured against `api.counterparty.io:4000`:

| URL length | Result | `server` | `Access-Control-Allow-Origin` |
|---|---|---|---|
| 32,053 | 400 (reached the app) | `waitress` | `*` |
| 33,053 | 503 | — | — |
| 65,000+ | 431 | — | — |

The cutoff is 32,768 bytes, and **none of the rejections carry CORS headers**. So the browser blocks the response, `fetch` rejects with a `TypeError`, and `client.ts` can only read that as a lost connection:

```ts
if (error instanceof TypeError && error.message.includes('fetch')) {
  throw createApiError('Network error. Please check your internet connection.', 'NETWORK_ERROR');
}
```

The extension never sees a status code. The user goes and checks their router.

The practical ceiling was therefore **~15KB of file**, while both upload forms advertised **400KB**.

The taproot address in the original report is incidental — nothing in the compose path varies by source address type. Inscriptions always use `encoding=taproot`, which is likely where the conflation came from.

## The fix

Compose sends a form-encoded **POST body** once the URL would overflow. Core reads the same parameters from a body — repeated keys included, so the MPMA array form survives the switch — and `application/x-www-form-urlencoded` is CORS-safelisted, so it costs no preflight round trip.

`GET` stays the default for everything that fits, which is every ordinary compose: cacheable, and legible in a network log. Only an inscription ever approaches the limit.

The two upload forms now read their limit from the transport instead of asserting one beside it. A body is refused past 512,000 bytes (a 491,610-byte body composed; 512,090 did not), so **240KB of file** is what can actually be carried. Past that, compose says so itself rather than leaving the node to answer a 500 that the error layer renders as a generic API failure.

## Verification

Against a live node, with the 150KB request from the report:

```
source address: bc1puyehg2u6xev7v6t3wcpdxcy8ax4cwfslhs3dcdy353kcelhemvxqqkknf4
file bytes: 153600, hex chars: 307200
url length: 307587 -> POST

BEFORE (GET)  -> HTTP 431, ACAO=null
AFTER  (POST) -> HTTP 400, ACAO=*
  body: {"error": "Insufficient funds for the target amount: 1835 < 78110"}
```

The POST parses in full and gets all the way to UTXO selection and fee sizing — it quotes 78,110 sats to fund the commit, against the 1,835 that test address happens to hold. That source is itself a `bc1p` address, which is where the report first pointed.

Also confirmed on the live node that repeated array keys parse identically from a body and a query string, which is what the MPMA path depends on.

## Tests

New `compose.largeRequest.test.ts` pins both halves — that the switch happens, and that it stays confined to the requests that need it:

- an ordinary send is still a GET
- a small inscription is still a GET
- a large inscription is a POST, with no query string on the URL, the form content type, and every parameter carried in the body
- MPMA repeated `memos` keys survive the body unchanged
- a file past the body limit is refused without touching the network
- a file at exactly the advertised maximum still composes

`vitest run src`: 5,696 passed, 51 skipped. `tsc --noEmit` and `biome check src` clean; `scripts/lint.mjs` within budget.
